### PR TITLE
Use tmt.utils.SerializableContainer for plugins' data

### DIFF
--- a/tests/execute/script/data/plan.fmf
+++ b/tests/execute/script/data/plan.fmf
@@ -1,7 +1,8 @@
 discover:
     how: shell
     tests:
-      - test: echo discover script
+      - name: dummy tests
+        test: echo discover script
 provision:
     how: local
 execute:

--- a/tests/plan/show/test.sh
+++ b/tests/plan/show/test.sh
@@ -16,7 +16,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Show a full plan"
-        rlRun -s "tmt plans show full"
+        rlRun -s "tmt plans show -v full"
         # Core
         rlAssertGrep "summary Plan keys are correctly displayed" $rlRun_LOG
         rlAssertGrep "description Some description" $rlRun_LOG
@@ -28,19 +28,19 @@ rlJournalStart
         rlAssertGrep "relates https://something.org/related" $rlRun_LOG
 
         # Steps
-        rlRun "grep -A2 '^ *discover' $rlRun_LOG > $output"
+        rlRun "grep -Pzo '(?sm)^ *discover ?$.*^ *provision' $rlRun_LOG > $output"
         rlAssertGrep "    how fmf" $output
         rlAssertGrep "    filter tier:1" $output
-        rlRun "grep -A2 '^ *provision' $rlRun_LOG > $output"
+        rlRun "grep -Pzo '(?sm)^ *provision ?$.*^ *prepare' $rlRun_LOG > $output"
         rlAssertGrep "    how container" $output
         rlAssertGrep "    image fedora" $output
-        rlRun "grep -A2 '^ *prepare' $rlRun_LOG > $output"
+        rlRun "grep -Pzo '(?sm)^ *prepare ?$.*^ *report' $rlRun_LOG > $output"
         rlAssertGrep "    how shell" $output
         rlAssertGrep "    script systemctl start libvirtd" $output
-        rlRun "grep -A2 '^ *report' $rlRun_LOG > $output"
+        rlRun "grep -Pzo '(?sm)^ *report ?$.*^ *finish' $rlRun_LOG > $output"
         rlAssertGrep "    how html" $output
         rlAssertGrep "    open true" $output
-        rlRun "grep -A2 '^ *finish' $rlRun_LOG > $output"
+        rlRun "grep -A30 '^ *finish' $rlRun_LOG > $output"
         rlAssertGrep "    how ansible" $output
         rlAssertGrep "    playbook cleanup.yaml" $output
 

--- a/tests/unit/test_report_junit.py
+++ b/tests/unit/test_report_junit.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, PropertyMock
 import pytest
 
 from tmt import Result
-from tmt.steps.report.junit import ReportJUnit
+from tmt.steps.report.junit import ReportJUnit, ReportJUnitData
 
 
 @pytest.fixture
@@ -24,9 +24,9 @@ def report_fix(tmpdir):
         return default
 
     report = ReportJUnit(
-        step=step_mock, data={
-            'name': 'x'}, workdir=str(
-            tmpdir.join('junit')))
+        step=step_mock,
+        data=ReportJUnitData(name='x', how='junit'),
+        workdir=str(tmpdir.join('junit')))
     report.get = get
     report.info = MagicMock()
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -262,6 +262,8 @@ class Core(tmt.utils.Common):
 
     def _normalize_adjust(
             self, value: Union[_RawAdjustRule, List[_RawAdjustRule]]) -> List[_RawAdjustRule]:
+        if value is None:
+            return []
         return [value] if not isinstance(value, list) else value
 
     def _normalize_tier(self, value: Optional[Union[int, str]]) -> Optional[str]:
@@ -399,7 +401,7 @@ class Core(tmt.utils.Common):
 
             value = getattr(self, key)
 
-            if key == 'link':
+            if key == 'link' and value:
                 data[key] = value.links
 
             else:
@@ -2229,7 +2231,7 @@ class Clean(tmt.utils.Common):
 
     def _matches_how(self, plan):
         """ Check if the given plan matches options """
-        how = plan.provision.data[0]['how']
+        how = plan.provision.data[0].how
         target_how = self.opt('how')
         if target_how:
             return how == target_how
