### PR TITLE
Reveal hidden errors during `testcloud` booting

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -555,7 +555,8 @@ class GuestTestcloud(tmt.GuestSsh):
     def stop(self):
         """ Stop provisioned guest """
         super().stop()
-        if self.instance:
+        # Stop only if the instance successfully booted
+        if self.instance and self.guest:
             self.debug(f"Stopping testcloud instance '{self.instance_name}'.")
             try:
                 self.instance.stop()


### PR DESCRIPTION
There's no point in stopping the instance if it has not booted
successfully. Furthermore, trying to stop it hides the real error.