### PR TITLE
Fix timeout behaviour in testcloud plugin

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -523,6 +523,7 @@ class GuestTestcloud(tmt.Guest):
         timeout = DEFAULT_CONNECT_TIMEOUT
         wait = 1
         while True:
+            start_time = time.time()
             try:
                 self.execute('whoami')
                 break
@@ -533,9 +534,10 @@ class GuestTestcloud(tmt.Guest):
                 self.debug(
                     f'Failed to connect to machine, retrying, '
                     f'{fmf.utils.listed(timeout, "second")} left.')
+            attempt_duration = round(time.time() - start_time)
             time.sleep(wait)
             wait += 1
-            timeout -= wait
+            timeout -= wait + attempt_duration
 
     def stop(self):
         """ Stop provisioned guest """


### PR DESCRIPTION
Substract the duration of ssh attempt from timeout. Note that since each ssh attempt takes around a minute, it means that ssh will effectively be attempted only twice. Timeout would need to be increased in order to allow more attempts.

Fixes: #1077