### PR TITLE
Updating module to allow for tmt import of 'metadata' file for #1002

### DIFF
--- a/tests/test/import/data/parent/child/metadata
+++ b/tests/test/import/data/parent/child/metadata
@@ -1,0 +1,13 @@
+[General]
+name=/tmt/smoke
+owner=Philip Daly <pdaly@redhat.com>
+description=Simple smoke test using restraint.
+license=GPLv2
+confidential=no
+destructive=no
+
+[restraint]
+entry_point=bash -x ./runtest.sh
+repoRequires=fmf
+max_time=6m
+softDependencies=fmf

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -449,6 +449,9 @@ def create(context, name, template, force, **kwargs):
     '--makefile / --no-makefile', default=True,
     help='Convert Beaker Makefile metadata')
 @click.option(
+    '--restraint / --no-restraint', default=False,
+    help='Convert restraint metadata file')
+@click.option(
     '--type', 'types', metavar='TYPE', default=['multihost'], multiple=True,
     show_default=True,
     help="Convert selected types from Makefile into tags. "
@@ -471,8 +474,8 @@ def create(context, name, template, force, **kwargs):
 @verbose_debug_quiet
 @force_dry
 def import_(
-        context, paths, makefile, types, nitrate, purpose, disabled, manual,
-        plan, case, with_script, **kwargs):
+        context, paths, makefile, restraint, types, nitrate, purpose, disabled,
+        manual, plan, case, with_script, **kwargs):
     """
     Import old test metadata into the new fmf format.
 
@@ -482,6 +485,8 @@ def import_(
 
     \b
     makefile ..... summary, component, duration, require
+    restraint .... name, description, entry_point, owner,
+                   max_time, repoRequires
     purpose ...... description
     nitrate ...... contact, component, tag,
                    environment, relevancy, enabled
@@ -506,7 +511,7 @@ def import_(
                 "Path '{0}' is not a directory.".format(path))
         # Gather old metadata and store them as fmf
         common, individual = tmt.convert.read(
-            path, makefile, nitrate, purpose, disabled, types)
+            path, makefile, restraint, nitrate, purpose, disabled, types)
         # Add path to common metadata if there are virtual test cases
         if individual:
             root = fmf.Tree(path).root


### PR DESCRIPTION
Module has been updated to allow for tmt to import 'metadata' file as well as 'Makefile'. If both exist in the directory, priority is given to 'metadata' file.

The command remains the same, 'tmt test import --makefile' to allow for backwards compatibility.

# Existing code behaviour.
# Makefile, Purpose file, and main.fmf present in the directory.

[root@pdaly parent]# tmt test import --makefile
Checking the '/root/auto-kernel/tmt_fork/tmt/tests/test/import/data/parent' directory.
Makefile found in '/root/auto-kernel/tmt_fork/tmt/tests/test/import/data/parent/Makefile'.
task: /tmt/smoke
summary: Simple smoke test
test: ./runtest.sh
framework: shell
contact: James Bond <007@MI6.com>
component: tmt
duration: 5m
environment:
{'AVC_ERROR': '+no_avc_check',
 'CONTEXT': 'distro=fedora',
 'TEST': 'one two three'}
require: tmt
recommend: fmf
tag: multihost
relates: https://bugzilla.redhat.com/show_bug.cgi?id=1234567
relates: https://bugzilla.redhat.com/show_bug.cgi?id=9876543
Purpose found in '/root/auto-kernel/tmt_fork/tmt/tests/test/import/data/parent/PURPOSE'.
description:
Just run 'tmt --help' to make sure the binary is sane.
This is really that simple. Nothing more here. Really.
Nitrate Major (851968): Unspecified GSS failure.  Minor code may provide more information, Minor (2529638944): Ticket expired
[root@pdaly parent]#



# Implemented code behaviour
# Makefile, Purpose file, and main.fmf present in the directory.

[root@pdaly parent]# tmt test import --makefile
Checking the '/root/auto-kernel/tmt_fork/tmt/tests/test/import/data/parent' directory.
Makefile found in '/root/auto-kernel/tmt_fork/tmt/tests/test/import/data/parent/Makefile'.
task: /tmt/smoke
summary: Simple smoke test
test: ./runtest.sh
framework: shell
contact: James Bond <007@MI6.com>
component: tmt
duration: 5m
environment:
{'AVC_ERROR': '+no_avc_check',
 'CONTEXT': 'distro=fedora',
 'TEST': 'one two three'}
require: tmt
recommend: fmf
tag: multihost
relates: https://bugzilla.redhat.com/show_bug.cgi?id=1234567
relates: https://bugzilla.redhat.com/show_bug.cgi?id=9876543
relates: https://bugzilla.redhat.com/show_bug.cgi?id=2222222
Purpose found in '/root/auto-kernel/tmt_fork/tmt/tests/test/import/data/parent/PURPOSE'.
description:
Just run 'tmt --help' to make sure the binary is sane.
This is really that simple. Nothing more here. Really.
Nitrate Major (851968): Unspecified GSS failure.  Minor code may provide more information, Minor (2529638944): Ticket expired
[root@pdaly parent]#


# metadata, Purpose file, and main.fmf present in the directory.

[root@pdaly parent]# tmt test import --makefile
Checking the '/root/auto-kernel/tmt_fork/tmt/tests/test/import/data/parent' directory.
metadata found in '/root/auto-kernel/tmt_fork/tmt/tests/test/import/data/parent/metadata'.
task: /tmt/smoke
summary: Simple smoke test
test: ./runtest.sh
framework: shell
contact: Napoleon Solo <TheManFrom@UNCLE.com>
component: tmt
duration: 5m
recommend: fmf tmt
Purpose found in '/root/auto-kernel/tmt_fork/tmt/tests/test/import/data/parent/PURPOSE'.
description:
Just run 'tmt --help' to make sure the binary is sane.
This is really that simple. Nothing more here. Really.
Nitrate Major (851968): Unspecified GSS failure.  Minor code may provide more information, Minor (2529638944): Ticket expired
[root@pdaly parent]#