### PR TITLE
Introduce new `_options` attribute to Common class

### DIFF
--- a/tests/core/dry/test.sh
+++ b/tests/core/dry/test.sh
@@ -2,10 +2,14 @@
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 rlJournalStart
-    rlPhaseStartTest
+    rlPhaseStartTest "Test debug/verbose levels"
         rlRun "tmt run --dry -r"
         rlRun "tmt run --dry -dvr"
         rlRun "tmt run --dry -ddvvr"
         rlRun "tmt run --dry -dddvvvr"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Dry provision propagation"
+        rlRun "tmt run --all --remove provision --how virtual --dry"
     rlPhaseEnd
 rlJournalEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1665,6 +1665,19 @@ class Run(tmt.utils.Common):
         # Attempt to load run data
         self.load()
 
+        # Attempt to propagate dry mode
+        for plan in self.plans:
+            # When provision is in dry mode, we should modify steps prepare,
+            # execute and finish options to have dry enabled as well
+            step_provision = plan.provision
+            step_prepare = plan.prepare
+            step_execute = plan.execute
+            step_finish = plan.finish
+            if step_provision.opt('dry'):
+                step_prepare._options['dry'] = True
+                step_execute._options['dry'] = True
+                step_finish._options['dry'] = True
+
         if self.opt('follow'):
             self.follow()
 


### PR DESCRIPTION
If `--dry` is specified in command `tmt run --id remote-001 --all provision -vvv --how connect --guest $GUEST --dry`, `self.opt('dry')` is `True` in `push()` but it is `None` in `pull()`, so I added a property `self.dry = self.opt('dry')` to help to fix issue https://github.com/teemtee/tmt/issues/1064.