### PR TITLE
WIP: Add 'sti' execute plugin

### DIFF
--- a/spec/steps/execute.fmf
+++ b/spec/steps/execute.fmf
@@ -174,3 +174,36 @@ description: |
                     systemctl start httpd
                     echo foo > /var/www/html/index.html
                     curl http://localhost/ | grep foo
+
+/sti:
+    story: As a user I want to easily run `STI`_ tests.
+    summary: Execute STI tests
+    description: |
+        Run tests in `STI`_ format via Ansible and `standard-test-roles`_.
+
+        .. _STI: https://docs.fedoraproject.org/en-US/ci/standard-test-interface/
+        .. _standard-test-roles: https://docs.fedoraproject.org/en-US/ci/standard-test-roles/
+
+        There are two deviations from the standard::
+
+        1. By default only playbook `tests/tests.yml` is executed. If you need
+           to run multiple playbooks, define separate plans for it, because each
+           playbook has to be executed in a separate environment.
+
+        2. It is possible to run playbook with any name really. The standard
+           defines that only playbooks `tests/tests*.yml` are executed.
+
+    /default:
+        summary: Execute default playbook
+        example: |
+            execute:
+                how: sti
+
+    /custom:
+        summary: Execute custom playbook
+        example: |
+            execute:
+                how: sti
+                playbook: tests/full-test-suite.yml
+
+    implemented: /tmt/steps/execute/sti.py

--- a/tmt.spec
+++ b/tmt.spec
@@ -57,6 +57,10 @@ The tmt Python module and command line tool implement the test
 metadata specification (L1 and L2) and allows easy test execution.
 This package contains the Python 3 module.
 
+%package execute-sti
+Summary: Dependencies for STI executor
+Requires: standard-test-roles
+
 %package provision-container
 Summary: Container provisioner for the Test Management Tool
 Obsoletes: tmt-container < 0.17
@@ -94,6 +98,7 @@ output thanks to direct links to output logs.
 %package all
 Summary: Extra dependencies for the Test Management Tool
 Requires: tmt >= %{version}
+Requires: tmt-execute >= %{version}
 Requires: tmt-provision-container >= %{version}
 Requires: tmt-provision-virtual >= %{version}
 Requires: tmt-test-convert >= %{version}

