### PR TITLE
Removes unused GuestContainer.container_id attribute

### DIFF
--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -141,7 +141,7 @@ class GuestContainer(tmt.Guest):
         self.podman(
             ['run'] + workaround +
             ['--name', self.container, '-v', f'{workdir}:{workdir}:z',
-             '-itd', self.image])[0].strip()
+             '-itd', self.image])
 
     def reboot(self, hard=False, command=None):
         """ Restart the container, return True if successful  """

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -100,9 +100,6 @@ class GuestContainer(tmt.Guest):
         self.force_pull = data.get('pull')
         self.container = data.get('container')
 
-        # Instances variables initialized later
-        self.container_id = None
-
     def save(self):
         """ Save guest data for future wake up """
         data = super().save()
@@ -141,7 +138,7 @@ class GuestContainer(tmt.Guest):
 
         # Run the container
         self.debug(f"Start container '{self.image}'.")
-        self.container_id = self.podman(
+        self.podman(
             ['run'] + workaround +
             ['--name', self.container, '-v', f'{workdir}:{workdir}:z',
              '-itd', self.image])[0].strip()


### PR DESCRIPTION
It was assigned to, but never read. Removing it simplifies load() method, which should be helpful in the longrun.