### PR TITLE
Ask mypy to show error codes in its messages

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,9 @@ implicit_reexport = True
 install_types = True
 non_interactive = True
 
+# Make error messages more rich, this helps better targeted waivers.
+show_error_codes = True
+
 files = tmt/__init__.py,
         tmt/__main__.py,
         tmt/beakerlib.py,


### PR DESCRIPTION
Error codes are then accepted in `# type: ignore` waivers, and allow
more precise waivers - instead of silencing all possible mypy reports
for the given line, only a specific subset of issues is suppressed,
leaving mypy free to report any issue outside of this subset.