### PR TITLE
Consolidate pytest arguments and increase verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,17 +19,17 @@ tmp:
 
 # Run the test suite, optionally with coverage
 test: tmp
-	python3 -m pytest -c tests/unit/pytest.ini tests/unit
+	python3 -m pytest -vvv -ra --showlocals -c tests/unit/pytest.ini tests/unit
 smoke: tmp
-	python3 -m pytest -c tests/unit/pytest.ini tests/unit/test_cli.py
+	python3 -m pytest -vvv -ra --showlocals -c tests/unit/pytest.ini tests/unit/test_cli.py
 coverage: tmp
-	coverage run --source=tmt,bin -m py.test tests
+	coverage run --source=tmt,bin -m pytest -vvv -ra --showlocals tests
 	coverage report
 	coverage annotate
 # Regenerate test data for integration tests
 # remove selected/all response files in tests/integration/test_data directory
 requre:
-	cd tests/integration; python3 -m pytest -v
+	cd tests/integration; python3 -m pytest -vvv -ra --showlocals
 	# response files cleanup
 	requre-patch purge --replaces :milestone_url:str:SomeText --replaces :latency:float:0 tests/integration/test_data/test_nitrate/*
 

--- a/tests/core/environment-file/data/main.fmf
+++ b/tests/core/environment-file/data/main.fmf
@@ -1,6 +1,6 @@
 /test:
     summary: This is a test with variables
-    test: python3 -m pytest -svv environment_file_data.py
+    test: python3 -m pytest -vvv -ra --showlocals -s environment_file_data.py
 
 /plan:
     summary: This is a plan with variables

--- a/tests/core/path/main.fmf
+++ b/tests/core/path/main.fmf
@@ -1,4 +1,4 @@
 summary: Verify the default path handling
-test: python3 -m pytest test.py
+test: python3 -m pytest -vvv -ra --showlocals test.py
 framework: shell
 require: python3-pytest

--- a/tests/integration/main.fmf
+++ b/tests/integration/main.fmf
@@ -45,7 +45,7 @@ tier: null
 link: https://github.com/packit/requre
 
 /coverage_bugzilla:
-    test: "python3 -m pytest -v -k 'test_coverage_bugzilla'"
+    test: "python3 -m pytest -vvv -ra --showlocals -k 'test_coverage_bugzilla'"
 
 /the_rest:
-    test: "python3 -m pytest -v -k 'not test_coverage_bugzilla'"
+    test: "python3 -m pytest -vvv -ra --showlocals -k 'not test_coverage_bugzilla'"

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -1,7 +1,7 @@
 summary: Python unit tests
 description:
     Run all available python unit tests using pytest.
-test: python3 -m pytest
+test: python3 -m pytest -vvv -ra --showlocals
 framework: shell
 require:
   - python3-pytest


### PR DESCRIPTION
For the sake of easier debugging of failed tests, patch adds
`--show-locals` and increased verbosity. Also, patch tries to address
all invocations of `pytest`, so they all provide the same level of
information.