### PR TITLE
Use decorator to register plugin methods

### DIFF
--- a/examples/plugins/discover.py
+++ b/examples/plugins/discover.py
@@ -1,10 +1,12 @@
 import tmt
+import tmt.steps
 import tmt.steps.discover
 
 # See the online documentation for more details about writing plugins
 # https://tmt.readthedocs.io/en/stable/plugins.html
 
 
+@tmt.steps.provides_method('example')
 class DiscoverExample(tmt.steps.discover.DiscoverPlugin):
     """
     A concise summary of what the plugin does
@@ -13,9 +15,6 @@ class DiscoverExample(tmt.steps.discover.DiscoverPlugin):
     in the --help message. It is recommended to include a couple
     of configuration examples as well.
     """
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='example', doc=__doc__, order=50)]
 
     def show(self):
         """ Show plugin details for given or all available keys """

--- a/examples/plugins/provision.py
+++ b/examples/plugins/provision.py
@@ -1,11 +1,13 @@
 import click
 
 import tmt
+import tmt.steps
 
 # See the online documentation for more details about writing plugins
 # https://tmt.readthedocs.io/en/stable/plugins.html
 
 
+@tmt.steps.provides_method('example')
 class ProvisionExample(tmt.steps.provision.ProvisionPlugin):
     """
     Provision guest using nothing. Just example
@@ -22,9 +24,6 @@ class ProvisionExample(tmt.steps.provision.ProvisionPlugin):
     """
 
     _guest = None
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='example', doc=__doc__, order=50)]
 
     @classmethod
     def options(cls, how=None):

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -205,7 +205,7 @@ class Discover(tmt.steps.Step):
 class DiscoverPlugin(tmt.steps.GuestlessPlugin):
     """ Common parent of discover plugins """
 
-    # List of all supported methods aggregated from all plugins
+    # List of all supported methods aggregated from all plugins of the same step.
     _supported_methods: List[tmt.steps.Method] = []
 
     # Common keys for all discover step implementations

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -9,10 +9,12 @@ import fmf
 
 import tmt
 import tmt.beakerlib
+import tmt.steps
 import tmt.steps.discover
 from tmt.utils import git_clone
 
 
+@tmt.steps.provides_method('fmf')
 class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
     """
     Discover available tests from fmf metadata
@@ -84,9 +86,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
     specified via 'test', so those tests will also be selected even if
     not modified.
     """
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='fmf', doc=__doc__, order=50)]
 
     # Supported keys
     _keys = [

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -6,12 +6,14 @@ import click
 import fmf
 
 import tmt
+import tmt.steps
 import tmt.steps.discover
 
 if TYPE_CHECKING:
     import tmt.base
 
 
+@tmt.steps.provides_method('shell')
 class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
     """
     Use provided list of shell script tests
@@ -42,9 +44,6 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
         - name: /upstream
           test: cd $TMT_SOURCE_DIR/*/tests && make test
     """
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='shell', doc=__doc__, order=50)]
 
     def show(self, keys: Optional[List[str]] = None) -> None:
         """ Show config details """

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -9,13 +9,13 @@ import fmf
 import pkg_resources
 
 import tmt
-from tmt.steps import Action, Method
+import tmt.steps
+from tmt.steps import Action
 from tmt.steps.provision import Guest
 from tmt.utils import GeneralError
 
 if TYPE_CHECKING:
     import tmt.options
-    import tmt.steps
     import tmt.steps.discover
     import tmt.steps.provision
 
@@ -201,8 +201,8 @@ class Execute(tmt.steps.Step):
 class ExecutePlugin(tmt.steps.Plugin):
     """ Common parent of execute plugins """
 
-    # List of all supported methods aggregated from all plugins
-    _supported_methods: List[Method] = []
+    # List of all supported methods aggregated from all plugins of the same step.
+    _supported_methods: List[tmt.steps.Method] = []
 
     # Common keys for all execute plugins
     _common_keys = ["exit-first"]

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -6,6 +6,7 @@ import time
 import click
 
 import tmt
