### PR TITLE
Fix chaining of tmt clean

### DIFF
--- a/tests/clean/chain/main.fmf
+++ b/tests/clean/chain/main.fmf
@@ -1,0 +1,10 @@
+summary: Checks that tmt clean command chaining works
+description: |
+    Chaining of subcommands under tmt clean requires special order
+    of operations to be forced to remove potential user error,
+    such as removing runs and then trying to clean guests (when
+    no runs are present and hence no information about guests is
+    available). Checks that this order is applied.
+
+    Also verifies that options from the top-level tmt clean command
+    are correctly propagated to the chained subcommands.

--- a/tests/clean/chain/test.sh
+++ b/tests/clean/chain/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "tmt init"
+        rlRun "tmt plan create -t mini plan"
+        rlRun -s "tmt run provision -h local"
+        rlRun "runid=\$(head -n 1 $rlRun_LOG)" 0 "Get the run ID"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verbosity and dryness is propagated"
+        rlRun -s "tmt clean -v --dry runs"
+        rlAssertGrep "Would remove workdir '$runid'" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Guest is cleaned before run"
+        rlRun -s "tmt clean --dry guests runs"
+        rlRun "sed -e '/guests/,/runs/!d' $rlRun_LOG > out"
+        rlAssertGrep "runs" "out"
+        rlAssertGrep "guests" "out"
+
+        rlRun -s "tmt clean -v --dry runs guests"
+        # If the order is incorrect, this won't include "runs"
+        rlRun "sed -e '/guests/,/runs/!d' $rlRun_LOG > out"
+        rlAssertGrep "runs" "out"
+        rlAssertGrep "guests" "out"
+
+        rlRun "rm out"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $runid" 0 "Remove initial run"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/clean/guests/test.sh
+++ b/tests/clean/guests/test.sh
@@ -55,8 +55,8 @@ rlJournalStart
         rlRun "tmprun=\$(mktemp -d)" 0 "Create a temporary directory for runs"
         rlRun "tmt run -i $tmprun/run1 --until provision provision -h local | tee run-output"
         rlRun "tmt run -i $tmprun/run2 --until provision provision -h local | tee run-output"
-        rlRun "tmt clean guests $tmprun"
-        rlRun "tmt status $tmprun -vv | tee output"
+        rlRun "tmt clean guests --workdir-root $tmprun"
+        rlRun "tmt status --workdir-root $tmprun -vv | tee output"
         rlAssertGrep "(done\s+){2}(todo\s+){3}done\s+$tmprun/run1" "output" -E
         rlAssertGrep "(done\s+){2}(todo\s+){3}done\s+$tmprun/run2" "output" -E
     rlPhaseEnd

--- a/tests/clean/runs/test.sh
+++ b/tests/clean/runs/test.sh
@@ -19,10 +19,10 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Dry mode"
-        rlRun "tmt clean runs --dry -v $tmprun | tee output"
+        rlRun "tmt clean runs --dry -v --workdir-root $tmprun | tee output"
         rlAssertGrep "Would remove workdir '$run1'" "output"
         rlAssertGrep "Would remove workdir '$run2'" "output"
-        rlRun "tmt status $tmprun -vv | tee output"
+        rlRun "tmt status --workdir-root $tmprun -vv | tee output"
         rlAssertGrep "(done\s+){1}(todo\s+){5}$run1\s+/plan1" "output" -E
         rlAssertGrep "(done\s+){1}(todo\s+){5}$run2\s+/plan1" "output" -E
     rlPhaseEnd
@@ -30,13 +30,13 @@ rlJournalStart
     rlPhaseStartTest "Specify ID"
         rlRun "tmt clean runs -v -i $run1 | tee output"
         rlAssertGrep "Removing workdir '$run1'" "output"
-        rlRun "tmt status $tmprun -vv | tee output"
+        rlRun "tmt status --workdir-root $tmprun -vv | tee output"
         rlAssertNotGrep "(done\s+){1}(todo\s+){5}$run1\s+/plan1" "output" -E
         rlAssertGrep "(done\s+){1}(todo\s+){5}$run2\s+/plan1" "output" -E
 
         rlRun "tmt clean runs -v -l | tee output"
         rlAssertGrep "Removing workdir '$run2'" "output"
-        rlRun "tmt status $tmprun -vv | tee output"
+        rlRun "tmt status --workdir-root $tmprun -vv | tee output"
         rlAssertNotGrep "(done\s+){1}(todo\s+){5}$run2\s+/plan1" "output" -E
 
         rlRun "wc -l output | tee lines" 0 "Get the number of lines"
@@ -48,15 +48,15 @@ rlJournalStart
         for i in $(seq 1 10); do
             rlRun "tmt run -i $tmprun/$i discover"
         done
