### PR TITLE
Retry getting environment file

### DIFF
--- a/tests/core/environment-file/data/main.fmf
+++ b/tests/core/environment-file/data/main.fmf
@@ -34,4 +34,4 @@
             - https://raw.githubusercontent.com/teemtee/tmt/22a46a4a6760517e3eadbbff0c9bebdb95442760/tests/core/env/data/vars.yaml
         /bad:
             environment-file:
-            - https://invalid.host.name/vars.yaml
+            - https://raw.githubusercontent.com/teemtee/tmt/22a46a4a6760517e3eadbbff0c9bebdb95442760/tests/core/env/data/wrong.yaml

--- a/tests/core/environment-file/test.sh
+++ b/tests/core/environment-file/test.sh
@@ -49,7 +49,7 @@ rlJournalStart
         # Bad
         rlRun "tmt plan show fetch/bad 2>&1 | tee output" 2
         rlAssertGrep "Failed to fetch the environment file" 'output'
-        rlAssertGrep "Name or service not known" 'output'
+        rlAssertGrep "Not Found" 'output'
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
We are hitting gitlab limits in the wild while getting
the enviornment-file in cases where a lot of plans is run.

This should help with that, introducing an exponential backoff
for getting the environment file on certain http return codes,
indicating possible outages or rate limiting.

Resolves #1229

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>