### PR TITLE
Add link-polarion option and fix link searching bug

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -632,6 +632,9 @@ def tests_import(
 @click.option(
     '--project-id', help='Use specific Polarion project ID.')
 @click.option(
+    '--link-polarion / --no-link-polarion', default=True,
+    help='Add Polarion link to fmf testcase metadata')
+@click.option(
     '--bugzilla', is_flag=True,
     help="Link Nitrate case to Bugzilla specified in the 'link' attribute "
          "with the relation 'verifies'.")


### PR DESCRIPTION
Sometimes we don't want polarion links, especially for public repositories this would expose internal servers.