### PR TITLE
Adding fix for TMT #1350

### DIFF
--- a/tests/test/import/test.sh
+++ b/tests/test/import/test.sh
@@ -41,7 +41,7 @@ rlJournalStart
         rlAssertGrep 'summary: Simple smoke test using restraint' 'main.fmf'
 	rlRun 'grep -A2 require main.fmf | grep "fmf\|tmt"'
         rlRun 'grep -A1 recommend main.fmf | grep fmf'
-        rlAssertGrep 'test: ./runtest.sh' 'output'
+        rlAssertGrep 'test: bash -x ./runtest.sh' 'output'
         rlAssertGrep 'duration: 6m' 'main.fmf'
     rlPhaseEnd
 
@@ -51,7 +51,7 @@ rlJournalStart
         rlAssertGrep 'summary: Simple smoke test using restraint' 'main.fmf'
 	rlRun 'grep -A2 require main.fmf | grep "fmf\|tmt"'
         rlRun 'grep -A1 recommend main.fmf | grep fmf'
-        rlAssertGrep 'test: ./runtest.sh' 'output'
+        rlAssertGrep 'test: bash -x ./runtest.sh' 'output'
         rlAssertGrep 'duration: 6m' 'main.fmf'
     rlPhaseEnd
 

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -6,10 +6,10 @@ import copy
 import os
 import pprint
 import re
+import shlex
 import subprocess
 from io import open
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
-import shlex
 
 import fmf.utils
 from click import echo, style

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 from io import open
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
+import shlex
 
 import fmf.utils
 from click import echo, style
@@ -256,9 +257,9 @@ def read_datafile(
     try:
         test_path = ""
         if data["test"].split()[0] != 'make':
-            match = re.search('\\./.+\\.sh', data['test'])
-            if match:
-                test_path = os.path.join(path, match.group(0))
+            script_paths = [s for s in shlex.split(data['test']) if s.endswith('.sh')]
+            if script_paths:
+                test_path = os.path.join(path, script_paths[0])
         else:
             # As 'make' command was specified for test, ensure Makefile present.
             makefile_path = os.path.join(path, 'Makefile')

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -254,14 +254,10 @@ def read_datafile(
 
     # Detect framework
     try:
-        print("##################################################")
-        print(data["test"].split()[0])
         test_path = ""
         if data["test"].split()[0] != 'make':
-            print("##### in make If statement")
-            match = re.search('\./.+\.sh', data['test'])
+            match = re.search('\\./.+\\.sh', data['test'])
             if match:
-                print("##### in match If statement")
                 test_path = os.path.join(path, match.group(0))
         else:
             # As 'make' command was specified for test, ensure Makefile present.

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -202,10 +202,11 @@ def read_datafile(
     """
 
     data: NitrateDataType = dict()
+    makefile_regex_test = r'^run:.*\n\t(.*)$'
     if filename == 'Makefile':
         regex_task = r'Name:\s*(.*)\n'
         regex_summary = r'^Description:\s*(.*)\n'
-        regex_test = r'^run:.*\n\t(.*)$'
+        regex_test = makefile_regex_test
         regex_contact = r'^Owner:\s*(.*)'
         regex_duration = r'^TestTime:\s*(.*)'
         regex_recommend = r'^Requires:\s*(.*)'
@@ -242,15 +243,32 @@ def read_datafile(
     # Test script
     search_result = re.search(regex_test, datafile, re.M)
     if search_result is None:
-        raise ConvertError("Makefile is missing the 'run' target.")
-    data['test'] = search_result.group(1)
-    if filename == 'metadata':
-        data['test'] = data['test'].split()[-1]
-    echo(style('test: ', fg='green') + data['test'])
+        if filename == 'metadata':
+            # entry_point property is optional. When absent 'make run' is used.
+            data['test'] = 'make run'
+        else:
+            raise ConvertError("Makefile is missing the 'run' target.")
+    else:
+        data['test'] = search_result.group(1)
+        echo(style('test: ', fg='green') + data['test'])
 
     # Detect framework
     try:
-        test_path = os.path.join(path, data["test"])
+        if data["test"].split()[0] != 'make':
+            test_path = os.path.join(path, data["test"].split()[-1])
+        else:
+            # As 'make' command was specified for test, ensure Makefile present.
+            makefile_path = os.path.join(path, 'Makefile')
+            try:
+                with open(makefile_path, encoding='utf-8') as makefile_file:
+                    makefile = makefile_file.read()
+                    search_result = \
+                        re.search(makefile_regex_test, makefile, re.M)
+            except IOError:
+                raise ConvertError("Makefile is missing.")
+            # Retrieve the path to the test file from the Makefile
+            test_path =  os.path.join(path, search_result.group(1).split()[-1])
+        # Read the test file and determine the framework used.
         with open(test_path, encoding="utf-8") as test_file:
             if re.search("beakerlib", test_file.read()):
                 data["framework"] = "beakerlib"

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -254,8 +254,15 @@ def read_datafile(
 
     # Detect framework
     try:
+        print("##################################################")
+        print(data["test"].split()[0])
+        test_path = ""
         if data["test"].split()[0] != 'make':
-            test_path = os.path.join(path, data["test"].split()[-1])
+            print("##### in make If statement")
+            match = re.search('\./.+\.sh', data['test'])
+            if match:
+                print("##### in match If statement")
+                test_path = os.path.join(path, match.group(0))
         else:
             # As 'make' command was specified for test, ensure Makefile present.
             makefile_path = os.path.join(path, 'Makefile')
@@ -267,13 +274,16 @@ def read_datafile(
             except IOError:
                 raise ConvertError("Makefile is missing.")
             # Retrieve the path to the test file from the Makefile
-            test_path =  os.path.join(path, search_result.group(1).split()[-1])
+            test_path = os.path.join(path, search_result.group(1).split()[-1])
         # Read the test file and determine the framework used.
-        with open(test_path, encoding="utf-8") as test_file:
-            if re.search("beakerlib", test_file.read()):
-                data["framework"] = "beakerlib"
-            else:
-                data["framework"] = "shell"
+        if test_path:
+            with open(test_path, encoding="utf-8") as test_file:
+                if re.search("beakerlib", test_file.read()):
+                    data["framework"] = "beakerlib"
+                else:
+                    data["framework"] = "shell"
+        else:
+            data["framework"] = "shell"
         echo(style("framework: ", fg="green") + data["framework"])
     except IOError:
         raise ConvertError("Unable to open '{0}'.".format(test_path))

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -270,7 +270,8 @@ def read_datafile(
             except IOError:
                 raise ConvertError("Makefile is missing.")
             # Retrieve the path to the test file from the Makefile
-            test_path = os.path.join(path, search_result.group(1).split()[-1])
+            if search_result is not None:
+                test_path = os.path.join(path, search_result.group(1).split()[-1])
         # Read the test file and determine the framework used.
         if test_path:
             with open(test_path, encoding="utf-8") as test_file:


### PR DESCRIPTION
Import code has been updated to account for cases where restraint 'metadata' file _entry_point_ property has a 'make' command as a value. In this case the code ensures that a Makefile is indeed present in the directory, and then reads that to ascertain the actual test file to be read to determine the framework utilised.