### PR TITLE
Several test improvements

### DIFF
--- a/tests/discover/libraries/main.fmf
+++ b/tests/discover/libraries/main.fmf
@@ -6,7 +6,7 @@ description:
     are fetched into the discover step workdir. Make sure that the
     test successfully passed. Needs a full virtualization.
 tier: 3
-duration: 15m
+duration: 20m
 tag-: [virtual, container]
 enabled: False
 require+:

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -5,4 +5,6 @@ test: python3 -m pytest
 framework: shell
 require:
   - python3-pytest
+environment:
+    LANG: en_US.UTF-8
 tier: 0


### PR DESCRIPTION
Run unit tests in English locale (error message checks).
Always clean up workdir after running tests.
Extend duration for the libraries test a bit.