### PR TITLE
Define PCI address for rng device

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -133,6 +133,7 @@ DOMAIN_TEMPLATE = """<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/d
     </memballoon>
     <rng model='virtio'>
       <backend model='random'>/dev/urandom</backend>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x0c' function='0x0'/>
     </rng>
   </devices>
   {{ qemu_args }}


### PR DESCRIPTION
Without explicit address assignment tmt errors out on my RHEL-8 system with
```
Failed to boot testcloud instance (internal error: qemu unexpectedly closed the monitor: 
2022-01-19T09:35:57.224124Z qemu-kvm: -device 
{"driver":"virtio-rng-pci","rng":"objrng0","id":"rng0","bus":"pci.0","addr":"0x2"}: 
PCI: slot 2 function 0 not available for virtio-rng-pci, in use by virtio-net-pci).
```
This particular address is copied over from example in RHBZ#1452581 and fixes my problem.