### PR TITLE
Update links and refs after migration to `teemtee`

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -23,7 +23,7 @@ jobs:
 - job: copr_build
   trigger: commit
   metadata:
-    branch: master
+    branch: main
     targets:
     - fedora-all
     - epel-8

--- a/README.rst
+++ b/README.rst
@@ -369,19 +369,19 @@ Links
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Git:
-https://github.com/psss/tmt
+https://github.com/teemtee/tmt
 
 Docs:
 http://tmt.readthedocs.io/
 
 Stories:
-https://tmt.readthedocs.io/en/latest/stories.html
+https://tmt.readthedocs.io/en/stable/stories.html
 
 Issues:
-https://github.com/psss/tmt/issues
+https://github.com/teemtee/tmt/issues
 
 Releases:
-https://github.com/psss/tmt/releases
+https://github.com/teemtee/tmt/releases
 
 Copr:
 http://copr.fedoraproject.org/coprs/psss/tmt
@@ -389,14 +389,8 @@ http://copr.fedoraproject.org/coprs/psss/tmt
 PIP:
 https://pypi.org/project/tmt/
 
-Travis:
-https://travis-ci.org/psss/tmt
-
-Coveralls:
-https://coveralls.io/github/psss/tmt
-
 Metadata Specification:
-https://tmt.readthedocs.io/en/latest/spec.html
+https://tmt.readthedocs.io/en/stable/spec.html
 
 Flexible Metadata Format:
 http://fmf.readthedocs.io/

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -25,7 +25,7 @@ couple of recommendations to keep on mind when writing code:
 * The closing brace/bracket/parenthesis on multiline constructs
   is under the first non-whitespace character of the last line
 
-__ https://github.com/psss/tmt
+__ https://github.com/teemtee/tmt
 __ https://www.python.org/dev/peps/pep-0008/
 
 
@@ -74,7 +74,7 @@ Now let's create a new virtual environment and install ``tmt`` in
 editable mode there::
 
     mkvirtualenv tmt
-    git clone https://github.com/psss/tmt
+    git clone https://github.com/teemtee/tmt
     cd tmt
     pip install -e .
 
@@ -178,9 +178,10 @@ amending the original commit and doing a force push. This will
 make it easier for the reviewers to see what has recently changed.
 
 Once the pull request has been successfully reviewed and all tests
-passed, please rebase on the latest master and squash the changes
-into a single commit. Use multiple commits to group relevant code
-changes if the pull request is too large for a single commit.
+passed, please rebase on the latest ``main`` branch content and
+squash the changes into a single commit. Use multiple commits to
+group relevant code changes if the pull request is too large for a
+single commit.
 
 
 Merging
@@ -194,7 +195,7 @@ good to check the following:
 * Documentation has been added or updated where appropriate
 * Commit messages are sane, commits are reasonably squashed
 * At least one positive review provided by the maintainers
-* Merge commits are not used, rebase on the master instead
+* Merge commits are not used, rebase on the ``main`` instead
 
 Pull requests which should not or cannot be merged are marked with
 the ``blocked`` label. For complex topics which need more eyes to
@@ -266,7 +267,7 @@ Release a new package to Fedora and EPEL repositories:
 Finally, if everything went well:
 
 * **Manually** merge the original release pull request on github (to avoid rebase)
-  ``git checkout master && git merge --ff-only <release_branch> && git push origin master``
+  ``git checkout main && git merge --ff-only <release_branch> && git push origin main``
 * Tag the commit with ``x.y.0``, push tags ``git push --tags``
 * Create a new `github release`__ based on the tag above
 * If the automation triggered by publishing the new github release
@@ -278,6 +279,6 @@ Finally, if everything went well:
 * Close the corresponding release milestone
 
 __ https://bodhi.fedoraproject.org/releases/
