### PR TITLE
Dist-git-source for Discover (fmf, shell)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -368,6 +368,10 @@ TMT_PLAN_DATA
     back from the guest and available for inspection after the
     plan is completed.
 
+TMT_SOURCE_DIR
+    Path to directory with downloaded and extracted sources if
+    dist-git-source option was used in discover.
+
 TMT_REBOOT_COUNT
     During the test execution the ``tmt-reboot`` command can be
     used to request reboot of the guest. This variable contains

--- a/README.rst
+++ b/README.rst
@@ -370,7 +370,8 @@ TMT_PLAN_DATA
 
 TMT_SOURCE_DIR
     Path to directory with downloaded and extracted sources if
-    dist-git-source option was used in discover.
+    the ``dist-git-source`` option was used in the ``discover``
+    step.
 
 TMT_REBOOT_COUNT
     During the test execution the ``tmt-reboot`` command can be

--- a/tests/discover/data/distgit_test_plugin.py
+++ b/tests/discover/data/distgit_test_plugin.py
@@ -1,0 +1,29 @@
+import os
+
+from tmt.utils import DistGitHandler
+
+MOCK_SOURCES_FILENAME = 'mock_sources'
+SERVER_PORT = 9000
+
+
+class TestDistGit(DistGitHandler):
+    """
+    Test handler
+
+    each line in MOCK_SOURCES_FILENAME contains
+    filename to serve and optional (after single space a custom filename)
+    """
+    usage_name = "TESTING"
+    server = f"http://localhost:{SERVER_PORT}"
+
+    def url_and_name(self, cwd='.'):
+        with open(os.path.join(cwd, MOCK_SOURCES_FILENAME)) as f:
+            data = f.read()
+        for line in data.splitlines():
+            split = line.split(' ', maxsplit=2)
+            url = split[0]
+            try:
+                src_name = split[1]
+            except IndexError:
+                src_name = url
+            yield (os.path.join(self.server, url), src_name)

--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -81,6 +81,7 @@ execute:
         discover:
             how: fmf
             dist-git-source: true
+            dist-git-init: true
             test: tests/prepare/install$
     /exclude:
         discover:

--- a/tests/discover/distgit.sh
+++ b/tests/discover/distgit.sh
@@ -2,19 +2,316 @@
 
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
+
+SERVER_PORT="9000"
+MOCK_SOURCES_FILENAME='mock_sources'
+
 rlJournalStart
     rlPhaseStartSetup
         rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
         rlRun 'set -o pipefail'
         rlRun "git clone https://src.fedoraproject.org/rpms/tmt.git $tmp/tmt"
-        rlRun "cp data/plans.fmf $tmp/tmt/plans"
+        export CLONED_TMT=$tmp/tmt
+        rlRun "cp data/plans.fmf $CLONED_TMT/plans"
+        # Append existing TMT_PLUGINS content
+        rlRun "export TMT_PLUGINS=$(pwd)/data${TMT_PLUGINS:+:$TMT_PLUGINS}"
         rlRun 'pushd $tmp'
