### PR TITLE
Test import --general is default now

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -342,6 +342,26 @@ Use the ``--bugzilla`` option together with ``--nitrate`` to link
 bugs marked as ``verifies`` in the :ref:`/spec/core/link`
 attribute with the corresponding Nitrate test case.
 
+Before export to ``--nitrate`` tmt checks that used test
+metadata are committed to git and present on ``origin`` remote.
+On own risk the failure can be ignored with ``--ignore-git-validation``.
+
+Nitrate test case can be created from test metadata with ``--create``.
+By default existing cases are detected each time, if you need to
+create additional nitrate test case use ``--duplicate``.
+Export will append ``extra-nitrate`` to the test metadata.
+Those changes have to be committed and pushed manually.
+
+To include nitrate test case in general plans use ``--general``.
+Set of general plans to which the test case will be linked is
+detected from the :ref:`/spec/tests/component`. Any additional
+general plan will be removed.
+
+For newly created nitrate test case it can be useful to add it
+to all open nitrate test runs under its general plans. This can be
+done using the ``--link-runs`` option.
+
+
 
 Test Libraries
 ------------------------------------------------------------------

--- a/tests/integration/test_data/test_nitrate/NitrateImportAutomated.test_basic.yaml
+++ b/tests/integration/test_data/test_nitrate/NitrateImportAutomated.test_basic.yaml
@@ -218,7 +218,7 @@ nitrate.xmlrpc_driver:
         is_active: true
         is_staff: true
         is_superuser: false
-        last_login: '2021-11-08 20:34:17'
+        last_login: '2022-06-27 17:32:11'
         last_name: "\u0160pl\xEDchal"
         user_permissions: []
         username: psplicha
@@ -260,15 +260,67 @@ nitrate.xmlrpc_driver:
       - nitrate.xmlrpc_driver
       - single_request_with_cookies
     output:
-    - - description: Test Management Tool
-        id: 59878
-        initial_owner: psplicha
-        initial_owner_id: 2117
-        initial_qa_contact: psplicha
-        initial_qa_contact_id: 2117
-        name: tmt
+    - - attachment: []
+        author: psplicha
+        author_id: 2117
+        case:
+        - 603489
+        - 608444
+        - 608445
+        - 609376
+        - 609377
+        - 609378
+        - 609379
+        - 609380
+        - 609899
+        - 609924
+        - 609925
+        - 609926
+        - 609927
+        - 609928
+        - 610020
+        component:
+        - 59878
+        create_date: '2020-05-15 02:40:40'
+        default_product_version: RHEL3
+        env_group: []
+        extra_link: ''
+        is_active: true
+        name: tmt / General
+        owner: psplicha
+        owner_id: 2117
+        parent: null
+        parent_id: null
+        plan_id: 28164
         product: RHEL Tests
         product_id: 182
+        product_version: RHEL3
+        product_version_id: 386
+        tag: []
+        type: General
+        type_id: 26
+  - metadata:
+      guess_type: Tuple
+      latency: 0.0
+      module_call_list:
+      - unittest.case
+      - integration.test_nitrate
+      - click.testing
+      - click.core
+      - click.decorators
+      - tmt.cli
+      - tmt.convert
+      - nitrate.base
+      - nitrate.immutable
+      - xmlrpc.client
+      - requre.objects
+      - requre.cassette
+      - nitrate.xmlrpc_driver
+      - single_request_with_cookies
+    output:
+    - description: General test plan of product
+      id: 26
+      name: General
   - metadata:
       guess_type: Tuple
       latency: 0.0

--- a/tests/integration/test_nitrate.py
+++ b/tests/integration/test_nitrate.py
@@ -202,7 +202,7 @@ class NitrateImport(Base):
         self.runner_output = runner.invoke(
             tmt.cli.main,
             ['-vvvvdddd', '--root', self.tmpdir / "import_case",
-             "test", "import", "--nitrate", "--manual", "--case=609704"],
+             "test", "import", "--no-general", "--nitrate", "--manual", "--case=609704"],
             catch_exceptions=False)
         self.assertEqual(self.runner_output.exit_code, 0)
         self.assertIn(
@@ -233,7 +233,7 @@ class NitrateImport(Base):
         runner = CliRunner()
         self.runner_output = runner.invoke(
             tmt.cli.main, ['--root', self.tmpdir / "import_case", "test",
-                           "import", "--nitrate", "--manual", "--case=609705"],
+                           "import", "--no-general", "--nitrate", "--manual", "--case=609705"],
             catch_exceptions=False)
         self.assertEqual(self.runner_output.exit_code, 0)
         # TODO: This is strange, expect at least some output in
@@ -331,7 +331,7 @@ extra-task: /tmt/integration
         runner = CliRunner()
         self.runner_output = runner.invoke(
             tmt.cli.main, [
-                "test", "import", "--nitrate"], catch_exceptions=False)
+                "test", "import", "--nitrate", "--no-general"], catch_exceptions=False)
         self.assertEqual(self.runner_output.exit_code, 0)
 
         tree_f36_intel = tmt.Tree(

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -461,8 +461,8 @@ def tests_create(context, name, template, force, **kwargs):
     '--restraint / --no-restraint', default=False,
     help='Convert restraint metadata file')
 @click.option(
-    '--general / --no-general', default=False,
-    help='Detect component from linked nitrate general plan '
+    '--general / --no-general', default=True,
+    help='Detect components from linked nitrate general plans '
          '(overrides Makefile/restraint component).')
 @click.option(
     '--type', 'types', metavar='TYPE', default=['multihost'], multiple=True,


### PR DESCRIPTION
Can be turned of by --no-general
Add documentation for export
Adjust tests to the new default