--- a/tmt/steps/execute/sti.py
+++ b/tmt/steps/execute/sti.py
@@ -1,0 +1,107 @@
+import os
+import click
+import tmt
+
+# The default playbook used to run the tests
+DEFAULT_PLAYBOOK = 'tests/tests.yml'
+
+# Ansible inventory file required to run the tests
+ANSIBLE_INVENTORY = """
+[localhost]
+sut  ansible_host={hostname} ansible_user=root ansible_remote_tmp={remote_tmp}
+"""
+
+
+class ExecutorSTI(tmt.steps.execute.ExecutePlugin):
+    """ Run tests using ansible according to Standard Test Interface spec """
+    _doc = """
+    Execute STI tests
+
+    An inventory file is prepared according to the STI specification
+    and ansible-playbook is used to run the given playbook.
+    """
+
+    # Supported methods
+    _methods = [
+        tmt.steps.Method(
+            name='sti', doc=_doc, order=50),
+        ]
+
+    @classmethod
+    def options(cls, how=None):
+        """ Prepare command line options for given method """
+        options = []
+        if how == 'sti':
+            options.append(click.option(
+                '-p', '--playbook', metavar='PLAYBOOK',
+                help=f"""
+                    Ansible playbook to be run as a test.
+                    By default '{DEFAULT_PLAYBOOK}'
+                """))
+        return options + super().options(how)
+
+    def show(self):
+        """ Show discover details """
+        super().show(['playbook'])
+
+    def default(self, option, default=None):
+        """ Return the default value for the given option """
+        defaults = {
+            'playbook': DEFAULT_PLAYBOOK
+        }
+        playbook = defaults.get(option, default)
+
+        if not os.path.exists(playbook):
+            raise tmt.utils.GeneralError(f"Playbook '{playbook}' not found.")
+
+        return playbook
+
+    def _inventory(self, guest):
+        """ Provides Ansible inventory compared to STI """
+        hostname = guest.guest or guest.container
+
+        inventory_file = os.path.join(
+            self.step.workdir, f'inventory-{hostname}')
+        # Note that we have to force remote_tmp because in rootless container
+        # it would default to '/root/.ansible/tmp' which is
+        # not accessible by ordinary users
+        inventory_content = ANSIBLE_INVENTORY.format(
+            hostname=hostname,
+            remote_tmp=os.path.expanduser('~/.ansible/tmp')
+        )
+
+        with open(inventory_file, 'w') as inventory:
+            inventory.write(inventory_content)
+
+        return inventory_file
+
+    def wake(self):
+        """ Wake up the plugin (override data with command line) """
+
+        value = self.opt('playbook')
+        if value:
+            self.data['playbook'] = value
+
+    def go(self):
+        """ Execute available tests """
+        super().go()
+
+        # Nothing to do in dry mode
+        if self.opt('dry'):
+            self._results = []
+            return
+
+        for guest in self.step.plan.provision.guests():
+            guest.ansible(
+                self.opt('playbook'),
+                inventory=self._inventory(guest),
+                options=f'-e artifacts={self.step.workdir}'
+            )
+
+    def results(self):
+        """ Returns results from executed tests """
+        return []
+
+    def requires(self):
+        """ No packages are required """
+        return []

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -45,12 +45,14 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
 class GuestLocal(tmt.Guest):
     """ Local Host """
 
-    def ansible(self, playbook):
+    def ansible(self, playbook, inventory=None, options=None):
         """ Prepare localhost using ansible playbook """
         playbook = self._ansible_playbook_path(playbook)
+        options = f'{options} ' or ''
         stdout, stderr = self.run(
             f'sudo sh -c "stty cols {tmt.utils.OUTPUT_WIDTH}; ansible-playbook'
-            f'{self._ansible_verbosity()} -c local -i localhost, {playbook}"')
+            f'{self._ansible_verbosity()} {options}'
+            f'-c local -i localhost, {playbook}"')
         self._ansible_summary(stdout)
 
     def execute(self, command, **kwargs):

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -1,3 +1,5 @@
+import os
+
 import tmt
 import click
 
@@ -136,14 +138,16 @@ class GuestContainer(tmt.Guest):
             '-v', f'{tmt_workdir}:{tmt_workdir}:Z', '-itd', self.image],
             message=f"Start container '{self.image}'.")[0].strip()
 
-    def ansible(self, playbook):
+    def ansible(self, playbook, inventory=None, options=None):
         """ Prepare container using ansible playbook """
         playbook = self._ansible_playbook_path(playbook)
+        inventory = inventory or f'{self.container},'
+        options = f'{options} ' or ''
         stdout, stderr = self.run(
             f'stty cols {tmt.utils.OUTPUT_WIDTH}; '
             f'{self._export_environment()}'
             f'podman unshare ansible-playbook'
-            f'{self._ansible_verbosity()} -c podman -i {self.container}, '
+            f'{self._ansible_verbosity()} -c podman -i {inventory} {options}'
             f'{playbook}')
         self._ansible_summary(stdout)
 


### PR DESCRIPTION
Support running sti tests via 'tmt'. Add an template for easily
create the test plan.

Example of the workflow

$ fedpkg clone python3
$ cd python3
$ tmt init --template sti

$ tmt run -a provision -h virtual.testcloud
or
$ tmt run -a provision -h container

Relates to https://pagure.io/fedora-ci/general/issue/4

Still needs some touches:
- [x] execution in container works
- [ ] ansible failure is considered as test failure

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>