### PR TITLE
Fail import for packages starting with  minus sign

### DIFF
--- a/tests/test/import/data/parent/negative-requires/Makefile
+++ b/tests/test/import/data/parent/negative-requires/Makefile
@@ -1,0 +1,26 @@
+export TEST=/negative_reqs
+export TESTVERSION=1.0
+
+FILES=$(METADATA) Makefile
+
+.PHONY: all install download clean
+
+run: $(FILES)
+	Makefile
+
+clean:
+	rm -f *~
+
+include /usr/share/rhts/lib/rhts-make.include
+
+$(METADATA): Makefile
+	@echo "Owner:           Name <nobody@localhost.localdomain>" > $(METADATA)
+	@echo "Name:            $(TEST)" >> $(METADATA)
+	@echo "TestVersion:     $(TESTVERSION)" >> $(METADATA)
+	@echo "Path:            $(TEST_DIR)" >> $(METADATA)
+	@echo "Requires:        -fmf" >> $(METADATA)
+	@echo "Description:     Negative requires" >> $(METADATA)
+	@echo "License:         MIT" >> $(METADATA)
+	@echo "TestTime:        5m" >> $(METADATA)
+
+	rhts-lint $(METADATA)

--- a/tests/test/import/test.sh
+++ b/tests/test/import/test.sh
@@ -129,6 +129,15 @@ rlJournalStart
         rlAssertGrep "tag: KernelTier1 SaNiTy" 'output'
     rlPhaseEnd
 
+    rlPhaseStartTest "Negative requires"
+        rlRun 'pushd $tmp/data/parent/negative-requires'
+        rlRun -s 'tmt test import --no-nitrate' '2'
+        rlAssertGrep 'Excluding packages is not supported' $rlRun_LOG
+        rlAssertNotExists "main.fmf"
+        rlRun 'popd'
+    rlPhaseEnd
+
+
     rlPhaseStartCleanup
         rlRun "rm -r $tmp" 0 "Removing tmp directory"
         rlRun 'popd'


### PR DESCRIPTION
In Beaker metadata this means to not install that package.
However tmt has not place for this in the Test metadata and it should be
done in Plan instead (which cannot be made automatically)

Fixes: #1165