### PR TITLE
Adds "missing" imports to help IDEs follow objects

### DIFF
--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -7,6 +7,7 @@ import time
 import click
 
 import tmt
+import tmt.steps.execute
 import tmt.utils
 from tmt.steps.execute import TEST_OUTPUT_FILENAME
 from tmt.steps.provision import DEFAULT_RSYNC_OPTIONS

--- a/tmt/steps/finish/ansible.py
+++ b/tmt/steps/finish/ansible.py
@@ -1,4 +1,5 @@
 import tmt
+import tmt.steps.finish
 from tmt.steps.prepare.ansible import PrepareAnsible
 
 

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -2,6 +2,7 @@ import click
 import fmf
 
 import tmt
+import tmt.steps.finish
 
 
 class FinishShell(tmt.steps.finish.FinishPlugin):

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 import click
 
 import tmt
+import tmt.steps.prepare
 import tmt.utils
 from tmt.steps import Step
 from tmt.steps.provision import Guest

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -6,6 +6,7 @@ import click
 import fmf
 
 import tmt
+import tmt.steps.prepare
 
 COPR_URL = 'https://copr.fedorainfracloud.org/coprs'
 

--- a/tmt/steps/prepare/multihost.py
+++ b/tmt/steps/prepare/multihost.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 
 import tmt
+import tmt.steps.prepare
 from tmt.steps import Method
 from tmt.steps.provision import Guest
 

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -4,6 +4,7 @@ import click
 import fmf
 
 import tmt
+import tmt.steps.prepare
 import tmt.utils
 from tmt.steps.provision import Guest
 

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -7,6 +7,7 @@ import click
 import requests
 
 import tmt
+import tmt.steps.provision
 from tmt.utils import ProvisionError, updatable_message
 
 if sys.version_info >= (3, 8):

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -1,6 +1,7 @@
 import click
 
 import tmt
+import tmt.steps.provision
 
 
 class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -1,4 +1,5 @@
 import tmt
+import tmt.steps.provision
 
 
 class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -3,6 +3,7 @@ import os
 import click
 
 import tmt
+import tmt.steps.provision
 
 # Timeout in seconds of waiting for a connection
 CONNECTION_TIMEOUT = 60

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -11,7 +11,7 @@ import fmf
 import requests
 
 import tmt
-from tmt.steps.provision import ProvisionPlugin
+import tmt.steps.provision
 from tmt.utils import WORKDIR_ROOT, ProvisionError, retry_session
 
 

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -1,6 +1,7 @@
 import os
 
 import tmt
+import tmt.steps.report
 from tmt.steps.execute import TEST_OUTPUT_FILENAME
 
 

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -5,6 +5,7 @@ import webbrowser
 import click
 
 import tmt
+import tmt.steps.report
 
 HTML_TEMPLATE = """
 <!DOCTYPE html>

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -3,6 +3,7 @@ import os
 import click
 
 import tmt
+import tmt.steps.report
 
 DEFAULT_NAME = "junit.xml"
 


### PR DESCRIPTION
These imports were not "missing" in the sense that Python interpreter
would report objects that couldn't be found. Thanks to some top-level
magic, even when importing just `tmt`, interpreter was able to locate
and use `tmt.steps.provision.ProvisionPlugin` as a base class for
classes in steps. But, this was opaque to some language servers that,
not seeing any `import tmt.steps.provision`, were unable to navigate
through the code to class, method and attribute definitions.

Adding these imports to make life easier for my Code and its poor
language server.