### PR TITLE
Adds normalization layer to base classes based on fmf

### DIFF
--- a/tests/test/lint/test.sh
+++ b/tests/test/lint/test.sh
@@ -29,7 +29,7 @@ rlJournalStart
     rlPhaseStartTest "Old yaml"
         if rlRun "tmt test lint old-yaml 2>&1 | tee output" 0,2; then
             # Before fmf-1.0 we give just a warning
-            rlAssertGrep 'warn seems to use YAML 1.1' output
+            rlAssertGrep "warn: /old-yaml:enabled - 'yes' is not of type 'boolean'" output
         else
             # Since fmf-1.0 old format is no more supported
             rlAssertGrep 'Invalid.*enabled.*in test' output

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -917,7 +917,7 @@ def write(path: str, data: NitrateDataType) -> None:
         'extra-summary', 'extra-task',
         'extra-hardware', 'extra-pepa']
     sorted_data = dict()
-    for key in tmt.base.Test._keys + extra_keys:
+    for key in tmt.base.Test._keys() + extra_keys:
         try:
             sorted_data[key] = data[key]
         except KeyError:

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -601,7 +601,7 @@ def export_to_nitrate(test: 'tmt.Test') -> None:
 
     # List of bugs test verifies
     verifies_bug_ids = []
-    for link in test.link:
+    for link in test.link.get():
         try:
             bug_id_search = re.search(RE_BUGZILLA_URL, link['verifies'])
             if not bug_id_search:

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -31,7 +31,7 @@ class Discover(tmt.steps.Step):
         super().load()
         try:
             tests = tmt.utils.yaml_to_dict(self.read('tests.yaml'))
-            self._tests = [tmt.Test(node=data, name=name, skip_validation=True)
+            self._tests = [tmt.Test.from_dict(data, name, skip_validation=True)
                            for name, data in tests.items()]
         except tmt.utils.FileError:
             self.debug('Discovered tests not found.', level=2)

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -309,7 +309,7 @@ class Common:
             workdir: WorkdirArgumentType = None,
             context: Optional[click.Context] = None,
             relative_indent: int = 1,
-            **kwargs: Any):
+            **kwargs: Any) -> None:
         """
         Initialize name and relation with the parent object
 


### PR DESCRIPTION
We already have a validation layer, using JSON schemas, this patch adds
a normalization layer that takes keys from fmf node and moves them to
`Test`, `Plan` or `Story` attributes. During this move, some keys are
normalized - for example, a key like `require` is allowed to be either a
string, fmf id, or a list of these two types. The normalization layer
converts the singular variant (string or fmf id) to a list to present
unambiguous data type within tmt's code.

Keys that are supposed to be loaded from an fmf node are defined as
class-level variables, and a mixin class takes care of setting them
during `__init__()` time. Optional `_normalize_*` callbacks can be
defined to take care of necessary conversions of particular keys.

Together with validation, this should give us a more powerful internal
data types while supporting more open input for users' comfort.