### PR TITLE
Handle empty fmf file as an empty dictionary

### DIFF
--- a/tests/lint/data/tests/empty/main.fmf
+++ b/tests/lint/data/tests/empty/main.fmf
@@ -1,0 +1,1 @@
+test: echo

--- a/tests/lint/test.sh
+++ b/tests/lint/test.sh
@@ -52,6 +52,10 @@ rlJournalStart
         rlAssertGrep 'relevancy converted into adjust' $rlRun_LOG
     rlPhaseEnd
 
+    rlPhaseStartTest "Check empty fmf file"
+        rlRun -s "tmt lint empty" 0 "Empty file should be ok"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
 rlJournalEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -785,6 +785,8 @@ class Plan(Core):
                     #        there may be a better way to do this.
                     try:
                         data = tmt.utils.yaml_to_dict(option, yaml_type='safe')
+                        if not (data):
+                            raise tmt.utils.GeneralError("Step data cannot be empty.")
                     except tmt.utils.GeneralError as error:
                         raise tmt.utils.GeneralError(
                             f"Invalid step data for {step}: '{option}'"

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1197,6 +1197,8 @@ def yaml_to_dict(data: Any,
     """ Convert yaml into dictionary """
     yaml = YAML(typ=yaml_type)
     loaded_data = yaml.load(data)
+    if loaded_data is None:
+        return dict()
     if not isinstance(loaded_data, dict):
         raise GeneralError(
             f"Expected dictionary in yaml data, "


### PR DESCRIPTION
If an empty FMF file is specified, yaml_to_dict() should return an empty dict instead of validating it is an instance of class dict.