+
+        # server runs in $tmp
+        rlRun "python3 -m http.server $SERVER_PORT &> server.out &"
+        SERVER_PID="$!"
+        rlRun "rlWaitForSocket $SERVER_PORT -t 5 -d 1"
+        export SERVER_DIR="$(pwd)"
+
+        # prepare cwd for mock distgit tests
+        rlRun "mkdir $tmp/mock_distgit"
+        export MOCK_DISTGIT_DIR=$tmp/mock_distgit
+        rlRun "pushd $MOCK_DISTGIT_DIR"
+        rlRun "git init" # should be git
+        rlRun "tmt init" # should has fmf tree
+
+        # Contains one test
+        echo 'test: echo' > top_test.fmf
+
+        # prepare simple-1
+        (
+            rlRun "mkdir -p $tmp/simple-1/tests"
+            (
+                rlRun "cd $tmp/simple-1"
+                rlRun "tmt init"
+            )
+            echo 'test: echo' > "$tmp/simple-1/tests/magic.fmf"
+            touch $tmp/outsider
+            rlRun "tar czvf $tmp/simple-1.tgz --directory $tmp simple-1 outsider"
+            rlRun "rm -rf $tmp/simple-1 outsider"
+        )
+
+        # prepare unit-no-tmt (e.g. pytest files inside tarball)
+        (
+            rlRun "mkdir -p $tmp/foo-123"
+            echo -e '#!/bin/sh\necho WORKS'> $tmp/foo-123/all_in_one
+            chmod a+x $tmp/foo-123/all_in_one
+
+            rlRun "tar czvf $tmp/unit-no-tmt.tgz --directory $tmp foo-123"
+            rlRun "rm -rf $tmp/foo-123"
+        )
+
+        rlRun "popd"
+    rlPhaseEnd
+
+
+    ### discover -h fmf ###
+
+for value in explicit auto; do
+    rlPhaseStartTest "extract sources to find unit tests (merge $value)"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun 'pushd $tmp'
+
+        rlRun "git init && tmt init" # should be git with fmf tree
+
+        # own "sources" for testing
+        echo "unit-no-tmt.tgz" > $MOCK_SOURCES_FILENAME
+
+# This can't be supported (mixing tests defined in discover and execute)
+#         cat <<EOF > plans.fmf
+# discover:
+#     how: fmf
+#     dist-git-source: true
+#     dist-git-type: TESTING
+# provision:
+#     how: local
+# execute:
+#     how: tmt
+#     script: foo-123/all_in_one
+# EOF
+
+        cat <<EOF > plans.fmf
+discover:
+    how: fmf
+    dist-git-source: true
+    dist-git-type: TESTING
+    dist-git-merge: true
+provision:
+    how: local
+execute:
+    how: tmt
+EOF
+
+    if [[ "$value" == "auto" ]]; then
+        rlRun "sed '/dist-git-merge:/d' -i plans.fmf"
+    fi
+        echo 'test: foo-123/all_in_one' > unit.fmf
+
+        WORKDIR=/var/tmp/tmt/XXX
+        WORKDIR_TESTS=$WORKDIR/plans/discover/default/tests
+
+        rlRun -s "tmt run -vv --id $WORKDIR --scratch"
+
+        rlAssertGrep "/unit" $rlRun_LOG -F
+        rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
+
+        rlAssertExists $WORKDIR_TESTS/foo-123/all_in_one
+
+        rlRun "popd"
+        rlRun "rm $rlRun_LOG"
+        rlRun "rm -rf $tmp"
+    rlPhaseEnd
+done
+
+    rlPhaseStartTest "More source files (fmf root in one of them)"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun 'pushd $tmp'
+
+        rlRun "git init" # should be git
+        rlRun "tmt init" # should has fmf tree
+
+        (
+            echo simple-1.tgz
+            echo unit-no-tmt.tgz
+        ) > $MOCK_SOURCES_FILENAME
+
+        WORKDIR=/var/tmp/tmt/XXX
+        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default/source
+        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default/tests
+
+        rlRun -s "tmt run --id $WORKDIR --scratch plans --default \
+             discover -vvv -ddd --how fmf --dist-git-source \
+             --dist-git-type TESTING tests --name /tests/magic"
+        rlAssertGrep "\s/tests/magic" $rlRun_LOG -E
+        rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
+
+        # Source dir has everything available
+        rlAssertExists $WORKDIR_SOURCE/simple-1/tests/magic.fmf
+        rlAssertExists $WORKDIR_SOURCE/simple-1.tgz
+        rlAssertExists $WORKDIR_SOURCE/foo-123/all_in_one
+        rlAssertExists $WORKDIR_SOURCE/unit-no-tmt.tgz
+        rlAssertExists $WORKDIR_SOURCE/outsider
+
+        # Test dir has only fmf_root from source (so one lest level)
+        rlAssertExists $WORKDIR_TESTS/tests/magic.fmf
+        rlAssertNotExists $WORKDIR_TESTS/simple-1/tests/magic.fmf
+        rlAssertNotExists $WORKDIR_TESTS/simple-1.tgz
+        rlAssertNotExists $WORKDIR_TESTS/foo-123/all_in_one
+        rlAssertNotExists $WORKDIR_TESTS/unit-no-tmt.tgz
+        rlAssertNotExists $WORKDIR_TESTS/outsider
+
+        rlRun "popd"
+        rlRun "rm $rlRun_LOG"
+        rlRun "rm -rf $tmp"
+    rlPhaseEnd
+
+
+
+    rlPhaseStartTest "signature files in sources are ignored"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun 'pushd $tmp'
+
+        rlRun "git init" # should be git
+        rlRun "tmt init" # should has fmf tree
+
+        # https://github.com/teemtee/tmt/issues/1055
+
+        (
+            echo simple-1.tgz
+            echo IGNORED file.tgz.asc
+            echo IGNORED file.key
+            echo IGNORED file.sign
+        ) > $MOCK_SOURCES_FILENAME
+        # only simple-1.tgz should be downloaded so all other would fail with
+        # File not found for url: http://localhost:9000/IGNORED
+
+        rlRun -s 'tmt run --id /var/tmp/tmt/XXX --scratch plans --default \
+             discover -vvv -ddd --how fmf --dist-git-source \
+             --dist-git-type TESTING tests --name /magic'
+        rlAssertGrep "/magic" $rlRun_LOG -F
+        rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
+
+        rlRun "popd"
+        rlRun "rm $rlRun_LOG"
+        rlRun "rm -rf $tmp"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Detect within extracted sources (inner fmf root is used)"
+        rlRun 'pushd $MOCK_DISTGIT_DIR'
+
+        echo "simple-1.tgz" > $MOCK_SOURCES_FILENAME
+
+        WORKDIR=/var/tmp/tmt/XXX
+        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default/source
+        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default/tests
+
+        rlRun -s 'tmt run --id $WORKDIR --scratch plans --default \
+             discover -vvv -ddd --how fmf --dist-git-source \
+             --dist-git-type TESTING'
+        rlAssertNotGrep "/top_test" $rlRun_LOG -F
+        rlAssertGrep "/magic" $rlRun_LOG -F
+        rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
+
+        # Source dir has everything available
+        rlAssertExists $WORKDIR_SOURCE/outsider
+        rlAssertExists $WORKDIR_SOURCE/simple-1
+        rlAssertExists $WORKDIR_SOURCE/simple-1.tgz
+
+        # Test dir has only fmf_root from source
+        rlAssertExists $WORKDIR_TESTS/tests/magic.fmf
+        rlAssertNotExists $WORKDIR_TESTS/outsider
+        rlAssertNotExists $WORKDIR_TESTS/simple-1
+        rlAssertNotExists $WORKDIR_TESTS/simple-1.tgz
+
+        rlRun 'popd'
+    rlPhaseEnd
+
+    rlPhaseStartTest "Detect within extracted sources and join with plan data (still respect fmf root)"
+        rlRun 'pushd $MOCK_DISTGIT_DIR'
+
+        echo "simple-1.tgz" > $MOCK_SOURCES_FILENAME
+
+        WORKDIR=/var/tmp/tmt/XXX
+        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default/source
+        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default/tests
+
+        rlRun -s 'tmt run --id $WORKDIR --scratch plans --default \
+            discover -v --how fmf --dist-git-source \
+            --dist-git-type TESTING --dist-git-merge'
+        rlAssertGrep "\s/top_test" $rlRun_LOG -E
+        rlAssertGrep "\s/tests/magic" $rlRun_LOG -E
+        rlAssertGrep "summary: 2 tests selected" $rlRun_LOG -F
+
+        # Source dir has everything available
+        rlAssertExists $WORKDIR_SOURCE/outsider
+        rlAssertExists $WORKDIR_SOURCE/simple-1
+        rlAssertExists $WORKDIR_SOURCE/simple-1.tgz
+
+        # Only fmf_root from source was merged
+        rlAssertExists $WORKDIR_TESTS/tests/magic.fmf
+        rlAssertNotExists $WORKDIR_TESTS/outsider
+        rlAssertNotExists $WORKDIR_TESTS/simple-1
+        rlAssertNotExists $WORKDIR_TESTS/simple-1.tgz
+        rlRun 'popd'
+    rlPhaseEnd
+
+    rlPhaseStartTest "Detect within extracted sources and join with plan data (override fmf root)"
+        rlRun 'pushd $MOCK_DISTGIT_DIR'
+
+        echo "simple-1.tgz renamed_simple.tgz" > $MOCK_SOURCES_FILENAME
+
+        WORKDIR=/var/tmp/tmt/XXX
+        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default/source
+        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default/tests
+
+        rlRun -s 'tmt run --id $WORKDIR --scratch plans --default \
+            discover -v --how fmf --dist-git-source \
+            --dist-git-type TESTING --dist-git-merge --dist-git-use-path /simple*/tests'
+        rlAssertGrep "\s/top_test" $rlRun_LOG -E
+        rlAssertGrep "\s/magic" $rlRun_LOG -E
+        rlAssertGrep "summary: 2 tests selected" $rlRun_LOG -F
+
+        # Source dir has everything available
+        rlAssertExists $WORKDIR_SOURCE/outsider
+        rlAssertExists $WORKDIR_SOURCE/simple-1
+        rlAssertExists $WORKDIR_SOURCE/renamed_simple.tgz
+
+        # copy path set to /tests within sources, so simple-1 is not copied
+        rlAssertExists $WORKDIR_TESTS/magic.fmf
+        rlAssertNotExists $WORKDIR_TESTS/outsider
+        rlAssertNotExists $WORKDIR_TESTS/simple-1
+        rlAssertNotExists $WORKDIR_TESTS/renamed_simple.tgz
+        rlRun 'popd'
+    rlPhaseEnd
+
+    rlPhaseStartTest "Detect within extracted sources and join with plan data (strip fmf root)"
+        rlRun 'pushd $MOCK_DISTGIT_DIR'
+
+        echo "simple-1.tgz simple.tgz" > $MOCK_SOURCES_FILENAME
+
+        WORKDIR=/var/tmp/tmt/XXX
+        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default/source
+        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default/tests
+
+        rlRun -s 'tmt run --id $WORKDIR --scratch plans --default \
+            discover -v --how fmf --dist-git-source \
+            --dist-git-type TESTING --dist-git-merge --dist-git-strip-fmf-root'
+        rlAssertGrep "\s/top_test" $rlRun_LOG -E
+        rlAssertGrep "\s/simple-1/tests/magic" $rlRun_LOG -E
+        rlAssertGrep "summary: 2 tests selected" $rlRun_LOG -F
+
+        # Source dir has everything available
+        rlAssertExists $WORKDIR_SOURCE/outsider
+        rlAssertExists $WORKDIR_SOURCE/simple-1
+        rlAssertExists $WORKDIR_SOURCE/simple.tgz
+
+        # fmf root stripped and dist-git-use-path not set so everything is copied
+        rlAssertExists $WORKDIR_TESTS/simple-1/tests/magic.fmf
+        rlAssertExists $WORKDIR_TESTS/outsider
+        rlAssertExists $WORKDIR_TESTS/simple-1
+        rlAssertExists $WORKDIR_TESTS/simple.tgz
+        rlRun 'popd'
     rlPhaseEnd
 
     rlPhaseStartTest "Run directly from the DistGit (Fedora) [cli]"
         rlRun 'pushd tmt'
         rlRun -s 'tmt run --remove plans --default \
-            discover -v --how fmf --dist-git-source \
+            discover -v --how fmf --dist-git-source --dist-git-init \
             tests --name tests/prepare/install$'
         rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
         rlAssertGrep "/tests/prepare/install" $rlRun_LOG -F