-        rlRun "tmt clean runs -v --keep 10 $tmprun"
-        rlRun "tmt status $tmprun -vv | tee output"
+        rlRun "tmt clean runs -v --keep 10 --workdir-root $tmprun"
+        rlRun "tmt status --workdir-root $tmprun -vv | tee output"
         rlLog "The runs should remain intact"
         for i in $(seq 1 10); do
             rlAssertGrep "$tmprun/$i\s+/plan1" "output" -E
         done
 
-        rlRun "tmt clean runs -v --keep 2 $tmprun"
-        rlRun "tmt status $tmprun -vv | tee output"
+        rlRun "tmt clean runs -v --keep 2 --workdir-root $tmprun"
+        rlRun "tmt status --workdir-root $tmprun -vv | tee output"
         rlAssertGrep "$tmprun/9" "output"
         rlAssertGrep "$tmprun/10" "output"
 
@@ -64,13 +64,13 @@ rlJournalStart
             rlAssertNotGrep "$tmprun/$i\s+/plan1" "output" -E
         done
 
-        rlRun "tmt clean runs -v --keep 1 $tmprun"
-        rlRun "tmt status $tmprun -vv | tee output"
+        rlRun "tmt clean runs -v --keep 1 --workdir-root $tmprun"
+        rlRun "tmt status --workdir-root $tmprun -vv | tee output"
         rlAssertNotGrep "$tmprun/9" "output"
         rlAssertGrep "$tmprun/10" "output"
 
-        rlRun "tmt clean runs -v --keep 0 $tmprun"
-        rlRun "tmt status $tmprun -vv | tee output"
+        rlRun "tmt clean runs -v --keep 0 --workdir-root $tmprun"
+        rlRun "tmt status --workdir-root $tmprun -vv | tee output"
         rlAssertNotGrep "$tmprun/10" "output"
     rlPhaseEnd
 
@@ -78,8 +78,8 @@ rlJournalStart
         for i in $(seq 1 10); do
             rlRun "tmt run -i $tmprun/$i discover"
         done
-        rlRun "tmt clean runs -v $tmprun"
-        rlRun "tmt status -vv $tmprun | tee output"
+        rlRun "tmt clean runs -v --workdir-root $tmprun"
+        rlRun "tmt status -vv --workdir-root $tmprun | tee output"
         rlRun "wc -l output | tee lines" 0 "Get the number of lines"
         rlLog "The status should only contain the heading"
         rlAssertGrep "1" "lines"

--- a/tests/status/base/test.sh
+++ b/tests/status/base/test.sh
@@ -47,7 +47,7 @@ rlJournalStart
     rlPhaseStartTest "Different root"
         rlRun "tmprun=\$(mktemp -d)" 0 "Create a temporary directory for runs"
         rlRun "tmt run -a -i $tmprun/run provision -h local"
-        rlRun "tmt status $tmprun | tee output"
+        rlRun "tmt status --workdir-root $tmprun | tee output"
         rlRun "wc -l output | tee lines" 0 "Get the number of lines"
         rlLog "The status should only show one run and its heading"
         rlAssertGrep "2" "lines"

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2433,8 +2433,11 @@ class Clean(tmt.utils.Common):
     def images(self):
         """ Clean images of provision plugins """
         self.info('images', color='blue')
+        successful = True
         for method in tmt.steps.provision.ProvisionPlugin.methods():
-            method.class_.clean_images(self, self.opt('dry'))
+            if not method.class_.clean_images(self, self.opt('dry')):
+                successful = False
+        return successful
 
     def _matches_how(self, plan):
         """ Check if the given plan matches options """
@@ -2520,8 +2523,7 @@ class Clean(tmt.utils.Common):
             last_run = Run(context=self._context)
             last_run._workdir_load(last_run._workdir_path)
             return self._clean_workdir(last_run.workdir)
-        all_workdirs = [
-            path for path in tmt.utils.generate_runs(root_path, id_)]
+        all_workdirs = [path for path in tmt.utils.generate_runs(root_path, id_)]
         keep = self.opt('keep')
         if keep is not None:
             # Sort by modify time of the workdirs and keep the newest workdirs

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2410,9 +2410,9 @@ class Status(tmt.utils.Common):
         """ Display the current status """
         # Prepare absolute workdir path if --id was used
         id_ = self.opt('id')
-        path = self.opt('path')
+        root_path = self.opt('workdir-root')
         self.print_header()
-        for abs_path in tmt.utils.generate_runs(path, id_):
+        for abs_path in tmt.utils.generate_runs(root_path, id_):
             run = Run(abs_path, self._context.obj.tree, self._context)
             self.process_run(run)
 
@@ -2483,14 +2483,14 @@ class Clean(tmt.utils.Common):
     def guests(self):
         """ Clean guests of runs """
         self.info('guests', color='blue')
