### PR TITLE
Disable network access when building in copr

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,6 +20,7 @@ jobs:
     - fedora-all
     - epel-8
     - epel-9
+    enable_net: False
 
 - job: copr_build
   trigger: commit
@@ -29,6 +30,7 @@ jobs:
     - fedora-all
     - epel-8
     - epel-9
+    enable_net: False
     list_on_homepage: True
     preserve_project: True
     owner: psss


### PR DESCRIPTION
Make the copr build environment as close to koji as possible to
prevent last-minute suprises just before the next release.