@@ -31,32 +328,128 @@ rlJournalStart
 
     rlPhaseStartTest "URL is path to a local distgit repo"
         rlRun -s 'tmt run --remove plans --default \
-            discover --how fmf --dist-git-source --dist-git-type fedora --url $tmp/tmt \
-            tests --name tests/prepare/install$'
+            discover --how fmf --dist-git-source --dist-git-type fedora --url $CLONED_TMT \
+            --dist-git-init --dist-git-merge tests --name tests/prepare/install$'
         rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
     rlPhaseEnd
 
-    # FIXME - use globbing once it is possible (--path tmt-*/tests/execute/framework/data)
     for prefix in "" "/"; do
         rlPhaseStartTest "${prefix}path pointing to the fmf root in the extracted sources"
             rlRun 'pushd tmt'
             rlRun -s "tmt run --remove plans --default discover -v --how fmf \
-            --dist-git-source --ref e2d36db --path ${prefix}tmt-1.7.0/tests/execute/framework/data \
+            --dist-git-source --dist-git-merge --ref e2d36db --dist-git-use-path ${prefix}tmt-*/tests/execute/framework/data \
             tests --name ^/tests/beakerlib/with-framework\$"
             rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
+
             rlRun 'popd'
         rlPhaseEnd
     done
 
     rlPhaseStartTest "Specify URL and REF of DistGit repo (Fedora)"
         rlRun -s 'tmt run --remove plans --default discover -v --how fmf \
-        --dist-git-source --ref e2d36db --url https://src.fedoraproject.org/rpms/tmt.git \
+        --dist-git-source --ref e2d36db --dist-git-merge  --dist-git-init \
+        --url https://src.fedoraproject.org/rpms/tmt.git \
         tests --name tests/prepare/install$'
         rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
         rlAssertGrep "/tmt-1.7.0/tests/prepare/install" $rlRun_LOG -F
     rlPhaseEnd
 
