### PR TITLE
Fix distgit testsuite after tmt packaging change

### DIFF
--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -81,7 +81,7 @@ execute:
         discover:
             how: fmf
             dist-git-source: true
-            dist-git-init: true
+            dist-git-init: false
             test: tests/prepare/install$
     /exclude:
         discover:

--- a/tests/discover/distgit.sh
+++ b/tests/discover/distgit.sh
@@ -311,7 +311,7 @@ done
     rlPhaseStartTest "Run directly from the DistGit (Fedora) [cli]"
         rlRun 'pushd tmt'
         rlRun -s 'tmt run --remove plans --default \
-            discover -v --how fmf --dist-git-source --dist-git-init \
+            discover -v --how fmf --dist-git-source \
             tests --name tests/prepare/install$'
         rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
         rlAssertGrep "/tests/prepare/install" $rlRun_LOG -F
@@ -329,7 +329,7 @@ done
     rlPhaseStartTest "URL is path to a local distgit repo"
         rlRun -s 'tmt run --remove plans --default \
             discover --how fmf --dist-git-source --dist-git-type fedora --url $CLONED_TMT \
-            --dist-git-init --dist-git-merge tests --name tests/prepare/install$'
+            --dist-git-merge tests --name tests/prepare/install$'
         rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
     rlPhaseEnd
 


### PR DESCRIPTION
Previously fmf root was not included in the srpm/tarball
Now (since 1.15) is and it doesn't play with --dist-git-init
because init creates fmf root one level above (tarball has it
in tmt-1* directory) and so tarball's fmf root is nested (and hidden)