@@ -2464,7 +2466,7 @@ class Result:
         return data
 
 
-class Link:
+class Link(tmt.utils.SerializableContainer):
     """ Core attribute link parsing """
 
     # The list of all supported link relations

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -1,16 +1,144 @@
 import copy
+import dataclasses
 import os
-from typing import TYPE_CHECKING, List, Optional
+from typing import (TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar,
+                    Union, cast)
 
 import click
 import fmf
 
 import tmt
+import tmt.base
 import tmt.steps
 import tmt.steps.discover
+import tmt.utils
 
 if TYPE_CHECKING:
     import tmt.base
+
+
+T = TypeVar('T', bound='TestDescription')
+
+
+@dataclasses.dataclass
+class TestDescription(tmt.utils.NormalizeKeysMixin, tmt.utils.SerializableContainer):
+    """
+    Keys necessary to describe a shell-based test.
+
+    Provides basic functionality for tansition between "raw" step data representation,
+    which consists of keys and values given by fmf tree and CLI options, and this
+    container representation for internal use.
+    """
+
+    name: str
+
+    # TODO: following keys are copy & pasted from base.Test. It would be much, much better
+    # to re-use the definitions from base.Test instead copying them here, but base.Test
+    # does not support save/load operations. This is a known issue, introduced by a patch
+    # transitioning step data to data classes, it is temporary, and it will be fixed as
+    # soon as possible - nobody want's to keep two very same lists of attributes.
+    test: str
+
+    # Core attributes (supported across all levels)
+    summary: Optional[str] = None
+    description: Optional[str] = None
+    enabled: bool = True
+    # TODO: ugly circular dependency (see tmt.base.DEFAULT_ORDER)
+    order: int = 50
+    link: Optional['tmt.base.Link'] = None
+    id: Optional[str] = None
+    tag: List[str] = dataclasses.field(default_factory=list)
+    tier: Optional[str] = None
+    adjust: Optional[List['tmt.base._RawAdjustRule']] = None
+
+    # Basic test information
+    contact: List[str] = dataclasses.field(default_factory=list)
+    component: List[str] = dataclasses.field(default_factory=list)
+
+    # Test execution data
+    path: Optional[str] = None
+    framework: Optional[str] = None
+    manual: bool = False
+    require: List[Union[str, 'tmt.base.FmfId']] = dataclasses.field(default_factory=list)
+    recommend: List[str] = dataclasses.field(default_factory=list)
+    environment: tmt.utils.EnvironmentType = dataclasses.field(default_factory=dict)
+    duration: str = '1h'
+    result: str = 'respect'
+
+    # We can't even re-use normalization callbacks from tmt.base because of the cyclic import :/
+    _normalize_tag = tmt.utils.LoadFmfKeysMixin._normalize_string_list
+    _normalize_contact = tmt.utils.LoadFmfKeysMixin._normalize_string_list
+    _normalize_component = tmt.utils.LoadFmfKeysMixin._normalize_string_list
+    _normalize_recommend = tmt.utils.LoadFmfKeysMixin._normalize_string_list
+
+    def _normalize_order(self, value: Optional[int]) -> int:
+        if value is None:
+            # TODO: ugly circular dependency (see tmt.base.DEFAULT_ORDER)
+            return 50
+        return int(value)
+
+    def _normalize_link(self, value: 'tmt.base._RawLink') -> 'tmt.base.Link':
+        import tmt.base
+
+        return tmt.base.Link(data=value)
+
+    def _normalize_adjust(self,
+                          value: Optional[Union[
+                              'tmt.base._RawAdjustRule',
+                              List['tmt.base._RawAdjustRule']]]
+                          ) -> List['tmt.base._RawAdjustRule']:
+        if value is None:
+            return []
+        return [value] if not isinstance(value, list) else value
+
+    def _normalize_tier(self, value: Optional[Union[int, str]]) -> Optional[str]:
+        if value is None:
+            return None
+        return str(value)
+
+    def _normalize_require(
+            self, value: Optional['tmt.base._RawRequire']) -> List[Union[str, 'tmt.base.FmfId']]:
+        if value is None:
+            return []
+        # TODO: remove ignore when base.py becomes annotated
+        return [value] if isinstance(value, str) else value  # type: ignore[no-any-return]
+
+    # Our own implementation, parent uses `name` and `how`, and tests don't have any `how`.
+    @classmethod
+    def from_raw(cls: Type[T], raw_data: Dict[str, Any], logger: tmt.utils.Common) -> T:
+        """
+        Unserialize step data instance from its a raw representation.
+        """
+
+        data = cls(name=raw_data['name'], test=raw_data['test'])
+        data._load_keys(raw_data, cls.__name__, logger)
+
+        return data
+
+    def to_serialized(self) -> Dict[str, Any]:
+        """
+        Return keys and values in the form allowing later reconstruction.
+
+        Used to transform container into a structure one can save in a
+        YAML file, and restore it later.
+
+        See :py:meth:`from_serialized` for its counterpart.
+        """
+
+        fields = super().to_serialized()
+
+        fields['link'] = self.link.to_serialized() if self.link else None
+
+        return fields
+
+
+@dataclasses.dataclass
+class DiscoverShellData(tmt.steps.discover.DiscoverStepData):
+    tests: List[TestDescription] = dataclasses.field(default_factory=list)
+
+    def _normalize_tests(self, value: List[Dict[str, Any]]
+                         ) -> List[TestDescription]:
+        return [TestDescription.from_raw(raw_datum, tmt.utils.Common()) for raw_datum in value]
 
 
 @tmt.steps.provides_method('shell')
