### PR TITLE
Fix package installation using `rpm-ostree`

### DIFF
--- a/tests/prepare/install/data/copr.fmf
+++ b/tests/prepare/install/data/copr.fmf
@@ -1,6 +1,4 @@
 summary: Just enable a copr repository
-provision:
-    how: container
 prepare:
     how: install
     copr: psss/fmf

--- a/tests/prepare/install/data/debuginfo.fmf
+++ b/tests/prepare/install/data/debuginfo.fmf
@@ -1,7 +1,5 @@
 summary:
     Install debuginfo packages
-provision:
-    how: container
 prepare:
   - name: debuginfo
     how: install

--- a/tests/prepare/install/data/epel7.fmf
+++ b/tests/prepare/install/data/epel7.fmf
@@ -1,5 +1,4 @@
-provision:
-    how: container
+provision+:
     image: centos:7
 prepare:
     how: install

--- a/tests/prepare/install/data/escape.fmf
+++ b/tests/prepare/install/data/escape.fmf
@@ -1,6 +1,3 @@
-provision:
-    how: container
-    image: fedora
 prepare:
     how: install
     package: dnf-command(copr)

--- a/tests/prepare/install/data/exclude.fmf
+++ b/tests/prepare/install/data/exclude.fmf
@@ -1,6 +1,4 @@
 summary: Exclude packages during installation
-provision:
-    how: container
 prepare:
     how: install
     package: httpd-*

--- a/tests/prepare/install/data/existing.fmf
+++ b/tests/prepare/install/data/existing.fmf
@@ -1,0 +1,6 @@
+summary: Install an existing package
+prepare:
+    how: install
+    package: tree
+execute:
+    script: rpm -q tree

--- a/tests/prepare/install/data/main.fmf
+++ b/tests/prepare/install/data/main.fmf
@@ -1,0 +1,2 @@
+provision:
+    how: container

--- a/tests/prepare/install/data/missing.fmf
+++ b/tests/prepare/install/data/missing.fmf
@@ -1,0 +1,6 @@
+summary: Report a missing package
+prepare:
+    how: install
+    package: forest
+execute:
+    script: we should not get here

--- a/tests/prepare/install/main.fmf
+++ b/tests/prepare/install/main.fmf
@@ -1,4 +1,17 @@
 summary: Various package installation options
 description:
+    Check basic installation of an existing and missing package.
     Make sure that special characters are correctly escaped.
-    Verify that installation from copr works for epel7.
+    Verify that installation from copr works for epel7. Exercises
+    all provision methods in full mode, container only by default.
+environment:
+    METHODS: container
+adjust:
+  - when: trigger == commit
+    environment:
+        METHODS: container local
+    because: the pipeline does not support nested virtualization
+  - when: how == full
+    environment:
+        METHODS: container virtual local
+    because: local/virtual provision needs root/full virtualization

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -6,6 +6,32 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
+    # Run basic tests against all enabled provision methods
+    for method in ${METHODS:-container}; do
+        provision="provision --how $method"
+
+        rlPhaseStartTest "Install an existing package ($method)"
+            rlRun "tmt run -adddvvvr $provision plan --name existing"
+        rlPhaseEnd
+
+        rlPhaseStartTest "Report a missing package ($method)"
+            rlRun "tmt run -adddvvvr $provision plan --name missing" 2
+        rlPhaseEnd
+
+        # Add one extra CoreOS run for virtual provision
+        if [[ "$method" == "virtual" ]]; then
+            provision="provision --how $method --image fedora-coreos"
+
+            rlPhaseStartTest "Install an existing package ($method, CoreOS)"
+                rlRun "tmt run -adddvvvr $provision plan --name existing"
+            rlPhaseEnd
+
+            rlPhaseStartTest "Report a missing package ($method, CoreOS)"
+                rlRun "tmt run -adddvvvr $provision plan --name missing" 2
+            rlPhaseEnd
+        fi
+    done
+
     rlPhaseStartTest "Just enable copr"
         rlRun "tmt run -adddvvvr plan --name copr"
     rlPhaseEnd


### PR DESCRIPTION
- bug with rpm-ostree install packages are already processed into a list, typo from variable carryover. 
- correct capitalization in error msg

https://github.com/teemtee/tmt/commit/1e858e87cf8b0bb67a43daa6309bbeb9e0c84b61

https://github.com/teemtee/tmt/pull/1164

introduced a couple of bugs, against rpm-ostree
additionally shows the need for some tests, the trick will be getting access to rpm-ostree images

