### PR TITLE
Allow raising an exception on validation errors

### DIFF
--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -819,6 +819,17 @@ class MetadataError(GeneralError):
 class SpecificationError(MetadataError):
     """ Metadata specification error """
 
+    def __init__(
+            self,
+            message: str,
+            validation_errors: Optional[List[Tuple[jsonschema.ValidationError, str]]] = None,
+            *args: Any,
+            **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.message = message
+        self.validation_errors = validation_errors
+
 
 class ConvertError(MetadataError):
     """ Metadata conversion error """


### PR DESCRIPTION
The original implementation of schema-based validation only reported the
issues, and moved on. This has been preserved, but I discovered there
are tests that focus on failed validation which, once the Python-based
implementation in `tmt.base` is removed, would began to fail.

To accomodate these tests and possible future enforced validation,
validation mixing gains a flag to enable it to raise an exception
instead of a mere warning. The default value of the flag is `False`, so
no change in the behavior for uninformed user.