### PR TITLE
Normalize step data to be always stored a list internally

### DIFF
--- a/tests/discover/distgit.sh
+++ b/tests/discover/distgit.sh
@@ -103,7 +103,7 @@ EOF
         echo 'test: foo-123/all_in_one' > unit.fmf
 
         WORKDIR=/var/tmp/tmt/XXX
-        WORKDIR_TESTS=$WORKDIR/plans/discover/default/tests
+        WORKDIR_TESTS=$WORKDIR/plans/discover/default-0/tests
 
         rlRun -s "tmt run -vv --id $WORKDIR --scratch"
 
@@ -131,8 +131,8 @@ done
         ) > $MOCK_SOURCES_FILENAME
 
         WORKDIR=/var/tmp/tmt/XXX
-        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default/source
-        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default/tests
+        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default-0/source
+        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default-0/tests
 
         rlRun -s "tmt run --id $WORKDIR --scratch plans --default \
              discover -vvv -ddd --how fmf --dist-git-source \
@@ -197,8 +197,8 @@ done
         echo "simple-1.tgz" > $MOCK_SOURCES_FILENAME
 
         WORKDIR=/var/tmp/tmt/XXX
-        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default/source
-        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default/tests
+        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default-0/source
+        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default-0/tests
 
         rlRun -s 'tmt run --id $WORKDIR --scratch plans --default \
              discover -vvv -ddd --how fmf --dist-git-source \
@@ -227,8 +227,8 @@ done
         echo "simple-1.tgz" > $MOCK_SOURCES_FILENAME
 
         WORKDIR=/var/tmp/tmt/XXX
-        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default/source
-        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default/tests
+        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default-0/source
+        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default-0/tests
 
         rlRun -s 'tmt run --id $WORKDIR --scratch plans --default \
             discover -v --how fmf --dist-git-source \
@@ -256,8 +256,8 @@ done
         echo "simple-1.tgz renamed_simple.tgz" > $MOCK_SOURCES_FILENAME
 
         WORKDIR=/var/tmp/tmt/XXX
-        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default/source
-        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default/tests
+        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default-0/source
+        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default-0/tests
 
         rlRun -s 'tmt run --id $WORKDIR --scratch plans --default \
             discover -v --how fmf --dist-git-source \
@@ -285,8 +285,8 @@ done
         echo "simple-1.tgz simple.tgz" > $MOCK_SOURCES_FILENAME
 
         WORKDIR=/var/tmp/tmt/XXX
-        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default/source
-        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default/tests
+        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default-0/source
+        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default-0/tests
 
         rlRun -s 'tmt run --id $WORKDIR --scratch plans --default \
             discover -v --how fmf --dist-git-source \
@@ -370,8 +370,8 @@ done
         rlRun "tmt init"
 
         WORKDIR=/var/tmp/tmt/XXX
-        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default/source
-        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default/tests
+        WORKDIR_SOURCE=$WORKDIR/plans/default/discover/default-0/source
+        WORKDIR_TESTS=$WORKDIR/plans/default/discover/default-0/tests
 
         rlRun -s "tmt run --id $WORKDIR --scratch plans --default \
              discover -vvv -ddd --how fmf --dist-git-source \
@@ -433,7 +433,7 @@ execute:
 EOF
 
         WORKDIR=/var/tmp/tmt/XXX
-        WORKDIR_SOURCE=$WORKDIR/plans/discover/default/source
+        WORKDIR_SOURCE=$WORKDIR/plans/discover/default-0/source
 
         rlRun -s "tmt run --id $WORKDIR --scratch -vvv"
 

--- a/tests/discover/no-git-needed/test.sh
+++ b/tests/discover/no-git-needed/test.sh
@@ -11,12 +11,12 @@ rlJournalStart
 
     rlPhaseStartTest
         rlRun "tmt --root tests run -i $run" 0
