### PR TITLE
Plugin support to map image to downloadable url

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -10,7 +10,8 @@ import requests
 
 import tmt
 from tmt.steps.provision import ProvisionPlugin
-from tmt.utils import WORKDIR_ROOT, ProvisionError, retry_session
+from tmt.utils import (WORKDIR_ROOT, GeneralError, ProvisionError,
+                       get_image_url, retry_session)
 
 
 def import_testcloud():
@@ -368,6 +369,14 @@ class GuestTestcloud(tmt.Guest):
             url = testcloud.util.get_fedora_image_url("rawhide")
 
         if not url:
+            try:
+                url = get_image_url(
+                    name, arch='x86_64', format=[
+                        'box', 'qcow2'])
+                if url is not None:
+                    return url
+            except GeneralError as error:
+                self.fail(str(error))
             raise ProvisionError(f"Could not map '{name}' to compose.")
         return url
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1791,3 +1791,35 @@ def get_distgit_handler(remotes=None, usage_name=None):
 def get_distgit_handler_names():
     """ All known distgit handlers """
     return [i.usage_name for i in DistGitHandler.__subclasses__()]
+
+
+class Image2URLConvertor(object):
+    """ Common parent for image to url conversion plugins """
+    @staticmethod
+    def convert(value, arch=None, format=[]):
+        """
+        Return url to download image from
+
+        Caller should set 'arch' and 'format'
+        If class can't convert value it should return 'None'
+        (e.g. class converts qcow2 images but asked to map podman)
+
+        Raises GeneralError when value was expected to be converted,
+        but couldn't be (e.g. old fedora release removed from download location)
+        """
+        raise NotImplementedError()
+
+
+def get_image_url(value, arch, format):
+    """
+    Map image 'value' for 'arch' and one of 'format' into URL to download
+
+    First plugin which knows how to map the value wins
+
+    GeneralError might come from the plugin
+    """
+    for candidate_class in Image2URLConvertor.__subclasses__():
+        url = candidate_class.convert(value, arch, format=format)
+        if url is not None:
+            log.debug(f"'{value}' mapped by '{candidate_class.__name__}'")
+            return url


### PR DESCRIPTION
Should be opened to other archictectures and formats.
Modified testcloud to use it for x86_64 and box|qcow2 which are
currently supported (non-intel arch support is work in progress)