### PR TITLE
Fixes data class used for local guest creation

### DIFF
--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -268,6 +268,8 @@ class ProvisionArtemis(
             api-retry-backoff-factor: 1
     """
 
+    _data_class = ArtemisGuestData
+
     # Guest instance
     _guest = None
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -37,7 +37,7 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
         super().go()
 
         # Create a GuestLocal instance
-        data = tmt.steps.provision.GuestSshData(
+        data = tmt.steps.provision.GuestData(
             guest='localhost',
             role=self.get('role')
             )


### PR DESCRIPTION
Instead of `GuestSshData`, `GuestData` is needed - there is no SSH support in play with the local plugin.