### PR TITLE
Convert Common to Generic type

### DIFF
--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -10,6 +10,7 @@ import fmf
 
 import tmt
 import tmt.utils
+from tmt.steps.discover import DiscoverPlugin
 
 # A beakerlib indetified type, can be a string or a dictionary
 BeakerlibIdentifierType = Union[str, Dict[str, str]]
@@ -35,7 +36,7 @@ STRIP_SUFFIX_FORGES = [
     ]
 
 
-class CommonWithLibraryCache(tmt.utils.Common):
+class CommonWithLibraryCache(tmt.utils.Common[DiscoverPlugin]):
     _library_cache: Dict[str, 'Library']
 
 
@@ -74,7 +75,7 @@ class Library:
     def __init__(
             self,
             identifier: BeakerlibIdentifierType,
-            parent: Optional[tmt.utils.Common] = None
+            parent: Optional[tmt.utils.Common[DiscoverPlugin]] = None
             ) -> None:
         """ Process the library identifier and fetch the library """
         # Use an empty common class if parent not provided (for logging, cache)
@@ -296,7 +297,7 @@ class Library:
 def dependencies(
     original_require: List[str],
     original_recommend: Optional[List[str]] = None,
-    parent: Optional[tmt.utils.Common] = None,
+    parent: Optional[tmt.utils.Common[DiscoverPlugin]] = None,
     imported_lib_ids: ImportedIdentifiersType = None,
         ) -> LibraryDependenciesType:
     """

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -38,7 +38,7 @@ tmt.plugins.explore()
 @dataclasses.dataclass
 class ContextObject:
     """ Click Context Object Container """
-    common: tmt.utils.Common
+    common: tmt.utils.Common[None]  # Root common object -> no parent
     fmf_context: tmt.utils.FmfContextType
     steps: Set[tmt.steps.Step]
     tree: tmt.Tree

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -45,7 +45,7 @@ fix = click.option(
 
 
 def show_step_method_hints(
-        log_object: tmt.utils.Common,
+        log_object: tmt.utils.Common['tmt.utils.CommonParentType'],
         step_name: str,
         how: str) -> None:
     """

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -39,7 +39,7 @@ PHASE_BASE = 50
 PHASE_END = 90
 
 
-class Phase(tmt.utils.Common):
+class Phase(tmt.utils.Common['Step']):
     """ A phase of a step """
 
     def __init__(
@@ -82,7 +82,7 @@ class StepData(TypedDict, total=False):
     tests: Optional[List['tmt.base.Test']]
 
 
-class Step(tmt.utils.Common):
+class Step(tmt.utils.Common['Plan']):
     """ Common parent of all test steps """
 
     # Default implementation for all steps is "shell", but some

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -12,7 +12,7 @@ import tmt.steps.prepare
 COPR_URL = 'https://copr.fedorainfracloud.org/coprs'
 
 
-class InstallBase(tmt.utils.Common):
+class InstallBase(tmt.utils.Common['PrepareInstall']):
     """ Base class for installation implementations """
 
     # Each installer knows its package manager and copr plugin

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 from functools import lru_cache
 from pathlib import Path
 from threading import Thread
-from typing import (IO, TYPE_CHECKING, Any, Callable, Dict, Generator,
+from typing import (IO, TYPE_CHECKING, Any, Callable, Dict, Generator, Generic,
                     Iterable, List, NamedTuple, Optional, Pattern, Tuple, Type,
                     TypeVar, Union, cast, overload)
 
@@ -263,7 +263,7 @@ class StreamLogger(Thread):
 #  Common
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-CommonDerivedType = TypeVar('CommonDerivedType', bound='Common')
+CommonParentType = TypeVar('CommonParentType', bound='Optional[Common[Any]]')
 
 
 class CommandOutput(NamedTuple):
@@ -271,7 +271,7 @@ class CommandOutput(NamedTuple):
     stderr: Optional[str]
 
 
-class Common:
+class Common(Generic[CommonParentType]):
     """
     Common shared stuff
 
@@ -296,15 +296,15 @@ class Common:
     # Common owns workdir, for example, whose value affects logging too, so no
     # clear solution so far.
     #
-    # Note: cannot use CommonDerivedType - it's a TypeVar filled in by the type
+    # Note: cannot use CommonParentType - it's a TypeVar filled in by the type
     # given to __init__() and therefore the type it's representing *now* is
     # unknown. but we know `parent` will be derived from `Common` class, so it's
     # mostly fine.
-    parent: Optional['Common'] = None
+    parent: Optional['Common[CommonParentType]'] = None
 
     def __init__(
             self,
-            parent: Optional[CommonDerivedType] = None,
+            parent: Optional[CommonParentType] = None,
             name: Optional[str] = None,
             workdir: WorkdirArgumentType = None,
             context: Optional[click.Context] = None,
@@ -2496,7 +2496,7 @@ def get_distgit_handler_names() -> List[str]:
 def git_clone(
         url: str,
         destination: str,
-        common: Common,
+        common: Common[CommonParentType],
         env: Optional[EnvironmentType] = None,
         shallow: bool = False
         ) -> CommandOutput:
@@ -2897,7 +2897,7 @@ WaitCheckType = Callable[[], T]
 
 
 def wait(
-    parent: Common,
+    parent: Common[CommonParentType],
     check: WaitCheckType[T],
     timeout: datetime.timedelta,
     tick: float = DEFAULT_WAIT_TICK,


### PR DESCRIPTION
Make parent-children typing relation stricter.

Fixes: #1372 

This will complement itself with #1412 since type of `parent` is the same as of `step` for children of `Phase`, however that PR is blocked for now.

I haven't touched `base.py` since types are not there yet so making use of the Generic type would probably be useless as of now.