### PR TITLE
Refactor internal executor scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,10 @@ with open('tmt.spec', encoding='utf-8') as specfile:
 __version__ = version
 __pkg__ = 'tmt'
 __pkgdata__ = {
-    'tmt': ['schemas/*.yaml']
+    'tmt': [
+        'schemas/*.yaml',
+        'steps/execute/scripts/*'
+        ]
 }
 __pkgdir__ = {}
 __pkgs__ = [

--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -170,13 +170,28 @@ description: |
 /tmt:
     summary: Internal test executor
     story: As a user I want to execute tests directly from tmt.
-    description:
+    description: |
         The internal ``tmt`` executor runs tests in the
         provisioned environment one by one directly from the
         tmt code which allows features such as showing live
         :ref:`/stories/cli/steps/execute/progress` or the
         :ref:`/stories/cli/steps/execute/interactive` session .
         This is the default execute step implementation.
+
+        The executor provides following shell scripts which can
+        be used by the tests for certain operations.
+
+        ``tmt-file-submit``
+            Archive the given file in the tmt test data directory.
+
+        ``tmt-reboot``
+            Soft reboot the machine from inside the test. After reboot
+            the execution starts from the test which rebooted the machine.
+            An environment variable ``TMT_REBOOT_COUNT`` is provided which
+            the test can use to handle the reboot. The variable holds the
+            number of reboots performed by the test. For more information
+            see the :ref:`/stories/features/reboot` feature documentation.
+
     example: |
         execute:
             how: tmt

--- a/stories/features/reboot.fmf
+++ b/stories/features/reboot.fmf
@@ -10,7 +10,7 @@ description: |
     variable provides number of successfully completed reboots.
 
     Note that this only works with guests provisioned by tmt, e.g.
-    ``container`` or ``virtual``, and doesn't work with the the
+    ``container`` or ``virtual``, and doesn't work with the
     ``local`` provision method. Support of the ``connect``
     provision is on a best effort basis and will not work on
     machines where ``reboot`` command is not available.
@@ -19,11 +19,14 @@ description: |
     option of the reboot script can be used, e.g. ``tmt-reboot -c
     "dnf system-upgrade reboot"``.
 
-    For backward-compatibility reasons the ``rstrnt-reboot`` and
-    ``rhts-reboot`` commands are provided as well together with
-    the ``RSTRNT_REBOOTCOUNT`` and ``REBOOTCOUNT`` environment
-    variables. Calling the script kills the parent process
-    (the running test).
+    For backward-compatibility with the `restraint`__ framework
+    the ``rstrnt-reboot`` and ``rhts-reboot`` commands are provided
+    as well together with the ``RSTRNT_REBOOTCOUNT`` and ``REBOOTCOUNT``
+    environment variables. Calling the script kills the parent process
+    (the running test). Please note that the content of these
+    scripts is not preserved, ``tmt`` overwrites them.
+
+    __ https://restraint.readthedocs.io/en/latest/commands.html#rstrnt-reboot
 
 example: |
     if [ "$TMT_REBOOT_COUNT" -eq 0 ]; then

--- a/tmt/steps/execute/scripts/tmt-file-submit
+++ b/tmt/steps/execute/scripts/tmt-file-submit
@@ -1,0 +1,5 @@
+#!/bin/sh
+FILENAME="$2"
+[ -d "$TMT_TEST_DATA" ] || mkdir -p "$TMT_TEST_DATA"
+cp "$FILENAME" "$TMT_TEST_DATA"
+echo "File $FILENAME stored to $TMT_TEST_DATA"

--- a/tmt/steps/execute/scripts/tmt-reboot
+++ b/tmt/steps/execute/scripts/tmt-reboot
@@ -1,0 +1,8 @@
+#!/bin/bash
+touch "$TMT_REBOOT_REQUEST"
+while getopts "c:" flag; do
+    case "${{flag}}" in
+        c) echo "${{OPTARG}}" >> "$TMT_REBOOT_REQUEST";;
+    esac
+done
+kill $PPID

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -258,6 +258,8 @@ class Guest(tmt.utils.Common):
         super().__init__(parent, name)
         # Initialize role, it will be overridden by load() if specified
         self.role = None
+        # Flag to indicate localhost guest, requires special handling
+        self.localhost = False
         self.load(data)
 
     def _random_name(self, prefix='', length=16):

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -52,6 +52,11 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
 class GuestLocal(tmt.Guest):
     """ Local Host """
 
+    def __init__(self, data, name=None, parent=None):
+        """ Initialize guest data """
+        super().__init__(data, name, parent)
+        self.localhost = True
+
     def ansible(self, playbook, extra_args=None):
         """ Prepare localhost using ansible playbook """
         playbook = self._ansible_playbook_path(playbook)

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -207,6 +207,10 @@ class GuestContainer(tmt.Guest):
         self.run(
             ["chcon", "--recursive", "--type=container_file_t",
              self.parent.plan.workdir], shell=False)
+        # In case explicit destination is given, use `podman cp` to copy data
+        # to the container
+        if destination:
+            self.podman(["cp", source, f"{self.container}:{destination}"])
 
     def pull(
             self,


### PR DESCRIPTION
* Move all scripts to files distributed with the package

* Provide a dataclass `Script` to easily define new scripts

* Introduce TMT_REBOOT_REQUEST env var to remove the need
  to generate the script on the fly

* Copy the scripts to the target, set their permissions
  via rsync

* Drop the setup and tierdown scripts, drop backup of the
  possibly rewritten files (I do not consider this use case
  valid enough to complicate the code)

* Update documentation

TODO
- [x] passing tests
- [x] container provisioner
- [x] dataclasses on python 3.6
- [x] push all scripts in one push
 - I do not see a speed benefit here worth looking improving this
- [x] add coreos testing
 - so Fedora CoreOS does not work via testcloud, so I am afraid we cannot add tests in this MR
 - the good information is, that the path /usr/local/bin is writable :guitar: 
- [x] document overwriting of restraint scripts

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>