-        rlAssertNotExists "$run/plan/discover/default/tests/foo"
+        rlAssertNotExists "$run/plan/discover/default-0/tests/foo"
     rlPhaseEnd
 
     rlPhaseStartTest
         rlRun "tmt --root tests run --scratch -ai $run discover -h fmf --sync-repo" 0
-        rlAssertExists "$run/plan/discover/default/tests/foo"
+        rlAssertExists "$run/plan/discover/default-0/tests/foo"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/plan/lint/test.sh
+++ b/tests/plan/lint/test.sh
@@ -13,7 +13,7 @@ rlJournalStart
         rlRun "rm $rlRun_LOG"
 
         rlRun -s "tmt plan lint valid_fmf"
-        rlAssertGrep "pass fmf remote id in 'default' is valid" $rlRun_LOG
+        rlAssertGrep "pass fmf remote id in 'default-0' is valid" $rlRun_LOG
         rlAssertNotGrep 'warn summary ' $rlRun_LOG
         rlRun "rm $rlRun_LOG"
 

--- a/tests/report/html/test.sh
+++ b/tests/report/html/test.sh
@@ -17,7 +17,7 @@ rlJournalStart
             rlRun "tmt run -av --scratch --id $run_dir execute -h $method report -h html | tee output" 2
             rlAssertGrep "summary: 2 tests passed, 1 test failed and 2 errors" output -F
 
-            HTML="$run_dir/plan/report/default/index.html"
+            HTML="$run_dir/plan/report/default-0/index.html"
 
             test_name_suffix=error
             grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -192,27 +192,23 @@ class Step(tmt.utils.Common):
         # Return status
         return self._status
 
-    def load(self, extra_keys: Optional[List[str]] = None) -> None:
+    def load(self) -> None:
         """ Load status and step data from the workdir """
-        extra_keys = extra_keys or []
         try:
             content: Dict[Any, Any] = tmt.utils.yaml_to_dict(
                 self.read('step.yaml'))
             self.debug('Successfully loaded step data.', level=2)
             self.data = content['data']
-            for key in extra_keys:
-                if key in content:
-                    setattr(self, key, content[key])
             self.status(content['status'])
         except tmt.utils.GeneralError:
             self.debug('Step data not found.', level=2)
 
-    def save(self, data: Optional[StepData] = None) -> None:
+    def save(self) -> None:
         """ Save status and step data to the workdir """
-        data = data or {}
-        content: Dict[Any, Any] = dict(
-            status=self.status(), data=self.data)
-        content.update(data)
+        content: Dict[str, Any] = {
+            'status': self.status(),
+            'data': self.data
+            }
         self.write('step.yaml', tmt.utils.dict_to_yaml(content))
 
     def wake(self) -> None:

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -26,10 +26,9 @@ class Discover(tmt.steps.Step):
         # List of Test() objects representing discovered tests
         self._tests: List[tmt.Test] = []
 
-    def load(self, extra_keys: Optional[List[str]] = None) -> None:
+    def load(self) -> None:
         """ Load step data from the workdir """