+import tmt.steps
 import tmt.steps.execute
 import tmt.utils
 from tmt.steps.execute import TEST_OUTPUT_FILENAME, Script
@@ -57,6 +58,9 @@ SCRIPTS = (TMT_FILE_SUBMIT_SCRIPT,
            )
 
 
+@tmt.steps.provides_method('tmt')
+@tmt.steps.provides_method('shell.tmt', order=80)
+@tmt.steps.provides_method('beakerlib.tmt', order=80)
 class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
     """
     Use the internal tmt executor to execute tests
@@ -66,13 +70,6 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
     result is based on the script exit code (for shell tests) or the
     results file (for beakerlib tests).
     """
-
-    # Supported methods
-    _methods = [
-        tmt.steps.Method(name='tmt', doc=__doc__, order=50),
-        tmt.steps.Method(name='shell.tmt', doc=__doc__, order=80),
-        tmt.steps.Method(name='beakerlib.tmt', doc=__doc__, order=80),
-        ]
 
     # Supported keys
     _keys = ["script", "interactive"]

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -2,6 +2,7 @@ import click
 import fmf.utils
 
 import tmt.base
+import tmt.steps
 import tmt.utils
 from tmt.steps.discover import DiscoverPlugin
 from tmt.steps.discover.fmf import DiscoverFmf
@@ -18,6 +19,7 @@ SUPPORTED_REMOTE_DISCOVER_KEYS = ['how', 'filter', 'test', 'exclude', 'tests']
 INHERIT_FROM_DISCOVER = ['ref', 'test', 'filter', 'exclude']
 
 
+@tmt.steps.provides_method('upgrade')
 class ExecuteUpgrade(ExecuteInternal):
     """
     Perform system upgrade during testing.
@@ -84,11 +86,6 @@ class ExecuteUpgrade(ExecuteInternal):
             url: https://github.com/teemtee/upgrade
             filter: "tag:fedora"
     """
-
-    # Supported methods
-    _methods = [
-        tmt.steps.Method(name='upgrade', doc=__doc__, order=50),
-        ]
 
     # Supported keys
     _keys = ['url', 'upgrade-path'] + INHERIT_FROM_DISCOVER

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -114,7 +114,7 @@ class Finish(tmt.steps.Step):
 class FinishPlugin(tmt.steps.Plugin):
     """ Common parent of finish plugins """
 
-    # List of all supported methods aggregated from all plugins
+    # List of all supported methods aggregated from all plugins of the same step.
     _supported_methods: List[Method] = []
 
     @classmethod

--- a/tmt/steps/finish/ansible.py
+++ b/tmt/steps/finish/ansible.py
@@ -1,8 +1,10 @@
 import tmt
+import tmt.steps
 import tmt.steps.finish
 from tmt.steps.prepare.ansible import PrepareAnsible
 
 
+@tmt.steps.provides_method('ansible')
 class FinishAnsible(tmt.steps.finish.FinishPlugin, PrepareAnsible):
     """
     Perform finishing tasks using ansible
@@ -27,11 +29,6 @@ class FinishAnsible(tmt.steps.finish.FinishPlugin, PrepareAnsible):
     should happen if there are multiple configs. Default order is '50'.
     """
 
-    # Supported methods
-    _methods = [tmt.steps.Method(name='ansible', doc=__doc__, order=50)]
-
-    # Explicitly use these from FinishPlugin class
-    _supported_methods = tmt.steps.finish.FinishPlugin._supported_methods
     # Assigning class methods seems to cause trouble to mypy
     # See also: https://github.com/python/mypy/issues/6700
     base_command = tmt.steps.finish.FinishPlugin.base_command  # type: ignore

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -4,10 +4,12 @@ import click
 import fmf
 
 import tmt
+import tmt.steps
 import tmt.steps.finish
 from tmt.steps.provision import Guest
 
 
