### PR TITLE
Remove unused keys parameter from wake() methods

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -613,7 +613,7 @@ class BasePlugin(Phase, metaclass=PluginIndex):
             return True
         return where in (guest.name, guest.role)
 
-    def wake(self, keys: Optional[List[str]] = None) -> None:
+    def wake(self) -> None:
         """
         Wake up the plugin, process data, apply options
 
@@ -626,8 +626,8 @@ class BasePlugin(Phase, metaclass=PluginIndex):
         in the 'keys' parameter can be used to override only
         selected ones.
         """
-        if keys is None:
-            keys = self._common_keys + self._keys
+        keys = self._common_keys + self._keys
+
         for key in keys:
             value = self.opt(key)
             if value:

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -172,7 +172,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 ),
             ] + super().options(how)
 
-    def wake(self, keys=None):
+    def wake(self):
         """ Wake up the plugin, process data, apply options """
         # Handle backward-compatible stuff
         if 'repository' in self.data:
@@ -184,7 +184,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         tmt.utils.listify(self.data, keys=["exclude", "filter", "test"])
 
         # Process command line options, apply defaults
-        super().wake(keys=keys)
+        super().wake()
 
     @property
     def is_in_standalone_mode(self):

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -53,9 +53,9 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
             test_names = [test['name'] for test in tests]
             click.echo(tmt.utils.format('tests', test_names))
 
-    def wake(self, keys: Optional[List[str]] = None) -> None:
+    def wake(self) -> None:
         """ Wake up the plugin, process data, apply options """
-        super().wake(keys=keys)
+        super().wake()
         # Check provided tests, default to an empty list
         if 'tests' not in self.data:
             self.data['tests'] = []

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -97,9 +97,9 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             help='Disable interactive progress bar showing the current test.'))
         return options + super().options(how)
 
-    def wake(self, keys=None):
+    def wake(self):
         """ Wake up the plugin, process data, apply options """
-        super().wake(keys=keys)
+        super().wake()
         # Make sure that script is a list
         tmt.utils.listify(self.data, keys=['script'])
 

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -47,9 +47,9 @@ class FinishShell(tmt.steps.finish.FinishPlugin):
         return default
 
     # TODO: use better types once superclass gains its annotations
-    def wake(self, keys: Optional[List[str]] = None) -> None:
+    def wake(self) -> None:
         """ Wake up the plugin, process data, apply options """
-        super().wake(keys=keys)
+        super().wake()
 
         # Convert to list if single script provided
         tmt.utils.listify(self.data, keys=['script'])

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -81,9 +81,9 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
         return default
 
     # TODO: use better types once superclass gains its annotations
-    def wake(self, keys: Optional[List[str]] = None) -> None:
+    def wake(self) -> None:
         """ Wake up the plugin, process data, apply options """
-        super().wake(keys=keys)
+        super().wake()
 
         # Convert to list if necessary
         tmt.utils.listify(self.data, keys=['playbook'])

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -381,9 +381,9 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
             return []
         return default
 
-    def wake(self, keys=None):
+    def wake(self):
         """ Wake up the plugin, process data, apply options """
-        super().wake(keys=keys)
+        super().wake()
         # Convert to list if necessary
         tmt.utils.listify(
             self.data, split=True,

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import click
 import fmf
@@ -48,9 +48,9 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
             return []
         return default
 
-    def wake(self, keys: Optional[List[str]] = None) -> None:
+    def wake(self) -> None:
         """ Wake up the plugin, process data, apply options """
-        super().wake(keys=keys)
+        super().wake()
 
         # Convert to list if single script provided
         tmt.utils.listify(self.data, keys=['script'])

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -237,14 +237,14 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin):
 
         return provision
 
-    def wake(self, keys: Optional[List[str]] = None, data: Optional['GuestData'] = None) -> None:
+    def wake(self, data: Optional['GuestData'] = None) -> None:
         """
         Wake up the plugin
 
         Override data with command line options.
         Wake up the guest based on provided guest data.
         """
-        super().wake(keys=keys)
+        super().wake()
 
     def guest(self) -> Optional['Guest']:
         """

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -366,11 +366,10 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
     # More specific type is a violation of Liskov substitution principle, and mypy
     # complains about it - rightfully so. Ignoring the issue which should be resolved
     # with https://github.com/teemtee/tmt/pull/1439.
-    def wake(self, keys: Optional[List[str]] = None,  # type: ignore[override]
-             data: Optional[ArtemisGuestData] = None) -> None:
+    def wake(self, data: Optional[ArtemisGuestData] = None) -> None:  # type: ignore[override]
         """ Wake up the plugin, process data, apply options """
 
-        super().wake(keys=keys, data=data)
+        super().wake(data=data)
 
         if data:
             self._guest = GuestArtemis(data, name=self.name, parent=self.step)

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -75,13 +75,9 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
         # No other defaults available
         return default
 
-    # More specific type is a violation of Liskov substitution principle, and mypy
-    # complains about it - rightfully so. Ignoring the issue which should be resolved
-    # with https://github.com/teemtee/tmt/pull/1439.
-    def wake(self, keys: Optional[List[str]] = None,  # type: ignore[override]
-             data: Optional[GuestSshData] = None) -> None:
+    def wake(self, data: Optional[GuestSshData] = None) -> None:  # type: ignore[override]
         """ Wake up the plugin, process data, apply options """
-        super().wake(keys=keys, data=data)
+        super().wake(data=data)
         if data:
             self._guest = tmt.GuestSsh(data, name=self.name, parent=self.step)
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -25,9 +25,9 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
     # Guest instance
     _guest = None
 
-    def wake(self, keys=None, data=None):
+    def wake(self, data=None):
         """ Wake up the plugin, process data, apply options """
-        super().wake(keys=keys, data=data)
+        super().wake(data=data)
         if data:
             self._guest = GuestLocal(data, name=self.name, parent=self.step)
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -76,9 +76,9 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
 
         return getattr(PodmanGuestData(), option.replace('-', '_'), default)
 
-    def wake(self, keys=None, data=None):
+    def wake(self, data=None):
         """ Wake up the plugin, process data, apply options """
-        super().wake(keys=keys, data=data)
+        super().wake(data=data)
         # Wake up podman instance
         if data:
             guest = GuestContainer(data, name=self.name, parent=self.step)

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -257,9 +257,9 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
         """ Return default data for given option """
         return getattr(TestcloudGuestData(), option, default)
 
-    def wake(self, keys=None, data=None):
+    def wake(self, data=None):
         """ Wake up the plugin, process data, apply options """
-        super().wake(keys=keys, data=data)
+        super().wake(data=data)
 
         # Wake up testcloud instance
         if data:


### PR DESCRIPTION
This seems to be no longer used, and makes `wake()` more complicated
than necessary.

This seems to be a story similar to #1428, `keys` were added but are no longer necessary. I have been unable to find any place where `keys` would have been set, all call sites either left it unset or passed the given `keys` input up the stream.