### PR TITLE
Add a reboot test that works w/o reexecuting tmt

### DIFF
--- a/tests/execute/reboot/main.fmf
+++ b/tests/execute/reboot/main.fmf
@@ -19,3 +19,7 @@ duration: 20m
         enabled: true
         when: how == full
         because: this can be run only with full virtualization
+
+/reboot:
+    summary: Verify that reboot in top level test script works
+    test: ./data/test.sh


### PR DESCRIPTION
The `/tests/execute/reboot/basic` test works by re-executing tmt in its beakerlib test script in a subdirectory with specially crafted  TMT/FMF metadata that specify among others that the test is going to be executed in a container, and allow processing the tmt output to check for the actual reboots.
This is not how one usually runs a test in a CI system though: one does not usually recursively re-execute tmt from inside a test script. Therefore, add another reboot test (called simply `reboot`) which runs directly in the CI environment.

RFC: Maybe the new reboot test should be called `basic`, the full name name `/tests/execute/reboot/reboot` is not very good. And the current `basic` test should be renamed to `recursive` or `container` or something, because it is not so basic.

ToDo: This test can have a false negative result. It does not check whether the machine actually got rebooted (so if one replaces all the `-reboot` commands by `/bin/true`, the test still succeeds, as can be seen in https://github.com/pcahyna/tmt/pull/3). It can not check whether the machine has actually rebooted, because this assert belongs only to a branch that gets called after a reboot, but without a reboot we will not get there, so the assert can never fail. @psss has suggested to put `rlJournalEnd` into the "after reboot" branch, so that without a reboot the test would fail because the journal would not be terminated. I tried that in https://github.com/pcahyna/tmt/pull/4, let's see how it works.