### PR TITLE
Prevent infinite recursion if --id is set

### DIFF
--- a/tests/run/recursion/main.fmf
+++ b/tests/run/recursion/main.fmf
@@ -1,0 +1,1 @@
+summary: Avoid recursion if workdir is under fmf tree

--- a/tests/run/recursion/test.sh
+++ b/tests/run/recursion/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "tmt init -t base"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun -s "tmt run --id $(pwd) --rm discover" 2 "Invalid run command"
+        rlAssertGrep "workdir must not be inside" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1661,6 +1661,9 @@ class Run(tmt.utils.Common):
         # Create the workdir and save last run
         self._save_tree(self._tree)
         self._workdir_load(self._workdir_path)
+        if self.tree.root and self._workdir.startswith(self.tree.root):
+            raise tmt.utils.GeneralError(
+                "Run workdir must not be inside fmf root.")
         self.config.last_run(self.workdir)
         # Show run id / workdir path
         self.info(self.workdir, color='magenta')


### PR DESCRIPTION
If a user specifies --id inside the fmf root, it will result in worktree
being copied over and over, eventually ending in RecursionError.
Ensure that run workdir is outside fmf root to prevent such errors.

Fixes: #1160 