+    rlPhaseStartTest "fmf and git root don't match"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun 'pushd $tmp'
+
+        rlRun "git init" # should be git
+
+        (
+            echo simple-1.tgz
+            echo unit-no-tmt.tgz
+        ) > $MOCK_SOURCES_FILENAME
+
+        rlRun "mkdir fmf"
+        rlRun "pushd fmf"
+        rlRun "tmt init"
+
+        WORKDIR=/var/tmp/tmt/XXX
+        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default/source
+        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default/tests
+
+        rlRun -s "tmt run --id $WORKDIR --scratch plans --default \
+             discover -vvv -ddd --how fmf --dist-git-source \
+             --dist-git-type TESTING tests --name /tests/magic"
+        rlAssertGrep "\s/tests/magic" $rlRun_LOG -E
+        rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
+
+        # Source dir has everything available
+        rlAssertExists $WORKDIR_SOURCE/simple-1/tests/magic.fmf
+        rlAssertExists $WORKDIR_SOURCE/simple-1.tgz
+        rlAssertExists $WORKDIR_SOURCE/foo-123/all_in_one
+        rlAssertExists $WORKDIR_SOURCE/unit-no-tmt.tgz
+        rlAssertExists $WORKDIR_SOURCE/outsider
+
+        # Test dir has only fmf_root from source (so one lest level)
+        rlAssertExists $WORKDIR_TESTS/tests/magic.fmf
+        rlAssertNotExists $WORKDIR_TESTS/simple-1/tests/magic.fmf
+        rlAssertNotExists $WORKDIR_TESTS/simple-1.tgz
+        rlAssertNotExists $WORKDIR_TESTS/foo-123/all_in_one
+        rlAssertNotExists $WORKDIR_TESTS/unit-no-tmt.tgz
+        rlAssertNotExists $WORKDIR_TESTS/outsider
+
+        rlRun "popd"
+        rlRun "popd"
+        rlRun "rm $rlRun_LOG"
+        rlRun "rm -rf $tmp"
+    rlPhaseEnd
+
+    ### discover -h shell ###
+
+    rlPhaseStartTest "shell with merge (tmt for plan only)"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun 'pushd $tmp'
+
+        rlRun "git init"
+        echo unit-no-tmt.tgz > $MOCK_SOURCES_FILENAME
+
+        rlRun "tmt init"
+        cat <<EOF > plans.fmf
+discover:
+    how: shell
+    tests:
+    -   name: /file-exists
+        test: ls \$TMT_SOURCE_DIR/foo-123/all_in_one
+        environment:
+            FOO: bar
+    -   name: /env-is-kept
+        test: declare -p FOO && test \$FOO == bar
+        environment:
+            FOO: bar
+    -   name: /run-it
+        test: cd \$TMT_SOURCE_DIR/foo* && sh all_in_one
+    dist-git-source: true
+    dist-git-type: TESTING
+provision:
+    how: local
+execute:
+    how: tmt
+EOF
+
+        WORKDIR=/var/tmp/tmt/XXX
+        WORKDIR_SOURCE=$WORKDIR/plans/discover/default/source
+
+        rlRun -s "tmt run --id $WORKDIR --scratch -vvv"
+
+        # Source dir has everything available
+        rlAssertExists $WORKDIR_SOURCE/foo-123/all_in_one
+        rlAssertExists $WORKDIR_SOURCE/unit-no-tmt.tgz
+
+        rlRun "popd"
+        rlRun "rm $rlRun_LOG"
+        rlRun "rm -rf $tmp"
+    rlPhaseEnd
+
+
     rlPhaseStartCleanup
+        echo $SERVER_PID
+        kill -9 $SERVER_PID
         rlRun 'popd'
     rlPhaseEnd
 rlJournalEnd

--- a/tests/discover/distgit.sh
+++ b/tests/discover/distgit.sh
@@ -261,7 +261,7 @@ done
 
         rlRun -s 'tmt run --id $WORKDIR --scratch plans --default \
             discover -v --how fmf --dist-git-source \
-            --dist-git-type TESTING --dist-git-merge --dist-git-use-path /simple*/tests'
+            --dist-git-type TESTING --dist-git-merge --dist-git-extract /simple*/tests'
         rlAssertGrep "\s/top_test" $rlRun_LOG -E
         rlAssertGrep "\s/magic" $rlRun_LOG -E
         rlAssertGrep "summary: 2 tests selected" $rlRun_LOG -F
@@ -290,7 +290,7 @@ done
 
         rlRun -s 'tmt run --id $WORKDIR --scratch plans --default \
             discover -v --how fmf --dist-git-source \
-            --dist-git-type TESTING --dist-git-merge --dist-git-strip-fmf-root'
+            --dist-git-type TESTING --dist-git-merge --dist-git-remove-fmf-root'
         rlAssertGrep "\s/top_test" $rlRun_LOG -E
         rlAssertGrep "\s/simple-1/tests/magic" $rlRun_LOG -E
         rlAssertGrep "summary: 2 tests selected" $rlRun_LOG -F
@@ -300,7 +300,7 @@ done
         rlAssertExists $WORKDIR_SOURCE/simple-1
         rlAssertExists $WORKDIR_SOURCE/simple.tgz
 
-        # fmf root stripped and dist-git-use-path not set so everything is copied
+        # fmf root stripped and dist-git-extract not set so everything is copied
         rlAssertExists $WORKDIR_TESTS/simple-1/tests/magic.fmf
         rlAssertExists $WORKDIR_TESTS/outsider
         rlAssertExists $WORKDIR_TESTS/simple-1
@@ -337,7 +337,7 @@ done
         rlPhaseStartTest "${prefix}path pointing to the fmf root in the extracted sources"
             rlRun 'pushd tmt'
             rlRun -s "tmt run --remove plans --default discover -v --how fmf \
-            --dist-git-source --dist-git-merge --ref e2d36db --dist-git-use-path ${prefix}tmt-*/tests/execute/framework/data \
+            --dist-git-source --dist-git-merge --ref e2d36db --dist-git-extract ${prefix}tmt-*/tests/execute/framework/data \
             tests --name ^/tests/beakerlib/with-framework\$"
             rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
 

