### PR TITLE
Reboot has to check for boot time

### DIFF
--- a/tests/full/plan.fmf
+++ b/tests/full/plan.fmf
@@ -3,5 +3,6 @@ discover:
 provision:
     how: virtual
     memory: 4000
+    disk: 40
 execute:
     how: tmt


### PR DESCRIPTION
Previous attempt with closing connection was not succesful as shown by
/tests/execute/reboot/reuse_provision

btime in /proc/stat is boot time in seconds since epoch and reboot()
will make sure that it has changed

Adds disk requirement for tests/full which is helps with testing