### PR TITLE
Require `libvirt-daemon-config-network` as well

### DIFF
--- a/plans/provision/virtual.fmf
+++ b/plans/provision/virtual.fmf
@@ -1,4 +1,7 @@
 summary: Virtual machine via testcloud
+discover:
+    how: fmf
+    filter: 'tag:virtual & tier:1 | tag:provision-virtual-only'
 provision:
     how: virtual
 #    image: fedora

--- a/tests/provision/virtual/dependencies/main.fmf
+++ b/tests/provision/virtual/dependencies/main.fmf
@@ -1,0 +1,11 @@
+summary: Verify `tmt-provision-virtual` package dependencies
+description:
+    Check that `tmt-provision-virtual` package brings with itself
+    all necessary dependencies needed for both `session` and
+    `system` connection to work without additional steps except
+    for setting group and starting the `libvirtd` service for the
+    `system` case.
+tag: provision-virtual-only
+tier: null
+require: tmt-provision-virtual
+order: 10

--- a/tests/provision/virtual/dependencies/test.sh
+++ b/tests/provision/virtual/dependencies/test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+USER="tester"
+
+rlJournalStart
+    rlPhaseStartSetup
+        # Directories
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
+        rlRun "pushd $tmp"
+        # Test user
+        rlRun "useradd $USER" 0 "Create test user"
+        rlRun "loginctl enable-linger $USER" 0 "Enable /run/user directory"
+        rlRun "chown $USER $tmp $run" 0 "Set permissions"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test session connection"
+        command="tmt run --id $run --verbose --scratch \
+            provision --how virtual --memory 1500 --connection session \
+            login -c \"echo works fine\" \
+            finish"
+        rlRun "su -l $USER -c '$command'"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test system connection"
+        rlRun "systemctl start libvirtd"
+        rlRun "usermod --append --groups libvirt $USER"
+        command="tmt run --id $run --verbose --scratch \
+            provision --how virtual --memory 1500 --connection system \
+            login -c \"echo works fine\" \
+            finish"
+        rlRun "su -l $USER -c '$command'"
+        rlRun "systemctl stop libvirtd"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        # Test user
+        rlRun "loginctl terminate-user $USER" 0,1 "Terminate session"
+        rlRun "pkill -u $USER" 0,1 "Kill user processes"
+        rlRun "userdel -r $USER" 0 "Remove the test user"
+        # Directories
+        rlRun "popd"
+        rlRun "rm -r $tmp $run" 0 "Remove tmp and run directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt.spec
+++ b/tmt.spec
@@ -72,6 +72,7 @@ Summary: Virtual machine provisioner for the Test Management Tool
 Obsoletes: tmt-testcloud < 0.17
 Requires: tmt == %{version}-%{release}
 Requires: python%{python3_pkgversion}-testcloud >= 0.8.1
+Requires: libvirt-daemon-config-network
 Requires: openssh-clients
 Requires: (ansible or ansible-core)
 # Recommend qemu system emulators for supported arches


### PR DESCRIPTION
In order to provide a fluent user experience when using `virtual`
provision with the `system` connection, include this extra package
in `tmt-provision-virtual` dependencies to make it working out of
the box. Add test coverage ensuring that all dependencies are
correctly installed.