### PR TITLE
Allow numbers and booleans to be values of environment

### DIFF
--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -117,7 +117,13 @@ definitions:
   # https://tmt.readthedocs.io/en/stable/spec/tests.html#environment
   # https://tmt.readthedocs.io/en/stable/spec/plans.html#environment
   environment:
-    $ref: "/schemas/common#/definitions/object_with_string_properties"
+    type: object
+
+    additionalProperties:
+      anyOf:
+        - type: string
+        - type: boolean
+        - type: number
 
   # https://fmf.readthedocs.io/en/stable/concept.html#identifiers
   fmf_id:

--- a/tmt/schemas/test.yaml
+++ b/tmt/schemas/test.yaml
@@ -41,10 +41,7 @@ properties:
 
   # https://tmt.readthedocs.io/en/stable/spec/tests.html#environment
   environment:
-    type: object
-
-    additionalProperties:
-      type: string
+    $ref: "/schemas/common#/definitions/environment"
 
   # https://tmt.readthedocs.io/en/stable/spec/tests.html#framework
   framework:


### PR DESCRIPTION
According to [1] and [2], there seem to be no rule forbidding keys of
`environment` to be numbers (both ints and floats) or booleans. What
would make less sense would be complex objects like mappings or lists,
but these primitive types would be actually fine.

tmt code applies `str()` to all values, therefore there's no reason to
not support more types than just `string`. Also, some of the examples in
[2] suggest it's perfectly fine (`KOJI_TASK_ID: 42890031`).

[1] https://tmt.readthedocs.io/en/stable/spec/tests.html#environment
[2] https://tmt.readthedocs.io/en/stable/spec/plans.html#environment