### PR TITLE
Replace blank "type: ignore" with more specific waivers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,22 @@ repos:
     hooks:
       - id: yamllint
         files: ^tmt/schemas/.*\.yaml
+
+  # Yet another static analysis - these hooks use regular expressions to
+  # process Python code, and offer interesting "metalinters", checks for
+  # what we do to appease flake8 and mypy linters.
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+      # Enforce `noqa` and `type: ignore` to always appear with specific
+      # error code(s).
+      - id: python-check-blanket-noqa
+      - id: python-check-blanket-type-ignore
+
+      # Other potentially useful hooks for future consideration:
+      #
+      # - id: python-check-mock-methods
+      # - id: python-no-eval
+      # - id: python-no-log-warn
+      # - id: python-use-type-annotations
+      # - id: text-unicode-replacement-char

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -394,7 +394,7 @@ if run_callback is None:
 
 
 # TODO: commands is unknown, needs revisit
-@run_callback()  # type: ignore
+@run_callback()  # type: ignore[misc]
 @click.pass_context
 def finito(
         click_context: click.core.Context,
@@ -1310,7 +1310,7 @@ if clean_callback is None:
 
 
 # TODO: commands is unknown, needs revisit
-@clean_callback()  # type: ignore
+@clean_callback()  # type: ignore[misc]
 @click.pass_context
 def perform_clean(
         click_context: click.core.Context,

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -66,7 +66,7 @@ def import_nitrate() -> Any:
     except ImportError:
         raise ConvertError(
             "Install tmt-test-convert to export tests to nitrate.")
-    except nitrate.NitrateError as error:  # type: ignore
+    except nitrate.NitrateError as error:  # type: ignore[union-attr]  # nitrate is no longer None
         raise ConvertError(error)
 
 

--- a/tmt/steps/finish/ansible.py
+++ b/tmt/steps/finish/ansible.py
@@ -34,4 +34,4 @@ class FinishAnsible(tmt.steps.finish.FinishPlugin, PrepareAnsible):
 
     # Assigning class methods seems to cause trouble to mypy
     # See also: https://github.com/python/mypy/issues/6700
-    base_command = tmt.steps.finish.FinishPlugin.base_command  # type: ignore
+    base_command = tmt.steps.finish.FinishPlugin.base_command  # type: ignore[assignment]

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -350,7 +350,7 @@ class GuestTestcloud(tmt.GuestSsh):
     """
 
     # TODO: Revisit this `type: ignore` once `Guest` becomes a generic type
-    _data_class = TestcloudGuestData  # type: ignore
+    _data_class = TestcloudGuestData  # type: ignore[assignment]
 
     image: str
     image_url: Optional[str]
@@ -362,8 +362,8 @@ class GuestTestcloud(tmt.GuestSsh):
 
     # Not to be saved, recreated from image_url/instance_name/... every
     # time guest is instantiated.
-    _image: Optional['testcloud.image.Image'] = None  # type: ignore
-    _instance: Optional['testcloud.instance.Instance'] = None  # type: ignore
+    _image: Optional['testcloud.image.Image'] = None  # type: ignore[name-defined]
+    _instance: Optional['testcloud.instance.Instance'] = None  # type: ignore[name-defined]
 
     def _get_url(self, url: str, message: str) -> requests.Response:
         """ Get url, retry when fails, return response """

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -124,10 +124,10 @@ class ReportJUnit(tmt.steps.report.ReportPlugin):
         try:
             with open(f_path, 'w') as fw:
                 if hasattr(junit_xml, 'to_xml_report_file'):
-                    junit_xml.to_xml_report_file(fw, [suite])  # type: ignore
+                    junit_xml.to_xml_report_file(fw, [suite])  # type: ignore[union-attr]
                 else:
                     # For older junit-xml
-                    junit_xml.TestSuite.to_file(fw, [suite])  # type: ignore
+                    junit_xml.TestSuite.to_file(fw, [suite])  # type: ignore[union-attr]
             self.info("output", f_path, 'yellow')
         except Exception as error:
             raise tmt.utils.ReportError(

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1798,7 +1798,7 @@ class TimeoutHTTPAdapter(requests.adapters.HTTPAdapter):
 
         super().__init__(*args, **kwargs)
 
-    def send(  # type: ignore # does not match superclass type on purpose
+    def send(  # type: ignore[override] # does not match superclass type on purpose
             self,
             request: requests.PreparedRequest,
             **kwargs: Any) -> requests.Response:
@@ -1839,7 +1839,7 @@ class RetryStrategy(requests.packages.urllib3.util.retry.Retry):  # type: ignore
         return super().increment(*args, **kwargs)
 
 
-class retry_session(contextlib.AbstractContextManager):  # type: ignore
+class retry_session(contextlib.AbstractContextManager):  # type: ignore[type-arg]
     """
     Context manager for requests.Session() with retries and timeout
     """
@@ -2627,7 +2627,7 @@ def git_clone(
         return git_clone(url, destination, common, env, shallow=False)
 
 
-class updatable_message(contextlib.AbstractContextManager):  # type: ignore
+class updatable_message(contextlib.AbstractContextManager):  # type: ignore[type-arg]
     """ Updatable message suitable for progress-bar-like reporting """
 
     def __init__(


### PR DESCRIPTION
Using mypy's error codes, waivers can target the actual erorr, leaving
space for other kind of violations to not be suppressed.