### PR TITLE
Rename "default how" step attribute to enhance its visibility

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -80,9 +80,10 @@ class StepData(TypedDict, total=False):
 class Step(tmt.utils.Common):
     """ Common parent of all test steps """
 
-    # Default implementation for all steps is shell
-    # except for provision (virtual) and report (display)
-    how: str = 'shell'
+    # Default implementation for all steps is "shell", but some
+    # steps like provision may have better defaults for their
+    # area of expertise.
+    DEFAULT_HOW: str = 'shell'
 
     def __init__(
             self,
@@ -122,7 +123,7 @@ class Step(tmt.utils.Common):
         for data in self.data:
             # Set 'how' to the default if not specified
             if data.get('how') is None:
-                data['how'] = self.how
+                data['how'] = self.DEFAULT_HOW
             # Ensure that each config has a name
             if 'name' not in data and len(self.data) > 1:
                 raise tmt.utils.GeneralError(

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -53,7 +53,7 @@ class Execute(tmt.steps.Step):
     """
 
     # Internal executor is the default implementation
-    how = 'tmt'
+    DEFAULT_HOW = 'tmt'
     data: List[tmt.steps.StepData]
 
     def __init__(self, plan: "tmt.Plan", data: tmt.steps.StepData) -> None:

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -32,7 +32,7 @@ class Provision(tmt.steps.Step):
     """ Provision an environment for testing or use localhost. """
 
     # Default implementation for provision is a virtual machine
-    how = 'virtual'
+    DEFAULT_HOW = 'virtual'
 
     def __init__(self, plan, data):
         """ Initialize provision step data """

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -11,7 +11,7 @@ class Report(tmt.steps.Step):
     """ Provide test results overview and send reports. """
 
     # Default implementation for report is display
-    how = 'display'
+    DEFAULT_HOW = 'display'
     data: List[tmt.steps.StepData]
 
     def wake(self) -> None:


### PR DESCRIPTION
The default value of "how" of each step is stored in the attribute named
`how`. The lower-cased name and similarity to plugins' `how` attribute
"hides" the importance if this attribute - it's not just any "how", it's
*the* default "how". Renaming the variable for better readability.