### PR TITLE
Capture provision error when login is used

### DIFF
--- a/tests/login/main.fmf
+++ b/tests/login/main.fmf
@@ -17,3 +17,13 @@
 /test:
     summary: Log into the guest after each test
     test: ./test.sh
+
+/ready:
+    summary: Try to log into guest to verify property is_ready
+    test: ./ready.sh
+    environment:
+        METHODS: local container
+    adjust:
+      - when: how == full
+        environment:
+            METHODS: local container virtual

--- a/tests/login/ready.sh
+++ b/tests/login/ready.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "pushd data"
+    rlPhaseEnd
+
+    for method in ${METHODS:-virtual}; do
+        rlPhaseStartTest "Positive login test for ($method)"
+            rlRun -s "tmt run -a provision -h $method login -c exit" 0-255
+            rlAssertGrep "login: Starting interactive shell" "$rlRun_LOG"
+        rlPhaseEnd
+
+        if [[ $method == "virtual" ]]; then
+            image_url="FOOOOO"
+            rlPhaseStartTest "Negative login test for $method (image url = $image_url)"
+                rlRun -s "tmt run -a provision -h $method -i $image_url login -c exit" 0-255 \
+                    "disallowed to login into guest which is virtual if image url is invalid"
+                rlAssertNotGrep "login: Starting interactive shell" "$rlRun_LOG"
+                rlAssertGrep "Could not map.*to compose" "$rlRun_LOG"
+            rlPhaseEnd
+
+            image_url="file:///rubbish"
+            rlPhaseStartTest "Negative login test for $method (image url = $image_url)"
+                rlRun -s "tmt run -a provision -h $method -i $image_url login -c exit" 0-255 \
+                    "disallowed to login into guest which is virtual if image url is invalid"
+                rlAssertNotGrep "login: Starting interactive shell" "$rlRun_LOG"
+                rlAssertGrep "Image .*rubbish' not found" "$rlRun_LOG"
+            rlPhaseEnd
+        fi
+    done
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -124,6 +124,12 @@ class Guest(tmt.utils.Common):
         _, run_id = os.path.split(parent.plan.my_run.workdir)
         return self._random_name(prefix="tmt-{0}-".format(run_id[-3:]))
 
+    @property
+    def is_ready(self) -> bool:
+        """ Detect guest is ready or not """
+
+        raise NotImplementedError()
+
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options related to guests """
@@ -1218,10 +1224,13 @@ class Provision(tmt.steps.Step):
 
                     if self.is_multihost:
                         self.info('')
+                except (tmt.utils.RunError, tmt.utils.ProvisionError) as error:
+                    self.fail(str(error))
+                    raise
                 finally:
                     if isinstance(phase, ProvisionPlugin):
                         guest = phase.guest()
-                        if guest:
+                        if guest and (guest.is_ready or self.opt('dry')):
                             self._guests.append(guest)
 
             # Give a summary, update status and save

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -270,6 +270,14 @@ class GuestArtemis(tmt.GuestSsh):
 
         return self._api
 
+    @property
+    def is_ready(self) -> bool:
+        """ Detect the guest is ready or not """
+
+        # FIXME: A more robust solution should be provided. Currently just
+        #        return True if self.guest is not None
+        return self.guest is not None
+
     def _create(self) -> None:
         environment: Dict[str, Any] = {
             'hw': {

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -20,6 +20,11 @@ class GuestLocal(tmt.Guest):
     localhost = True
     parent: tmt.steps.Step
 
+    @property
+    def is_ready(self) -> bool:
+        """ Local is always ready """
+        return True
+
     def ansible(self, playbook: str, extra_args: Optional[str] = None) -> None:
         """ Prepare localhost using ansible playbook """
         playbook = self._ansible_playbook_path(playbook)

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -219,6 +219,22 @@ class GuestTestcloud(tmt.GuestSsh):
     _image: Optional['testcloud.image.Image'] = None  # type: ignore[name-defined]
     _instance: Optional['testcloud.instance.Instance'] = None  # type: ignore[name-defined]
 
+    @property
+    def is_ready(self) -> bool:
+        if self._instance is None:
+            return False
+
+        assert testcloud is not None
+        assert libvirt is not None
+        try:
+            state = testcloud.instance._find_domain(self._instance.name, self._instance.connection)
+            # Note the type of variable 'state' is 'Any'. Hence, we don't use:
+            #     return state == 'running'
+            # to avoid error from type checking.
+            return True if state == 'running' else False
+        except libvirt.libvirtError:
+            return False
+
     def _get_url(self, url: str, message: str) -> requests.Response:
         """ Get url, retry when fails, return response """
 


### PR DESCRIPTION
To capture the provision error when login is used, we introduced method `__bool__()` and property `is_valid` to class `Guest`. To change the property `is_valid`, we also introduced method `ready()` to `Guest`. Hence, if [phase.guest()](https://github.com/teemtee/tmt/blob/main/tmt/steps/provision/__init__.py#L139) is `True`, it make sense to invoke `self._guests.append(phase.guest())`. 