### PR TITLE
Outline specification for using ansible roles

### DIFF
--- a/spec/plans/prepare.fmf
+++ b/spec/plans/prepare.fmf
@@ -60,11 +60,22 @@ example: |
         using ``ansible-playbook`` in the given order. The path
         should be relative to the metadata tree root.
     example: |
+        # Apply local playbooks
         prepare:
             how: ansible
             playbook:
                 - playbooks/common.yml
                 - playbooks/os/rhel7.yml
+
+        # Download a role from the ansible galaxy
+        prepare:
+            how: ansible
+            role: nginxinc.nginx
+
+        # Fetch a role from a git repository
+        prepare:
+            how: ansible
+            role: https://github.com/bennojoy/nginx
     link:
       - implemented-by: /tmt/steps/provision
 


### PR DESCRIPTION
For now just rough draft of how roles could be specified. It seems
the `ansible-galaxy` command already supports fetching roles from
git repositories so the implementation should not be hard I guess.

https://galaxy.ansible.com/docs/using/installing.html