### PR TITLE
Print result for execute -h tmt -v

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -940,6 +940,57 @@ some of them it is possible to use the ``--all`` option::
     tmt run --all provision --how=local
 
 
+Execute Progress
+------------------------------------------------------------------
+
+When run in terminal ``execute`` step prints name of the executed test
+unless ``--debug`` or ``--verbose`` options are used::
+
+    $ tmt run
+
+        execute
+            how: tmt
+            progress: /tests/core/enabled [5/16]
+
+
+In the verbose mode the duration and result after the test is executed
+are printed::
+
+    $ tmt run --all execute -v
+
+        execute
+            how: tmt
+                00:00:03 pass /tests/core/adjust [1/16]
+
+More verbose mode prints summary of the test being executed first::
+
+    $ tmt run --all execute -vv
+
+        execute
+            how: tmt
+            exit-first: False
+                test: Verify test/plan adjustments based on context
+                    00:00:04 pass /tests/core/adjust [1/16]
+
+The most verbose mode prints also the test output::
+
+    $ tmt run --all execute -vvv
+
+        execute
+            how: tmt
+            order: 50
+            exit-first: False
+                test: Verify test/plan adjustments based on context
+                    out:
+                    out: ::::::::::::::::::::::::::::::::::::::::::::
+                    out: ::   Setup
+                    out: ::::::::::::::::::::::::::::::::::::::::::::
+                    out:
+                    out: :: [ 17:03:06 ] :: [  BEGIN   ] :: Create...
+                        ....
+                    00:00:04 pass /tests/core/adjust [1/16]
+
+
 Check Report
 ------------------------------------------------------------------
 

--- a/tests/execute/restraint/tmt-abort/test.sh
+++ b/tests/execute/restraint/tmt-abort/test.sh
@@ -3,18 +3,23 @@
 
 rlJournalStart
     rlPhaseStartSetup
+        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
         rlRun "pushd data"
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun -s "tmt run -vvv --remove" 2 "Expect error from execution to tmt-abort."
+        rlRun -s "tmt run -vvv --id \${run}" 2 "Expect error from execution to tmt-abort."
         # 2 tests discovered but only one is executed due to abort
         rlAssertGrep "1 test executed" $rlRun_LOG
         rlAssertNotGrep "This test should not be executed." $rlRun_LOG
         rlAssertNotGrep "This should not be executed either." $rlRun_LOG
+
+        rlAssertGrep "result: error" "${run}/plan/execute/results.yaml"
+        rlAssertGrep "note: aborted" "${run}/plan/execute/results.yaml"
     rlPhaseEnd
 
     rlPhaseStartCleanup
         rlRun "popd"
+        rlRun "rm -r ${run}" 0 "Remove run directory"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/execute/result/data/test.fmf
+++ b/tests/execute/result/data/test.fmf
@@ -7,6 +7,10 @@
 /error:
     summary: Run a non-existing command
     test: a-weird-command
+/error-timeout:
+    summary: Too long execution
+    test: sleep 10
+    duration: 1s
 
 /xfail-fail:
     summary: Run command 'false' but report pass
@@ -41,3 +45,13 @@
     summary: Always report fail
     test: 'true'
     result: fail
+
+/xfail-with-reboot:
+    summary: Do reboot in the test
+    test: "if [ $TMT_REBOOT_COUNT -eq 0 ]; then tmt-reboot; fi; false"
+    result: xfail
+    tag: [cherry_pick]
+/abort:
+    summary: test will abort
+    test: "echo working; tmt-abort"
+    tag: [cherry_pick]

--- a/tests/execute/result/test.sh
+++ b/tests/execute/result/test.sh
@@ -46,6 +46,49 @@ rlJournalStart
         run   "errr"   "/test/always-error"   "pass"     2
     rlPhaseEnd
 