--- a/tests/discover/distgit.sh
+++ b/tests/discover/distgit.sh
@@ -147,7 +147,7 @@ done
         rlAssertExists $WORKDIR_SOURCE/unit-no-tmt.tgz
         rlAssertExists $WORKDIR_SOURCE/outsider
 
-        # Test dir has only fmf_root from source (so one lest level)
+        # Test dir has only fmf_root from source (so one less level)
         rlAssertExists $WORKDIR_TESTS/tests/magic.fmf
         rlAssertNotExists $WORKDIR_TESTS/simple-1/tests/magic.fmf
         rlAssertNotExists $WORKDIR_TESTS/simple-1.tgz
@@ -386,7 +386,7 @@ done
         rlAssertExists $WORKDIR_SOURCE/unit-no-tmt.tgz
         rlAssertExists $WORKDIR_SOURCE/outsider
 
-        # Test dir has only fmf_root from source (so one lest level)
+        # Test dir has only fmf_root from source (so one less level)
         rlAssertExists $WORKDIR_TESTS/tests/magic.fmf
         rlAssertNotExists $WORKDIR_TESTS/simple-1/tests/magic.fmf
         rlAssertNotExists $WORKDIR_TESTS/simple-1.tgz

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -196,6 +196,12 @@ class DiscoverPlugin(tmt.steps.Plugin):
     # List of all supported methods aggregated from all plugins
     _supported_methods = []
 
+    # Common keys for all discover step implementations
+    _common_keys = [
+        "dist-git-source",
+        "dist-git-type",
+        ]
+
     @classmethod
     def base_command(cls, method_class=None, usage=None):
         """ Create base click command (common for all discover plugins) """
@@ -222,6 +228,21 @@ class DiscoverPlugin(tmt.steps.Plugin):
             Discover._save_context(context)
 
         return discover
