### PR TITLE
Kill the running test when rebooting

### DIFF
--- a/stories/features/reboot.fmf
+++ b/stories/features/reboot.fmf
@@ -22,7 +22,8 @@ description: |
     For backward-compatibility reasons the ``rstrnt-reboot`` and
     ``rhts-reboot`` commands are provided as well together with
     the ``RSTRNT_REBOOTCOUNT`` and ``REBOOTCOUNT`` environment
-    variables.
+    variables. Calling the script kills the parent process
+    (the running test).
 
 example: |
     if [ "$TMT_REBOOT_COUNT" -eq 0 ]; then

--- a/tests/execute/reboot/data/test.sh
+++ b/tests/execute/reboot/data/test.sh
@@ -19,6 +19,8 @@ rlJournalStart
     if [ "$TMT_REBOOT_COUNT" == "0" ]; then
         rlPhaseStartTest "Before reboot"
             rlRun "tmt-reboot" 0 "Reboot using 'tmt-reboot'."
+            # Add sleep to check that the test is killed by tmt-reboot
+            rlRun "sleep 3600"
         rlPhaseEnd
 
     # First

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -29,6 +29,7 @@ while getopts "c:" flag; do
         c) echo "${{OPTARG}}" >> "$TMT_TEST_DATA/{REBOOT_REQUEST_FILENAME}";;
     esac
 done
+kill $PPID
 """
 REBOOT_BACKUP_EXT = ".tmt.backup"
 REBOOT_SETUP_NAME = "reboot_setup"


### PR DESCRIPTION
This makes our reboot implementation more backwards compatible with
restraint. Previously, things such as:

    tmt-reboot
    sleep 3600

would result in tmt hitting the hour-long sleep which should not happen
(the reboot should seem like it happened right after calling the
tmt-reboot command). Kill the parent process to achieve this.

Fixes: #1212 