### PR TITLE
Implement reboot reconnect timeout configuration

### DIFF
--- a/stories/features/reboot.fmf
+++ b/stories/features/reboot.fmf
@@ -19,6 +19,11 @@ description: |
     option of the reboot script can be used, e.g. ``tmt-reboot -c
     "dnf system-upgrade reboot"``.
 
+    In some scenarios, rebooting may take longer than usual. The
+    default timeout used in tmt can be overriden using the ``-t``
+    option of the reboot script, e.g. ``tmt-reboot -t 3600`` to
+    wait for up to an hour for the guest to come back up.
+
     For backward-compatibility with the `restraint`__ framework
     the ``rstrnt-reboot`` and ``rhts-reboot`` commands are provided
     as well together with the ``RSTRNT_REBOOTCOUNT`` and ``REBOOTCOUNT``

--- a/tmt/steps/execute/scripts/tmt-reboot
+++ b/tmt/steps/execute/scripts/tmt-reboot
@@ -1,8 +1,12 @@
 #!/bin/bash
-touch "$TMT_REBOOT_REQUEST"
-while getopts "c:" flag; do
+command=""
+timeout=""
+while getopts "c:t:" flag; do
     case "${flag}" in
-        c) echo "${OPTARG}" >> "$TMT_REBOOT_REQUEST";;
+        c) command="${OPTARG}";;
+        t) timeout="${OPTARG}";;
     esac
 done
+json_fmt='{"command": "%s", "timeout": "%s"}'
+printf "$json_fmt" "$command" "$timeout" > "$TMT_REBOOT_REQUEST"
 kill $PPID

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -82,7 +82,7 @@ class GuestLocal(tmt.Guest):
 
         self.debug(f"Doing nothing to stop guest '{self.guest}'.")
 
-    def reboot(self, hard=False):
+    def reboot(self, hard=False, command=None, timeout=None):
         """ Reboot the guest, return True if successful """
 
         self.debug(f"Doing nothing to reboot guest '{self.guest}'.")

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -164,7 +164,7 @@ class GuestContainer(tmt.Guest):
             ['--name', self.container, '-v', f'{workdir}:{workdir}:z',
              '-itd', '--user', self.user, self.image])
 
-    def reboot(self, hard=False, command=None):
+    def reboot(self, hard=False, command=None, timeout=None):
         """ Restart the container, return True if successful  """
         if command:
             raise tmt.utils.ProvisionError(
@@ -174,7 +174,7 @@ class GuestContainer(tmt.Guest):
                 "Containers do not support soft reboot, they can only be "
                 "stopped and started again (hard reboot).")
         self.podman(['container', 'restart', self.container])
-        return self.reconnect(timeout=CONNECTION_TIMEOUT)
+        return self.reconnect(timeout=timeout or CONNECTION_TIMEOUT)
 
     def ansible(self, playbook, extra_args=None):
         """ Prepare container using ansible playbook """

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -624,7 +624,7 @@ class GuestTestcloud(tmt.GuestSsh):
                     f"Failed to remove testcloud instance: {error}")
             self.info('guest', 'removed', 'green')
 
-    def reboot(self, hard=False, command=None):
+    def reboot(self, hard=False, command=None, timeout=None):
         """ Reboot the guest, return True if successful """
         # Use custom reboot command if provided
         if command:
@@ -632,4 +632,4 @@ class GuestTestcloud(tmt.GuestSsh):
         if not self._instance:
             raise tmt.utils.ProvisionError("No instance initialized.")
         self._instance.reboot(soft=not hard)
-        return self.reconnect()
+        return self.reconnect(timeout=timeout)


### PR DESCRIPTION
In most cases, rebooting a machine is rather quick (e.g. under a minute
before it comes back up). However for other scenarios, such as upgrade
testing, the reboot may take way longer, e.g. an hour before the machine
starts responding again. Make this configurable from the test rather
than relying on tmt's default values.

Fixes: #1214
Related (example usage): https://github.com/teemtee/upgrade/pull/7

I am not sure how to go about testing this functionality. Currently I don't have an idea how to simulate reconnect taking long so I'd appreciate any pointers in this regard.

@mmacura311 and @mkluson this is probably relevant for upgrades testing ;)