### PR TITLE
Explicitly set the docs language in the config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ release = ''
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/plans/install/docs.fmf
+++ b/plans/install/docs.fmf
@@ -12,5 +12,5 @@ execute:
         pip3 install .[docs]
         cd docs
         python3 -m sphinx -T -E -b html -d _build/doctrees \
-            -D language=en . _build/html 2>&1 | tee output
+            . _build/html 2>&1 | tee output
         grep WARNING output && exit 1 || exit 0


### PR DESCRIPTION
To fix the following warning during docs building:

    WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).