+@tmt.steps.provides_method('shell')
 class FinishShell(tmt.steps.finish.FinishPlugin):
     """
     Perform finishing tasks using shell scripts
@@ -23,9 +25,6 @@ class FinishShell(tmt.steps.finish.FinishPlugin):
     Use the 'order' attribute to select in which order finishing tasks
     should happen if there are multiple configs. Default order is '50'.
     """
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='shell', doc=__doc__, order=50)]
 
     # Supported keys
     _keys = ["script"]

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -1,6 +1,6 @@
 import collections
 import copy
-from typing import Optional, Type
+from typing import List, Optional, Type
 
 import click
 import fmf
@@ -183,8 +183,8 @@ class Prepare(tmt.steps.Step):
 class PreparePlugin(tmt.steps.Plugin):
     """ Common parent of prepare plugins """
 
-    # List of all supported methods aggregated from all plugins
-    _supported_methods = []
+    # List of all supported methods aggregated from all plugins of the same step.
+    _supported_methods: List[tmt.steps.Method] = []
 
     # Common keys for all prepare step implementations
     _common_keys = ['where']

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional
 import click
 
 import tmt
+import tmt.steps
 import tmt.steps.prepare
 import tmt.utils
 from tmt.steps import Step
@@ -23,6 +24,7 @@ StepDataType = TypedDict(
     )
 
 
+@tmt.steps.provides_method('ansible')
 class PrepareAnsible(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
     """
     Prepare guest using ansible
@@ -48,9 +50,6 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
     happen if there are multiple configs. Default order is '50'.
     Default order of required packages installation is '70'.
     """
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='ansible', doc=__doc__, order=50)]
 
     # Supported keys
     _keys = ["playbook", "extra-args"]

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -6,6 +6,7 @@ import click
 import fmf
 
 import tmt
+import tmt.steps
 import tmt.steps.prepare
 
 COPR_URL = 'https://copr.fedorainfracloud.org/coprs'
@@ -300,6 +301,7 @@ class InstallRpmOstree(InstallBase):
             self.guest.execute(f"{self.command} install {self.options} {packages}")
 
 
+@tmt.steps.provides_method('install')
 class PrepareInstall(tmt.steps.prepare.PreparePlugin):
     """
     Install packages on the guest
@@ -345,9 +347,6 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
         Cannot install new version of already installed local rpm.
         No support for installing debuginfo packages at this time.
     """
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='install', doc=__doc__, order=50)]
 
     # Supported keys
     _keys = ["package", "directory", "copr", "exclude", "missing"]

--- a/tmt/steps/prepare/multihost.py
+++ b/tmt/steps/prepare/multihost.py
@@ -1,11 +1,12 @@
 from typing import Any, Optional
 
 import tmt
+import tmt.steps
 import tmt.steps.prepare
-from tmt.steps import Method
 from tmt.steps.provision import Guest
 
 
+@tmt.steps.provides_method('multihost')
 class PrepareMultihost(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
     """
     Prepare the guest for running a multihost test.
@@ -28,9 +29,6 @@ class PrepareMultihost(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
 
     The exported roles are comma-separated.
     """
-
-    # Supported methods
-    _methods = [Method(name='multihost', doc=__doc__, order=50)]
 
     # Supported keys
     _keys = ['roles', 'hosts']

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -4,12 +4,14 @@ import click
 import fmf
 
 import tmt
+import tmt.steps
 import tmt.steps.prepare
 import tmt.utils
 from tmt.steps.provision import Guest
 
 
 # TODO: drop ignore once type annotations between modules enabled
+@tmt.steps.provides_method('shell')
 class PrepareShell(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
     """
     Prepare guest using shell scripts
@@ -27,9 +29,6 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
     happen if there are multiple configs. Default order is '50'.
     Default order of required packages installation is '70'.
     """
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='shell', doc=__doc__, order=50)]
 
     # Supported keys
     _keys = ["script"]

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -186,8 +186,8 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin):
     # Default implementation for provision is a virtual machine
     how = 'virtual'
 
