### PR TITLE
Do not truncate `RunError` output in verbose mode

### DIFF
--- a/bin/tmt
+++ b/bin/tmt
@@ -21,15 +21,27 @@ try:
 
 # Show detailed output upon command execution errors
 except tmt.utils.RunError as error:
+    # Check verbosity level used during raising exception,
+    # Supported way to correctly get verbosity is
+    # tmt.util.Common.opt('verbose')
+    if isinstance(error.caller, tmt.utils.Common):
+        verbose = error.caller.opt('verbose')
+    else:
+        verbose = 0
     for name, output in (('stdout', error.stdout), ('stderr', error.stderr)):
         if not output:
             continue
         lines = output.strip().split('\n')
-        displayed = min(len(lines), tmt.utils.OUTPUT_LINES)
+        # Show all lines in verbose mode, limit to maximum otherwise
+        if verbose > 0:
+            line_summary = f"{len(lines)}"
+        else:
+            line_summary = f"{min(len(lines), tmt.utils.OUTPUT_LINES)}/{len(lines)}"
+            lines = lines[-tmt.utils.OUTPUT_LINES:]
         print(
-            f"\n{name} ({displayed}/{len(lines)} lines)"
+            f"\n{name} ({line_summary} lines)"
             f"\n{tmt.utils.OUTPUT_WIDTH * '~'}\n" +
-            '\n'.join(lines[-tmt.utils.OUTPUT_LINES:]))
+            '\n'.join(lines))
     print()
     show_exception(error)
     raise SystemExit(2)

--- a/tests/run/error/main.fmf
+++ b/tests/run/error/main.fmf
@@ -1,0 +1,3 @@
+summary: Check how errors are printed to the user
+description:
+    Verbose mode should print whole output of failed command.

--- a/tests/run/error/test.sh
+++ b/tests/run/error/test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "run=\$(mktemp -d)" 0 "Creating run directory"
+        rlRun "pushd $tmp"
+    rlPhaseEnd
+
+    # 2 ... Errors occured during test execution.
+    ECODE=2
+
+    rlPhaseStartTest "Truncated"
+        for v in '' '-v'; do
+          rlRun -s "tmt run --id $run --scratch --all \
+            provision $v --how local \
+            execute --how tmt --script true \
+            prepare --how shell --script 'for i in {001..101}; do echo OUT-\$i; done; false'" "$ECODE"
+
+          # Prepare is never in verbose mode
+          rlAssertNotGrep 'OUT-001' $rlRun_LOG -F
+          rlAssertGrep 'stdout (100/101 lines)' $rlRun_LOG -F
+        done
+    rlPhaseEnd
+
+    rlPhaseStartTest "Not Truncated"
+        # Whole run is in verbose mode
+        rlRun -s "tmt run -v --id $run --scratch --all \
+          provision $v --how local \
+          execute --how tmt --script true \
+          prepare --how shell --script 'for i in {001..101}; do echo OUT-\$i; done; false'" "$ECODE"
+
+        rlAssertGrep 'stdout (101 lines)' $rlRun_LOG -F
+        rlAssertGrep 'OUT-001' $rlRun_LOG -F
+
+        # Prepare is in verbose mode
+        rlRun -s "tmt run --id $run --scratch --all \
+          provision --how local \
+          execute --how tmt --script true \
+          prepare -v --how shell --script 'for i in {001..101}; do echo OUT-\$i; done; false'" "$ECODE"
+
+        rlAssertGrep 'stdout (101 lines)' $rlRun_LOG -F
+        rlAssertGrep 'OUT-001' $rlRun_LOG -F
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Removing tmp directory"
+        rlRun "rm -r $run" 0 "Removing run directory"
+    rlPhaseEnd
+rlJournalEnd


### PR DESCRIPTION
Respects verbosity of step which raised the exception.

Fixes: #1248