+
+    @classmethod
+    def options(cls, how=None):
+        """ Prepare command line options for given method """
+        return [
+            click.option(
+                '--dist-git-source',
+                is_flag=True,
+                help='Extract DistGit sources'),
+            click.option(
+                '--dist-git-type',
+                type=click.Choice(
+                    tmt.utils.get_distgit_handler_names()),
+                help='Use the provided DistGit handler instead of the auto detection.'),
+            ] + super().options(how)
 
     def tests(self):
         """

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -236,12 +236,12 @@ class DiscoverPlugin(tmt.steps.Plugin):
             click.option(
                 '--dist-git-source',
                 is_flag=True,
-                help='Extract DistGit sources'),
+                help='Extract DistGit sources.'),
             click.option(
                 '--dist-git-type',
-                type=click.Choice(
-                    tmt.utils.get_distgit_handler_names()),
-                help='Use the provided DistGit handler instead of the auto detection.'),
+                type=click.Choice(tmt.utils.get_distgit_handler_names()),
+                help='Use the provided DistGit handler '
+                     'instead of the auto detection.'),
             ] + super().options(how)
 
     def tests(self):

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import re
 import shutil
@@ -9,7 +10,6 @@ import fmf
 import tmt
 import tmt.beakerlib
 import tmt.steps.discover
-from tmt.utils import MetadataError
 
 
 class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
@@ -36,13 +36,20 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
 
     For DistGit repo one can extract source tarball first and discover
     tests from it by using 'distgit-source: true'. It can be used
-    together with 'ref', 'path' and 'url'.
+    together with 'ref', 'path' and 'url', However 'ref' is not possible
+    without using 'url'.
 
         discover:
             how: fmf
             dist-git-source: true
 
-    Selecting tests containting specified link is possible using 'link'
+    Related config options (all optional):
+    * dist-git-merge - set to True if you want to copy in extracted sources to the local repo
+    * dist-git-init - set to True and 'fmf init' will be called inside extracted sources (at dist-git-copy-path or top directory)
+    * dist-git-copy-path - directory (glob supported) to copy from extracted sources (defaults to inner fmf-root)
+    * dist-git-strip-fmf-root - set to True to remove fmf root from extracted sources
+
+    Selecting tests containing specified link is possible using 'link'
     option accepting RELATION:TARGET format of values. Regular
     expressions are supported for both relation and target part of the
     value. Relation can be omitted to target match any relation.
@@ -80,7 +87,10 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
     _keys = [
         "url", "ref", "path", "test", "link", "filter",
         "modified-only", "modified-url", "modified-ref",
-        "dist-git-source", "dist-git-type", "fmf-id", "exclude"]
+        "dist-git-source", "dist-git-type",
+        "dist-git-init", "dist-git-strip-fmf-root", "dist-git-merge",
+        "dist-git-use-path",
+        "fmf-id", "exclude"]
 
     REF_OPTION = click.option(
         '-r', '--ref', metavar='REVISION',
@@ -146,6 +156,19 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 '--sync-repo', default=False, is_flag=True,
                 help='Force the sync of the whole git repo. By default, the '
                      'repo is copied only if the used options require it.'),
+            click.option(
+                '--dist-git-init', is_flag=True,
+                help='Initialize fmf root inside extracted sources (at dist-git-copy-path or top directory)'),
+            click.option(
+                '--dist-git-strip-fmf-root', is_flag=True,
+                help='Remove fmf root from extracted source (top one or selected by copy-path, happens before dist-git-copy-path'),
+            click.option(
+                '--dist-git-merge', is_flag=True,
+                help='Merge copied sources and plan fmf root'),
+            click.option(
+                '--dist-git-use-path',
+                help=f'What to copy from extracted sources, globbing is supported. Defaults to the top fmf root if it is present, otherwise top directory (shortcut "/")'
+                ),
             ] + super().options(how)
 
     def wake(self, keys=None):
@@ -177,8 +200,24 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         url = self.get('url')
         path = self.get('path')
         # Save the test directory so that others can reference it
-        self.testdir = os.path.join(self.workdir, 'tests')
+        ref = self.get('ref')
+        self.testdir = testdir = os.path.join(self.workdir, 'tests')
+        sourcedir = os.path.join(self.workdir, 'source')
         dist_git_source = self.get('dist-git-source', False)
+        dist_git_merge = self.get('dist-git-merge', False)
+        dist_git_init = self.get('dist-git-init', False)
+        dist_git_use_path = self.get('dist-git-use-path', None)
+        dist_git_strip_fmf_root = self.get('dist-git-strip-fmf-root', False)
+
+        # Self checks
+        if dist_git_source and not dist_git_merge and (ref or url):
+            raise tmt.utils.DiscoverError(
+                "Cannot manipulate with dist-git without --dist-git-merge option")
+
+        def get_git_root(dir):
+            return self.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                cwd=dir, dry=True)[0].strip('\n')
 
         # Raise an exception if --fmf-id uses w/o url and git root
         # doesn't exist for discovered plan
@@ -225,6 +264,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             self.run(
                 ['git', 'clone', url, self.testdir],
                 env={"GIT_ASKPASS": "echo"})
+            git_root = testdir
         # Copy git repository root to workdir
         else:
             fmf_root = path or self.step.plan.my_run.tree.root
@@ -236,17 +276,18 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 raise tmt.utils.DiscoverError(
                     f"Provided path '{path}' is not a directory.")
             if dist_git_source:
-                git_root = self.step.plan.my_run.tree.root
+                try:
+                    git_root = get_git_root(self.step.plan.my_run.tree.root)
+                except tmt.utils.RunError:
+                    raise tmt.utils.DiscoverError(
+                        f"{self.step.plan.my_run.tree.root} is not a git repo")
             else:
                 if fmf_root is None:
                     raise tmt.utils.DiscoverError(
                         f"No metadata found in the current directory.")
                 # Check git repository root (use fmf root if not found)
                 try:
-                    output = self.run(
-                        ["git", "rev-parse", "--show-toplevel"],
-                        cwd=fmf_root, dry=True)
-                    git_root = output[0].strip('\n')
+                    git_root = get_git_root(fmf_root)
                 except tmt.utils.RunError:
                     self.debug(f"Git root not found, using '{fmf_root}.'")
                     git_root = fmf_root
@@ -256,11 +297,11 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             directory = git_root if requires_git else fmf_root
             self.info('directory', directory, 'green')
             self.debug(f"Copy '{directory}' to '{self.testdir}'.")
-            if not self.opt('dry'):
-                shutil.copytree(directory, self.testdir, symlinks=True)
+            if not dist_git_source or dist_git_merge:
+                if not self.opt('dry'):
+                    shutil.copytree(directory, self.testdir, symlinks=True)
 
         # Checkout revision if requested
-        ref = self.get('ref')
         if ref:
             self.info('ref', ref, 'green')
             self.debug(f"Checkout ref '{ref}'.")
@@ -269,21 +310,72 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 cwd=self.testdir)
 
         # Show current commit hash if inside a git repository
-        try:
-            hash_, _ = self.run(["git", "rev-parse", "--short", "HEAD"],
-                                cwd=self.testdir)
-            self.verbose('hash', hash_.strip(), 'green')
-        except (tmt.utils.RunError, AttributeError):
-            pass
+        if os.path.isdir(self.testdir):
+            try:
+                hash_, _ = self.run(["git", "rev-parse", "--short", "HEAD"],
+                                    cwd=self.testdir)
+                self.verbose('hash', hash_.strip(), 'green')
+            except (tmt.utils.RunError, AttributeError):
+                pass
 
         # Fetch and extract distgit sources
         if dist_git_source:
             try:
                 self.extract_distgit_source(
-                    self.testdir, self.testdir, self.get('dist-git-type'))
+                    git_root, sourcedir, self.get('dist-git-type'))
             except Exception as error:
                 raise tmt.utils.DiscoverError(
                     f"Failed to process 'dist-git-source'.", original=error)
+
+            if dist_git_use_path:
+                if dist_git_use_path == '/':
+                    dist_git_use_path = sourcedir
+                else:
+                    try:
+                        dist_git_use_path = glob.glob(os.path.join(
+                            sourcedir, dist_git_use_path.lstrip('/')))[0]
+                    except IndexError:
+                        raise tmt.utils.DiscoverError(
+                            f"Couldn't glob {dist_git_use_path} within extracted sources")
+
+            if not dist_git_init and not dist_git_use_path:
+                try:
+                    top_fmf_root = tmt.utils.find_fmf_root(sourcedir)[0]
+                except tmt.utils.MetadataError:
+                    dist_git_use_path = sourcedir
+                    if not dist_git_merge:
+                        self.warn(
+                            "Extracted sources doesn't contain fmf root, merging with plan data."
+                            " Avoid this warning by explicit use of '--dist-git-merge' option")
+                        self.debug(f"Copy '{git_root}' to '{testdir}'.")
+                        if not self.opt('dry'):
+                            shutil.copytree(git_root, testdir, symlinks=True)
+
+            if dist_git_init:
+                if not dist_git_use_path:
+                    dist_git_use_path = sourcedir
+                if not self.opt('dry'):
+                    fmf.Tree.init(dist_git_use_path)
+            elif dist_git_strip_fmf_root:
+                if not self.opt('dry'):
+                    shutil.rmtree(
+                        os.path.join(
+                            dist_git_use_path or top_fmf_root,
+                            '.fmf'))
+                if not dist_git_use_path:
+                    dist_git_use_path = sourcedir
+
+            # now can safely default to top_fmf_root
+            if not dist_git_use_path:
+                dist_git_use_path = top_fmf_root
+
+            # now copy dist_git_use_path into tests
+            if not self.opt('dry'):
+                shutil.copytree(
+                    dist_git_use_path,
+                    testdir,
+                    symlinks=True,
+                    dirs_exist_ok=True)
 
         # Adjust path and optionally show
         if path is None or path == '.':
@@ -359,6 +451,11 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             if test.require or test.recommend:
                 test.require, test.recommend, _ = tmt.beakerlib.dependencies(
                     test.require, test.recommend, parent=self)
+
+        # Add TMT_SOURCE_DIR variable for each test
+        if dist_git_source:
+            for test in self._tests:
+                test.environment['TMT_SOURCE_DIR'] = sourcedir
 
     def tests(self):
         """ Return all discovered tests """

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -389,7 +389,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
 
             # Now copy dist_git_extract into tests
             if not self.opt('dry'):
-                shutil.copytree(
+                tmt.utils.copytree(
                     dist_git_extract,
                     self.testdir,
                     symlinks=True,

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -44,10 +44,14 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             dist-git-source: true
 
     Related config options (all optional):
-    * dist-git-merge - set to True if you want to copy in extracted sources to the local repo
-    * dist-git-init - set to True and 'fmf init' will be called inside extracted sources (at dist-git-copy-path or top directory)
-    * dist-git-copy-path - directory (glob supported) to copy from extracted sources (defaults to inner fmf-root)
-    * dist-git-strip-fmf-root - set to True to remove fmf root from extracted sources
+    * dist-git-merge - set to True if you want to copy in extracted
+      sources to the local repo
+    * dist-git-init - set to True and 'fmf init' will be called inside
+      extracted sources (at dist-git-copy-path or top directory)
+    * dist-git-copy-path - directory (glob supported) to copy from
+      extracted sources (defaults to inner fmf-root)
+    * dist-git-strip-fmf-root - set to True to remove fmf root from
+      extracted sources
 
     Selecting tests containing specified link is possible using 'link'
     option accepting RELATION:TARGET format of values. Regular
@@ -141,13 +145,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 help="Filter by linked objects (regular expressions are "
                      "supported for both relation and target)."),
             cls.FILTER_OPTION,
-            click.option(
-                '--dist-git-source', is_flag=True,
-                help='Extract DistGit sources and run discover on top of it.'),
-            click.option(
-                '--dist-git-type',
-                type=click.Choice(tmt.utils.get_distgit_handler_names()),
-                help='Use the provided DistGit handler instead of detection.'),
             cls.EXCLUDE_OPTION,
             click.option(
                 '--fmf-id', default=False, is_flag=True,
@@ -157,17 +154,29 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 help='Force the sync of the whole git repo. By default, the '
                      'repo is copied only if the used options require it.'),
             click.option(
+                '--dist-git-source', is_flag=True,
+                help='Extract DistGit sources and run discover on top of it.'),
+            click.option(
+                '--dist-git-type',
+                type=click.Choice(tmt.utils.get_distgit_handler_names()),
+                help='Use the provided DistGit handler instead of detection.'),
+            click.option(
                 '--dist-git-init', is_flag=True,
-                help='Initialize fmf root inside extracted sources (at dist-git-copy-path or top directory)'),
+                help='Initialize fmf root inside extracted sources '
+                     '(at dist-git-copy-path or top directory).'),
             click.option(
                 '--dist-git-strip-fmf-root', is_flag=True,
-                help='Remove fmf root from extracted source (top one or selected by copy-path, happens before dist-git-copy-path'),
+                help='Remove fmf root from extracted source '
+                     '(top one or selected by copy-path, '
+                     'happens before dist-git-copy-path'),
             click.option(
                 '--dist-git-merge', is_flag=True,
-                help='Merge copied sources and plan fmf root'),
+                help='Merge copied sources and plan fmf root.'),
             click.option(
                 '--dist-git-use-path',
-                help=f'What to copy from extracted sources, globbing is supported. Defaults to the top fmf root if it is present, otherwise top directory (shortcut "/")'
+                help='What to copy from extracted sources, globbing is '
+                     'supported. Defaults to the top fmf root if it is '
+                     'present, otherwise top directory (shortcut "/").'
                 ),
             ] + super().options(how)
 

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -27,6 +27,18 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
         - name: /help/smoke
           test: ./smoke.sh
           path: /tests/shell
+
+
+    For DistGit repo one can extract source tarball and use its code.
+    It is extracted to TMT_SOURCE_DIR however no patches are applied
+    (only source tarball is extracted)
+
+    discover:
+        how: shell
+        dist-git-source: true
+        tests:
+        - name: /upstream
+          test: cd $TMT_SOURCE_DIR/*/tests && make test
     """
 
     # Supported methods
