### PR TITLE
Remove successful runs unless explicitely blocked

### DIFF
--- a/tests/core/force/test.sh
+++ b/tests/core/force/test.sh
@@ -28,7 +28,7 @@ rlJournalStart
         rlAssertNotGrep "1 guest provisioned" output
 
         # Force, all steps should be executed again
-        rlRun "tmt run --force -ddvvi $run | tee output" 0 "Third run (force)"
+        rlRun "tmt run --force -ddvvki $run | tee output" 0 "Third run (force)"
         rlAssertGrep "Run data not found." output
         rlAssertGrep "Discovered tests not found." output
         rlAssertNotGrep "Discover.*already done" output

--- a/tests/execute/metadata/test.sh
+++ b/tests/execute/metadata/test.sh
@@ -9,7 +9,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "tmt run -vi $tmp"
+        rlRun "tmt run -vki $tmp"
         metadata="$tmp/plan/execute/data/test/metadata.yaml"
         rlRun "cat $metadata" 0 "Check metadata.yaml content"
         rlAssertGrep "name: /test" $metadata

--- a/tests/finish/basic/test.sh
+++ b/tests/finish/basic/test.sh
@@ -14,7 +14,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Finish"
-        rlRun "tmt run -i $tmp finish"
+        rlRun "tmt run -ki $tmp finish"
         rlRun "ls -l $tmp"
         rlAssertNotExists "$tmp/cleanup-test"
     rlPhaseEnd

--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -33,7 +33,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Last run"
-        rlRun "tmt run -a provision -h local"
+        rlRun "tmt run -ak provision -h local"
         rlRun "tmt run -rl login -c true | tee output"
         rlAssertGrep "interactive" "output"
     rlPhaseEnd

--- a/tests/run/default/test.sh
+++ b/tests/run/default/test.sh
@@ -18,7 +18,7 @@ rlJournalStart
         rlRun "tmt init"
         rlRun "tmt test create -t shell tests/smoke"
         rlRun "echo 'touch $tmp/no-plan' >> tests/smoke/test.sh"
-        rlRun "tmt run $options"
+        rlRun "tmt run -k $options"
         rlAssertExists "$tmp/no-plan"
         rlRun "tmt run -r --last report -fv finish -f" 0 "Try --last report (verify #287)"
     rlPhaseEnd

--- a/tests/run/remove/test.sh
+++ b/tests/run/remove/test.sh
@@ -12,8 +12,15 @@ rlJournalStart
     rlPhaseStartTest "All steps at once (don't remove)"
         rlRun "tmt run --id $run --all \
             provision --how local \
-            execute --how shell --script true"
+            execute --how shell --script false" 1
         rlAssertExists $run
+    rlPhaseEnd
+
+    rlPhaseStartTest "All steps at once (remove implicit)"
+        rlRun "tmt run -f --id $run --all \
+            provision --how local \
+            execute --how shell --script true"
+        rlAssertNotExists $run
     rlPhaseEnd
 
     rlPhaseStartTest "All steps at once (remove)"
@@ -32,6 +39,30 @@ rlJournalStart
         rlRun "tmt run --last report"
         rlAssertExists $run
         rlRun "tmt run --last finish"
+        rlAssertNotExists $run
+    rlPhaseEnd
+
+    rlPhaseStartTest "All steps at once (keep)"
+        rlRun "tmt run -k --id $run --all \
+            provision --how local \
+            execute --how shell --script true"
+        rlAssertExists $run
+    rlPhaseEnd
+
+    rlPhaseStartTest "Selected steps (keep)"
+        rlRun "tmt run -f --id $run --keep \
+            discover \
+            provision --how local \
+            execute --how shell --script true"
+        rlAssertExists $run
+        rlRun "tmt run --last report"
+        rlAssertExists $run
+        rlRun "tmt run --last finish"
+        rlAssertExists $run
+    rlPhaseEnd
+
+    rlPhaseStartTest "Override keep with remove"
+        rlRun "tmt run --last --remove finish"
         rlAssertNotExists $run
     rlPhaseEnd
 

--- a/tests/status/base/test.sh
+++ b/tests/status/base/test.sh
@@ -10,7 +10,7 @@ rlJournalStart
         rlRun "tmt init"
         rlRun "tmt plan create -t mini plan1"
         rlRun "tmt plan create -t mini plan2"
-        rlRun "tmt run -a -S report provision -h local | tee run-output"
+        rlRun "tmt run -ka -S report provision -h local | tee run-output"
         rlRun "runid=\$(head -n 1 run-output)" 0 "Get the run ID"
     rlPhaseEnd
 
@@ -46,7 +46,7 @@ rlJournalStart
 
     rlPhaseStartTest "Different root"
         rlRun "tmprun=\$(mktemp -d)" 0 "Create a temporary directory for runs"
-        rlRun "tmt run -a -i $tmprun/run provision -h local"
+        rlRun "tmt run -ka -i $tmprun/run provision -h local"
         rlRun "tmt status $tmprun | tee output"
         rlRun "wc -l output | tee lines" 0 "Get the number of lines"
         rlLog "The status should only show one run and its heading"
@@ -75,7 +75,6 @@ rlJournalStart
     rlPhaseStartCleanup
         rlRun "tmt run -i $runid finish" 0 "Get rid of an active provision"
         rlRun "popd"
-        rlRun "rm -r $runid" 0 "Remove the initial testing run"
         rlRun "rm -r $tmp" 0 "Remove tmp directory"
         rlRun "rm -r $tmprun" 0 "Remove a temporary directory for runs"
     rlPhaseEnd

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -203,6 +203,9 @@ def main(click_contex, root, context, **kwargs):
     '-r', '--rm', '--remove', 'remove', is_flag=True,
     help='Remove the workdir when test run is finished.')
 @click.option(
+    '-k', '--keep', 'keep', is_flag=True,
+    help='Keep the workdir even if all tests pass.')
+@click.option(
     '--follow', is_flag=True,
     help='Output the logfile as it grows.')
 @click.option(


### PR DESCRIPTION
This is probably the most non-invasive way of reducing space used by tmt - from my experience it is very rare to want to do something with a run where `finish` step ran and all tests were successful. However, it may slightly break some use-cases (`--keep` may be needed) which turned out to be the case in some of our tests (however I feel like those scenarios wouldn't be common when using tmt on a daily basis). What do you think about this change @psss @thrix @lukaszachy ? Does this sound reasonable to you?

Resolves:  #645 