### PR TITLE
Use `must` for all mandatory spec requirements

### DIFF
--- a/spec/core/adjust.fmf
+++ b/spec/core/adjust.fmf
@@ -34,11 +34,11 @@ description: |
     continue
         By default, all provided rules are evaluated. When set to
         ``false``, the first successful rule finishes the
-        evaluation and the rest is ignored.
+        evaluation and the rest is ignored. Must be a ``boolean``.
 
     because
         An optional comment with justification of the adjustment.
-        Should be a plain string.
+        Must be a ``string``.
 
     .. note::
         This covers and extends the original concept of `Test Case

--- a/spec/core/enabled.fmf
+++ b/spec/core/enabled.fmf
@@ -11,7 +11,7 @@ description: |
     might be used to mark stories which should be skipped when
     generating the documentation.
 
-    Should be a ``boolean``. The default value is ``true``.
+    Must be a ``boolean``. The default value is ``true``.
 
 example: |
     # Mark as disabled

--- a/spec/core/id.fmf
+++ b/spec/core/id.fmf
@@ -12,7 +12,7 @@ description: |
     to track the complete test execution history even if the test
     changed the location or name.
 
-    Should be a uniqe ``string``, using a `uuid`__ is recommended.
+    Must be a uniqe ``string``, using a `uuid`__ is recommended.
 
     __ https://fmf.readthedocs.io/en/latest/concept.html#identifiers
     __ https://en.wikipedia.org/wiki/Universally_unique_identifier

--- a/spec/core/order.fmf
+++ b/spec/core/order.fmf
@@ -5,7 +5,7 @@ description:
     processed. For example when running tests we need to
     execute some tests first or when exporting stories we need
     to arrange content in the right sequence to create a
-    meaningful documentation. Should be an ``integer``, negative
+    meaningful documentation. Must be an ``integer``, negative
     values are allowed as well. The default value is ``50``.
 
 example: |

--- a/spec/core/summary.fmf
+++ b/spec/core/summary.fmf
@@ -1,9 +1,9 @@
 summary: Concise summary describing purpose of the object
 
 description:
-    Should be a one-line ``string`` with up to 50 characters.
-    It is challenging to be both concise and descriptive, but
-    that is what a well-written summary should do.
+    Must be a one-line ``string``, should be up to 50 characters
+    long. It is challenging to be both concise and descriptive,
+    but that is what a well-written summary should do.
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/plans/context.fmf
+++ b/spec/plans/context.fmf
@@ -6,13 +6,13 @@ story:
 
 description: |
     Define the default context values for all tests executed under
-    the given plan. This overrides context values auto-detected
-    from the environment, such as ``distro``, ``variant`` or
-    ``arch`` but can overriden by context provided directly on the
-    command line. See the :ref:`/spec/context` definition for the
-    full list of supported context dimensions.
+    the given plan. Can be overriden by context provided directly
+    on the command line. See the :ref:`/spec/context` definition
+    for the full list of supported context dimensions. Must be a
+    ``dictionary``.
 
-example: |
+example:
+  - |
     summary:
         Test basic functionality of the httpd24 collection
     discover:
@@ -22,6 +22,7 @@ example: |
     context:
         collection: httpd24
 
+  - |
     summary:
         Verify dash against the shared shell tests repository
     discover:

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -10,7 +10,7 @@ description: |
     .. _require: https://tmt.readthedocs.io/en/latest/spec/tests.html#require
 
     Store the list of aggregated tests with their corresponding
-    metadata in the ``tests.yaml`` file. The format should be a
+    metadata in the ``tests.yaml`` file. The format must be a
     dictionary of dictionaries structured in the following way::
 
         /test/one:
@@ -77,7 +77,7 @@ description: |
             branch if url given or to the current ``HEAD`` if url
             not provided.
         path
-            Path to the metadata tree root. Should be relative to
+            Path to the metadata tree root. Must be relative to
             the git repository root if url provided, absolute
             local filesystem path otherwise. By default ``.`` is
             used.
@@ -93,7 +93,7 @@ description: |
             listed test order.
         link
             Select tests using the :ref:`/spec/core/link` keys.
-            Values should be in the form of ``RELATION:TARGET``,
+            Values must be in the form of ``RELATION:TARGET``,
             tests containing at least one of them are selected.
             Regular expressions are supported for both relation
             and target. Relation part can be omitted to match all

--- a/spec/plans/environment-file.fmf
+++ b/spec/plans/environment-file.fmf
@@ -6,7 +6,7 @@ description:
     Supported formats are dotenv/shell with ``KEY=VALUE`` pairs
     and ``yaml``. Full `url` can be used to fetch variables from a
     remote source. The ``environment`` key has a higher priority.
-    File path should be relative to the metadata tree root.
+    File path must be relative to the metadata tree root.
 example: |
     # Load from a dotenv/shell format
     /plan:

--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -18,7 +18,7 @@ description: |
     :ref:`/spec/tests` attributes it also contains fmf ``name`` of
     the test.
 
-    For each ``plan`` the execute step should produce a
+    For each ``plan`` the execute step must produce a
     ``results.yaml`` file with the list of results for each test
     in the following format::
 
@@ -40,18 +40,18 @@ description: |
             Test finished but only produced an informational
             message. Represents a soft pass, used for skipped
             tests and for tests with the :ref:`/spec/tests/result`
-            attribute set to *ignore*. Automation should treat
+            attribute set to *ignore*. Automation must treat
             this as a passed test.
         warn
             A problem appeared during test execution which does
             not affect test results but might be worth checking
             and fixing. For example test cleanup phase failed.
-            Automation should treat this as a failed test.
+            Automation must treat this as a failed test.
         error
             Undefined problem encountered during test execution.
             Human inspection is needed to investigate whether it
             was a test bug, infrastructure error or a real test
-            failure. Automation should treat it as a failed test.
+            failure. Automation must treat it as a failed test.
         fail
             Test execution successfully finished and failed.
 
@@ -232,7 +232,7 @@ description: |
     description: |
         Execute arbitratry shell commands and check their exit
         code which is used as a test result. The ``script`` field
-        is provided to cover simple test use cases only and should
+        is provided to cover simple test use cases only and must
         not be combined with the :ref:`/spec/plans/discover` step
         which is more suitable for more complex test scenarios.
 

--- a/spec/plans/finish.fmf
+++ b/spec/plans/finish.fmf
@@ -3,9 +3,10 @@ summary: Finishing tasks
 description:
     Additional actions to be performed after the test execution
     has been completed.  Counterpart of the ``prepare`` step
-    useful for various cleanup actions. Use the 'order' attribute
-    to select in which order finishing tasks  should happen if there
-    are multiple configs. Default order is '50'
+    useful for various cleanup actions. Use the
+    :ref:`/spec/core/order` attribute to select in which order
+    finishing tasks should happen if there are multiple configs.
+    Default order is ``50``.
 
 example: |
     finish:
@@ -32,7 +33,7 @@ example: |
         One or more playbooks can be provided as a list under the
         ``playbook`` attribute.  Each of them will be applied
         using ``ansible-playbook`` in the given order. The path
-        should be relative to the metadata tree root.
+        must be relative to the metadata tree root.
     example: |
         finish:
             how: ansible

--- a/spec/plans/import.fmf
+++ b/spec/plans/import.fmf
@@ -15,14 +15,14 @@ description: |
     the information. This can be useful for example when enabling
     integration testing between related components.
 
-    Remote plans are identified by the ``plan`` key which should
+    Remote plans are identified by the ``plan`` key which must
     contain an ``import`` dictionary with an `fmf identifier`__ of
     the remote plan. The ``url`` and ``name`` keys have to be
     defined, ``ref`` and ``path`` are optional. Only one remote
-    plan can be referenced and a full plan ``name`` should be used
+    plan can be referenced and a full plan ``name`` must be used
     (no string matching is applied).
 
-    No plan steps should be defined in the remote plan reference.
+    Plan steps must not be defined in the remote plan reference.
     Inheriting or overriding remote plan config with local plan
     steps might be possible in the future but currently is not
     supported in any way.

--- a/spec/plans/prepare.fmf
+++ b/spec/plans/prepare.fmf
@@ -58,7 +58,7 @@ example: |
         One or more playbooks can be provided as a list under the
         ``playbook`` attribute.  Each of them will be applied
         using ``ansible-playbook`` in the given order. The path
-        should be relative to the metadata tree root.
+        must be relative to the metadata tree root.
 
         Use ``extra-args`` attribute to enable optional arguments for
         ``ansible-playbook``.

--- a/spec/plans/summary.fmf
+++ b/spec/plans/summary.fmf
@@ -1,11 +1,10 @@
 summary: Concise summary describing the plan
 
 description:
-    Should shortly describe purpose of the test plan. One-line
-    ``string`` with up to 50 characters. It is challenging to be
-    both concise and descriptive, but that is what a well-written
-    summary should do.
-
+    Should shortly describe purpose of the test plan. Must be a
+    one-line ``string``, should be up to 50 characters long. It
+    is challenging to be both concise and descriptive, but that is
+    what a well-written summary should do.
 
 example: |
     /pull-request:

--- a/spec/stories/example.fmf
+++ b/spec/stories/example.fmf
@@ -6,7 +6,7 @@ description: |
     and get inspiration for initial experimenting.
 
     One or more examples can be defined, each of them is rendered
-    into a separate box during export. Should be a ``string`` or a
+    into a separate box during export. Must be a ``string`` or a
     ``list of strings``.
 
 example:

--- a/spec/stories/priority.fmf
+++ b/spec/stories/priority.fmf
@@ -35,7 +35,7 @@ description: |
         current schedule, might be dropped or reconsidered for
         inclusion in a later timebox
 
-    Should be a ``string`` with one of the above-mentioned values.
+    Must be a ``string`` with one of the above-mentioned values.
 
     __ https://en.wikipedia.org/wiki/MoSCoW_method
 

--- a/spec/stories/title.fmf
+++ b/spec/stories/title.fmf
@@ -10,7 +10,7 @@ description:
     in order to render content into online documentation it is
     sometimes useful to provide a custom user story title rather
     then using the story name which can be too short to describe
-    well the section content.
+    well the section content. Must be a ``string``.
 
 example: |
     title: Nice title

--- a/spec/tests/component.fmf
+++ b/spec/tests/component.fmf
@@ -9,7 +9,7 @@ description:
     It's useful to be able to easily select all tests relevant for
     given component or package. As they do not always have to be
     stored in the same repository and because many tests cover
-    multiple components a dedicated field is needed. Should be a
+    multiple components a dedicated field is needed. Must be a
     ``string`` or a ``list of strings``. Component name usually
     corresponds to the source package name.
 

--- a/spec/tests/contact.fmf
+++ b/spec/tests/contact.fmf
@@ -8,7 +8,7 @@ story:
 description:
     When there are several people collaborating on tests it's
     useful to have a way how find who is responsible for what.
-    Should be a ``string`` or a ``list of strings`` (email address
+    Must be a ``string`` or a ``list of strings`` (email address
     format with name and surname).
 
 example:

--- a/spec/tests/description.fmf
+++ b/spec/tests/description.fmf
@@ -9,8 +9,8 @@ description:
     For complex tests it makes sense to provide more detailed
     description to better clarify what is covered by the test.
     This can be useful for test writer as well when reviewing a
-    test written long time ago. Should be a ``string`` (multi
-    line, plain text).
+    test written long time ago. Must be a ``string`` (multi line,
+    plain text).
 
 example: |
     description:

--- a/spec/tests/duration.fmf
+++ b/spec/tests/duration.fmf
@@ -8,7 +8,7 @@ description:
     In order to prevent stuck tests consuming resources we define a
     maximum time for test execution. If the limit is exceeded the
     running test is killed by the test harness. Use the same
-    format as the ``sleep`` command. Should be a ``string``. The
+    format as the ``sleep`` command. Must be a ``string``. The
     default value is ``5m``.
 
 example:

--- a/spec/tests/environment.fmf
+++ b/spec/tests/environment.fmf
@@ -11,7 +11,7 @@ description:
     dedicated field for this, especially when the number of
     parameters grows. This might be useful for virtual test cases
     as well. Plan :ref:`/spec/plans/environment` overrides test
-    environment. Should be a ``dictionary``.
+    environment. Must be a ``dictionary``.
 
 example: |
     environment:

--- a/spec/tests/framework.fmf
+++ b/spec/tests/framework.fmf
@@ -12,10 +12,10 @@ description: |
     installed on the test environment.
 
     Currently ``shell`` and ``beakerlib`` are supported. Each
-    `execute` step plugin should list which frameworks it supports
+    `execute` step plugin must list which frameworks it supports
     and raise an error when an unsupported framework is detected.
 
-    Should be a ``string``, by default ``shell`` is used.
+    Must be a ``string``, by default ``shell`` is used.
 
     shell
         Only the exit code determines the test result. Exit code

--- a/spec/tests/manual.fmf
+++ b/spec/tests/manual.fmf
@@ -11,9 +11,9 @@ description: |
     executed in a semi-automated way, waiting on human
     interaction.
 
-    It's value should be a ``boolean``. The default value is
+    It's value must be a ``boolean``. The default value is
     ``false``. When set to ``true``, the :ref:`/spec/tests/test`
-    attribute should point to a Markdown document following the
+    attribute must point to a Markdown document following the
     `CommonMark`__ specification.
 
     __ https://spec.commonmark.org/0.29
@@ -46,7 +46,7 @@ description: |
 
     Step
         Required level 2 heading ``## Step`` or ``## Test Step``
-        marking a single step of the test, should be in pair with
+        marking a single step of the test, must be in pair with
         the Expect section which follows it. Cannot be used
         outside of test sections.
 

--- a/spec/tests/path.fmf
+++ b/spec/tests/path.fmf
@@ -10,8 +10,8 @@ description: |
     the test script, automation changes the current working
     directory to the provided ``path`` before running the test.
 
-    It should be a ``string`` containing path from the metadata
-    :ref:`tree root<tree>` to the desired directory and should
+    It must be a ``string`` containing path from the metadata
+    :ref:`tree root<tree>` to the desired directory and must
     start with a slash. If path is not defined, the directory
     where the test metadata are stored is used as a default.
 

--- a/spec/tests/recommend.fmf
+++ b/spec/tests/recommend.fmf
@@ -24,7 +24,7 @@ description: |
     as well. See the :ref:`/spec/tests/require` attribute for more
     details about available reference options.
 
-    Should be a ``string`` or a ``list of strings`` using package
+    Must be a ``string`` or a ``list of strings`` using package
     specification supported by ``dnf`` which takes care of the
     installation.
 

--- a/spec/tests/require.fmf
+++ b/spec/tests/require.fmf
@@ -9,7 +9,7 @@ description: |
     In order to execute the test, additional packages may need to
     be installed on the system. For example `gcc` and `make` are
     needed to compile tests written in C on the target machine. If
-    the package cannot be installed test execution should result
+    the package cannot be installed test execution must result
     in an ``error``.
 
     For tests shared across multiple components or product
@@ -32,7 +32,7 @@ description: |
     the development version directly from the local filesystem.
     Use the ``path`` key to specify a full path to the library.
 
-    Should be a ``string`` or a ``list of strings`` using package
+    Must be a ``string`` or a ``list of strings`` using package
     specification supported by ``dnf`` which takes care of the
     installation or a ``dictionary`` if using fmf identifier to
     fetch dependent repositories.

--- a/spec/tests/summary.fmf
+++ b/spec/tests/summary.fmf
@@ -6,8 +6,8 @@ story:
 
 description:
     In order to efficiently collaborate on test maintenance it's
-    crucial to have a short summary of what the test does. Should
-    be a ``string`` (one line, up to 50 characters).
+    crucial to have a short summary of what the test does. Must be a one-line
+    ``string``, should be up to 50 characters long.
 
 example: |
     summary: Test wget recursive download options

--- a/spec/tests/tag.fmf
+++ b/spec/tests/tag.fmf
@@ -7,7 +7,7 @@ description:
     Throughout the years, free-form tags proved to be useful for
     many, many scenarios. Primarily to provide an easy way how to
     select a subset of objects. Tags are case-sensitive. Using
-    lowercase is recommended. Should be a ``string`` or a ``list
+    lowercase is recommended. Must be a ``string`` or a ``list
     of strings``. Tag name must not contain spaces or commas.
 
 example:

--- a/spec/tests/test.fmf
+++ b/spec/tests/test.fmf
@@ -13,7 +13,7 @@ description: |
     document describing the manual test case steps in Markdown
     format with defined structure.
 
-    Should be a ``string``. This is a **required** attribute.
+    Must be a ``string``. This is a **required** attribute.
 
     Shell options ``errexit`` and ``pipefail`` are applied by
     default using ``set -eo pipefail`` to avoid potential errors


### PR DESCRIPTION
Previously `tmt` was a bit polite when describing what is the
expected format of the data. Let's use unambiguous `must` key word
as defined in https://datatracker.ietf.org/doc/html/rfc2119.

Fix #1260.