### PR TITLE
Reboot improvements

### DIFF
--- a/tests/execute/reboot/basic.sh
+++ b/tests/execute/reboot/basic.sh
@@ -8,22 +8,27 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    rlPhaseStartTest "Simple reboot test"
-        rlRun -s "tmt run -i $run -dddvvv"
-        rlAssertGrep "Reboot during test '/test' with reboot count 1" $rlRun_LOG
-        rlAssertGrep "After first reboot" $rlRun_LOG
-        rlAssertGrep "Reboot during test '/test' with reboot count 2" $rlRun_LOG
-        rlAssertGrep "After second reboot" $rlRun_LOG
-        rlAssertGrep "Reboot during test '/test' with reboot count 3" $rlRun_LOG
-        rlAssertGrep "After third reboot" $rlRun_LOG
-        rlRun "rm $rlRun_LOG"
+    for interactive in "" "--interactive"; do
+        rlPhaseStartTest "Simple reboot test (interactivity: $interactive)"
+            rlRun -s "tmt run --scratch -i $run -dddvvva execute -h tmt $interactive"
+            rlAssertGrep "Reboot during test '/test' with reboot count 1" $rlRun_LOG
+            rlAssertGrep "After first reboot" $rlRun_LOG
+            rlAssertGrep "Reboot during test '/test' with reboot count 2" $rlRun_LOG
+            rlAssertGrep "After second reboot" $rlRun_LOG
+            rlAssertGrep "Reboot during test '/test' with reboot count 3" $rlRun_LOG
+            rlAssertGrep "After third reboot" $rlRun_LOG
+            rlRun "rm $rlRun_LOG"
 
-        # Check that the whole output log is kept
-        rlRun "log=$run/plan/execute/data/test/output.txt"
-        rlAssertGrep "After first reboot" $log
-        rlAssertGrep "After second reboot" $log
-        rlAssertGrep "After third reboot" $log
-    rlPhaseEnd
+            # Check that the whole output log is kept
+            # The test output is not stored in log in interactive mode
+            if [ -z "$interactive" ]; then
+                rlRun "log=$run/plan/execute/data/test/output.txt"
+                rlAssertGrep "After first reboot" $log
+                rlAssertGrep "After second reboot" $log
+                rlAssertGrep "After third reboot" $log
+            fi
+        rlPhaseEnd
+    done
 
     rlPhaseStartCleanup
         rlRun "rm -rf output $run" 0 "Remove run directory"

--- a/tests/execute/reboot/main.fmf
+++ b/tests/execute/reboot/main.fmf
@@ -1,3 +1,5 @@
+duration: 10m
+
 /basic:
     summary: Verify that reboot during test works
     test: ./basic.sh
@@ -11,7 +13,6 @@
 /reuse_provision:
     summary: Verify that provision can be reused for reboot
     test: ./reuse.sh
-    duration: 10m
     enabled: false
 
     adjust:

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1,7 +1,5 @@
 import os
 import re
-import secrets
-import string
 import time
 
 import click
@@ -17,12 +15,6 @@ DEFAULT_FRAMEWORK = 'shell'
 
 # The main test output filename
 TEST_OUTPUT_FILENAME = 'output.txt'
-
-# Length of the token used for identifying reboot request
-REBOOT_TOKEN_LEN = 32
-
-# Key under which the token is stored in step.yaml
-REBOOT_TOKEN_KEY = 'reboot_token'
 
 
 class Execute(tmt.steps.Step):
@@ -47,10 +39,6 @@ class Execute(tmt.steps.Step):
         # List of Result() objects representing test results
         self._results = []
 
-        token_alphabet = string.ascii_letters + string.digits
-        self.reboot_token = ''.join(secrets.choice(token_alphabet)
-                                    for _ in range(REBOOT_TOKEN_LEN))
-
         # Default test framework and mapping old methods
         # FIXME remove when we drop the old execution methods
         self._framework = DEFAULT_FRAMEWORK
@@ -61,7 +49,6 @@ class Execute(tmt.steps.Step):
     def load(self, extra_keys=None):
         """ Load test results """
         extra_keys = extra_keys or []
-        extra_keys.append(REBOOT_TOKEN_KEY)
         super().load(extra_keys)
         try:
             results = tmt.utils.yaml_to_dict(self.read('results.yaml'))
@@ -73,7 +60,6 @@ class Execute(tmt.steps.Step):
     def save(self, data=None):
         """ Save test results to the workdir """
         data = data or {}
-        data.update({REBOOT_TOKEN_KEY: self.reboot_token})
         super().save(data)
         results = dict([
             (result.name, result.export()) for result in self.results()])

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -18,6 +18,9 @@ import tmt.utils
 CONNECTION_TIMEOUT = 60 * 4
 # Wait time when reboot happens in seconds
 SSH_INITIAL_WAIT_TIME = 5
+# Default rsync options
+DEFAULT_RSYNC_OPTIONS = [
+    "-R", "-r", "-z", "--links", "--safe-links", "--delete"]
 
 
 class Provision(tmt.steps.Step):
@@ -533,7 +536,7 @@ class Guest(tmt.utils.Common):
         """
         # Prepare options and the push command
         if options is None:
-            options = "-Rrz --links --safe-links --delete".split()
+            options = DEFAULT_RSYNC_OPTIONS
         if destination is None:
             destination = "/"
         if source is None:


### PR DESCRIPTION
- Reboot is now correctly supported even in `--interactive` mode (this is achieved by a change of mechanism, a new file is created rather than relying on stdout). (Fixes: #915 )
- Reboot should be faster to setup due to the reduction of the number of `guest.execute()` calls, these are replaced by a setup and teardown script which are pushed to the guest and only these scripts are executed. ( Fixes: #926 )

Since the mechanism has changed, it would be helpful if we reached out to some of the users of this feature so that they could try it out and avoid breaking stuff. Our test coverage is definitely far from perfect...