-__ https://github.com/psss/tmt/releases/
+__ https://github.com/teemtee/tmt/releases/
 __ https://pypi.org/project/tmt/
 __ https://copr.fedorainfracloud.org/coprs/psss/tmt/builds/

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -129,7 +129,7 @@ the list of source files where metadata are defined and its full id::
          sources /home/psss/git/tmt/tests/main.fmf
                  /home/psss/git/tmt/tests/docs/main.fmf
           fmf-id name: /tests/docs
-                 url: https://github.com/psss/tmt.git
+                 url: https://github.com/teemtee/tmt.git
 
 
 Filter Tests
@@ -328,7 +328,7 @@ directory::
     fmf id:
     name: /
     path: /examples/convert
-    url: https://github.com/psss/tmt.git
+    url: https://github.com/teemtee/tmt.git
     Test case 'TC#0603489' successfully exported to nitrate.
 
 Use the ``--bugzilla`` option together with ``--nitrate`` to link
@@ -392,7 +392,7 @@ and detailed plan information, respectively::
          summary Essential command line features
         discover
              how fmf
-      repository https://github.com/psss/tmt
+      repository https://github.com/teemtee/tmt
         revision devel
           filter tier: 0,1
          prepare
@@ -461,7 +461,7 @@ inheritance to prevent unnecessary duplication of the data::
 
     discover:
         how: fmf
-        url: https://github.com/psss/tmt
+        url: https://github.com/teemtee/tmt
     prepare:
         how: ansible
         playbook: ansible/packages.yml
@@ -509,7 +509,7 @@ the :ref:`/spec/plans/discover` step::
     discover:
       - name: upstream
         how: fmf
-        url: https://github.com/psss/tmt
+        url: https://github.com/teemtee/tmt
       - name: fedora
         how: fmf
         url: https://src.fedoraproject.org/rpms/tmt/
@@ -549,7 +549,7 @@ set in the environment have the highest priority)::
 
     discover:
         how: fmf
-        url: https://github.com/psss/${REPO}
+        url: https://github.com/teemtee/${REPO}
 
     $ REPO=tmt tmt run
     $ tmt run -e REPO=tmt
@@ -770,7 +770,7 @@ Choose which plans should be executed::
     /plans/basic
         discover
             how: fmf
-            url: https://github.com/psss/tmt
+            url: https://github.com/teemtee/tmt
             ref: devel
             filter: tier: 0,1
             tests: 2 tests selected
@@ -792,7 +792,7 @@ Run only a subset of available tests across all plans::
     /plans/basic
         discover
             how: fmf
-            url: https://github.com/psss/tmt
+            url: https://github.com/teemtee/tmt
             ref: devel
             filter: tier: 0,1
             tests: 1 test selected
@@ -833,7 +833,7 @@ running them choose the ``discover`` step::
     /plans/basic
         discover
             how: fmf
-            url: https://github.com/psss/tmt
+            url: https://github.com/teemtee/tmt
             ref: devel
             filter: tier: 0,1
             tests: 2 tests selected
@@ -854,7 +854,7 @@ test environment provisioning::
     /plans/basic
         discover
             how: fmf
-            url: https://github.com/psss/tmt
+            url: https://github.com/teemtee/tmt
             ref: devel
             filter: tier: 0,1
             tests: 2 tests selected

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -55,4 +55,4 @@ implements the ``GuestExample`` class which inherits from
 features which cannot be covered by generic ssh implementation of
 the ``Guest`` class.
 
-__ https://github.com/psss/tmt/tree/master/examples/plugins
+__ https://github.com/teemtee/tmt/tree/main/examples/plugins

--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -130,7 +130,7 @@ Each tmt test has a unique `fmf identifier`__ which can look like
 this::
 
     name: /tests/core/docs
-    url: https://github.com/psss/tmt.git
+    url: https://github.com/teemtee/tmt.git
     ref: main
 
 These identifiers can be used for integration with other tools,

--- a/examples/discover/discover.fmf
+++ b/examples/discover/discover.fmf
@@ -23,11 +23,11 @@ provision:
             summary: Minimal from repository
             discover:
                 how: fmf
