### PR TITLE
Refactor location and signature of Phase's go() method

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.931"
+    rev: "v0.961"
     hooks:
       - id: mypy
         additional_dependencies: [types-click]

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -762,7 +762,7 @@ def export_to_polarion(test: 'tmt.Test') -> None:
     for link in test.link:
         bug_ids_search = re.search(RE_BUGZILLA_URL, link['verifies'])
         if bug_ids_search:
-            bug_ids.append(bug_ids_search.group(1))
+            bug_ids.append(int(bug_ids_search.group(1)))
         else:
             log.debug('Failed to find bug ID in verifies link')
         polarion_url_search = re.search(RE_POLARION_URL, link['verifies'])
@@ -773,7 +773,7 @@ def export_to_polarion(test: 'tmt.Test') -> None:
 
     # Add bugs to the Polarion case
     if not dry_mode:
-        polarion_case.tcmsbug = ', '.join(bug_ids)
+        polarion_case.tcmsbug = ', '.join(str(bug_ids))
 
     # Add TCMS Case ID to Polarion case
     if test.node.get('extra-nitrate') and not dry_mode:

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -266,7 +266,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
 
     def go(self, guest):
         """ Execute available tests """
-        super().go()
+        super().go(guest)
         self._results = []
 
         # Nothing to do in dry mode

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -126,7 +126,7 @@ class ExecuteUpgrade(ExecuteInternal):
         """ Execute available tests """
         self._results = []
         # Inform about the how, skip the actual execution
-        super(ExecutePlugin, self).go()
+        super(ExecutePlugin, self).go(guest)
 
         self.url = self.get('url')
         self.upgrade_path = self.get('upgrade-path')

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -5,6 +5,9 @@ import click
 import fmf
 
 import tmt
+import tmt.steps
+from tmt.steps import Action
+from tmt.utils import GeneralError
 
 
 class Finish(tmt.steps.Step):
@@ -69,8 +72,16 @@ class Finish(tmt.steps.Step):
             # finish step config rather than provision step config.
             guest_copy = copy.copy(guest)
             guest_copy.parent = self
-            for phase in self.phases():
-                phase.go(guest_copy)
+            for phase in self.phases(classes=(Action, FinishPlugin)):
+                if isinstance(phase, Action):
+                    phase.go()
+
+                elif isinstance(phase, FinishPlugin):
+                    phase.go(guest_copy)
+
+                else:
+                    raise GeneralError(f'Unexpected phase in finish step: {phase}')
+
             # Pull artifacts created in the plan data directory
             # if there was at least one plugin executed
             if self.phases():

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -55,7 +55,7 @@ class FinishShell(tmt.steps.finish.FinishPlugin):  # type: ignore[misc]
 
     def go(self, guest: Guest) -> None:
         """ Perform finishing tasks on given guest """
-        super().go()
+        super().go(guest)
 
         # Give a short summary
         scripts = self.get('script')

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -15,8 +15,9 @@ import click
 import fmf
 
 import tmt
-import tmt.plugins
+import tmt.steps
 import tmt.utils
+from tmt.steps import Action
 
 # Timeout in seconds of waiting for a connection after reboot
 # (long enough to allow operations such as system upgrade)
@@ -137,7 +138,7 @@ class Provision(tmt.steps.Step):
         self.is_multihost = sum([isinstance(phase, ProvisionPlugin)
                                 for phase in self.phases()]) > 1
         try:
-            for phase in self.phases():
+            for phase in self.phases(classes=(Action, ProvisionPlugin)):
                 try:
                     phase.go()
                     if isinstance(phase, ProvisionPlugin):
@@ -181,7 +182,7 @@ class Provision(tmt.steps.Step):
         return list(requires)
 
 
-class ProvisionPlugin(tmt.steps.Plugin):
+class ProvisionPlugin(tmt.steps.GuestlessPlugin):
     """ Common parent of provision plugins """
 
     # Default implementation for provision is a virtual machine

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -1,5 +1,4 @@
 import os
-from typing import Any
 
 import tmt
 import tmt.steps.report
@@ -36,7 +35,7 @@ class ReportDisplay(tmt.steps.report.ReportPlugin):
                 self.verbose(
                     'content', self.read(full_path), color='yellow', shift=2)
 
-    def go(self, *args: Any, **kwargs: Any) -> None:
+    def go(self) -> None:
         """ Discover available tests """
         super().go()
         # Show individual test results only in verbose mode

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -2,7 +2,7 @@ import os
 import os.path
 import types
 import webbrowser
-from typing import Any, List, Optional
+from typing import List, Optional
 
 import click
 import pkg_resources
@@ -59,7 +59,7 @@ class ReportHtml(tmt.steps.report.ReportPlugin):
             ]
         return options
 
-    def go(self, *args: Any, **kwargs: Any) -> None:
+    def go(self) -> None:
         """ Process results """
         super().go()
 

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -1,6 +1,6 @@
 import os
 import types
-from typing import Any, List, Optional, overload
+from typing import List, Optional, overload
 
 import click
 
@@ -72,7 +72,7 @@ class ReportJUnit(tmt.steps.report.ReportPlugin):
             ]
         return options
 
-    def go(self, *args: Any, **kwargs: Any) -> None:
+    def go(self) -> None:
         """ Read executed tests and write junit """
         super().go()
 


### PR DESCRIPTION
The method has been defined in `Phase` class, making it shared among all
of its subclasses. Unfortunately, some subclasses accept more specific
arguments, which makes their methods incompatible with superclass
definition.

This is a violation of Liskov substitution principle which states that
objects of superclass can be replaced with objects of subclass without
breaking an application. Note that while the implementation looks so,
`tmt` code is not actually using this freedom - not all subclasses of
`Phase` can be, and are not, in fact, used everywhere. For example,
`execute` plugins never meet `discovery` step.

The patch removes `go()` from `Phase`, and introduces more specific
methods into its subclasses. This involves adding two plugin-like base
classes replacing the original `Plugin`, because plugins that need to
be aware of a guest to do their job are common, therefore we now have a
base plugins class plus two thin wrappers with `go()` methods tailored
for their line of work.