### PR TITLE
Clarify motivation for creating `id` during export

### DIFF
--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -123,6 +123,17 @@ Metadata Specification and are supposed to be synced temporarily
 to keep backward compatibility.
 
 
+Why is the 'id' key added to my test during export?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When exporting ``tmt`` test metadata using ``tmt tests export`` to
+other test case management systems, a unique ``id`` is created in
+order to provide a persistent way to identify the test even if it
+is renamed, moved across the directory structure or into a
+different repository. See the :ref:`/spec/core/id` key
+specification for more details.
+
+
 How can I integrate tmt tests with other tools?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/spec/core/id.fmf
+++ b/spec/core/id.fmf
@@ -1,5 +1,9 @@
 summary: Persistent unique identifier of the object
 
+story:
+    As a user I want to be able to track execution history of a
+    test even if it is renamed or moved to another repository.
+
 description: |
     Sometimes tests, plans or stories are renamed or moved across
     the directory structure, into a different git branch or even


### PR DESCRIPTION
Some users seems to be confused by the new `id` key added to their
`main.fmf` files during export. Let's clarify the motivation a bit
and also add the missing story to the `id` key specification.