-                url: https://github.com/psss/tmt
+                url: https://github.com/teemtee/tmt
         /full:
             summary: Full from repository
             discover:
                 how: fmf
-                url: https://github.com/psss/tmt
+                url: https://github.com/teemtee/tmt
                 ref: devel
                 filter: 'tier: 1'

--- a/examples/inherit/main.fmf
+++ b/examples/inherit/main.fmf
@@ -1,6 +1,6 @@
 discover:
     how: fmf
-    url: https://github.com/psss/tmt
+    url: https://github.com/teemtee/tmt
 prepare:
     how: ansible
     playbook: ansible/packages.yml

--- a/examples/l2/gating.fmf
+++ b/examples/l2/gating.fmf
@@ -3,7 +3,7 @@
     /pull-request:
         /pep:
             summary: All code must comply with the PEP8 style guide
-            # Do not allow ugly code to be merged into master
+            # Do not allow ugly code to be merged into the main branch
             gate:
                 - merge-pull-request
         /lint:

--- a/examples/multiple/basic.fmf
+++ b/examples/multiple/basic.fmf
@@ -8,14 +8,14 @@ discover:
   - name: tier0
     how: fmf
     filter: 'tier: 0'
-    url: https://github.com/psss/tmt
+    url: https://github.com/teemtee/tmt
   - name: tier1
     how: fmf
     filter: 'tier: 1'
-    url: https://github.com/psss/tmt
+    url: https://github.com/teemtee/tmt
   - name: all
     how: fmf
-    url: https://github.com/psss/tmt
+    url: https://github.com/teemtee/tmt
 prepare:
   - how: ansible
     name: packages

--- a/examples/wow/full/test.sh
+++ b/examples/wow/full/test.sh
@@ -12,7 +12,7 @@ rlJournalStart
         # Install tmt, start libvirtd, clone report and look around
         rlRun "dnf install -y tmt-all" 0 "Install the full tmt package"
         rlRun "systemctl start libvirtd" 0 "Start libvirtd"
-        rlRun "git clone https://github.com/psss/tmt"
+        rlRun "git clone https://github.com/teemtee/tmt"
         rlRun "pushd tmt"
         rlRun "tmt" 0 "Explore the repo"
 

--- a/examples/wow/run.sh
+++ b/examples/wow/run.sh
@@ -2,8 +2,8 @@
 # Example workflow-tomorrow command lines
 
 # Git url, git ref and root path
-url='https://github.com/psss/tmt'
-ref='master'
+url='https://github.com/teemtee/tmt'
+ref='main'
 path='/examples/wow'
 
 # The mini test

--- a/setup.py
+++ b/setup.py
@@ -58,8 +58,8 @@ readme = 'README.rst'
 with open(readme, encoding='utf-8') as _file:
     readme = _file.read()
 