@@ -53,6 +65,10 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
         super(DiscoverShell, self).go()
         tests = fmf.Tree(dict(summary='tests'))
 
+        # dist-git related
+        sourcedir = os.path.join(self.workdir, 'source')
+        dist_git_source = self.get('dist-git-source', False)
+
         # Check and process each defined shell test
         for data in self.data['tests']:
             # Create data copy (we want to keep original data for save()
@@ -75,7 +91,10 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
             # Apply default test duration unless provided
             if 'duration' not in data:
                 data['duration'] = tmt.base.DEFAULT_TEST_DURATION_L2
-
+            # Add source dir path variable
+            if dist_git_source:
+                data.setdefault('environment', {})[
+                    'TMT_SOURCE_DIR'] = sourcedir
             # Create a simple fmf node, adjust its name
             tests.child(name, data)
 
@@ -83,6 +102,21 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
         testdir = os.path.join(self.workdir, "tests")
         relative_path = os.path.relpath(self.step.plan.worktree, self.workdir)
         os.symlink(relative_path, testdir)
+
+        if dist_git_source:
+            try:
+                git_root = self.run(
+                    ["git", "rev-parse", "--show-toplevel"],
+                    cwd=self.step.plan.my_run.tree.root, dry=True)[0].strip('\n')
+            except tmt.utils.RunError:
+                raise tmt.utils.DiscoverError(
+                    f"{self.step.plan.my_run.tree.root} is not a git repo")
+            try:
+                self.extract_distgit_source(
+                    git_root, sourcedir, self.get('dist-git-type'))
+            except Exception as error:
+                raise tmt.utils.DiscoverError(
+                    f"Failed to process 'dist-git-source'.", original=error)
 
         # Use a tmt.Tree to apply possible command line filters
         tests = tmt.Tree(tree=tests).tests(conditions=["manual is False"])

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -28,10 +28,9 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
           test: ./smoke.sh
           path: /tests/shell
 
