### PR TITLE
Tweak merging guideline, add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence
+*   @psss @FrNecas @lukaszachy

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -200,9 +200,10 @@ single commit.
 Merging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Pull request merging is done by maintainers who have a good
-overview of the whole code. Before merging a pull request it's
-good to check the following:
+Pull request merging is done by one of maintainers who have a good
+overview of the whole code. Maintainer who will take care of
+the process will assign themselves to the pull request.
+Before merging it's good to check the following:
 
 * New test coverage added if appropriate, all tests passed
 * Documentation has been added or updated where appropriate


### PR DESCRIPTION
More details: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
Can be used in branch protection to explicitly require codeowner review
before merging