### PR TITLE
Introduce dataclasses as a requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,19 +32,23 @@ __desc__ = 'Test Management Tool'
 __scripts__ = ['bin/tmt']
 
 # Prepare install requires and extra requires
-
-# typing_extensions is needed with Python 3.7 and older, types imported
-# from that package (Literal, Protocol, TypedDict, ...) become available
-# from typing since Python 3.8.
-typing_extensions_requirement = [
-    'typing-extensions>=3.7.4.3'] if sys.version_info.minor <= 7 else []
-
 install_requires = [
     'fmf>=1.0.0',
     'click',
     'requests',
     'ruamel.yaml',
-] + typing_extensions_requirement
+]
+
+# typing_extensions is needed with Python 3.7 and older, types imported
+# from that package (Literal, Protocol, TypedDict, ...) become available
+# from typing since Python 3.8.
+if sys.version_info.minor <= 7:
+    install_requires.append('typing-extensions>=3.7.4.3')
+
+# dataclasses is needed with Python 3.6
+if sys.version_info.minor <= 6:
+    install_requires.append('dataclasses')
+
 extras_require = {
     'docs': [
         'sphinx>=3',
@@ -55,7 +59,7 @@ extras_require = {
         'requre',
         'pre-commit',
         'mypy'
-        ] + typing_extensions_requirement,
+        ],
     'provision': ['testcloud>=0.7.0'],
     'convert': [
         'nitrate',

--- a/tests/unit/test_dataclasses.py
+++ b/tests/unit/test_dataclasses.py
@@ -1,0 +1,8 @@
+import dataclasses
+
+# TODO: more tests will come for functionality based on dataclasses.
+# As of now, just make sure it's possible to import the package.
+
+
+def test_sanity():
+    pass

--- a/tmt.spec
+++ b/tmt.spec
@@ -40,9 +40,10 @@ BuildRequires: python%{python3_pkgversion}-testcloud
 BuildRequires: python%{python3_pkgversion}-markdown
 BuildRequires: python%{python3_pkgversion}-junit_xml
 BuildRequires: python%{python3_pkgversion}-ruamel-yaml
-# The typing-extensions are only needed for rhel-8
+# The typing-extensions and dataclasses are only needed for rhel-8
 %if 0%{?rhel} == 8
 BuildRequires: python%{python3_pkgversion}-typing-extensions
+BuildRequires: python%{python3_pkgversion}-dataclasses
 %endif
 # Required for tests
 BuildRequires: rsync


### PR DESCRIPTION
Dataclasses will be used to enforce type annotations and type checks of
various "data" blobs. These are used by constructors, for load/save
operations, and other places. `TypedDict` is fine, but a dataclass can
have helper methods which will come handy for logging and so on.