### PR TITLE
Do not inherit classes from object

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2124,7 +2124,7 @@ class Clean(tmt.utils.Common):
         return successful
 
 
-class Result(object):
+class Result:
     """
     Test result
 
@@ -2255,7 +2255,7 @@ class Result(object):
         return data
 
 
-class Link(object):
+class Link:
     """ Core attribute link parsing """
 
     # The list of all supported link relations

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -43,7 +43,7 @@ class LibraryError(Exception):
     """ Used when library cannot be parsed from the identifier """
 
 
-class Library(object):
+class Library:
     """
     A beakerlib library
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -191,7 +191,7 @@ def indent(
     return indent + message
 
 
-class Config(object):
+class Config:
     """ User configuration """
 
     def __init__(self) -> None:
@@ -271,7 +271,7 @@ class CommandOutput(NamedTuple):
     stderr: Optional[str]
 
 
-class Common(object):
+class Common:
     """
     Common shared stuff
 
@@ -1955,7 +1955,7 @@ def load_run(run: 'tmt.base.Run') -> Tuple[bool, Optional[Exception]]:
 SFSectionValueType = Union[str, List[str]]
 
 
-class StructuredField(object):
+class StructuredField:
     """
     Handling multiple text data in a single text field
 
@@ -2401,7 +2401,7 @@ class StructuredField(object):
             self._sections[section] = self._write_section(dictionary)
 
 
-class DistGitHandler(object):
+class DistGitHandler:
     """ Common functionality for DistGit handlers """
     sources_file_name = 'sources'
     uri = "/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}"


### PR DESCRIPTION
This was only necessary in Python 2, however since we've fully migrated
to Python 3, it's no longer necessary and just adds unnecessary noise.