### PR TITLE
Changes timeout handling in Guest.reconnect() to be based on time

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1,4 +1,5 @@
 import collections
+import datetime
 import os
 import random
 import re
@@ -478,15 +479,20 @@ class Guest(tmt.utils.Common):
         # Try to wait for machine to really shutdown
         time.sleep(RECONNECT_INITIAL_WAIT_TIME)
         self.debug("Wait for a connection to the guest.")
-        for attempt in range(1, timeout):
+
+        # A small shortcut... `now` or `utcnow`, should not matter, becase we
+        # need a difference between two values. As long as we use the same
+        # function for both sides of the equation, we should be fine.
+        now = datetime.datetime.utcnow
+        deadline = now() + datetime.timedelta(seconds=timeout)
+        while now() < deadline:
             try:
                 self.execute('whoami')
                 break
             except tmt.utils.RunError:
                 self.debug('Failed to connect to the guest, retrying.')
                 time.sleep(1)
-
-        if attempt == timeout:
+        else:
             self.debug("Connection to guest failed after reboot.")
             return False
         return True


### PR DESCRIPTION
Current implementation was counting from 1 to given "timeout", and slept
1 second after every attempt. When facing possible network delays and
latencies, each attempt may easily take several seconds. At works case,
reconnect() would go through `timeout` attempts, each many seconds long,
resulting in a `timeout` being overshot by *hours*. For example,
`timeout` attempts * (30 second SSH timeout (guest not ready) + 1 second
between ticks) => `3600 * 31` before `tmt` reporting a failed reconnect
operation.

The patch changes the loop to work with a deadline, computed from "now"
and given timeout. No matter how long each attempt may be, the total
timeout budget is honored, or overshot by whatever time the last attempt
may need to fail.