-        path = self.opt('path')
+        root_path = self.opt('workdir-root')
         id_ = self.opt('id_')
         if self.opt('last'):
             # Pass the context containing --last to Run to choose
             # the correct one.
             return self._stop_running_guests(Run(context=self._context))
         successful = True
-        for abs_path in tmt.utils.generate_runs(path, id_):
+        for abs_path in tmt.utils.generate_runs(root_path, id_):
             run = Run(abs_path, self._context.obj.tree, self._context)
             if not self._stop_running_guests(run):
                 successful = False
@@ -2512,7 +2512,7 @@ class Clean(tmt.utils.Common):
     def runs(self):
         """ Clean workdirs of runs """
         self.info('runs', color='blue')
-        path = self.opt('path')
+        root_path = self.opt('workdir-root')
         id_ = self.opt('id_')
         if self.opt('last'):
             # Pass the context containing --last to Run to choose
@@ -2520,7 +2520,8 @@ class Clean(tmt.utils.Common):
             last_run = Run(context=self._context)
             last_run._workdir_load(last_run._workdir_path)
             return self._clean_workdir(last_run.workdir)
-        all_workdirs = [path for path in tmt.utils.generate_runs(path, id_)]
+        all_workdirs = [
+            path for path in tmt.utils.generate_runs(root_path, id_)]
         keep = self.opt('keep')
         if keep is not None:
             # Sort by modify time of the workdirs and keep the newest workdirs

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -45,8 +45,8 @@ fix = click.option(
 
 workdir_root = click.option(
     '--workdir-root', metavar='PATH', default=tmt.utils.WORKDIR_ROOT,
-    help=f'Path to root directory containing run workdirs. '
-         f'Defaults to {tmt.utils.WORKDIR_ROOT}.')
+    help=f"Path to root directory containing run workdirs. "
+         f"Defaults to '{tmt.utils.WORKDIR_ROOT}'.")
 
 
 def show_step_method_hints(

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -43,6 +43,11 @@ fix = click.option(
     '-F', '--fix', is_flag=True,
     help='Attempt to fix all discovered issues.')
 
+workdir_root = click.option(
+    '--workdir-root', metavar='PATH', default=tmt.utils.WORKDIR_ROOT,
+    help=f'Path to root directory containing run workdirs. '
+         f'Defaults to {tmt.utils.WORKDIR_ROOT}.')
+
 
 def show_step_method_hints(
         log_object: tmt.utils.Common,

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -260,8 +260,9 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin):
         return Guest.requires()
 
     @classmethod
-    def clean_images(cls, clean: 'tmt.base.Clean', dry: bool) -> None:
+    def clean_images(cls, clean: 'tmt.base.Clean', dry: bool) -> bool:
         """ Remove the images of one particular plugin """
+        return True
 
 
 @dataclasses.dataclass

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -313,20 +313,26 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
         return self._guest
 
     @classmethod
-    def clean_images(cls, clean: Any, dry: Any) -> None:
+    def clean_images(cls, clean: Any, dry: Any) -> bool:
         """ Remove the testcloud images """
         clean.info('testcloud', shift=1, color='green')
         if not os.path.exists(TESTCLOUD_IMAGES):
             clean.warn(
                 f"Directory '{TESTCLOUD_IMAGES}' does not exist.", shift=2)
-            return
+            return True
+        successful = True
         for image in os.listdir(TESTCLOUD_IMAGES):
             image = os.path.join(TESTCLOUD_IMAGES, image)
             if dry:
                 clean.verbose(f"Would remove '{image}'.", shift=2)
             else:
                 clean.verbose(f"Removing '{image}'.", shift=2)
-                os.remove(image)
+                try:
+                    os.remove(image)
+                except OSError:
+                    clean.error(f"Failed to remove '{image}'.", shift=2)
+                    successful = False
+        return successful
 
 
 class GuestTestcloud(tmt.GuestSsh):

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -327,7 +327,7 @@ class Common:
 
         # Store command line context
         if context:
-            self._save_context(context)
+            self._save_context_to_instance(context)
 
         # Initialize the workdir if requested
         self._workdir_load(workdir)
@@ -341,6 +341,11 @@ class Common:
         """ Save provided command line context and options for future use """
         cls._context = context
         cls._options = context.params
+
+    def _save_context_to_instance(self, context: click.Context) -> None:
+        """ Save provided command line context and options to the instance """
+        self._context = context
+        self._options = context.params
 
     @overload
     @classmethod


### PR DESCRIPTION
In order for chaining to work, arguments cannot be used, hence the conversion to options. The order of cleaning is now forced to guests -> runs -> images.

TODO:
- [x] Figure out how to make `tmt clean runs guests` and `tmt clean guests runs` equivalent

Fixes: #1176 