-    # List of all supported methods aggregated from all plugins
-    _supported_methods = []
+    # List of all supported methods aggregated from all plugins of the same step.
+    _supported_methods: List[tmt.steps.Method] = []
 
     # Common keys for all provision step implementations
     _common_keys = ['role']

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -7,6 +7,7 @@ import click
 import requests
 
 import tmt
+import tmt.steps
 import tmt.steps.provision
 import tmt.utils
 from tmt.utils import ProvisionError, retry_session, updatable_message
@@ -218,8 +219,8 @@ class ArtemisAPI:
 
 
 # TODO: get rid of `ignore` once superclass is no longer `Any`
-class ProvisionArtemis(
-        tmt.steps.provision.ProvisionPlugin):  # type: ignore[misc]
+@tmt.steps.provides_method('artemis')
+class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):  # type: ignore[misc]
     """
     Provision guest using Artemis backend
 
@@ -270,11 +271,6 @@ class ProvisionArtemis(
 
     # Guest instance
     _guest = None
-
-    # Supported methods
-    _methods = [
-        tmt.steps.Method(name='artemis', doc=__doc__, order=50),
-        ]
 
     _keys = [
         'api-url',

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -1,9 +1,11 @@
 import click
 
 import tmt
+import tmt.steps
 import tmt.steps.provision
 
 
+@tmt.steps.provides_method('connect')
 class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
     """
     Connect to a provisioned guest using ssh
@@ -34,9 +36,6 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
 
     # Guest instance
     _guest = None
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='connect', doc=__doc__, order=50)]
 
     # Supported keys
     _keys = ["guest", "key", "user", "password", "port"]

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -1,7 +1,9 @@
 import tmt
+import tmt.steps
 import tmt.steps.provision
 
 
+@tmt.steps.provides_method('local')
 class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
     """
     Use local host for test execution
@@ -22,9 +24,6 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
 
     # Guest instance
     _guest = None
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='local', doc=__doc__, order=50)]
 
     def wake(self, keys=None, data=None):
         """ Wake up the plugin, process data, apply options """

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -6,6 +6,7 @@ from typing import Optional
 import click
 
 import tmt
+import tmt.steps
 import tmt.steps.provision
 
 # Timeout in seconds of waiting for a connection
@@ -27,6 +28,7 @@ class PodmanGuestData(tmt.steps.provision.GuestData):  # type: ignore[misc]
     container: Optional[str] = None
 
 
+@tmt.steps.provides_method('container')
 class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
     """
     Create a new container using podman
@@ -48,9 +50,6 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
 
     # Supported keys
     _keys = ["image", "container", "pull", "user"]
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='container', doc=__doc__, order=50)]
 
     @classmethod
     def options(cls, how=None):

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -12,6 +12,7 @@ import click
 import requests
 
 import tmt
+import tmt.steps
 import tmt.steps.provision
 import tmt.utils
 from tmt.utils import WORKDIR_ROOT, ProvisionError, retry_session
