### PR TITLE
Give a nice error for old `guests.yaml` format

### DIFF
--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1379,6 +1379,11 @@ class SerializableContainer:
         from tmt.plugins import import_
 
         # Unpack class info, to get nicer variable names
+        if "__class__" not in serialized:
+            raise GeneralError(
+                "Failed to load saved state, probably because of old data format.\n"
+                "Use 'tmt clean runs' to clean up old runs.")
+
         klass_info = serialized.pop('__class__')
         klass_module_name = klass_info['module']
         klass_name = klass_info['name']


### PR DESCRIPTION
When a fresh `tmt` is used with older runs stored on disk, parsing
the `guests.yaml` file might fail because of missing class info.
Give a reasonable error and suggest to clean up old runs.

Fix #1422.