### PR TITLE
Convert guest implementations to use serializable container for load/save

### DIFF
--- a/tests/multihost/provision/test.sh
+++ b/tests/multihost/provision/test.sh
@@ -25,7 +25,7 @@ rlJournalStart
 
         # 2 guests without role are saved
         guests="$run/noroles/provision/guests.yaml"
-        rlAssertNotGrep "role" $guests
+        rlAssertNotGrep "role: [a-z]" $guests "File '$guests' should leave role unspecified"
         rlAssertGrep "client" $guests
         rlAssertGrep "server" $guests
 

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -91,23 +91,27 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
         if not guest:
             raise tmt.utils.SpecificationError(
                 'Provide a host name or an ip address to connect.')
-        data = dict(guest=guest, user=user, role=self.get('role'))
+        data = tmt.steps.provision.GuestSshData(
+            role=self.get('role'),
+            guest=guest,
+            user=user
+            )
         self.info('guest', guest, 'green')
         self.info('user', user, 'green')
         if port:
             self.info('port', port, 'green')
-            data['port'] = port
+            data.port = port
 
         # Use provided password for authentication
         if password:
             self.info('password', password, 'green')
             self.debug('Using password authentication.')
-            data['password'] = password
+            data.password = password
         # Default to using a private key (user can have configured one)
         else:
             self.info('key', key or 'not provided', 'green')
             self.debug('Using private key authentication.')
-            data['key'] = key
+            data.key = key
 
         # And finally create the guest
         self._guest = tmt.GuestSsh(data, name=self.name, parent=self.step)

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -37,7 +37,10 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
         super().go()
 
         # Create a GuestLocal instance
-        data = {'guest': 'localhost', 'role': self.get('role')}
+        data = tmt.steps.provision.GuestSshData(
+            guest='localhost',
+            role=self.get('role')
+            )
         self._guest = GuestLocal(data, name=self.name, parent=self.step)
 
     def guest(self):
@@ -52,10 +55,7 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
 class GuestLocal(tmt.Guest):
     """ Local Host """
 
-    def __init__(self, data, name=None, parent=None):
-        """ Initialize guest data """
-        super().__init__(data, name, parent)
-        self.localhost = True
+    localhost = True
 
     def ansible(self, playbook, extra_args=None):
         """ Prepare localhost using ansible playbook """


### PR DESCRIPTION
Instead of custom load/save methods, use those based on dataclasses. We
gain type annotations, automagic conversion from/to YAML, no need for
explicit moves of fields between instances and serialized data.