### PR TITLE
Add `environment-file` to possible Plan keys

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -592,6 +592,7 @@ class Plan(Core):
     extra_L2_keys = [
         'context',
         'environment',
+        'environment-file',
         'gate',
         ]
 


### PR DESCRIPTION
I do not think it is needed to cover more with tests,
as this validation is going away sooner or later anyway.

Resolves #1252

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>