### PR TITLE
Add --exclude search option

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -159,6 +159,13 @@ condition or link expression::
     $ tmt tests ls --link verifies:issues/423$
     /tests/prepare/shell
 
+    $ tmt tests ls unit
+    /tests/report/junit
+    /tests/unit
+
+    $ tmt tests ls unit --exclude junit
+    /tests/unit
+
 In order to select tests under the current working directory use
 the single dot notation::
 

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -101,6 +101,8 @@ description: |
         filter
             Apply advanced filter based on test metadata
             attributes. See ``pydoc fmf.filter`` for more info.
+        exclude
+            Exclude tests which match a regular expression.
 
         It is also possible to limit tests only to those that have
         changed in git since a given revision. This can be

--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -28,6 +28,17 @@ rlJournalStart
         rlAssertNotGrep '/tests/discover3' output
     rlPhaseEnd
 
+    for exclude in '-x' '--exclude'; do
+        rlPhaseStartTest "Exclude tests using $exclude <regex>"
+            plan='plan --name fmf/nourl/noref/nopath'
+            discover='discover --how fmf'
+            rlRun 'tmt run -dvr $discover $plan | tee output'
+            rlAssertGrep '/tests/discover1' output
+            rlRun 'tmt run -dvr $discover --exclude discover1 $plan | tee output'
+            rlAssertNotGrep '/tests/discover1' output
+        rlPhaseEnd
+    done
+
     rlPhaseStartTest "Filter by link"
         plan='plans --default'
         for link_relation in "" "relates:" "rel.*:"; do

--- a/tests/plan/select/test.sh
+++ b/tests/plan/select/test.sh
@@ -44,6 +44,15 @@ rlJournalStart
         rlPhaseEnd
     done
 
+    for exclude in '-x' '--exclude'; do
+        rlPhaseStartTest "tmt plan ls $exclude <regex>"
+            rlRun "tmt plan ls | tee $output"
+            rlAssertGrep "/plans/features/core" $output
+            rlRun "tmt plan ls $exclude core | tee $output"
+            rlAssertNotGrep "/plans/features/core" $output
+        rlPhaseEnd
+    done
+
     rlPhaseStartCleanup
         rlRun "rm -r $tmp" 0 "Remove temporary run workdir"
         rlRun "rm $output" 0 "Remove output file"

--- a/tests/test/select/test.sh
+++ b/tests/test/select/test.sh
@@ -209,6 +209,15 @@ rlJournalStart
         rlRun "popd"
     rlPhaseEnd
 
+    for exclude in '-x' '--exclude'; do
+        rlPhaseStartTest "tmt test ls $exclude <regex>"
+            rlRun "tmt test ls | tee $output"
+            rlAssertGrep "/tests/enabled/default" $output
+            rlRun "tmt test ls $exclude default | tee $output"
+            rlAssertNotGrep "/tests/enabled/default" $output
+        rlPhaseEnd
+    done
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm $output" 0 "Remove output file"

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -89,6 +89,9 @@ def name_filter_condition(function):
             '--link', 'links', metavar="RELATION:TARGET", multiple=True,
             help="Filter by linked objects (regular expressions are "
                  "supported for both relation and target)."),
+        click.option(
+            '-x', '--exclude', 'exclude', metavar='[REGEXP]', multiple=True,
+            help="Exclude a regular expression from search result."),
         ]
 
     for option in reversed(options):
@@ -111,6 +114,9 @@ def name_filter_condition_long(function):
             '--link', 'links', metavar="RELATION:TARGET", multiple=True,
             help="Filter by linked objects (regular expressions are "
                  "supported for both relation and target)."),
+        click.option(
+            '--exclude', 'exclude', metavar='[REGEXP]', multiple=True,
+            help="Exclude a regular expression from search result."),
         ]
 
     for option in reversed(options):

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -80,7 +80,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
     _keys = [
         "url", "ref", "path", "test", "link", "filter",
         "modified-only", "modified-url", "modified-ref",
-        "dist-git-source", "dist-git-type", "fmf-id"]
+        "dist-git-source", "dist-git-type", "fmf-id", "exclude"]
 
     @classmethod
     def options(cls, how=None):
@@ -123,6 +123,9 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 '--dist-git-type',
                 type=click.Choice(tmt.utils.get_distgit_handler_names()),
                 help='Use the provided DistGit handler instead of detection.'),
+            click.option(
+                '-x', '--exclude', metavar='[REGEXP]', multiple=True,
+                help="Exclude a regular expression from search result."),
             click.option(
                 '--fmf-id', default=False, is_flag=True,
                 help='Show fmf identifiers for tests discovered in plan.')
@@ -279,6 +282,9 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         for link_ in links:
             self.info('link', link_, 'green')
 
+        excludes = list(tmt.base.Test._opt('exclude')
+                        or self.get('exclude', []))
+
         # Filter only modified tests if requested
         modified_only = self.get('modified-only')
         modified_url = self.get('modified-url')
@@ -312,7 +318,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             names=names,
             conditions=["manual is False"],
             unique=False,
-            links=links)
+            links=links,
+            excludes=excludes)
 
         # Prefix tests and handle library requires
         for test in self._tests:


### PR DESCRIPTION
This option behaves as if non-matching regular expression would be used, but in a more user friendly way. Also add the option to discover by fmf. Test coverage is included as well.

resolves #934 