-
     For DistGit repo one can extract source tarball and use its code.
     It is extracted to TMT_SOURCE_DIR however no patches are applied
-    (only source tarball is extracted)
+    (only source tarball is extracted).
 
     discover:
         how: shell
@@ -107,10 +106,12 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
             try:
                 git_root = self.run(
                     ["git", "rev-parse", "--show-toplevel"],
-                    cwd=self.step.plan.my_run.tree.root, dry=True)[0].strip('\n')
+                    cwd=self.step.plan.my_run.tree.root,
+                    dry=True)[0].strip('\n')
             except tmt.utils.RunError:
                 raise tmt.utils.DiscoverError(
-                    f"{self.step.plan.my_run.tree.root} is not a git repo")
+                    f"Directory '{self.step.plan.my_run.tree.root}' "
+                    f"is not a git repository.")
             try:
                 self.extract_distgit_source(
                     git_root, sourcedir, self.get('dist-git-type'))

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2102,3 +2102,23 @@ class updatable_message(contextlib.AbstractContextManager):  # type: ignore
 
         sys.stdout.write(f"\r{message}")
         sys.stdout.flush()
+
+
+def find_fmf_root(path: str) -> List[str]:
+    """
+    Search trough path and return all fmf roots that exist there
+
+    Returned list is ordered by path length, shorted one first.
+
+    Raise MetadataError if no fmf root is found
+    """
+    fmf_roots = []
+    for root, _, files in os.walk(path):
+        if not os.path.basename(root) == '.fmf':
+            continue
+        if 'version' in files:
+            fmf_roots.append(os.path.dirname(root))
+    if len(fmf_roots) == 0:
+        raise MetadataError(f"No fmf root present inside {path}")
+    fmf_roots.sort()
+    return fmf_roots

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -844,17 +844,16 @@ def listify(
 
 
 def copytree(
-    src: str,
-    dst: str,
-    symlinks: bool = False,
-    dirs_exist_ok: bool = False,
-) -> Any:
+        src: str,
+        dst: str,
+        symlinks: bool = False,
+        dirs_exist_ok: bool = False,
+        ) -> Any:
     """ Similar to shutil.copytree but with dirs_exist_ok for Python < 3.8 """
     # No need to reimplement for newer python or if argument is not requested
     if not dirs_exist_ok or sys.version_info >= (3, 8):
         return shutil.copytree(
-            src=src,
-            dst=dst, symlinks=symlinks, dirs_exist_ok=dirs_exist_ok)
+            src=src, dst=dst, symlinks=symlinks, dirs_exist_ok=dirs_exist_ok)
     # Choice was to either copy python implementation and change ONE line
     # or use rsync (or cp with shell)
     # We need to copy CONTENT of src into dst
@@ -869,17 +868,15 @@ def copytree(
         command.append('-l')
     command.extend([src, dst])
 
-    log.debug(f"Calling {command}")
+    log.debug(f"Calling command '{command}'.")
     outcome = subprocess.run(
         command,
         stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        universal_newlines=True,
-        )
+        stderr=subprocess.STDOUT, universal_newlines=True)
 
     if outcome.returncode != 0:
         raise shutil.Error(
-            [f"Unable to copy '{src}' into '{dst}' using rsync",
+            [f"Unable to copy '{src}' into '{dst}' using rsync.",
              outcome.returncode, outcome.stdout])
     return dst
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2108,9 +2108,9 @@ def find_fmf_root(path: str) -> List[str]:
     """
     Search trough path and return all fmf roots that exist there
 
-    Returned list is ordered by path length, shorted one first.
+    Returned list is ordered by path length, shortest one first.
 
-    Raise MetadataError if no fmf root is found
+    Raise `MetadataError` if no fmf root is found.
     """
     fmf_roots = []
     for root, _, files in os.walk(path):
@@ -2118,7 +2118,7 @@ def find_fmf_root(path: str) -> List[str]:
             continue
         if 'version' in files:
             fmf_roots.append(os.path.dirname(root))
-    if len(fmf_roots) == 0:
-        raise MetadataError(f"No fmf root present inside {path}")
-    fmf_roots.sort()
+    if not fmf_roots:
+        raise MetadataError(f"No fmf root present inside '{path}'.")
+    fmf_roots.sort(key=lambda path: len(path))
     return fmf_roots


### PR DESCRIPTION
Attempt on dist-git, so far still discover -h fmf only.
Needs more documentation and better names. Also please check if it captures reasonable usages.

Within sources fmf root from there is preferred (top fmf root is detected). However `--dist-git-copy-path` can be used to override that (needs better name, possible dist-git-fmf-root-path ?)

If source doesn't contain fmf root, `--dist-git-init` can be used to initialize that (at / or `--dist-git-copy-path`).
If wants to remove fmf root from the source `--dist-git-strip-fmf-root` (top fmf root or --dist-git-copy-path). This is handy with `--dist-git-merge` otherwise fmf root from sources makes inner objects disappear.

Also test-only plugin to inject tarball is used (so one can prepare sources as one needs)

What is not possible now is to used `ref`,`url` without `--dist-git-merge` - This would need to fetch url / checkout ref first (ideally copy it elsewhere first) and then detect source from there (so without merge tmt would need to remove such data or place it to temporary directory). 

Also copying files outside (above) fmf root from sources is not possible and imho it shouldn't be. See tests which asserts existence of `outsider` file - it has to strip fmf root and so copy whole sources. 