@@ -45,21 +173,17 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
           test: cd $TMT_SOURCE_DIR/*/tests && make test
     """
 
+    _data_class = DiscoverShellData
+
+    _tests: List[tmt.base.Test] = []
+
     def show(self, keys: Optional[List[str]] = None) -> None:
         """ Show config details """
         super().show([])
-        tests = self.get('tests')
+        tests = cast(List[TestDescription], self.get('tests'))
         if tests:
-            test_names = [test['name'] for test in tests]
+            test_names = [test.name for test in tests]
             click.echo(tmt.utils.format('tests', test_names))
-
-    def wake(self) -> None:
-        """ Wake up the plugin, process data, apply options """
-        super().wake()
-        # Check provided tests, default to an empty list
-        if 'tests' not in self.data:
-            self.data['tests'] = []
-        self._tests: List[tmt.base.Test] = []
 
     def go(self) -> None:
         """ Discover available tests """
@@ -72,34 +196,29 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
         dist_git_source = self.get('dist-git-source', False)
 
         # Check and process each defined shell test
-        assert self.data['tests'] is not None
-        for data in self.data['tests']:
+        for data in cast(DiscoverShellData, self.data).tests:
             # Create data copy (we want to keep original data for save()
             data = copy.deepcopy(data)
             # Extract name, make sure it is present
-            try:
-                name = data.pop('name')
-            except KeyError:
+            # TODO: can this ever happen? With annotations, `name: str` and `test: str`, nothing
+            # should ever assign `None` there and pass the test.
+            if not data.name:
                 raise tmt.utils.SpecificationError(
                     f"Missing test name in '{self.step.plan.name}'.")
             # Make sure that the test script is defined
-            if 'test' not in data:
+            if not data.test:
                 raise tmt.utils.SpecificationError(
                     f"Missing test script in '{self.step.plan.name}'.")
             # Prepare path to the test working directory (tree root by default)
-            try:
-                data['path'] = f"/tests{data['path']}"
-            except KeyError:
-                data['path'] = "/tests"
+            data.path = f"/tests{data.path}" if data.path else '/tests'
             # Apply default test duration unless provided
-            if 'duration' not in data:
-                data['duration'] = tmt.base.DEFAULT_TEST_DURATION_L2
+            if not data.duration:
+                data.duration = tmt.base.DEFAULT_TEST_DURATION_L2
             # Add source dir path variable
             if dist_git_source:
-                data.setdefault('environment', {})[
-                    'TMT_SOURCE_DIR'] = sourcedir
+                data.environment['TMT_SOURCE_DIR'] = sourcedir
             # Create a simple fmf node, adjust its name
-            tests.child(name, data)
+            tests.child(data.name, data.to_dict())
 
         # Symlink tests directory to the plan work tree
         testdir = os.path.join(self.workdir, "tests")

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -1,7 +1,9 @@
+import dataclasses
 import json
 import os
 import sys
 import time
+from typing import List
 
 import click
 
@@ -11,6 +13,14 @@ import tmt.steps.execute
 import tmt.utils
 from tmt.steps.execute import (SCRIPTS, TEST_OUTPUT_FILENAME,
                                TMT_FILE_SUBMIT_SCRIPT, TMT_REBOOT_SCRIPT)
+
+
+@dataclasses.dataclass
+class ExecuteInternalData(tmt.steps.execute.ExecuteStepData):
+    script: List[str] = dataclasses.field(default_factory=list)
+    interactive: bool = False
+
+    _normalize_script = tmt.utils.NormalizeKeysMixin._normalize_string_list
 
 
 @tmt.steps.provides_method('tmt')
@@ -26,8 +36,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
     results file (for beakerlib tests).
     """
 
-    # Supported keys
-    _keys = ["script", "interactive"]
+    _data_class = ExecuteInternalData
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -51,12 +60,6 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             '--no-progress-bar', is_flag=True,
             help='Disable interactive progress bar showing the current test.'))
         return options + super().options(how)
-
-    def wake(self):
-        """ Wake up the plugin, process data, apply options """
-        super().wake()
-        # Make sure that script is a list
-        tmt.utils.listify(self.data, keys=['script'])
 
     # TODO: consider switching to utils.updatable_message() - might need more
     # work, since use of _show_progress is split over several methods.

--- a/tmt/steps/finish/ansible.py
+++ b/tmt/steps/finish/ansible.py
@@ -1,6 +1,7 @@
 import tmt
 import tmt.steps
 import tmt.steps.finish
+import tmt.steps.prepare.ansible
 from tmt.steps.prepare.ansible import PrepareAnsible
 
 
@@ -28,6 +29,8 @@ class FinishAnsible(tmt.steps.finish.FinishPlugin, PrepareAnsible):
     Use 'order' attribute to select in which order finishing tasks
     should happen if there are multiple configs. Default order is '50'.
     """
+
+    _data_class = tmt.steps.prepare.ansible.PrepareAnsibleData
 
     # Assigning class methods seems to cause trouble to mypy
     # See also: https://github.com/python/mypy/issues/6700

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -1,4 +1,5 @@
-from typing import Any, List, Optional
+import dataclasses
+from typing import List, Optional
 
 import click
 import fmf
@@ -7,6 +8,13 @@ import tmt
 import tmt.steps
 import tmt.steps.finish
 from tmt.steps.provision import Guest
+
+
+@dataclasses.dataclass
+class FinishShellData(tmt.steps.finish.FinishStepData):
+    script: List[str] = dataclasses.field(default_factory=list)
+
+    _normalize_script = tmt.utils.NormalizeKeysMixin._normalize_string_list
 
 
 @tmt.steps.provides_method('shell')
@@ -26,8 +34,7 @@ class FinishShell(tmt.steps.finish.FinishPlugin):
     should happen if there are multiple configs. Default order is '50'.
     """
 
-    # Supported keys
-    _keys = ["script"]
+    _data_class = FinishShellData
 
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
@@ -39,20 +46,6 @@ class FinishShell(tmt.steps.finish.FinishPlugin):
                 help='Shell script to be executed.')
             ]
         return options
-
-    def default(self, option: str, default: Optional[Any] = None) -> Any:
-        """ Return default data for given option """
-        if option == 'script':
-            return []
-        return default
-
-    # TODO: use better types once superclass gains its annotations
-    def wake(self) -> None:
-        """ Wake up the plugin, process data, apply options """
-        super().wake()
-
-        # Convert to list if single script provided
-        tmt.utils.listify(self.data, keys=['script'])
 
     def go(self, guest: Guest) -> None:
         """ Perform finishing tasks on given guest """

--- a/tmt/steps/prepare/multihost.py
+++ b/tmt/steps/prepare/multihost.py
@@ -1,9 +1,19 @@
-from typing import Any, Optional
+import dataclasses
+from typing import Dict, List
 
 import tmt
 import tmt.steps
 import tmt.steps.prepare
 from tmt.steps.provision import Guest
+
+
+# Derived from StepData, not PrepareStepData, on purpose: this is not a plugin
+# per se, but rather a metadata structure. Other plugins may refer to data
+# defined by this "step" by using `where` key in their own data.
+@dataclasses.dataclass
+class PrepareMultihostData(tmt.steps.StepData):
+    roles: Dict[str, List[str]] = dataclasses.field(default_factory=dict)
+    hosts: Dict[str, str] = dataclasses.field(default_factory=dict)
 
 
 @tmt.steps.provides_method('multihost')
@@ -30,14 +40,7 @@ class PrepareMultihost(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
     The exported roles are comma-separated.
     """
 
-    # Supported keys
-    _keys = ['roles', 'hosts']
-
-    def default(self, option: str, default: Optional[Any] = None) -> Any:
-        """ Return default data for given option """
-        if option in ('roles', 'hosts'):
-            return {}
-        return default
+    _data_class = PrepareMultihostData
 
     def go(self, guest: 'Guest') -> None:
         """ Prepare the guests """

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -1,4 +1,5 @@
-from typing import Any, Optional
+import dataclasses
+from typing import Any, List, Optional
 
 import click
 import fmf
@@ -8,6 +9,14 @@ import tmt.steps
 import tmt.steps.prepare
 import tmt.utils
 from tmt.steps.provision import Guest
+
+
+# TODO: remove `ignore` with follow-imports enablement
+@dataclasses.dataclass
+class PrepareShellData(tmt.steps.prepare.PrepareStepData):  # type: ignore[misc]
+    script: List[str] = dataclasses.field(default_factory=list)
+
+    _normalize_script = tmt.utils.NormalizeKeysMixin._normalize_string_list
 
 
 # TODO: drop ignore once type annotations between modules enabled
@@ -30,8 +39,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
     Default order of required packages installation is '70'.
     """
 
-    # Supported keys
-    _keys = ["script"]
+    _data_class = PrepareShellData
 
     @classmethod
     def options(cls, how: Optional[str] = None) -> Any:
@@ -41,19 +49,6 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
                 '-s', '--script', metavar='SCRIPT',
                 help='Shell script to be executed.')
             ] + super().options(how)
-
-    def default(self, option: str, default: Optional[Any] = None) -> Any:
-        """ Return default data for given option """
-        if option == 'script':
-            return []
-        return default
-
-    def wake(self) -> None:
-        """ Wake up the plugin, process data, apply options """
-        super().wake()
-
-        # Convert to list if single script provided
-        tmt.utils.listify(self.data, keys=['script'])
 
     def go(self, guest: Guest) -> None:
         """ Prepare the guests """

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -85,6 +85,11 @@ class ArtemisGuestData(tmt.steps.provision.GuestSshData):
     api_retry_backoff_factor: int = DEFAULT_RETRY_BACKOFF_FACTOR
 
 
+@dataclasses.dataclass
+class ProvisionArtemisData(ArtemisGuestData, tmt.steps.StepData):
+    pass
+
+
 GUEST_STATE_COLOR_DEFAULT = 'green'
 
 GUEST_STATE_COLORS = {
@@ -269,26 +274,10 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
             api-retry-backoff-factor: 1
     """
 
-    _data_class = ArtemisGuestData
+    _data_class = ProvisionArtemisData
 
     # Guest instance
     _guest = None
-
-    _keys = [
-        'api-url',
-        'api-version',
-        'arch',
-        'image',
-        'hardware',
-        'pool',
-        'priority-group',
-        'keyname',
-        'user-data',
-        'provision-timeout',
-        'provision-tick',
-        'api-timeout',
-        'api-retries',
-        'api-retry-backoff-factor']
 
     # TODO: fix types once superclass gains its annotations
     @classmethod
@@ -359,11 +348,6 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
                      f'{DEFAULT_RETRY_BACKOFF_FACTOR} by default.',
                 ),
             ]) + super().options(how)
-
-    def default(self, option: str, default: Optional[Any] = None) -> Any:
-        """ Return default data for given option """
-
-        return getattr(ArtemisGuestData(), option.replace('-', '_'), default)
 
     # More specific type is a violation of Liskov substitution principle, and mypy
     # complains about it - rightfully so. Ignoring the issue which should be resolved

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -1,8 +1,15 @@
+import dataclasses
 from typing import Any, List, Optional, Union
 
 import tmt
 import tmt.steps
 import tmt.steps.provision
+import tmt.utils
+
+
+@dataclasses.dataclass
+class ProvisionLocalData(tmt.steps.provision.GuestData, tmt.steps.StepData):
+    pass
 
 
 @tmt.steps.provides_method('local')
@@ -23,6 +30,8 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
     If there are admin rights required (for example in the prepare step)
     you might be asked for a sudo password.
     """
+
+    _data_class = ProvisionLocalData
 
     # Guest instance
     _guest = None

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -26,6 +26,11 @@ class PodmanGuestData(tmt.steps.provision.GuestData):
     container: Optional[str] = None
 
 
+@dataclasses.dataclass
+class ProvisionPodmanData(PodmanGuestData, tmt.steps.StepData):
+    pass
+
+
 @tmt.steps.provides_method('container')
 class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
     """
@@ -43,11 +48,10 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
     use 'user: USER'.
     """
 
+    _data_class = ProvisionPodmanData
+
     # Guest instance
     _guest = None
-
-    # Supported keys
-    _keys = ["image", "container", "pull", "user"]
 
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
@@ -72,9 +76,9 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
     def default(self, option: str, default: Any = None) -> Any:
         """ Return default data for given option """
         if option == 'pull':
-            return PodmanGuestData().force_pull
+            return self.get('force-pull', default=default)
 
-        return getattr(PodmanGuestData(), option.replace('-', '_'), default)
+        return super().default(option, default=default)
 
     def wake(self, data: Optional[tmt.steps.provision.GuestData] = None) -> None:
         """ Wake up the plugin, process data, apply options """

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -178,6 +178,11 @@ class TestcloudGuestData(tmt.steps.provision.GuestSshData):
     instance_name: Optional[str] = None
 
 
+@dataclasses.dataclass
+class ProvisionTestcloudData(TestcloudGuestData, tmt.steps.StepData):
+    pass
+
+
 @tmt.steps.provides_method('virtual.testcloud')
 class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
     """
@@ -221,11 +226,10 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
     testcloud will take care of unpacking the image for you.
     """
 
+    _data_class = ProvisionTestcloudData
+
     # Guest instance
     _guest = None
-
-    # Supported keys
-    _keys = ["image", "user", "memory", "disk", "connection", "arch"]
 
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
@@ -255,10 +259,6 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
                 help="What architecture to virtualize, host arch by default."),
             ]
         return options
-
-    def default(self, option: str, default: Any = None) -> Any:
-        """ Return default data for given option """
-        return getattr(TestcloudGuestData(), option, default)
 
     # TODO: Revisit this `type: ignore` once `Guest` becomes a generic type
     def wake(self, data: Optional[TestcloudGuestData] = None) -> None:  # type: ignore[override]

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -54,7 +54,9 @@ class Report(tmt.steps.Step):
 
         # Choose the right plugin and wake it up
         for data in self.data:
-            plugin = ReportPlugin.delegate(self, data)
+            # TODO: with generic BasePlugin, delegate() should return more fitting type,
+            # not the base class.
+            plugin = cast(ReportPlugin, ReportPlugin.delegate(self, data=data))
             plugin.wake()
             self._phases.append(plugin)
 
@@ -70,7 +72,7 @@ class Report(tmt.steps.Step):
     def show(self) -> None:
         """ Show discover details """
         for data in self.data:
-            ReportPlugin.delegate(self, data).show()
+            ReportPlugin.delegate(self, data=data).show()
 
     def summary(self) -> None:
         """ Give a concise report summary """

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 import os.path
 import types
@@ -32,6 +33,11 @@ def import_jinja2() -> None:
             "Missing 'jinja2', fixable by 'pip install tmt[report-html]'")
 
 
+@dataclasses.dataclass
+class ReportHtmlData(tmt.steps.StepData):
+    open: bool = False
+
+
 @tmt.steps.provides_method('html')
 class ReportHtml(tmt.steps.report.ReportPlugin):
     """
@@ -44,8 +50,7 @@ class ReportHtml(tmt.steps.report.ReportPlugin):
             open: true
     """
 
-    # Supported keys
-    _keys = ["open"]
+    _data_class = ReportHtmlData
 
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -1,3 +1,4 @@
+import dataclasses
 import os
 import types
 from typing import Any, List, Optional, cast, overload
@@ -85,6 +86,11 @@ def make_junit_xml(report: "tmt.steps.report.ReportPlugin") -> JunitTestSuite:
     return cast(JunitTestSuite, suite)
 
 
+@dataclasses.dataclass
+class ReportJUnitData(tmt.steps.StepData):
+    file: Optional[str] = None
+
+
 @tmt.steps.provides_method('junit')
 class ReportJUnit(tmt.steps.report.ReportPlugin):
     """
@@ -94,8 +100,7 @@ class ReportJUnit(tmt.steps.report.ReportPlugin):
     located in the current workdir.
     """
 
-    # Supported keys
-    _keys = ["file"]
+    _data_class = ReportJUnitData
 
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import os
 import xml.etree.ElementTree as ET
@@ -14,12 +15,21 @@ from .junit import make_junit_xml
 DEFAULT_NAME = 'xunit.xml'
 
 
+@dataclasses.dataclass
+class ReportPolarionData(tmt.steps.StepData):
+    file: Optional[str] = None
+    no_upload: bool = False
+    project_id: Optional[str] = None
+    testrun_title: Optional[str] = None
+
+
 @tmt.steps.provides_method('polarion')
 class ReportPolarion(tmt.steps.report.ReportPlugin):
     """
     Write test results into a xUnit file and upload to Polarion
     """
-    _keys = ['file', 'no-upload', 'project-id', 'testrun-title']
+
+    _data_class = ReportPolarionData
 
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -924,10 +924,9 @@ def ascii(text: Any) -> bytes:
 
 
 def listify(
-        data: Union[Tuple[Any, ...], List[Any], str, Dict[Any, Any], 'tmt.steps.StepData'],
+        data: Union[Tuple[Any, ...], List[Any], str, Dict[Any, Any]],
         split: bool = False,
-        keys: Optional[List[str]] = None) -> Union[List[Any], Dict[Any, Any],
-                                                   'tmt.steps.StepData']:
+        keys: Optional[List[str]] = None) -> Union[List[Any], Dict[Any, Any]]:
     """
     Ensure that variable is a list, convert if necessary
     For dictionaries check all items or only those with provided keys.
@@ -943,8 +942,7 @@ def listify(
     if isinstance(data, dict):
         for key in keys or data:
             if key in data:
-                # TODO: this "type: ignore" should go away once StepData becomes a dataclass
-                data[key] = listify(data[key], split=split)  # type: ignore
+                data[key] = listify(data[key], split=split)
         return data
     return [data]
 
@@ -1372,7 +1370,7 @@ class SerializableContainer:
     @property
     def is_bare(self) -> bool:
         """
-        Check whether all keys are set to their default values.
+        Check whether all keys are either unset or have their default value.
 
         :returns: ``True`` if all keys either hold their default value
             or are not set at all, ``False`` otherwise.


### PR DESCRIPTION
These packages, describing plugin's configuration (and later state,
too), are called "step data" in tmt code. They are represended with
dictionaries, and values often follow the fmf input closely.

Following the lead of guest data, things are changing for plugins:

* step data are represented as dataclasses, with a base class providing
  common fields, inheritance and so on;
* all fields are declared as dataclass fields, with type annotations;
* derived from `tmt.utils.SerializableContainer`, save/load/restore
  actions are shared with guest data, using the same implementation;

This brings several advantages, including linters like mypy now having
more visibility into step data content and handling (e.g. malformed key
vs. non-existent parameter), more visible fields wrapped by a plugin,
and, thanks to normalization layer now separated from validation,
simpler data types for various fields that allow wide range of inputs
for users' comfort.

## Current state

* passes all upstream tests
* patches for out-of-tree plugins pending

## The series

* #1477
* #1478
* #1479
* #1481
* #1480
* #1461