### PR TITLE
Testcloud: MultiArch Support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ install_requires = [
 extras_require = {
     'docs': ['sphinx>=3', 'sphinx_rtd_theme'],
     'tests': ['pytest', 'python-coveralls', 'requre', 'pre-commit'],
-    'provision': ['testcloud>=0.6.1'],
+    'provision': ['testcloud>=0.7.0'],
     'convert': ['nitrate', 'markdown', 'python-bugzilla', 'html2text'],
     'report-html': ['jinja2'],
     'report-junit': ['junit_xml'],

--- a/tmt.spec
+++ b/tmt.spec
@@ -62,7 +62,7 @@ Dependencies required to run tests in a container environment.
 Summary: Virtual machine provisioner for the Test Management Tool
 Obsoletes: tmt-testcloud < 0.17
 Requires: tmt == %{version}-%{release}
-Requires: python%{python3_pkgversion}-testcloud >= 0.6.1
+Requires: python%{python3_pkgversion}-testcloud >= 0.7.0
 Requires: openssh-clients
 Requires: (ansible or ansible-core)
 


### PR DESCRIPTION
Fixes https://github.com/psss/tmt/issues/856

Needs testcloud with https://pagure.io/testcloud/pull-request/115 

Both patched testcloud and tmt can be found at https://copr.fedorainfracloud.org/coprs/frantisekz/testcloud-wip/ .

For aarch64 run, you'll need: edk2-aarch64 qemu-system-aarch64
For ppc64le run, you'll need: qemu-system-ppc
For s390x run, you'll need: qemu-system-s390x

To test this, you can specify -a <desired_arch> to the tmt command, eg.
```
$ tmt run --remove provision -vvv -h virtual -i fedora-35 -a aarch64 finish
$ tmt run --remove provision -vvv -h virtual -i fedora-35 -a ppc64le finish
$ tmt run --remove provision -vvv -h virtual -i fedora-35 -a s390x finish
```

I've had some issues with running this on non-x86_64 host, I'll look into that. 