### PR TITLE
Fix exclude option in fmf discover

### DIFF
--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -82,3 +82,7 @@ execute:
             how: fmf
             dist-git-source: true
             test: tests/prepare/install$
+    /exclude:
+        discover:
+            how: fmf
+            exclude: /tests/discover1

--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -39,6 +39,14 @@ rlJournalStart
         rlPhaseEnd
     done
 
+    rlPhaseStartTest "Exclude tests via exclude option within a plan metadata"
+        plan='plan --name fmf/exclude'
+        discover='discover --how fmf'
+        rlRun 'tmt run -dvr $discover $plan | tee output'
+        rlAssertNotGrep '/tests/discover1' output
+        rlAssertGrep '/tests/discover2' output
+    rlPhaseEnd
+
     rlPhaseStartTest "Filter by link"
         plan='plans --default'
         for link_relation in "" "relates:" "rel.*:"; do

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -139,8 +139,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         if 'revision' in self.data:
             self.data['ref'] = self.data.pop('revision')
 
-        # Make sure that 'filter' and 'test' keys are lists
-        tmt.utils.listify(self.data, keys=["filter", "test"])
+        # Make sure that 'exclude', 'filter' and 'test' keys are lists
+        tmt.utils.listify(self.data, keys=["exclude", "filter", "test"])
 
         # Process command line options, apply defaults
         super().wake(keys=keys)


### PR DESCRIPTION
Make sure exclude arguments in plans are converted into list to avoid iterating over each letter. Add test coverage for this feature.

Fixes #1130