### PR TITLE
Require fresh testcloud with coreos support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ extras_require = {
         'pre-commit',
         'mypy'
         ],
-    'provision': ['testcloud>=0.7.0'],
+    'provision': ['testcloud>=0.8.1'],
     'convert': [
         'nitrate',
         'markdown',

--- a/tmt.spec
+++ b/tmt.spec
@@ -68,7 +68,7 @@ Dependencies required to run tests in a container environment.
 Summary: Virtual machine provisioner for the Test Management Tool
 Obsoletes: tmt-testcloud < 0.17
 Requires: tmt == %{version}-%{release}
-Requires: python%{python3_pkgversion}-testcloud >= 0.7.0
+Requires: python%{python3_pkgversion}-testcloud >= 0.8.1
 Requires: openssh-clients
 Requires: (ansible or ansible-core)
 # Recommend qemu system emulators for supported arches


### PR DESCRIPTION
Suggested for `1.15` by @frantisekz as the fresh `testcloud` packages are now in [stable](https://bodhi.fedoraproject.org/updates/?packages=testcloud) Fedora repositories.