+    rlPhaseStartTest "Verbose execute prints result"
+        rlRun -s "tmt run --id \${run} --scratch --until execute tests --filter tag:-cherry_pick provision --how local execute -v" "2"
+        while read -r line; do
+            if rlIsRHELLike "=8" && [[ $line =~ /test/error-timeout ]]; then
+                # Centos stream 8 doesn't do watchdog properly https://github.com/teemtee/tmt/issues/1387
+                # so we can't assert expected duration (1s) in /test/error-timeout
+                # FIXME remove this once issue is fixed
+                rlAssertGrep "errr /test/error-timeout (timeout) [7/12]" "$rlRun_LOG" -F
+            else
+                rlAssertGrep "$line" "$rlRun_LOG" -F
+            fi
+        done <<-EOF
+00:00:00 errr /test/always-error (original result: pass) [1/12]
+00:00:00 fail /test/always-fail (original result: pass) [2/12]
+00:00:00 info /test/always-info (original result: pass) [3/12]
+00:00:00 pass /test/always-pass (original result: fail) [4/12]
+00:00:00 warn /test/always-warn (original result: pass) [5/12]
+00:00:00 errr /test/error [6/12]
+00:00:01 errr /test/error-timeout (timeout) [7/12]
+00:00:00 fail /test/fail [8/12]
+00:00:00 pass /test/pass [9/12]
+00:00:00 errr /test/xfail-error (original result: error) [10/12]
+00:00:00 pass /test/xfail-fail (original result: fail) [11/12]
+00:00:00 fail /test/xfail-pass (original result: pass) [12/12]
+EOF
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verbose execute prints result - reboot case"
+        # Before the reboot results is not known
+        rlRun -s "tmt run --id \${run} --scratch --until execute tests -n /xfail-with-reboot provision --how container execute -v"
+        EXPECTED=$(cat <<EOF
+            00:00:00 /test/xfail-with-reboot [1/1]
+            00:00:00 pass /test/xfail-with-reboot (original result: fail) [1/1]
+EOF
+)
+    rlAssertEquals "Output matches the expectation" "$EXPECTED" "$(grep /test/xfail-with-reboot $rlRun_LOG)"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verbose execute prints result - abort case"
+        rlRun -s "tmt run --id \${run} --scratch --until execute tests tests -n /abort provision --how container execute -v" "2"
+        rlAssertGrep "00:00:00 errr /test/abort (aborted) [1/1" $rlRun_LOG -F
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r ${run}" 0 "Remove run directory"

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -167,12 +167,8 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
 
         return environment
 
-    def execute(self, test, guest, progress, extra_environment):
+    def execute(self, test, guest, extra_environment):
         """ Run test on the guest """
-        # Provide info/debug message
-        self._show_progress(progress, test.name)
-        self.verbose(
-            'test', test.summary or test.name, color='cyan', shift=1, level=2)
         self.debug(f"Execute '{test.name}' as a '{test.framework}' test.")
 
         # Test will be executed in it's own directory, relative to the workdir
@@ -193,7 +189,6 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             self.verbose(key, value, color, shift=2, level=3)
 
         # Execute the test, save the output and return code
