### PR TITLE
Fix login during `execute` and `prepare` step

### DIFF
--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -21,11 +21,13 @@ rlJournalStart
         rlRun "grep '^    finish$' -A4 output | grep -i interactive"
     rlPhaseEnd
 
-    rlPhaseStartTest "Selected step"
-        rlRun "$tmt login -c true -s discover | tee output"
-        rlAssertGrep "interactive" "output"
-        rlRun "grep '^    discover$' -A4 output | grep -i interactive"
-    rlPhaseEnd
+    for step in discover provision prepare execute report finish; do
+        rlPhaseStartTest "Selected step ($step)"
+            rlRun "$tmt login -c true -s $step | tee output"
+            rlAssertGrep "interactive" "output"
+            rlRun "grep '^    $step$' -A4 output | grep -i interactive"
+        rlPhaseEnd
+    done
 
     rlPhaseStartTest "Failed command"
         rlRun "$tmt login -c false | tee output"

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -491,6 +491,10 @@ class Action(tmt.utils.Common):
                 phases[step_name] = [phase]
         return phases
 
+    def enabled_on_guest(self, guest):
+        """ Actions are enabled across all guests """
+        return True
+
 
 class Reboot(Action):
     """ Reboot guest """


### PR DESCRIPTION
The new support for `where` key in `execute` and `prepare` has
caused a regression when using `login` action with those steps.
Added `Action.enabled_on_guest()` method and extended the test
coverage to check all steps.