### PR TITLE
Enables mypy coverage for empty-ish Python files

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,8 @@ install_types = True
 non_interactive = True
 
 files = tmt/steps/provision/artemis.py,
+        tmt/__init__.py,
+        tmt/__main__.py,
         tmt/templates.py,
         tmt/utils.py
 


### PR DESCRIPTION
These contain no interesting code, so let's protect them by mypy just in
case someone tries to add any new code into these files.