### PR TITLE
Buildrequire python3-docutils, append plan adjust

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -8,7 +8,7 @@ execute:
 
 # Install packages in full mode
 adjust:
-  - prepare:
+  - prepare+:
       - name: tmt
         how: install
         directory: tmp/RPMS/noarch

--- a/tests/full/test.sh
+++ b/tests/full/test.sh
@@ -45,6 +45,7 @@ rlJournalStart
             rlRun "userdel -r $USER" 0 "Removing existing user"
         }
         rlRun "useradd $USER"
+        rlRun "usermod --append --groups libvirt $USER"
         rlRun "echo '$USER ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers" 0 "password-less sudo for test user"
         rlRun "chmod 400 /etc/sudoers"
         rlRun "loginctl enable-linger $USER" # start session so /run/ directory is initialized

--- a/tmt.spec
+++ b/tmt.spec
@@ -30,6 +30,7 @@ This package contains the command line tool.
 %package -n     python%{python3_pkgversion}-%{name}
 Summary:        Python library for the %{summary}
 BuildRequires: python%{python3_pkgversion}-devel
+BuildRequires: python%{python3_pkgversion}-docutils
 BuildRequires: python%{python3_pkgversion}-setuptools
 BuildRequires: python%{python3_pkgversion}-pytest
 BuildRequires: python%{python3_pkgversion}-click


### PR DESCRIPTION
docutils necessary for rst2man (needed by make rpm)
adjust used in plan needs to append, not replace existing (e.g.
/plans/integration uses prepare to pip install its requires)