### PR TITLE
Change base fmf-backed classes to use keyword-only __init__

### DIFF
--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -32,7 +32,7 @@ def test_invalid_yaml_syntax():
 
 def test_test_defaults():
     """ Test default test attributes """
-    test = tmt.Test(dict(test='./test.sh'), name='/smoke')
+    test = tmt.Test(node=dict(test='./test.sh'), name='/smoke')
     assert test.name == '/smoke'
     assert test.component == list()
     assert test.test == './test.sh'
@@ -49,21 +49,21 @@ def test_test_invalid():
     """ Test invalid test """
     # Missing name
     with pytest.raises(tmt.utils.GeneralError):
-        tmt.Test({})
+        tmt.Test(node={})
     # Invalid name
     with pytest.raises(SpecificationError):
-        tmt.Test({}, name='bad')
+        tmt.Test(node={}, name='bad')
     # Invalid attributes
     for key in ['component', 'require', 'tag']:
         with pytest.raises(SpecificationError):
-            tmt.Test({key: 1}, name='/smoke')
+            tmt.Test(node={key: 1}, name='/smoke')
     with pytest.raises(SpecificationError):
-        tmt.Test({'environment': 'string'}, name='/smoke')
+        tmt.Test(node={'environment': 'string'}, name='/smoke')
     # Listify attributes
     assert tmt.Test(
-        {'test': 'test', 'tag': 'a'}, name='/smoke').tag == ['a']
+        node={'test': 'test', 'tag': 'a'}, name='/smoke').tag == ['a']
     assert tmt.Test(
-        {'test': 'test', 'tag': ['a', 'b']}, name='/smoke').tag == ['a', 'b']
+        node={'test': 'test', 'tag': ['a', 'b']}, name='/smoke').tag == ['a', 'b']
 
 
 def test_link():

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -26,7 +26,7 @@ class IdLocationDefined(TestCase):
 
     def test_defined_partially(self):
         node = self.base_tree.find("/partial")
-        test = tmt.Test(node)
+        test = tmt.Test(node=node)
         self.assertEqual(locate_key(node, ID_KEY), test.node)
 
     def test_not_defined(self):
@@ -71,19 +71,19 @@ class IdEmpty(TestCase):
 
     def test_base(self):
         node = self.base_tree.find("/some/structure")
-        test = tmt.Test(node)
+        test = tmt.Test(node=node)
         self.assertEqual(test.id, None)
 
     def test_manually_add_id(self):
         node = self.base_tree.find("/some/structure")
-        test = tmt.Test(node)
+        test = tmt.Test(node=node)
         self.assertEqual(test.id, None)
         identifier = tmt.identifier.add_uuid_if_not_defined(node, dry=False)
         self.assertGreater(len(identifier), 10)
 
         self.base_tree = fmf.Tree(self.path)
         node = self.base_tree.find("/some/structure")
-        test = tmt.Test(node)
+        test = tmt.Test(node=node)
         self.assertEqual(test.id, identifier)
 
 

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -851,7 +851,7 @@ def enabled_for_environment(test: 'tmt.Test', tcms_notes: str) -> bool:
         test_node = test.node.copy()
         test_node.adjust(context)
         # TODO: remove cast later
-        return cast(bool, tmt.Test(test_node).enabled)
+        return cast(bool, tmt.Test(node=test_node).enabled)
     except BaseException as exception:
         log.debug(f"Failed to process adjust: {exception}")
         return True

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -31,8 +31,8 @@ class Discover(tmt.steps.Step):
         super().load()
         try:
             tests = tmt.utils.yaml_to_dict(self.read('tests.yaml'))
-            self._tests = [
-                tmt.Test(data, name, skip_validation=True) for name, data in tests.items()]
+            self._tests = [tmt.Test(node=data, name=name, skip_validation=True)
+                           for name, data in tests.items()]
         except tmt.utils.FileError:
             self.debug('Discovered tests not found.', level=2)
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -308,7 +308,8 @@ class Common(object):
             name: Optional[str] = None,
             workdir: WorkdirArgumentType = None,
             context: Optional[click.Context] = None,
-            relative_indent: int = 1):
+            relative_indent: int = 1,
+            **kwargs: Any):
         """
         Initialize name and relation with the parent object
 


### PR DESCRIPTION
This makes the inheritance much easier to handle. With various classes
involved, from `Core` and `Common` to mixins with specific feature sets,
`__init__()`s with keyword-only arguments make propagation of
`__init__()` calls easy to sort out, since there are no positional
arguments that could be given in wrong/unexpected order.