### PR TITLE
Adds a fmf node validation layer to core classes (Test/Plan/Story)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -60,6 +60,9 @@ ignore_missing_imports = True
 [mypy-pylero.*]
 ignore_missing_imports = True
 
+[mypy-jsonschema.*]
+ignore_missing_imports = True
+
 [mypy-requests.packages.urllib3.*]
 ignore_missing_imports = True
 

--- a/tests/multihost/provision/data/wrong.fmf
+++ b/tests/multihost/provision/data/wrong.fmf
@@ -1,5 +1,7 @@
 provision:
-    - name: client
-    - name: client
+    - how: container
+      name: client
+    - how: container
+      name: client
 execute:
     script: tmt --help

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -6,70 +6,73 @@ import tmt
 import tmt.utils
 
 PATH = os.path.dirname(os.path.realpath(__file__))
-SCHEMADIR = os.path.join(PATH, "../../tmt/schemas")
 ROOTDIR = os.path.join(PATH, "../..")
 
-
-@pytest.fixture
-def tests_schema():
-    return tmt.utils.load_schema('test.yaml')
+TREE = tmt.Tree(ROOTDIR)
 
 
-@pytest.fixture
-def stories_schema():
-    return tmt.utils.load_schema('story.yaml')
+# This is what `Tree.{tests,plans,stories}`` do internally, but after getting
+# all nodes, these methods would construct tmt objects representing found
+# nodes. That is *not* what we want, because the act of instantiating a `Plan``
+# object, for example, would affect content of the corresponding node, e.g.
+# `Plan` class would add some missing keys, using predefined default values.
+#
+# We want raw nodes here, therefore we need to get our hands on them before
+# `Tree` modifies them - use the underlying fmf tree's `prune()` method, and
+# use the right keys to filter out nodes we're interested in (the same `Tree`
+# uses).
+def _iter_nodes(tree, keys):
+    for node in tree.tree.prune(keys=keys):
+        yield node
 
 
-@pytest.fixture
-def plans_schema():
-    return tmt.utils.load_schema('plan.yaml')
+def iter_tests(tree):
+    yield from _iter_nodes(tree, ['test'])
 
 
-@pytest.fixture
-def schema_store():
-    return tmt.utils.load_schema_store()
+def iter_plans(tree):
+    yield from _iter_nodes(tree, ['execute'])
 
 
-@pytest.fixture(params=tmt.Tree(ROOTDIR).tests())
-def test_validation_result(request, schema_store, tests_schema):
-    node = request.param.node
-    return node.name, node.validate(tests_schema, schema_store)
+def iter_stories(tree):
+    yield from _iter_nodes(tree, ['story'])
 
 
-@pytest.fixture(params=tmt.Tree(ROOTDIR).stories())
-def story_validation_result(request, schema_store, stories_schema):
-    node = request.param.node
-    return node.name, node.validate(stories_schema, schema_store)
+# pytest.mark.parametrize expects us to deliver an iterable for each test invocation,
+# and since there's only a single argument for our test cases, the node to validate,
+# we need to construct the iterable with this single item.
+def as_parameters(nodes):
+    for node in nodes:
+        yield (node,)
 
 
-@pytest.fixture(params=tmt.Tree(ROOTDIR).plans())
-def plan_validation_result(request, schema_store, plans_schema):
-    node = request.param.node
-    return node.name, node.validate(plans_schema, schema_store)
+TESTS = list(as_parameters(iter_tests(TREE)))
+PLANS = list(as_parameters(iter_plans(TREE)))
+STORIES = list(as_parameters(iter_stories(TREE)))
 
 
-def test_tests_schema(test_validation_result):
-    name, result = test_validation_result
-    if not result.result:
-        for error in result.errors:
-            print(error)
+def validate_node(node, schema, label, name):
+    errors = tmt.utils.validate_fmf_node(node, schema)
 
-    assert result.result, f'Test {name} fails validation'
+    if errors:
+        for error, message in errors:
+            print(f'* {message}')
+            print(f'    {error}')
+            print()
 