-github = 'https://github.com/psss/tmt'
-download_url = '{0}/archive/master.zip'.format(github)
+github = 'https://github.com/teemtee/tmt'
+download_url = '{0}/archive/main.zip'.format(github)
 
 default_setup = dict(
     url=github,

--- a/spec/core/link.fmf
+++ b/spec/core/link.fmf
@@ -82,7 +82,7 @@ description: |
 
 example: |
     # A related issue
-    link: https://github.com/psss/tmt/issues/461
+    link: https://github.com/teemtee/tmt/issues/461
 
     # A test verifying a story
     link:
@@ -102,7 +102,7 @@ example: |
     # A story blocked by a remote story with optional note
     link:
         blocked-by:
-            url: https://github.com/psss/fmf
+            url: https://github.com/teemtee/fmf
             name: /stories/select/filter/regexp
         note: Need to get the regexp filter working first.
 link:

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -147,8 +147,8 @@ description: |
         # Fetch tests from a remote repo, filter by name/tier
         discover:
             how: fmf
-            url: https://github.com/psss/tmt
-            ref: master
+            url: https://github.com/teemtee/tmt
+            ref: main
             path: /metadata/tree/path
             test: [regexp]
             filter: tier:1
@@ -162,7 +162,7 @@ description: |
         discover:
             how: fmf
             modified-only: true
-            modified-url: https://github.com/psss/tmt-official
+            modified-url: https://github.com/teemtee/tmt-official
             modified-ref: reference/main
 
         # Extract tests from the distgit sources

--- a/spec/plans/gate.fmf
+++ b/spec/plans/gate.fmf
@@ -21,7 +21,7 @@ example: |
         /pull-request:
             /pep:
                 summary: All code must comply with the PEP8 style guide
-                # Do not allow ugly code to be merged into master
+                # Do not allow ugly code to be merged into the main branch
                 gate:
                     - merge-pull-request
             /lint:

--- a/spec/tests/manual.fmf
+++ b/spec/tests/manual.fmf
@@ -68,7 +68,7 @@ description: |
 
     See the `manual test examples`__ to get a better idea.
 
-    __ https://github.com/psss/tmt/tree/master/examples/manual/
+    __ https://github.com/teemtee/tmt/tree/main/examples/manual/
 
 example: |
   manual: true

--- a/stories/features/coverage.fmf
+++ b/stories/features/coverage.fmf
@@ -36,8 +36,8 @@ story:
         :ref:`/spec/core/link` attribute.
     example: |
         verified-by:
-            url: https://github.com/psss/fmf
-            ref: master
+            url: https://github.com/teemtee/fmf
+            ref: main
             name: /tests/basic/repo
     priority: should
 
@@ -54,7 +54,7 @@ story:
             identifiers.
         example: |
             tmt story ls --filter "url:https://gitlab/project"
-            tmt story ls --filter "url:https://gitlab/project & ref:master name:/tests/smoke"
+            tmt story ls --filter "url:https://gitlab/project & ref:main name:/tests/smoke"
         priority: should
 
     /tags:

--- a/tests/core/environment-file/data/main.fmf
+++ b/tests/core/environment-file/data/main.fmf
@@ -18,7 +18,7 @@
         environment-file:
           - env
           - env.yaml
-          - https://raw.githubusercontent.com/psss/tmt/22a46a4a6760517e3eadbbff0c9bebdb95442760/tests/core/env/data/vars.yaml
+          - https://raw.githubusercontent.com/teemtee/tmt/22a46a4a6760517e3eadbbff0c9bebdb95442760/tests/core/env/data/vars.yaml
     /bad:
         environment-file:
           - bad
@@ -31,7 +31,7 @@
     /fetch:
         /good:
             environment-file:
-            - https://raw.githubusercontent.com/psss/tmt/22a46a4a6760517e3eadbbff0c9bebdb95442760/tests/core/env/data/vars.yaml
+            - https://raw.githubusercontent.com/teemtee/tmt/22a46a4a6760517e3eadbbff0c9bebdb95442760/tests/core/env/data/vars.yaml
         /bad:
             environment-file:
             - https://invalid.host.name/vars.yaml

--- a/tests/core/link/data/plans/core.fmf
+++ b/tests/core/link/data/plans/core.fmf
@@ -6,4 +6,4 @@ link:
   - verifies: /stories/covered
   - verifies: /stories/verified
   - blocks: /plans/full
-  - https://github.com/psss/tmt/pull/215
+  - https://github.com/teemtee/tmt/pull/215

--- a/tests/core/link/data/tests/smoke/main.fmf
+++ b/tests/core/link/data/tests/smoke/main.fmf
@@ -3,4 +3,4 @@ test: tmt --version
 link:
   - verifies: /stories/covered
   - verifies: /stories/verified
-  - https://github.com/psss/tmt/pull/215
+  - https://github.com/teemtee/tmt/pull/215

--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -13,36 +13,36 @@ execute:
             /path:
                 discover:
                     how: fmf
-                    url: https://github.com/psss/tmt
+                    url: https://github.com/teemtee/tmt
                     ref: eae4d52
                     path: /examples/together
             /nopath:
                 discover:
                     how: fmf
-                    url: https://github.com/psss/tmt
+                    url: https://github.com/teemtee/tmt
                     ref: 5407fe5
         /noref:
             /path:
                 discover:
                     how: fmf
-                    url: https://github.com/psss/tmt
+                    url: https://github.com/teemtee/tmt
                     path: /examples/together
 
             /nopath:
                 discover:
                     how: fmf
-                    url: https://github.com/psss/tmt
+                    url: https://github.com/teemtee/tmt
         /parametrize:
             /environment:
                 environment:
                     REPO: tmt
                 discover:
                     how: fmf
-                    url: https://github.com/psss/$REPO
+                    url: https://github.com/teemtee/$REPO
             /noenvironment:
                 discover:
                     how: fmf
-                    url: https://github.com/psss/${REPO}
+                    url: https://github.com/teemtee/${REPO}
     /nourl:
         /ref:
             /path:

--- a/tests/discover/data/tests.fmf
+++ b/tests/discover/data/tests.fmf
@@ -10,7 +10,7 @@ test: /bin/true
     tier: 2
     link:
     - note: Some text
-      verifies: https://github.com/psss/tmt/issues/870
+      verifies: https://github.com/teemtee/tmt/issues/870
 
 /discover3:
     summary: Discover three

--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -36,7 +36,7 @@ rlJournalStart
             rlAssertGrep '1 test selected' output
             rlAssertGrep '/tests/discover1' output
         done
-        for link_relation in "verifies:https://github.com/psss/tmt/issues/870" \
+        for link_relation in "verifies:https://github.com/teemtee/tmt/issues/870" \
             "ver.*:.*/issues/870" ".*/issues/870"; do
             discover="discover -h fmf --link $link_relation --link rubbish"
             rlRun "tmt run -dvr $discover $plan finish | tee output"

--- a/tests/discover/libraries/data/strip_git_suffix.fmf
+++ b/tests/discover/libraries/data/strip_git_suffix.fmf
@@ -23,7 +23,7 @@ test: ./file.sh
     - url: https://github.com/beakerlib/database
       name: /postgresql
     - library(database/postgresql)
-    - url: https://github.com/psss/fmf.git
+    - url: https://github.com/teemtee/fmf.git
 /test3:
   recommend:
     - url: https://github.com/beakerlib/database.git

--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -57,7 +57,7 @@ rlJournalStart
         rlAssertGrep "summary: 3 tests selected" "$tmp/output"
         rlAssertGrep "/strip_git_suffix/test2" "$tmp/output"
         rlAssertGrep \
-            "Detected library '{'url': 'https://github.com/psss/fmf.git'}'." \
+            "Detected library '{'url': 'https://github.com/teemtee/fmf.git'}'." \
             "$tmp/output"
         rlAssertNotGrep 'Library.*conflicts with already fetched library' \
             "$tmp/output"

--- a/tests/discover/parametrize.sh
+++ b/tests/discover/parametrize.sh
@@ -12,28 +12,28 @@ rlJournalStart
     steps='discover finish'
     rlPhaseStartTest 'From environment attribute'
         rlRun "tmt run -r $plan_env $steps | tee output"
-        rlAssertGrep 'url: https://github.com/psss/tmt' 'output'
+        rlAssertGrep 'url: https://github.com/teemtee/tmt' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'From command line'
         rlRun "tmt run -r -e REPO=tmt $plan $steps | tee output"
-        rlAssertGrep 'url: https://github.com/psss/tmt' 'output'
+        rlAssertGrep 'url: https://github.com/teemtee/tmt' 'output'
         # Precedence of option over environment attribute
         rlRun "tmt run -r -e REPO=fmf $plan_env $steps | tee output"
-        rlAssertGrep 'url: https://github.com/psss/fmf' 'output'
+        rlAssertGrep 'url: https://github.com/teemtee/fmf' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'Process environment should be ignored'
         rlRun "REPO=fmf tmt run -r $plan_env $steps | tee output"
-        rlAssertGrep 'url: https://github.com/psss/tmt' 'output'
+        rlAssertGrep 'url: https://github.com/teemtee/tmt' 'output'
         # No substitution should happen
         rlRun "REPO=tmt tmt run -r $plan $steps | tee output" 2
-        rlAssertGrep 'url: https://github.com/psss/${REPO}' 'output'
+        rlAssertGrep 'url: https://github.com/teemtee/${REPO}' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'Undefined variable'
         rlRun "tmt run -r $plan $steps | tee output" 2
-        rlAssertGrep 'url: https://github.com/psss/${REPO}' 'output'
+        rlAssertGrep 'url: https://github.com/teemtee/${REPO}' 'output'
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/discover/references.sh
+++ b/tests/discover/references.sh
@@ -60,7 +60,7 @@ rlJournalStart
     rlPhaseStartTest $plan
         rlRun 'tmt run -dddvr discover plan --name $plan finish | tee output'
         rlAssertGrep 'Cloning into' output
-        rlAssertNotGrep 'Checkout ref.*master' output
+        rlAssertNotGrep 'Checkout ref.*main' output
         rlAssertGrep /tests/core/docs output
         rlAssertGrep /tests/core/env output
         rlAssertGrep /tests/core/ls output
@@ -70,7 +70,7 @@ rlJournalStart
     rlPhaseStartTest $plan
         rlRun 'tmt run -dddvr discover plan --name $plan finish | tee output'
         rlAssertGrep 'Cloning into' output
-        rlAssertNotGrep 'Checkout ref.*master' output
+        rlAssertNotGrep 'Checkout ref.*main' output
         rlAssertGrep '2 tests selected' output
         rlAssertGrep /tests/full output
         rlAssertGrep /tests/smoke output

--- a/tests/lint/data/plans/bad.fmf
+++ b/tests/lint/data/plans/bad.fmf
@@ -1,7 +1,7 @@
 summary: This is just a plan
 discovery:
     how: fmf
-    url: https://github.com/psss/tmt
+    url: https://github.com/teemtee/tmt
 prepareahoj:
     how: ansible
     playbook: plans/packages.yml

--- a/tests/lint/data/plans/good.fmf
+++ b/tests/lint/data/plans/good.fmf
@@ -1,7 +1,7 @@
 summary: This is just a plan
 discover:
     how: fmf
-    url: https://github.com/psss/tmt
+    url: https://github.com/teemtee/tmt
 prepare:
     how: ansible
     playbook: plans/packages.yml

--- a/tests/plan/lint/data/invalid_path.fmf
+++ b/tests/plan/lint/data/invalid_path.fmf
@@ -1,7 +1,7 @@
 discover:
     how: fmf
-    url: https://github.com/psss/tmt
-    ref: master
+    url: https://github.com/teemtee/tmt
+    ref: main
     path: /invalid-path-123456
 execute:
     how: tmt

--- a/tests/plan/lint/data/invalid_ref.fmf
+++ b/tests/plan/lint/data/invalid_ref.fmf
@@ -1,6 +1,6 @@
 discover:
     how: fmf
-    url: https://github.com/psss/tmt
+    url: https://github.com/teemtee/tmt
     ref: invalid-ref-123456
 execute:
     how: tmt

--- a/tests/plan/lint/data/multi_discover.fmf
+++ b/tests/plan/lint/data/multi_discover.fmf
@@ -2,7 +2,7 @@ summary: Multi-discover plan
 discover:
   - name: a
     how: fmf
-    url: https://github.com/psss/tmt
+    url: https://github.com/teemtee/tmt
   - name: b
     how: fmf
     url: http://invalid-url

--- a/tests/plan/lint/data/valid_fmf.fmf
+++ b/tests/plan/lint/data/valid_fmf.fmf
@@ -1,7 +1,7 @@
 summary: This is a valid plan
 discover:
     how: fmf
-    url: https://github.com/psss/tmt
-    ref: master
+    url: https://github.com/teemtee/tmt
+    ref: main
 execute:
     how: tmt

--- a/tests/prepare/shell/main.fmf
+++ b/tests/prepare/shell/main.fmf
@@ -1,3 +1,3 @@
 summary: Test preparing guest using a shell script
 link:
-  - verifies: https://github.com/psss/tmt/issues/423
+  - verifies: https://github.com/teemtee/tmt/issues/423

--- a/tests/pull/simple/main.fmf
+++ b/tests/pull/simple/main.fmf
@@ -4,7 +4,7 @@ description:
     expected even if no preparation, test execution or finish step
     scripts are performed.
 link:
-  - verifies: https://github.com/psss/tmt/issues/1011
+  - verifies: https://github.com/teemtee/tmt/issues/1011
 
 environment:
     METHODS: container local

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -98,7 +98,7 @@ def test_link():
     # Full fmf id
     fmf_id = tmt.utils.yaml_to_dict("""
         blocked-by:
-            url: https://github.com/psss/fmf
+            url: https://github.com/teemtee/fmf
             name: /stories/select/filter/regexp
         note: Need to get the regexp filter working first.
         """)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,8 +14,8 @@ def test_public_git_url():
     """ Verify url conversion """
     examples = [
         {
-            'original': 'git@github.com:psss/tmt.git',
-            'expected': 'https://github.com/psss/tmt.git',
+            'original': 'git@github.com:teemtee/tmt.git',
+            'expected': 'https://github.com/teemtee/tmt.git',
             }, {
             'original': 'ssh://psplicha@pkgs.devel.redhat.com/tests/bash',
             'expected': 'git://pkgs.devel.redhat.com/tests/bash',

--- a/tmt.spec
+++ b/tmt.spec
@@ -7,8 +7,8 @@ License: MIT
 BuildArch: noarch
 %{?kernel_arches:ExclusiveArch: %{kernel_arches} noarch}
 
-URL: https://github.com/psss/tmt
-Source0: https://github.com/psss/tmt/releases/download/%{version}/tmt-%{version}.tar.gz
+URL: https://github.com/teemtee/tmt
+Source0: https://github.com/teemtee/tmt/releases/download/%{version}/tmt-%{version}.tar.gz
 
 # Main tmt package requires the Python module
 Requires: python%{python3_pkgversion}-%{name} == %{version}-%{release}

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -158,6 +158,7 @@ class Core(tmt.utils.Common):
 
         # Get the ref (skip for master as it is the default)
         ref = run('git rev-parse --abbrev-ref HEAD')
+        # FIXME: We need to detect the default branch instead
         if ref != 'master':
             fmf_id['ref'] = ref
 

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -24,7 +24,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
 
         discover:
             how: fmf
-            url: https://github.com/psss/tmt
+            url: https://github.com/teemtee/tmt
             ref: main
             path: /fmf/root
             test: /tests/basic
@@ -63,7 +63,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         discover:
             how: fmf
             modified-only: True
-            modified-url: https://github.com/psss/tmt
+            modified-url: https://github.com/teemtee/tmt
             modified-ref: reference/main
 
     Note that internally the modified tests are appended to the list

--- a/tmt/templates.py
+++ b/tmt/templates.py
@@ -90,7 +90,7 @@ summary:
     Essential command line features
 discover:
     how: fmf
-    url: https://github.com/psss/tmt
+    url: https://github.com/teemtee/tmt
 prepare:
     how: ansible
     playbook: plans/packages.yml

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1088,8 +1088,8 @@ def public_git_url(url):
     """
 
     # GitHub, GitLab
-    # old: git@github.com:psss/tmt.git
-    # new: https://github.com/psss/tmt.git
+    # old: git@github.com:teemtee/tmt.git
+    # new: https://github.com/teemtee/tmt.git
     matched = re.match('git@(.*):(.*)', url)
     if matched:
         host, project = matched.groups()


### PR DESCRIPTION
Update urls to use the new GitHub organization.
Use `main` instead of `master` as the default branch.
Point users by default to the `stable` version of the docs.
Also remove some old obsoleted links (travis, coveralls).