### PR TITLE
Do not disable building for power arch on Fedora

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -8,7 +8,9 @@ BuildArch: noarch
 
 # Build only on arches where libguestfs (needed by testcloud) is available
 %{?kernel_arches:ExclusiveArch: %{kernel_arches} noarch}
+%if 0%{?rhel} >= 9
 ExcludeArch: %{power64}
+%endif
 
 URL: https://github.com/teemtee/tmt
 Source0: https://github.com/teemtee/tmt/releases/download/%{version}/tmt-%{version}.tar.gz


### PR DESCRIPTION
The `libguestfs` package and virt stack for `ppc64le` is available
on Fedora. It's only missing for `centos-stream-9` and `rhel-9`.