-
-def test_stories_schema(story_validation_result):
-    name, result = story_validation_result
-    if not result.result:
-        for error in result.errors:
-            print(error)
-
-    assert result.result, f'Story {name} fails validation'
+        assert False, f'{label} {name} fails validation'
 
 
-def test_plans_schema(plan_validation_result):
-    name, result = plan_validation_result
-    if not result.result:
-        for error in result.errors:
-            print(error)
+@pytest.mark.parametrize(('test',), TESTS)
+def test_tests_schema(test):
+    validate_node(test, 'test.yaml', 'Test', test.name)
 
-    assert result.result, f'Plan {name} fails validation'
+
+@pytest.mark.parametrize(('story',), STORIES)
+def test_stories_schema(story):
+    validate_node(story, 'story.yaml', 'Story', story.name)
+
+
+@pytest.mark.parametrize(('plan',), PLANS)
+def test_plans_schema(plan):
+    validate_node(plan, 'plan.yaml', 'Plan', plan.name)

--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -66,13 +66,33 @@ definitions:
 
     additionalProperties: false
 
+    # NOTE: Because of old jsonschema package on RHEL-8, we cannot use
+    # `url: true` and inherit `url` attributes from parent schema. It
+    # seems like we have to repeat properties schemas here as well.
     properties:
-      url: true
-      ref: true
-      path: true
-      name: true
+      url:
+        # https://github.com/teemtee/tmt/issues/1258
+        type: string
+
+      ref:
+        type: string
+
+      path:
+        type: string
+
+      name:
+        type: string
+        pattern: "^/"
+
       nick:
         type: string
+
+    # This would have been the easy way, understandable by newer jsonschema
+    # packages.
+    # url: true
+    # ref: true
+    # path: true
+    # name: true
 
   # https://tmt.readthedocs.io/en/stable/spec/plans.html#fmf
   # https://tmt.readthedocs.io/en/stable/spec/plans.html#shell
@@ -106,13 +126,37 @@ definitions:
 
     additionalProperties: false
 
+    # NOTE: Because of old jsonschema package on RHEL-8, we cannot use
+    # `url: true` and inherit `url` attributes from parent schema. It
+    # seems like we have to repeat properties schemas here as well.
     properties:
-      url: true
-      ref: true
-      path: true
-      name: true
+      url:
+        # https://github.com/teemtee/tmt/issues/1258
+        type: string
+
+      ref:
+        type: string
+
+      path:
+        type: string
+
+      name:
+        type: string
+        pattern: "^/"
+
+    # This would have been the easy way, understandable by newer jsonschema
+    # packages.
+    #
+    # url: true
+    # ref: true
+    # path: true
+    # name: true
 
   # helper used by beakerlib_library and fmf_id
+  #
+  # NOTE: when changing the following properties, thanks to old jsonschema tmt
+  # depends on in RHEL-8 lands, update also their copies in `fmf_id` and
+  # `beaker_library` definitions.
   fmf_id_base:
     type: object
     minProperties: 1

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -35,7 +35,7 @@ class Discover(tmt.steps.Step):
         try:
             tests = tmt.utils.yaml_to_dict(self.read('tests.yaml'))
             self._tests = [
-                tmt.Test(data, name) for name, data in tests.items()]
+                tmt.Test(data, name, skip_validation=True) for name, data in tests.items()]
         except tmt.utils.FileError:
             self.debug('Discovered tests not found.', level=2)
 

--- a/tmt/templates.py
+++ b/tmt/templates.py
@@ -75,6 +75,7 @@ PLAN['mini'] = """
 summary:
     Basic smoke test
 execute:
+    how: tmt
     script: tmt --help
 """.lstrip()
 


### PR DESCRIPTION
Before letting core classes consume data loaded from fmf files, a JSON
schema-based validation is applied to discover possible issues.

Validation is implemented as a mixin class, therefore it is not limited
to these classes and may be re-used by other parts of code.