### PR TITLE
Use sudo where necessary

### DIFF
--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -221,18 +221,20 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
                         backup = reboot_file + REBOOT_BACKUP_EXT
                         self.debug(
                             f"Back up '{reboot_file}' as '{backup}'.", level=2)
-                        guest.execute(f'mv "{reboot_file}" "{backup}"')
+                        guest.execute(
+                            f'{guest.sudo}mv "{reboot_file}" "{backup}"')
                         backed_up.append(reboot_file)
                     else:
                         # Unrelated error, re-raise
                         raise error
-                guest.execute(f'cp "{reboot_script_path}" "{reboot_file}" && '
-                              f'chmod +x "{reboot_file}"')
+                guest.execute(
+                    f'{guest.sudo}cp "{reboot_script_path}" "{reboot_file}" && '
+                    f'{guest.sudo}chmod +x "{reboot_file}"')
             yield
         finally:
             self.debug("Remove our reboot script implementations.", level=2)
             for reboot_file in REBOOT_SCRIPT_PATHS:
-                guest.execute(f'rm "{reboot_file}"')
+                guest.execute(f'{guest.sudo}rm "{reboot_file}"')
             # FIXME: This part may not be executed if connection to the guest
             #        drops in the middle and the guest may be left in an
             #        inconsistent state.
@@ -240,7 +242,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
                 backup = reboot_file + REBOOT_BACKUP_EXT
                 self.debug(
                     f"Move backup '{backup}' to '{reboot_file}'.", level=2)
-                guest.execute(f'mv "{backup}" "{reboot_file}"')
+                guest.execute(f'{guest.sudo}mv "{backup}" "{reboot_file}"')
 
     def _handle_reboot(self, test, guest):
         """

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -157,18 +157,14 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
         if self.opt('dry'):
             return
 
-        # Prepare the right dnf/yum command
-        self.debug('Check if sudo is necessary.', level=2)
-        user = guest.execute('whoami')[0].strip()
-        sudo = '' if user == 'root' else 'sudo '
         self.debug('Check if dnf is available.', level=2)
         skip = ' --skip-broken' if self.get('missing') == 'skip' else ''
         try:
             guest.execute('rpm -q dnf')
-            command = f"{sudo}dnf{skip}"
+            command = f"{guest.sudo}dnf{skip}"
             plugin = 'dnf-plugins-core'
         except tmt.utils.RunError:
-            command = f"{sudo}yum{skip}"
+            command = f"{guest.sudo}yum{skip}"
             plugin = 'yum-plugin-copr'
         self.debug(f"Using '{command}' for all package operations.")
 
@@ -253,4 +249,4 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
                 debuginfo_packages, title="debuginfo")
             # Make sure debuginfo-install is present on the target system
             guest.execute(f"{command} install -y /usr/bin/debuginfo-install")
-            guest.execute(f"debuginfo-install -y {packages}")
+            guest.execute(f"{guest.sudo}debuginfo-install -y {packages}")

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -222,6 +222,7 @@ class Guest(tmt.utils.Common):
         """ Initialize guest data """
         super().__init__(parent, name)
         self.load(data)
+        self._sudo = None
 
     def _random_name(self, prefix='', length=16):
         """ Generate a random name """
@@ -266,6 +267,17 @@ class Guest(tmt.utils.Common):
             return " ".join(command) + " " + self._ssh_options(join=True)
         else:
             return command + self._ssh_options()
+
+    @property
+    def sudo(self):
+        """ If necessary return sudo string including trailing space """
+        if not self._sudo:
+            if self.user is None:
+                user = self.execute('whoami')[0].strip()
+            else:
+                user = self.user
+            self._sudo = '' if user == 'root' else 'sudo '
+        return self._sudo
 
     def load(self, data):
         """
@@ -567,7 +579,7 @@ class Guest(tmt.utils.Common):
         For now works only with RHEL based distributions.
         """
         self.debug("Ensure that rsync is installed on the guest.", level=3)
-        self.execute("rpm -q rsync || yum install -y rsync")
+        self.execute(f"rpm -q rsync || {self.sudo}yum install -y rsync")
 
     @classmethod
     def requires(cls):

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -55,7 +55,7 @@ class GuestLocal(tmt.Guest):
         """ Prepare localhost using ansible playbook """
         playbook = self._ansible_playbook_path(playbook)
         stdout, stderr = self.run(
-            f'sudo sh -c "stty cols {tmt.utils.OUTPUT_WIDTH}; '
+            f'{self.sudo} sh -c "stty cols {tmt.utils.OUTPUT_WIDTH}; '
             f'{self._export_environment()}ansible-playbook'
             f'{self._ansible_verbosity()} -c local -i localhost, {playbook}"')
         self._ansible_summary(stdout)


### PR DESCRIPTION
This PR just adds sudo everywhere I could find 'install' + reboot script
IMHO we could use guest method to check+install and for "run as root" to detect if sudo is necessary.

Also tests will be nice. Do we have somewhere documented that password-less sudo is necessary for provision/execute to work correctly? 


