### PR TITLE
Tests/full with copy-in (no push necessary)

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -173,7 +173,14 @@ the full test suite wrapper against the desired branch::
 Or schedule the full test suite under an external test system::
 
     cd tests/full
-    tmt test export --fmf-id | wow fedora-35 x86_64 --fmf-id -
+    tmt test export --fmf-id | wow fedora-35 x86_64 --fmf-id - --taskparam=BRANCH=target
+
+Or run local modifications copied to the virtual machine. Because this
+requires changes outside of the fmf root you need to run make
+which tars sources to the expected location::
+
+    cd tests/full
+    make test
 
 To run unit tests using pytest and generate coverage report::
 

--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -32,7 +32,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Destination"
-        rlRun "$tmt destination 2>&1 | tee $tmp/output" 1
+        rlRun "$tmt destination 2>&1 | tee $tmp/output" 0
         rlAssertGrep 'Cloning into.*custom/openssl' $tmp/output
     rlPhaseEnd
 

--- a/tests/execute/reboot/get_value.py
+++ b/tests/execute/reboot/get_value.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+import click
+from ruamel.yaml import YAML
+
+
+@click.command()
+@click.argument("KEY")
+@click.argument("YAML_FILE")
+def main(key, yaml_file):
+    """
+    Find 'key' somewhere in the yaml_file and print its value
+
+    If it returns list then prints first item
+    """
+
+    with open(yaml_file) as f:
+        data = YAML(typ="safe").load(f)
+
+    value = find_value(data, key)
+    if not isinstance(value, (str, int)):
+        if value:
+            print(value[0])
+    else:
+        print(value)
+
+
+def find_value(data, key):
+    if not isinstance(data, dict):
+        raise ValueError()
+    try:
+        return data[key]
+    except KeyError:
+        for value in data.values():
+            try:
+                return find_value(value, key)
+            except ValueError:
+                pass
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/execute/reboot/reuse.sh
+++ b/tests/execute/reboot/reuse.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
-trim() {
-    sed -e 's/ *$//g' -e 's/^ *//g'
-}
 
-get_value() {
-    grep "$1:" "$2" | cut -d':' -f2 | trim
+TEST_DIR="$(pwd)"
+
+get_value(){
+    $TEST_DIR/get_value.py "$1" "$2"
 }
 
 rlJournalStart

--- a/tests/full/Makefile
+++ b/tests/full/Makefile
@@ -1,0 +1,10 @@
+# Run local changes in tests/full
+# We need to escape fmf root placed in tests/full
+# so current repo is put to tar into directory which is copied
+# to the VM
+test: bundle
+	tmt run -vvv -e COPY_IN=1
+bundle: clean
+	tar czf ./repo_copy.tgz --exclude repo_copy.tgz -C $(shell git rev-parse --show-toplevel) .
+clean:
+	test -e ./repo_copy.tgz && rm -f ./repo_copy.tgz || true

--- a/tests/full/test.fmf
+++ b/tests/full/test.fmf
@@ -1,10 +1,15 @@
 summary: Run the full tmt test suite in an external system
 description: |
+    To check local changes without pushing to git:
+    make test
+
     Run under a local virtual machine:
-    tmt run
+    tmt run -vvv -e BRANCH=<tested branch>
 
     Schedule a job using workflow-tomorrow:
-    tmt test export --fmf-id | wow fedora-35 x86_64 --fmf-id -
+    tmt test export --fmf-id | wow fedora-35 x86_64 --fmf-id - --taskparam=BRANCH=<branch>
+
+    See head of the test.sh for future information
 
 test: ./test.sh
 framework: beakerlib


### PR DESCRIPTION
- [x] tests/full needs more space (real fedora upgrade test happens) -> go for 40g
- [x] be really explicit about BRANCH= and how test work (it doesn't respect local changes at all)
- [x] add `make vmtest` target to inject local changes into test/full without the need to push to github
- [x] do not submit testcloud images
- [x] update connect plan correctly so schema validation running in /tests/unit passes
- [x] fix /tests/discover/libraries where destination passes (but is expected to fail)

