### PR TITLE
Build `epel9` packages, update install docs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,6 +19,7 @@ jobs:
     targets:
     - fedora-all
     - epel-8
+    - epel-9
 
 - job: copr_build
   trigger: commit
@@ -27,6 +28,7 @@ jobs:
     targets:
     - fedora-all
     - epel-8
+    - epel-9
     list_on_homepage: True
     preserve_project: True
     owner: psss

--- a/README.rst
+++ b/README.rst
@@ -235,13 +235,18 @@ features right at hand install everything::
 
     sudo dnf install tmt-all
 
-For RHEL 8 and CentOS 8, first make sure that you have available
-the `EPEL <https://fedoraproject.org/wiki/EPEL>`_ repository. You
-might also have to enable additional repositories::
+For CentOS and RHEL, first make sure that you have available the
+`EPEL <https://docs.fedoraproject.org/en-US/epel/>`_ repository.
+You might also have to enable additional repositories::
 
-    sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
     sudo dnf config-manager --enable powertools  # CentOS 8
     sudo dnf config-manager --enable rhel-CRB    # RHEL 8
+    sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+    sudo dnf config-manager --enable crb         # CentOS 9
+    sudo dnf config-manager --enable rhel-CRB    # RHEL 9
+    sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+
     sudo dnf install tmt
 
 For plugins which cannot work outside of VPN and so live within


### PR DESCRIPTION
Now we should be ready for `epel9`, both building and testing should work.