### PR TITLE
Convert FmfIdType from TypedDict to a dataclass

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -929,11 +929,13 @@ class Plan(Core):
     def _lint_discover_fmf(discover):
         """ Lint fmf discover method """
         # Validate remote id and translate to human readable errors
-        valid, error = FmfId(**{
+        fmf_id_data = {
             key: value
             for key, value in discover.items()
             if key in ['url', 'ref', 'path']
-            }).validate()
+            }
+
+        valid, error = FmfId(**fmf_id_data).validate()
 
         if valid:
             name = discover.get('name')

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1776,34 +1776,6 @@ def validate_git_status(test: 'tmt.base.Test') -> Tuple[bool, str]:
     return (True, '')
 
 
-def validate_fmf_id(fmf_id: 'tmt.base.FmfIdType') -> Tuple[bool, str]:
-    """
-    Validate given fmf id and return a human readable error
-
-    Return a tuple (boolean, message) as the result of validation.
-    The boolean specifies the validation result and the message
-    the validation error. In case the FMF id is valid, return an empty
-    string as the message.
-    """
-    # Validate remote id and translate to human readable errors
-    try:
-        fmf.base.Tree.node(fmf_id)
-    except fmf.utils.GeneralError as error:
-        # Map fmf errors to more user friendly alternatives
-        error_map = [
-            ('git clone', f"repo '{fmf_id.get('url')}' cannot be cloned"),
-            ('git checkout', f"git ref '{fmf_id.get('ref')}' is invalid"),
-            ('directory path', f"path '{fmf_id.get('path')}' is invalid"),
-            ('tree root',
-             f"No tree found in repo '{fmf_id.get('url')}', "
-             f"missing an '.fmf' directory?")
-            ]
-        errors = [err[1] for err in error_map if err[0] in str(error)]
-        return (False, errors[0] if errors else str(error))
-
-    return (True, '')
-
-
 def generate_runs(
         path: str, id_: Optional[str] = None) -> Generator[str, None, None]:
     """ Generate absolute paths to runs from path """


### PR DESCRIPTION
While TypedDict is imposed to a dictionary with no other effect, a
dataclass can serve as a type on its own while providing methods related
to the type. Patch converts fmf id type to a dataclass to both carry the
values and to tie "validate fmf id" function to the given id stored in
the container. Instead of a dictionary and a function, we now have a fmf
id "instance" with relevant methods directly connected.