### PR TITLE
Increase `duration` for the reboot-related tests

### DIFF
--- a/tests/execute/reboot/main.fmf
+++ b/tests/execute/reboot/main.fmf
@@ -1,4 +1,4 @@
-duration: 10m
+duration: 20m
 
 /basic:
     summary: Verify that reboot during test works


### PR DESCRIPTION
Here and there slow network causes these tests to fail.
Let's increase the duration a bit to prevent such failures.