### PR TITLE
Adds missing multihost keys, role and where, to schemas

### DIFF
--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -35,6 +35,9 @@ definitions:
       summary:
         $ref: "/schemas/core#/definitions/summary"
 
+      where:
+        $ref: "/schemas/common#/definitions/where"
+
     required:
       - how
 
@@ -228,6 +231,11 @@ definitions:
         items:
           type: string
 
+  # In multihost scenarios, guests can be given roles
+  # https://tmt.readthedocs.io/en/stable/spec/plans.html#multihost
+  role:
+    type: string
+
   # common definition of a shell execution method
   shell:
     type: object
@@ -251,6 +259,9 @@ definitions:
       summary:
         $ref: "/schemas/core#/definitions/summary"
 
+      where:
+        $ref: "/schemas/common#/definitions/where"
+
     required:
       - how
 
@@ -268,3 +279,8 @@ definitions:
         pattern: "^/"
 
       - $ref: "/schemas/common#/definitions/fmf_id"
+
+  # In multihost scenarios, some steps can be executed on some guests only.
+  # https://tmt.readthedocs.io/en/stable/spec/plans.html#multihost
+  where:
+    $ref: "/schemas/common#/definitions/one_or_more_strings"

--- a/tmt/schemas/execute/tmt.yaml
+++ b/tmt/schemas/execute/tmt.yaml
@@ -31,9 +31,8 @@ properties:
   script:
     $ref: "/schemas/common#/definitions/one_or_more_strings"
 
-  # https://tmt.readthedocs.io/en/stable/spec/plans.html#where
   where:
-    type: string
+    $ref: "/schemas/common#/definitions/where"
 
 required:
   - how

--- a/tmt/schemas/execute/upgrade.yaml
+++ b/tmt/schemas/execute/upgrade.yaml
@@ -47,5 +47,8 @@ properties:
     type: string
     format: uri
 
+  where:
+    $ref: "/schemas/common#/definitions/where"
+
 required:
   - how

--- a/tmt/schemas/prepare/install.yaml
+++ b/tmt/schemas/prepare/install.yaml
@@ -53,5 +53,8 @@ properties:
   package:
     $ref: "/schemas/common#/definitions/one_or_more_strings"
 
+  where:
+    $ref: "/schemas/common#/definitions/where"
+
 required:
   - how

--- a/tmt/schemas/provision/artemis.yaml
+++ b/tmt/schemas/provision/artemis.yaml
@@ -64,6 +64,9 @@ properties:
     type: integer
     minimum: 1
 
+  role:
+    $ref: "/schemas/common#/definitions/role"
+
   keyname:
     type: string
 

--- a/tmt/schemas/provision/connect.yaml
+++ b/tmt/schemas/provision/connect.yaml
@@ -31,6 +31,9 @@ properties:
   password:
     type: string
 
+  role:
+    $ref: "/schemas/common#/definitions/role"
+
   key:
     type: string
 

--- a/tmt/schemas/provision/container.yaml
+++ b/tmt/schemas/provision/container.yaml
@@ -28,6 +28,9 @@ properties:
   pull:
     type: boolean
 
+  role:
+    $ref: "/schemas/common#/definitions/role"
+
   user:
     type: string
 

--- a/tmt/schemas/provision/local.yaml
+++ b/tmt/schemas/provision/local.yaml
@@ -22,5 +22,8 @@ properties:
   name:
     type: string
 
+  role:
+    $ref: "/schemas/common#/definitions/role"
+
 required:
   - how

--- a/tmt/schemas/provision/virtual.yaml
+++ b/tmt/schemas/provision/virtual.yaml
@@ -43,5 +43,8 @@ properties:
   arch:
     $ref: "/schemas/common#/definitions/arch"
 
+  role:
+    $ref: "/schemas/common#/definitions/role"
+
 required:
   - how


### PR DESCRIPTION
These are defined, and some bits were already present in schemas, but
incomplete. Fixing that, validation patches reported these as unknown.