@@ -176,6 +177,7 @@ class TestcloudGuestData(
     instance_name: Optional[str] = None
 
 
+@tmt.steps.provides_method('virtual.testcloud')
 class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
     """
     Local virtual machine using testcloud
@@ -220,11 +222,6 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
 
     # Guest instance
     _guest = None
-
-    # Supported methods
-    _methods = [
-        tmt.steps.Method(name='virtual.testcloud', doc=__doc__, order=50),
-        ]
 
     # Supported keys
     _keys = ["image", "user", "memory", "disk", "connection", "arch"]

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -87,7 +87,7 @@ class ReportPlugin(tmt.steps.GuestlessPlugin):
     # Default implementation for report is display
     how = 'display'
 
-    # List of all supported methods aggregated from all plugins
+    # List of all supported methods aggregated from all plugins of the same step.
     _supported_methods: List[tmt.steps.Method] = []
 
     @classmethod

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -1,10 +1,12 @@
 import os
 
 import tmt
+import tmt.steps
 import tmt.steps.report
 from tmt.steps.execute import TEST_OUTPUT_FILENAME
 
 
+@tmt.steps.provides_method('display')
 class ReportDisplay(tmt.steps.report.ReportPlugin):
     """
     Show test results on the terminal
@@ -12,9 +14,6 @@ class ReportDisplay(tmt.steps.report.ReportPlugin):
     Give a concise summary of test results directly on the terminal.
     List individual test results in verbose mode.
     """
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='display', doc=__doc__, order=50)]
 
     def details(self, result: tmt.Result, verbosity: int) -> None:
         """ Print result details based on the verbose mode """

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -9,6 +9,7 @@ import pkg_resources
 
 import tmt
 import tmt.options
+import tmt.steps
 import tmt.steps.report
 
 HTML_TEMPLATE_PATH = pkg_resources.resource_filename(
@@ -31,6 +32,7 @@ def import_jinja2() -> None:
             "Missing 'jinja2', fixable by 'pip install tmt[report-html]'")
 
 
+@tmt.steps.provides_method('html')
 class ReportHtml(tmt.steps.report.ReportPlugin):
     """
     Format test results into an html report
@@ -41,9 +43,6 @@ class ReportHtml(tmt.steps.report.ReportPlugin):
             how: html
             open: true
     """
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='html', doc=__doc__, order=50)]
 
     # Supported keys
     _keys = ["open"]

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -6,6 +6,7 @@ import click
 
 import tmt
 import tmt.options
+import tmt.steps
 import tmt.steps.report
 
 DEFAULT_NAME = "junit.xml"
@@ -84,6 +85,7 @@ def make_junit_xml(report: "tmt.steps.report.ReportPlugin") -> JunitTestSuite:
     return cast(JunitTestSuite, suite)
 
 
+@tmt.steps.provides_method('junit')
 class ReportJUnit(tmt.steps.report.ReportPlugin):
     """
     Write test results in JUnit format
@@ -91,9 +93,6 @@ class ReportJUnit(tmt.steps.report.ReportPlugin):
     When FILE is not specified output is written to the 'junit.xml'
     located in the current workdir.
     """
-
-    # Supported methods
-    _methods = [tmt.steps.Method(name='junit', doc=__doc__, order=50)]
 
     # Supported keys
     _keys = ["file"]

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -7,17 +7,18 @@ import click
 from requests import post
 
 import tmt
+import tmt.steps
 
 from .junit import make_junit_xml
 
 DEFAULT_NAME = 'xunit.xml'
 
 
+@tmt.steps.provides_method('polarion')
 class ReportPolarion(tmt.steps.report.ReportPlugin):
     """
     Write test results into a xUnit file and upload to Polarion
     """
-    _methods = [tmt.steps.Method(name='polarion', doc=__doc__, order=50)]
     _keys = ['file', 'no-upload', 'project-id', 'testrun-title']
 
     @classmethod


### PR DESCRIPTION
Instead of listing Method instances, and dedicated `_methods` list in each
plugin class, patch adds a class decorator for this task. It's a different
approach, replacing `_methods` and `PluginIndex` metaclass, but it has some
advantages, the most visible being less characters to write:

With regard to #1373, the necessity of annotating each `_methods`
instance would become even more painful as soon as `BasePlugin` would
become a generic type. With the decorator, the list is not needed at
all.

A few more changes included in the decorator to make our lives easier:
the default value for `doc` can be extracted, the default value for `order`
can be found in the code and declared explicitly, and both are used in the
common manner of keyword arguments. With the metaclass, extracting
docstring and default values would be possible too, but would have to be
done as explicit assignments in the code of metaclass, which makes them
less visible. The same goes for `Method.class_` which can be given as a
parameter of `Method.__init__()`.