### PR TITLE
Allow fmf-id to be exported from run discover

### DIFF
--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -202,6 +202,15 @@ in plan \`/plans/z-non-url\` can be used only within git repo." output
         rlRun "rm -rf $tmp_dir1 $tmp_dir2"
     rlPhaseEnd
 
+    # If current dir has .fmf and --url CLI option exists
+    rlPhaseStartTest "fmf-id (with url on CLI): no fmf metadata"
+        tmp_dir="$(mktemp -d)"
+        rlRun "cd $tmp_dir"
+        rlRun "tmt run -rdvvv discover -h fmf --fmf-id \
+               --url https://github.com/teemtee/fmf finish | tee output" 0
+        rlRun "rm -rf $tmp_dir"
+    rlPhaseEnd
+
     # Raise an exception if current dir doesn't have .fmf
     rlPhaseStartTest "fmf-id (w/o url): current dir doesn't have fmf metadata"
         tmp_dir="$(mktemp -d)"

--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -110,6 +110,20 @@ rlJournalStart
                        "$ids_amount" "$tests_amount"
     rlPhaseEnd
 
+    # If the test exists in 2 or more plans than the test should be printed
+    # only once
+    rlPhaseStartTest "fmf-id: one test exists in 2 or more plans"
+        path="$(git rev-parse --show-toplevel)"
+        rlRun "cd $path"
+        ids_amount=$(tmt run -r discover --how fmf --fmf-id \
+                     tests --name /tests/unit |
+                     grep "name:" |
+                     wc -l)
+        tests_amount=1
+        rlAssertEquals "Check that number of fmf-ids equals to tests number" \
+                       "$ids_amount" "$tests_amount"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun 'rm -f output' 0 'Removing tmp file'
         rlRun 'popd'

--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -47,12 +47,11 @@ rlJournalStart
 
     rlPhaseStartTest 'fmf-id (w/ url): Show fmf ids for discovered tests'
         plan='plan --name fmf/url/ref/path'
-        rlRun "tmt run -r $plan discover --fmf-id finish | tee output"
+        rlRun "tmt run -r $plan discover -h fmf --fmf-id finish | tee output"
 
         # check "discover --fmf-id" shows the same tests as "tmt run discover"
         rlRun "tmt run -v $plan discover | tee discover"
-        tests_list=$(cat discover |
-                     tac |
+        tests_list=$(tac discover |
                      sed -n '/summary:/q;p')
         url_discover=$(grep "url:" discover | awk '{print $2}')
 
@@ -73,7 +72,8 @@ rlJournalStart
 
     rlPhaseStartTest 'fmf-id (w/o url): Show fmf ids for discovered tests'
         plan='plan --name fmf/nourl/noref/nopath'
-        rlRun "tmt run -dvvvr $plan discover --fmf-id finish | tee output"
+        rlRun "tmt run -dvvvr $plan discover -h fmf --fmf-id finish \
+               | tee output"
 
         # check "discover --fmf-id" shows the same tests as "tmt run discover"
         tests_list=$(tmt run -v $plan discover |
@@ -101,7 +101,7 @@ rlJournalStart
     rlPhaseStartTest "fmf-id (w/o url): all steps(discover, provision, etc.) \
                       are enabled"
         plan='plan --name fmf/nourl/noref/nopath'
-        rlRun "tmt run -dvvvr --all $plan discover --fmf-id | tail -n1 \
+        rlRun "tmt run -dvvvr --all $plan discover -h fmf --fmf-id | tail -n1 \
                | tee output"
         rlAssertGrep "path:" output
     rlPhaseEnd
@@ -151,8 +151,7 @@ rlJournalStart
                           plan --name /plans/sanity/lint \
                           discover -h shell --fmf-id finish 2>&1 | \
                           tee output" 2
-        rlAssertGrep "\`tmt run discover --fmf-id\` is supported only for \
-\`fmf\` method." output
+        rlAssertGrep "Error: no such option: --fmf-id" output
     rlPhaseEnd
 
     # Raise an exception if --fmf-id uses w/o --url and git root doesn't exist
@@ -180,10 +179,9 @@ can be used only within git repo." output
         rlRun "cp plans/example.fmf $tmp_dir1/plans/non-url.fmf"
         rlRun "cd $tmp_dir1"
         # check "discover --fmf-id" shows the same tests as "tmt run discover"
-        rlRun "tmt run -r discover --fmf-id finish | tee output"
+        rlRun "tmt run -r discover -h fmf --fmf-id finish | tee output"
         rlRun "tmt run -v $plan discover | tee discover"
-        tests_list=$(cat discover |
-                     tac |
+        tests_list=$(tac discover |
                      sed -n '/summary:/q;p')
         url_discover=$(grep "url:" discover | awk '{print $2}')
 
@@ -204,7 +202,8 @@ can be used only within git repo." output
     rlPhaseStartTest "fmf-id (w/o url): current dir doesn't have fmf metadata"
         tmp_dir="$(mktemp -d)"
         rlRun "cd $tmp_dir"
-        rlRun "tmt run -rdvvv discover --fmf-id finish 2>&1 | tee output" 2
+        rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 \
+               | tee output" 2
         rlAssertGrep "No metadata found in the current directory" output
         rlRun "rm -rf $tmp_dir"
     rlPhaseEnd

--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -151,7 +151,7 @@ rlJournalStart
                           plan --name /plans/sanity/lint \
                           discover -h shell --fmf-id finish 2>&1 | \
                           tee output" 2
-        rlAssertGrep "Error: no such option: --fmf-id" output
+        rlAssertGrep "Error: no such option: --fmf-id" output -i
     rlPhaseEnd
 
     # Raise an exception if --fmf-id uses w/o --url and git root doesn't exist
@@ -196,6 +196,7 @@ can be used only within git repo." output
         rlAssertEquals "Check that number of fmf-ids equals to tests number" \
                        "$ids_amount" "$tests_amount"
         rlAssertEquals "Check url" "$url_discover" "$url_fmf_id"
+        rlRun "rm -rf $tmp_dir1 $tmp_dir2"
     rlPhaseEnd
 
     # Raise an exception if current dir doesn't have .fmf

--- a/tests/discover/options.sh
+++ b/tests/discover/options.sh
@@ -11,7 +11,7 @@ rlJournalStart
     rlPhaseStartTest 'fmf help'
         rlRun 'tmt run discover --help --how fmf | tee output'
         rlAssertGrep 'Discover available tests from fmf metadata' 'output'
-        for option in url ref path test filter; do
+        for option in url ref path test filter fmf-id; do
             rlAssertGrep "--$option" output
         done
     rlPhaseEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -151,11 +151,6 @@ class Core(tmt.utils.Common):
                 cwd=cwd)
             return result.stdout.strip().decode("utf-8")
 
-        fmf_root = self.node.root
-        # `tmt run discover -h shell` doesn't have .fmf
-        if not fmf_root:
-            return None
-
         fmf_id = {'name': self.name}
 
         # Prepare url (for now handle just the most common schemas)
@@ -176,9 +171,11 @@ class Core(tmt.utils.Common):
 
         # Construct path (if different from git root)
         git_root = run('git rev-parse --show-toplevel')
+        fmf_root = self.node.root
         if git_root != fmf_root:
             fmf_id['path'] = os.path.join(
                 '/', os.path.relpath(fmf_root, git_root))
+
         return fmf_id
 
     @classmethod

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -143,20 +143,13 @@ class Core(tmt.utils.Common):
 
         def run(command):
             """ Run command, return output """
+            cwd = fmf_root if self.steps() == {'discover'} else None
             result = subprocess.run(
-                command,
+                command.split(),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
-                shell=True)
+                cwd=cwd)
             return result.stdout.strip().decode("utf-8")
-
-        def discover_step(command):
-            if self.steps() == {'discover'}:
-                return f"pushd {fmf_root} > /dev/null ; " \
-                       f"{command} ; " \
-                       f"popd > /dev/null"
-            else:
-                return command
 
         fmf_root = self.node.root
         # `tmt run discover -h shell` doesn't have .fmf
@@ -166,32 +159,26 @@ class Core(tmt.utils.Common):
         fmf_id = {'name': self.name}
 
         # Prepare url (for now handle just the most common schemas)
-        branch = run(discover_step(
-            "git rev-parse --abbrev-ref --symbolic-full-name @{u}"))
+        branch = run("git rev-parse --abbrev-ref --symbolic-full-name @{u}")
         try:
             remote_name = branch[:branch.index('/')]
         except ValueError:
             remote_name = 'origin'
-        remote = run(discover_step(
-            f"git config --get remote.{remote_name}.url"))
+        remote = run(f"git config --get remote.{remote_name}.url")
         fmf_id['url'] = tmt.utils.public_git_url(remote)
         if fmf_id['url'] == '' and self.steps() == {'discover'}:
             return None
 
         # Get the ref (skip for master as it is the default)
-        ref = run(discover_step('git rev-parse --abbrev-ref HEAD'))
+        ref = run('git rev-parse --abbrev-ref HEAD')
         if ref != 'master':
             fmf_id['ref'] = ref
 
         # Construct path (if different from git root)
-        git_root = run(discover_step('git rev-parse --show-toplevel'))
-
+        git_root = run('git rev-parse --show-toplevel')
         if git_root != fmf_root:
-            try:
-                fmf_id['path'] = os.path.join(
-                    '/', os.path.relpath(fmf_root, git_root))
-            except ValueError:
-                fmf_id['path'] = git_root
+            fmf_id['path'] = os.path.join(
+                '/', os.path.relpath(fmf_root, git_root))
         return fmf_id
 
     @classmethod

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -170,9 +170,11 @@ class Core(tmt.utils.Common):
         git_root = run('git rev-parse --show-toplevel')
         fmf_root = self.node.root
         if git_root != fmf_root:
-            fmf_id['path'] = os.path.join(
-                '/', os.path.relpath(fmf_root, git_root))
-
+            try:
+                fmf_id['path'] = os.path.join(
+                    '/', os.path.relpath(fmf_root, git_root))
+            except ValueError:
+                fmf_id['path'] = git_root
         return fmf_id
 
     @classmethod

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -153,6 +153,7 @@ class Core(tmt.utils.Common):
 
         fmf_id = {'name': self.name}
 
+        fmf_root = self.node.root
         # Prepare url (for now handle just the most common schemas)
         branch = run("git rev-parse --abbrev-ref --symbolic-full-name @{u}")
         try:
@@ -171,7 +172,6 @@ class Core(tmt.utils.Common):
 
         # Construct path (if different from git root)
         git_root = run('git rev-parse --show-toplevel')
-        fmf_root = self.node.root
         if git_root != fmf_root:
             fmf_id['path'] = os.path.join(
                 '/', os.path.relpath(fmf_root, git_root))

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -143,7 +143,7 @@ class Core(tmt.utils.Common):
 
         def run(command):
             """ Run command, return output """
-            cwd = fmf_root if self.steps() == {'discover'} else None
+            cwd = fmf_root
             result = subprocess.run(
                 command.split(),
                 stdout=subprocess.PIPE,
@@ -162,8 +162,6 @@ class Core(tmt.utils.Common):
             remote_name = 'origin'
         remote = run(f"git config --get remote.{remote_name}.url")
         fmf_id['url'] = tmt.utils.public_git_url(remote)
-        if fmf_id['url'] == '' and self.steps() == {'discover'}:
-            return None
 
         # Get the ref (skip for master as it is the default)
         ref = run('git rev-parse --abbrev-ref HEAD')

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -146,6 +146,13 @@ class Discover(tmt.steps.Step):
                 test.environment.update(self.plan.environment)
                 self._tests.append(test)
 
+        # Show fmf identifiers for tests discovered in plan
+        if self.opt('fmf_id'):
+            fmf_id_yaml = [tmt.utils.dict_to_yaml(test.fmf_id, start=True)
+                           for test in self.tests()]
+            click.echo(''.join(fmf_id_yaml), nl=False)
+            return
+
         # Give a summary, update status and save
         self.summary()
         self.status('done')
@@ -192,7 +199,14 @@ class DiscoverPlugin(tmt.steps.Plugin):
         @click.option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method to discover tests.')
+        @click.option(
+            '--fmf-id', default=False, is_flag=True,
+            help='Show fmf identifiers for tests discovered in plan.')
         def discover(context, **kwargs):
+            if kwargs.get('fmf_id'):
+                context.parent.params['quiet'] = True
+                context.parent.params['debug'] = 0
+                context.parent.params['verbose'] = 0
             context.obj.steps.add('discover')
             Discover._save_context(context)
 

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -230,6 +230,8 @@ class DiscoverPlugin(tmt.steps.Plugin):
             help='Use specified method to discover tests.')
         def discover(context, **kwargs):
             if kwargs.get('fmf_id'):
+                # Set quiet, disable debug and verbose to avoid logging
+                # to terminal with discover --fmf-id
                 context.parent.params['quiet'] = True
                 context.parent.params['debug'] = 0
                 context.parent.params['verbose'] = 0

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 
 import click
 from fmf.utils import listed
@@ -235,20 +234,6 @@ class DiscoverPlugin(tmt.steps.Plugin):
                 context.parent.params['quiet'] = True
                 context.parent.params['debug'] = 0
                 context.parent.params['verbose'] = 0
-                # Raise an exception if --fmf-id uses w/o --url and git root
-                # doesn't exist for ALL discovered plans
-                url = tmt.utils.Common.get_fmf_attr('discover', 'url')
-                if not context.params.get('url') and not url:
-                    try:
-                        subprocess.run(
-                            'git rev-parse --show-toplevel'.split(),
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.DEVNULL,
-                            check=True)
-                    except subprocess.CalledProcessError:
-                        raise tmt.utils.GeneralError(
-                            f"`tmt run discover --fmf-id` without `url` option"
-                            f" can be used only within git repo.")
             context.obj.steps.add('discover')
             Discover._save_context(context)
 

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -235,11 +235,11 @@ class DiscoverPlugin(tmt.steps.Plugin):
             '--fmf-id', default=False, is_flag=True,
             help='Show fmf identifiers for tests discovered in plan.')
         def discover(context, **kwargs):
-            if kwargs.get('how') == 'shell':
-                raise tmt.utils.GeneralError(
-                    f"`tmt run discover --fmf-id` is supported only for `fmf`"
-                    f" method.")
             if kwargs.get('fmf_id'):
+                if kwargs.get('how') == 'shell':
+                    raise tmt.utils.GeneralError(
+                        f"`tmt run discover --fmf-id` is supported only"
+                        f" for `fmf` method.")
                 import subprocess
                 context.parent.params['quiet'] = True
                 context.parent.params['debug'] = 0

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -148,9 +148,16 @@ class Discover(tmt.steps.Step):
 
         # Show fmf identifiers for tests discovered in plan
         if self.opt('fmf_id'):
-            fmf_id_yaml = [tmt.utils.dict_to_yaml(test.fmf_id, start=True)
-                           for test in self.tests()]
-            click.echo(''.join(fmf_id_yaml), nl=False)
+            # don't run steps except discover
+            if self._context.obj.steps != {'discover'}:
+                tmt_steps_wo_discover = list(filter(lambda x: x != 'discover',
+                                                    tmt.steps.STEPS))
+                self._context.obj.steps.\
+                    difference_update(tmt_steps_wo_discover)
+            if self.tests():
+                fmf_id_yaml = [tmt.utils.dict_to_yaml(test.fmf_id, start=True)
+                               for test in self.tests()]
+                click.echo(''.join(fmf_id_yaml), nl=False)
             return
 
         # Give a summary, update status and save

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -154,30 +154,7 @@ class Discover(tmt.steps.Step):
             if self.tests():
                 fmf_id_list = [tmt.utils.dict_to_yaml(test.fmf_id, start=True)
                                for test in self.tests()
-                               if test.fmf_id]
-                '''
-                # fmf-ids duplication is allowed
-                plan_fmf_ids = dict()
-                plan_fmf_ids[self.plan.name] = fmf_id_list
-                try:
-                    workdir_root = self.plan.workdir[:self.plan.workdir.index(
-                        self.plan.name)] + '/plan_fmf_id.yaml'
-                except ValueError:
-                    workdir_root = self.plan.workdir
-                self.write(workdir_root,
-                           tmt.utils.dict_to_yaml(plan_fmf_ids),
-                           'a')
-                try:
-                    plan_fmf_ids = tmt.utils.yaml_to_dict(
-                        self.read(workdir_root))
-                except tmt.utils.FileError:
-                    self.debug('File path does not exist.', level=2)
-                sum_fmf_ids = set()
-                for plan, fmf_ids in plan_fmf_ids.items():
-                    if self.plan.name != plan:
-                        sum_fmf_ids.update(fmf_ids)
-                fmf_id_list = set(fmf_id_list).difference(sum_fmf_ids)
-                '''
+                               if 'url' in test.fmf_id]
                 click.echo(''.join(fmf_id_list), nl=False)
             return
 

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 import click
 from fmf.utils import listed
@@ -150,11 +151,7 @@ class Discover(tmt.steps.Step):
         # Show fmf identifiers for tests discovered in plan
         if self.opt('fmf_id'):
             # don't run steps except discover
-            if self.steps() != {'discover'}:
-                tmt_steps_wo_discover = list(filter(lambda x: x != 'discover',
-                                                    tmt.steps.STEPS))
-                self.steps().\
-                    difference_update(tmt_steps_wo_discover)
+            self._context.obj.steps = {'discover'}
             if self.tests():
                 fmf_id_list = [tmt.utils.dict_to_yaml(test.fmf_id, start=True)
                                for test in self.tests()
@@ -231,16 +228,8 @@ class DiscoverPlugin(tmt.steps.Plugin):
         @click.option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method to discover tests.')
-        @click.option(
-            '--fmf-id', default=False, is_flag=True,
-            help='Show fmf identifiers for tests discovered in plan.')
         def discover(context, **kwargs):
             if kwargs.get('fmf_id'):
-                if kwargs.get('how') == 'shell':
-                    raise tmt.utils.GeneralError(
-                        f"`tmt run discover --fmf-id` is supported only"
-                        f" for `fmf` method.")
-                import subprocess
                 context.parent.params['quiet'] = True
                 context.parent.params['debug'] = 0
                 context.parent.params['verbose'] = 0

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -163,7 +163,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                         stderr=subprocess.DEVNULL,
                         check=True)
                 except subprocess.CalledProcessError:
-                    raise tmt.utils.GeneralError(
+                    raise tmt.utils.DiscoverError(
                         f"`tmt run discover --fmf-id` without `url` option in "
                         f"plan `{plan_name}` can be used only within"
                         f" git repo.")
@@ -174,7 +174,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 try:
                     fmf_tree = fmf.Tree(os.getcwd())
                 except fmf.utils.RootError:
-                    raise MetadataError(
+                    raise tmt.utils.DiscoverError(
                         f"No metadata found in the current directory. "
                         f"Use 'tmt init' to get started.")
                 for i, attr in enumerate(fmf_tree.climb()):
@@ -208,6 +208,9 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 git_root = self.step.plan.my_run.tree.root
             else:
                 fmf_root = path or self.step.plan.my_run.tree.root
+                if fmf_root is None:
+                    raise tmt.utils.DiscoverError(
+                        f"No metadata found in the current directory.")
                 # Check git repository root (use fmf root if not found)
                 try:
                     output = self.run(

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -167,24 +167,24 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                         f"`tmt run discover --fmf-id` without `url` option in "
                         f"plan `{plan_name}` can be used only within"
                         f" git repo.")
-
-            try:
-                fmf_tree = fmf.Tree(os.getcwd())
-            except fmf.utils.RootError:
-                raise MetadataError(
-                    f"No metadata found in the current directory. "
-                    f"Use 'tmt init' to get started.")
             # It covers only one case, when there is:
             # 1) no --url on CLI
             # 2) plan w/o url exists in test run
-            for i, attr in enumerate(fmf_tree.climb()):
+            if not self.opt('url'):
                 try:
-                    plan_url = attr.data.get('discover').get('url')
-                    plan_name = attr.name
-                    if not plan_url and not self.opt('url'):
-                        assert_git_url(plan_name)
-                except AttributeError:
-                    pass
+                    fmf_tree = fmf.Tree(os.getcwd())
+                except fmf.utils.RootError:
+                    raise MetadataError(
+                        f"No metadata found in the current directory. "
+                        f"Use 'tmt init' to get started.")
+                for i, attr in enumerate(fmf_tree.climb()):
+                    try:
+                        plan_url = attr.data.get('discover').get('url')
+                        plan_name = attr.name
+                        if not plan_url:
+                            assert_git_url(plan_name)
+                    except AttributeError:
+                        pass
             # All other cases are covered by this condition
             if not url:
                 assert_git_url(self.step.plan.name)

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -78,7 +78,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
     _keys = [
         "url", "ref", "path", "test", "link", "filter",
         "modified-only", "modified-url", "modified-ref",
-        "dist-git-source", "dist-git-type"]
+        "dist-git-source", "dist-git-type", "fmf-id"]
 
     @classmethod
     def options(cls, how=None):
@@ -121,6 +121,9 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 '--dist-git-type',
                 type=click.Choice(tmt.utils.get_distgit_handler_names()),
                 help='Use the provided DistGit handler instead of detection.'),
+            click.option(
+                '--fmf-id', default=False, is_flag=True,
+                help='Show fmf identifiers for tests discovered in plan.')
             ] + super().options(how)
 
     def wake(self, keys=None):

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -155,7 +155,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         # Raise an exception if --fmf-id uses w/o url and git root
         # doesn't exist for discovered plan
         if self.opt('fmf_id'):
-            def print_error(plan_name=None):
+            def assert_git_url(plan_name=None):
                 try:
                     subprocess.run(
                         'git rev-parse --show-toplevel'.split(),
@@ -182,12 +182,12 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                     plan_url = attr.data.get('discover').get('url')
                     plan_name = attr.name
                     if not plan_url and not self.opt('url'):
-                        print_error(plan_name)
+                        assert_git_url(plan_name)
                 except AttributeError:
                     pass
             # All other cases are covered by this condition
             if not url:
-                print_error(self.step.plan.name)
+                assert_git_url(self.step.plan.name)
 
         # Clone provided git repository (if url given) with disabled
         # prompt to ignore possibly missing or private repositories

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -149,7 +149,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
 
         # Clone provided git repository (if url given) with disabled
         # prompt to ignore possibly missing or private repositories
-        fmf_root = path or self.step.plan.my_run.tree.root
         if url:
             self.info('url', url, 'green')
             self.debug(f"Clone '{url}' to '{testdir}'.")
@@ -166,6 +165,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             if dist_git_source:
                 git_root = self.step.plan.my_run.tree.root
             else:
+                fmf_root = path or self.step.plan.my_run.tree.root
                 # Check git repository root (use fmf root if not found)
                 try:
                     output = self.run(
@@ -214,10 +214,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             self.info('path', path, 'green')
 
         # Prepare the whole tree path and test path prefix
-        if self.parent.opt('fmf_id'):
-            tree_path = fmf_root
-        else:
-            tree_path = os.path.join(testdir, path.lstrip('/'))
+        tree_path = os.path.join(testdir, path.lstrip('/'))
         if not os.path.isdir(tree_path) and not self.opt('dry'):
             raise tmt.utils.DiscoverError(
                 f"Metadata tree path '{path}' not found.")

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -176,15 +176,12 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                     f"Use 'tmt init' to get started.")
             # It covers only one case, when there is:
             # 1) no --url on CLI
-            # 2) plan with url attr is alphabetically first (0 position)
-            # 3) plan w/o url exists in test run
+            # 2) plan w/o url exists in test run
             for i, attr in enumerate(fmf_tree.climb()):
                 try:
                     plan_url = attr.data.get('discover').get('url')
                     plan_name = attr.name
-                    if i == 0 and not plan_url:
-                        break
-                    elif not plan_url and not self.opt('url'):
+                    if not plan_url and not self.opt('url'):
                         print_error(plan_name)
                 except AttributeError:
                     pass

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -149,6 +149,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
 
         # Clone provided git repository (if url given) with disabled
         # prompt to ignore possibly missing or private repositories
+        fmf_root = path or self.step.plan.my_run.tree.root
         if url:
             self.info('url', url, 'green')
             self.debug(f"Clone '{url}' to '{testdir}'.")
@@ -165,7 +166,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             if dist_git_source:
                 git_root = self.step.plan.my_run.tree.root
             else:
-                fmf_root = path or self.step.plan.my_run.tree.root
                 # Check git repository root (use fmf root if not found)
                 try:
                     output = self.run(
@@ -214,7 +214,10 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             self.info('path', path, 'green')
 
         # Prepare the whole tree path and test path prefix
-        tree_path = os.path.join(testdir, path.lstrip('/'))
+        if self.parent.opt('fmf_id'):
+            tree_path = fmf_root
+        else:
+            tree_path = os.path.join(testdir, path.lstrip('/'))
         if not os.path.isdir(tree_path) and not self.opt('dry'):
             raise tmt.utils.DiscoverError(
                 f"Metadata tree path '{path}' not found.")

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -185,6 +185,13 @@ class Common(object):
         except AttributeError:
             return dict()
 
+    def steps(self):
+        """ Return the current steps """
+        try:
+            return self._context.obj.steps
+        except AttributeError:
+            return set()
+
     def opt(self, option, default=None):
         """
         Get an option from the command line context
@@ -534,10 +541,28 @@ class Common(object):
             create_directory(self._workdir, 'workdir', quiet=True)
         return self._workdir
 
+    @staticmethod
+    def get_fmf_attr(step, attribute):
+        try:
+            fmf_tree = fmf.Tree(os.getcwd())
+        except fmf.utils.RootError:
+            raise MetadataError(
+                f"No metadata found in the current directory. "
+                f"Use 'tmt init' to get started.")
+        attr = ''
+        for i in fmf_tree.climb():
+            try:
+                attr = i.data.get(step).get(attribute)
+                if attr:
+                    break
+            except AttributeError:
+                pass
+        return attr
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Exceptions
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 
 class GeneralError(Exception):
     """ General error """

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -185,13 +185,6 @@ class Common(object):
         except AttributeError:
             return dict()
 
-    def steps(self):
-        """ Return the current steps """
-        try:
-            return self._context.obj.steps
-        except AttributeError:
-            return set()
-
     def opt(self, option, default=None):
         """
         Get an option from the command line context
@@ -540,24 +533,6 @@ class Common(object):
             # Create a child workdir under the parent workdir
             create_directory(self._workdir, 'workdir', quiet=True)
         return self._workdir
-
-    @staticmethod
-    def get_fmf_attr(step, attribute):
-        try:
-            fmf_tree = fmf.Tree(os.getcwd())
-        except fmf.utils.RootError:
-            raise MetadataError(
-                f"No metadata found in the current directory. "
-                f"Use 'tmt init' to get started.")
-        attr = ''
-        for i in fmf_tree.climb():
-            try:
-                attr = i.data.get(step).get(attribute)
-                if attr:
-                    break
-            except AttributeError:
-                pass
-        return attr
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Exceptions


### PR DESCRIPTION
#880

Add an option `fmf-id` to discover step. It allows returning fmf identifiers for tests discovered in plan.
Catch the exception found during implementation. In master we have:
`$ tmt run test --name=/lint/tests plan --name=/plans/sanity/lint discover --fmf-id`
```
Traceback (most recent call last):
...
  File "/home/dkarpele/fork/tmt/tmt/base.py", line 169, in fmf_id
    '/', os.path.relpath(fmf_root, git_root))
  File "/usr/lib64/python3.9/posixpath.py", line 454, in relpath
    raise ValueError("no path specified")
```
because `self.node.root = None` in https://github.com/psss/tmt/blob/67dae23a77c4b5f0f9ab0d71470e343041ef4454/tmt/base.py#L166
I don't know if it's expected or not, maybe weird case. I'm returning git root path in this case.
Tests were added.