-        extra_keys = extra_keys or []
-        super().load(extra_keys)
+        super().load()
         try:
             tests = tmt.utils.yaml_to_dict(self.read('tests.yaml'))
             self._tests = [
@@ -37,10 +36,9 @@ class Discover(tmt.steps.Step):
         except tmt.utils.FileError:
             self.debug('Discovered tests not found.', level=2)
 
-    def save(self, data: Optional[tmt.steps.StepData] = None) -> None:
+    def save(self) -> None:
         """ Save step data to the workdir """
-        data = data or {}
-        super().save(data)
+        super().save()
 
         # Create tests.yaml with the full test data
         tests = dict([

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -19,8 +19,6 @@ from tmt.utils import GeneralError
 class Discover(tmt.steps.Step):
     """ Gather information about test cases to be executed. """
 
-    data: List[tmt.steps.StepData]
-
     def __init__(self, plan: 'tmt.base.Plan', data: tmt.steps.StepData):
         """ Store supported attributes, check for sanity """
         super().__init__(plan=plan, data=data)
@@ -71,7 +69,7 @@ class Discover(tmt.steps.Step):
             scripts = [scripts]
 
         # Give a warning when discover step defined as well
-        default_data = [{'name': 'default', 'how': 'shell'}]
+        default_data = [{'name': 'default-0', 'how': 'shell'}]
         if self.data and self.data != default_data:
             raise tmt.utils.DiscoverError(
                 "Use either 'discover' or 'execute' step "

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -68,10 +68,9 @@ class Execute(tmt.steps.Step):
         if not self.plan.my_run:
             self._map_old_methods()
 
-    def load(self, extra_keys: Optional[List[str]] = None) -> None:
+    def load(self) -> None:
         """ Load test results """
-        extra_keys = extra_keys or []
-        super().load(extra_keys)
+        super().load()
         try:
             results = tmt.utils.yaml_to_dict(self.read('results.yaml'))
             self._results = [
@@ -79,10 +78,9 @@ class Execute(tmt.steps.Step):
         except tmt.utils.FileError:
             self.debug('Test results not found.', level=2)
 
-    def save(self, data: Optional[tmt.steps.StepData] = None) -> None:
+    def save(self) -> None:
         """ Save test results to the workdir """
-        data = data or {}
-        super().save(data)
+        super().save()
         results = dict([
             (result.name, result.export()) for result in self.results()])
         self.write('results.yaml', tmt.utils.dict_to_yaml(results))

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -54,7 +54,6 @@ class Execute(tmt.steps.Step):
 
     # Internal executor is the default implementation
     DEFAULT_HOW = 'tmt'
-    data: List[tmt.steps.StepData]
 
     def __init__(self, plan: "tmt.Plan", data: tmt.steps.StepData) -> None:
         """ Initialize execute step data """

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -57,10 +57,9 @@ class Provision(tmt.steps.Step):
         self._guest_data: Dict[str, 'GuestData'] = {}
         self.is_multihost = False
 
-    def load(self, extra_keys=None):
+    def load(self):
         """ Load guest data from the workdir """
-        extra_keys = extra_keys or []
-        super().load(extra_keys)
+        super().load()
         try:
             raw_guest_data = tmt.utils.yaml_to_dict(self.read('guests.yaml'))
 
@@ -72,10 +71,9 @@ class Provision(tmt.steps.Step):
         except tmt.utils.FileError:
             self.debug('Provisioned guests not found.', level=2)
 
-    def save(self, data=None):
+    def save(self):
         """ Save guest data to the workdir """
-        data = data or {}
-        super().save(data)
+        super().save()
         try:
             raw_guest_data = {guest.name: guest.save().to_serialized()
                               for guest in self.guests()}

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -118,7 +118,7 @@ class Provision(tmt.steps.Step):
         self.info('summary', f'{guests} provisioned', 'green', shift=1)
         # Guest list in verbose mode
         for guest in self.guests():
-            if guest.name != tmt.utils.DEFAULT_NAME:
+            if not guest.name.startswith(tmt.utils.DEFAULT_NAME):
                 self.verbose(guest.name, color='red', shift=2)
 
     def go(self):

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -12,7 +12,6 @@ class Report(tmt.steps.Step):
 
     # Default implementation for report is display
     DEFAULT_HOW = 'display'
-    data: List[tmt.steps.StepData]
 
     def wake(self) -> None:
         """ Wake up the step (process workdir and command line) """


### PR DESCRIPTION
`Step.data` was annotated as `Union[StepData, List[StepData]]`, allowing
both a single item and list of items. This complicates things when one
wants to do stuff like `self.data.get('foo')` - not possible with the
list. And if done in loop, one must first check `self.data` is actually
a list.

Which it was, the code in `Step.__init__` took care of that, but
annotations were puzzling. This patch settles down on `List[StepData]`
only, and changes normalization code to take advantage of this fact.