### PR TITLE
Prevent koji build failures on unsupported arches

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -5,7 +5,10 @@ Release: 1%{?dist}
 Summary: Test Management Tool
 License: MIT
 BuildArch: noarch
+
+# Build only on arches where libguestfs (needed by testcloud) is available
 %{?kernel_arches:ExclusiveArch: %{kernel_arches} noarch}
+ExcludeArch: %{power64}
 
 URL: https://github.com/teemtee/tmt
 Source0: https://github.com/teemtee/tmt/releases/download/%{version}/tmt-%{version}.tar.gz


### PR DESCRIPTION
The `libguestfs` package is not available for `power64` arches
but it is required by `testcloud` which is causing failures.
Make sure `tmt` is not built in koji on these architectures.
See also https://bugzilla.redhat.com/show_bug.cgi?id=1946532