### PR TITLE
Correcting rhts aliases & adding rhts opt.

### DIFF
--- a/tests/execute/restraint/report-log/data/log.sh
+++ b/tests/execute/restraint/report-log/data/log.sh
@@ -17,6 +17,12 @@ rlJournalStart
         rlRun "rstrnt-report-log --server http://test-example.com --port 77 --filename $TMP_FILE_SRC_PATH" 0 "Saving log with rstrnt-report-log."
         rlRun "ls $TMP_FILE_DEST_PATH" 0 "Checking log saved to expected destination."
         rlRun "rm -f $TMP_FILE_DEST_PATH" 0 "Removing log file."
+        rlRun "rhts-submit-log -T ignored --server http://test-example.com --port 77 --filename $TMP_FILE_SRC_PATH" 0 "Saving log with rhts-submit-log."
+        rlRun "ls $TMP_FILE_DEST_PATH" 0 "Checking log saved to expected destination."
+        rlRun "rm -f $TMP_FILE_DEST_PATH" 0 "Removing log file."
+        rlRun "rhts_submit_log -T ignored --server http://test-example.com --port 77 --filename $TMP_FILE_SRC_PATH" 0 "Saving log with rhts_submit_log."
+        rlRun "ls $TMP_FILE_DEST_PATH" 0 "Checking log saved to expected destination."
+        rlRun "rm -f $TMP_FILE_DEST_PATH" 0 "Removing log file."
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -33,7 +33,8 @@ TMT_REPORT_RESULT_SCRIPT = Script("/usr/local/bin/tmt-report-result",
 TMT_FILE_SUBMIT_SCRIPT = Script("/usr/local/bin/tmt-file-submit",
                                 aliases=[
                                     "/usr/local/bin/rstrnt-report-log",
-                                    "/usr/local/bin/rhts-report-log"],
+                                    "/usr/local/bin/rhts-submit-log",
+                                    "/usr/local/bin/rhts_submit_log"],
                                 related_variables=[]
                                 )
 

--- a/tmt/steps/execute/scripts/tmt-file-submit
+++ b/tmt/steps/execute/scripts/tmt-file-submit
@@ -6,7 +6,7 @@ needs_arg() { if [ -z "$OPTARG" ]; then die "No arg for --$OPT option"; fi; }
 
 check_opt_args () {
     local OPTIND
-    while getopts l:filename:s:server:port-: OPT; do
+    while getopts T:l:filename:s:server:port-: OPT; do
         # support long options: https://stackoverflow.com/a/28466267/519360
         if [ "$OPT" = "-" ]; then   # long option: reformulate OPT and OPTARG
             OPT="${OPTARG%%=*}"       # extract long option name
@@ -15,6 +15,7 @@ check_opt_args () {
             filename )       needs_arg; eval "FILENAME=\"\$$OPTIND\"" ; OPTIND=$((OPTIND+1)) ;;
             l )              needs_arg; FILENAME=$OPTARG ;;
             s )              continue;;
+            T )              continue;;
             server )         OPTIND=$((OPTIND+1));;
             port )           OPTIND=$((OPTIND+1));;
         esac


### PR DESCRIPTION
It was observed during a test conversion activity that the correct alias for rhts is actually 'rhts-submit-log' and 'rhts_submit_log'. RHTS also has a specific -T option, which I've now included in the bash script.