### PR TITLE
Exclude namespaced backup in beakerlib

### DIFF
--- a/tests/pull/results/data/test.fmf
+++ b/tests/pull/results/data/test.fmf
@@ -16,5 +16,6 @@
         rlJournalStart
             rlPhaseStartSetup
                 rlFileBackup "test.fmf" # backup this file
+                rlFileBackup --namespace NS1 "test.fmf"
             rlPhaseEnd
         rlJournalEnd

--- a/tests/pull/results/test.sh
+++ b/tests/pull/results/test.sh
@@ -32,9 +32,13 @@ rlJournalStart
             if [[ "$method" =~ local|container ]]; then
                 # No pull happened so it shoud be present
                 rlAssertExists "$data/test/beakerlib/backup"
+                rlAssertExists "$data/test/beakerlib/backup-NS1"
+                rlAssertNotEquals "any backup dir is present" "$(eval 'echo $data/test/beakerlib/backup*')" "$data/test/beakerlib/backup*"
             else
                 # Should be ignored
                 rlAssertNotExists "$data/test/beakerlib/backup"
+                rlAssertNotExists "$data/test/beakerlib/backup-NS1"
+                rlAssertEquals "no backup dir is present" "$(eval 'echo $data/test/beakerlib/backup*')" "$data/test/beakerlib/backup*"
             fi
         rlPhaseEnd
     done

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -343,7 +343,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
                 if test.framework == "beakerlib":
                     exclude = [
                         "--exclude",
-                        self.data_path(test, "backup", full=True)]
+                        self.data_path(test, "backup*", full=True)]
                 else:
                     exclude = None
                 guest.pull(


### PR DESCRIPTION
Extends dc15cab so it now works properly for namespace backups as well
(which are called backup-<namespace>)

Solves: #1232