-        timeout = ''
         start = time.time()
         try:
             stdout, stderr = guest.execute(
@@ -205,17 +200,12 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             stdout = error.stdout
             test.returncode = error.returncode
             if test.returncode == tmt.utils.PROCESS_TIMEOUT:
-                timeout = ' (timeout)'
                 self.debug(f"Test duration '{test.duration}' exceeded.")
         end = time.time()
         self.write(
             self.data_path(test, TEST_OUTPUT_FILENAME, full=True),
             stdout or '', mode='a', level=3)
         test.real_duration = self.test_duration(start, end)
-        duration = click.style(test.real_duration, fg='cyan')
-        shift = 1 if self.opt('verbose') < 2 else 2
-        self.verbose(
-            f"{duration} {test.name} [{progress}]{timeout}", shift=shift)
 
     def check(self, test):
         """ Check the test result """
@@ -228,6 +218,18 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             except tmt.utils.FileError:
                 return self.check_shell(test)
 
+    def _will_reboot(self, test):
+        """ True if reboot is requested """
+        return os.path.exists(self._reboot_request_path(test))
+
+    def _reboot_request_path(self, test):
+        """ Return reboot_request """
+        reboot_request_path = os.path.join(
+            self.data_path(test, full=True),
+            tmt.steps.execute.TEST_DATA,
+            REBOOT_REQUEST_FILENAME)
+        return reboot_request_path
+
     def _handle_reboot(self, test, guest):
         """
         Reboot the guest if the test requested it.
@@ -237,13 +239,14 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
         REBOOTCOUNT variable, reset it to 0 if no reboot was requested
         (going forward to the next test). Return whether reboot was done.
         """
-        test_data = os.path.join(
-            self.data_path(test, full=True), tmt.steps.execute.TEST_DATA)
-        reboot_request_path = os.path.join(test_data, REBOOT_REQUEST_FILENAME)
-        if os.path.exists(reboot_request_path):
+        if self._will_reboot(test):
             test._reboot_count += 1
             self.debug(f"Reboot during test '{test}' "
                        f"with reboot count {test._reboot_count}.")
+            reboot_request_path = self._reboot_request_path(test)
+            test_data = os.path.join(
+                self.data_path(test, full=True),
+                tmt.steps.execute.TEST_DATA)
             with open(reboot_request_path, 'r') as reboot_file:
                 reboot_command = reboot_file.read().strip()
             # Reset the file
@@ -296,8 +299,14 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             test = tests[index]
             if not hasattr(test, "_reboot_count"):
                 test._reboot_count = 0
+
+            progress = f"{index + 1}/{len(tests)}"
+            self._show_progress(progress, test.name)
+            self.verbose(
+                'test', test.summary or test.name, color='cyan', shift=1, level=2)
+
             self.execute(
-                test, guest, progress=f"{index + 1}/{len(tests)}",
+                test, guest,
                 extra_environment=extra_environment)
 
             # Pull test logs from the guest, exclude beakerlib backups
@@ -311,13 +320,23 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
                 source=self.data_path(test, full=True),
                 extend_options=exclude)
 
-            # Handle reboot, check results
-            if self._handle_reboot(test, guest):
-                continue
-            self._results.append(self.check(test))
+            result = self.check(test)
+            duration = click.style(test.real_duration, fg='cyan')
+            shift = 1 if self.opt('verbose') < 2 else 2
+
+            # Handle reboot, abort, exit-first
+            if self._will_reboot(test):
+                # Output before the reboot
+                self.verbose(
+                    f"{duration} {test.name} [{progress}]", shift=shift)
+                if self._handle_reboot(test, guest):
+                    continue
+            self._results.append(result)
             abort = self.check_abort_file(test)
+            self.verbose(
+                f"{duration} {result.show()} [{progress}]", shift=shift)
             if (abort or exit_first and
-                    self._results[-1].result not in ('pass', 'info')):
+                    result.result not in ('pass', 'info')):
                 # Clear the progress bar before outputting
                 self._show_progress('', '', True)
                 what_happened = "aborted" if abort else "failed"

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -331,8 +331,10 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
                     f"{duration} {test.name} [{progress}]", shift=shift)
                 if self._handle_reboot(test, guest):
                     continue
-            self._results.append(result)
             abort = self.check_abort_file(test)
+            if abort:
+                result.note = 'aborted'
+            self._results.append(result)
             self.verbose(
                 f"{duration} {result.show()} [{progress}]", shift=shift)
             if (abort or exit_first and


### PR DESCRIPTION
New attempt, moved output methods a bit. I'll add tests later if this change will be acceptable.

The difference is that in verbose modes
 `00:00:01 errr /d (timeout) [4/4]` is printed instead of 
`00:00:01 /d [4/4] (timeout)`.

Thus I changed: 
1. Added colored result after duration (n/a before)
2. Prints result.note after test name (was explicit check for timeout, not a result.note) so xfail is reported properly as `00:00:00 pass /e (original result: fail) [5/5]`

I've used  `plan.fmf`  to test
```
discover:
  how: shell
  tests:
  - name: a
    test: sleep 1
  - name: b
    test: "sleep 1; false"
  - name: c
    test: "if [ $TMT_REBOOT_COUNT -eq 0 ]; then sleep 10 && tmt-reboot; fi; echo post-reboot"
    duration: 1s
  - name: d
    test: sleep 2
    duration: 1s
  - name: e
    test: "false"
    result: xfail
execute:
  how: tmt
provision:
  how: container
```

