### PR TITLE
Guest pull: rsync --fake-super, rename constants

### DIFF
--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -9,7 +9,7 @@ import click
 import tmt
 import tmt.utils
 from tmt.steps.execute import TEST_OUTPUT_FILENAME
-from tmt.steps.provision import DEFAULT_RSYNC_OPTIONS
+from tmt.steps.provision import RSYNC_PUSH_OPTIONS
 from tmt.steps.provision.local import GuestLocal
 
 REBOOT_VARIABLES = (
@@ -240,7 +240,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
         template = setup_file(REBOOT_TEMPLATE_NAME, REBOOT_SCRIPT)
         setup = setup_file(REBOOT_SETUP_NAME, REBOOT_SETUP_SCRIPT)
         teardown = setup_file(REBOOT_TEARDOWN_NAME, REBOOT_TEARDOWN_SCRIPT)
-        guest.push(self.workdir, options=DEFAULT_RSYNC_OPTIONS + ["-p"])
+        guest.push(self.workdir, options=RSYNC_PUSH_OPTIONS + ["-p"])
         return template, setup, teardown
 
     @contextlib.contextmanager

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -24,8 +24,10 @@ CONNECTION_TIMEOUT = 60 * 60
 RECONNECT_INITIAL_WAIT_TIME = 5
 
 # Default rsync options
-DEFAULT_RSYNC_OPTIONS = [
-    "-R", "-r", "-z", "--links", "--safe-links", "--delete"]
+RSYNC_PUSH_OPTIONS = [
+    "-Rrz", "--links", "--safe-links", "--delete"]
+RSYNC_PULL_OPTIONS = [
+    "-Rrz", "--links", "--safe-links", "--protect-args", "--fake-super"]
 
 
 class Provision(tmt.steps.Step):
@@ -702,12 +704,12 @@ class GuestSsh(Guest):
 
         By default the whole plan workdir is synced to the same location
         on the guest. Use the 'source' and 'destination' to sync custom
-        location and the 'options' parametr to modify default options
+        location and the 'options' parameter to modify default options
         which are '-Rrz --links --safe-links --delete'.
         """
         # Prepare options and the push command
         if options is None:
-            options = DEFAULT_RSYNC_OPTIONS
+            options = RSYNC_PUSH_OPTIONS
         if destination is None:
             destination = "/"
         if source is None:
@@ -749,13 +751,12 @@ class GuestSsh(Guest):
 
         By default the whole plan workdir is synced from the same
         location on the guest. Use the 'source' and 'destination' to
-        sync custom location, the 'options' parameter to modify
-        default options '-Rrz --links --safe-links --protect-args'
-        and 'extend_options' to extend them (e.g. by exclude).
+        sync custom location and the 'options' parametr to modify
+        default options '-Rrz --links --safe-links --protect-args --fake-super'.
         """
         # Prepare options and the pull command
         if options is None:
-            options = "-Rrz --links --safe-links --protect-args".split()
+            options = RSYNC_PULL_OPTIONS
         if extend_options is not None:
             options.extend(extend_options)
         if destination is None:


### PR DESCRIPTION
Renamed constant for rsync options in push and pull.
Other usage of rsync has its own options hidden in the code.