### PR TITLE
Remove workdir only when it's defined

### DIFF
--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -516,9 +516,10 @@ class Common(object):
     def _workdir_cleanup(self, path=None):
         """ Clean up the work directory """
         directory = path or self._workdir_name()
-        if os.path.isdir(directory):
-            self.debug(f"Clean up workdir '{directory}'.", level=2)
-            shutil.rmtree(directory)
+        if directory is not None:
+            if os.path.isdir(directory):
+                self.debug(f"Clean up workdir '{directory}'.", level=2)
+                shutil.rmtree(directory)
         self._workdir = None
 
     @property


### PR DESCRIPTION
Despite `directory = path or self._workdir_name()`, `directory` can be
`None` because `self._workdir_name()` can return `None`. Hence removing
the directory only when the value is valid.