### PR TITLE
Reorder step and their base plugin classes (step data conversion, part 1)

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -90,6 +90,9 @@ class Step(tmt.utils.Common):
     # area of expertise.
     DEFAULT_HOW: str = 'shell'
 
+    # Refers to a base class for all plugins registered with this step.
+    _plugin_base_class: Type['BasePlugin']
+
     def __init__(
             self,
             plan: 'Plan',

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -99,165 +99,6 @@ SCRIPTS = (
     )
 
 
-class Execute(tmt.steps.Step):
-    """
-    Run tests using the specified executor.
-
-    Note that the old execution methods 'shell.tmt' and 'beakerlib.tmt'
-    have been deprecated and the backward-compatible support for them
-    will be dropped in tmt-2.0.
-
-    Use the new L1 metadata attribute 'framework' instead to specify
-    which test framework should be used for execution. This allows to
-    combine tests using different test frameworks in a single plan.
-    """
-
-    # Internal executor is the default implementation
-    DEFAULT_HOW = 'tmt'
-
-    def __init__(self, plan: "tmt.Plan", data: tmt.steps.StepData) -> None:
-        """ Initialize execute step data """
-        super().__init__(plan=plan, data=data)
-        # List of Result() objects representing test results
-        self._results: List[tmt.Result] = []
-
-        # Default test framework and mapping old methods
-        # FIXME remove when we drop the old execution methods
-        self._framework = DEFAULT_FRAMEWORK
-        # Map old methods now if there is no run (and thus no wake up)
-        if not self.plan.my_run:
-            self._map_old_methods()
-
-    def load(self) -> None:
-        """ Load test results """
-        super().load()
-        try:
-            results = tmt.utils.yaml_to_dict(self.read('results.yaml'))
-            self._results = [
-                tmt.Result(data, name=test) for test, data in results.items()]
-        except tmt.utils.FileError:
-            self.debug('Test results not found.', level=2)
-
-    def save(self) -> None:
-        """ Save test results to the workdir """
-        super().save()
-        results = dict([
-            (result.name, result.export()) for result in self.results()])
-        self.write('results.yaml', tmt.utils.dict_to_yaml(results))
-
-    def _map_old_methods(self) -> None:
-        """ Map the old execute methods in a backward-compatible way """
-        how = self.data[0]['how']
-        matched = re.search(r"^(shell|beakerlib)(\.tmt)?$", how)
-        if not matched:
-            return
-        # Show the old method deprecation warning to users
-        self.warn(f"The '{how}' execute method has been deprecated.")
-        # Map the old syntax to the appropriate executor
-        # shell, beakerlib ---> tmt
-        # shell.tmt, beakerlib.tmt ---> tmt
-        how = 'tmt'
-        self.warn(f"Use 'how: {how}' in the execute step instead (L2).")
-        self.data[0]['how'] = how
-        # Store shell or beakerlib as the default test framework
-        # (used when the framework is not defined in the L1 metadata)
-        framework = matched.group(1)
-        self.warn(f"Set 'framework: {framework}' in test metadata (L1).")
-        self._framework = framework
-        self.warn("Support for old methods will be dropped in tmt-2.0.")
-
-    def wake(self) -> None:
-        """ Wake up the step (process workdir and command line) """
-        super().wake()
-
-        # There should be just a single definition
-        if len(self.data) > 1:
-            raise tmt.utils.SpecificationError(
-                "Multiple execute steps defined in '{}'.".format(self.plan))
-
-        # Choose the right plugin and wake it up
-        self._map_old_methods()
-        executor = ExecutePlugin.delegate(self, self.data[0])
-        executor.wake()
-        self._phases.append(executor)
-
-        # Nothing more to do if already done
-        if self.status() == 'done':
-            self.debug(
-                'Execute wake up complete (already done before).', level=2)
-        # Save status and step data (now we know what to do)
-        else:
-            self.status('todo')
-            self.save()
-
-    def show(self) -> None:
-        """ Show execute details """
-        ExecutePlugin.delegate(self, self.data[0]).show()
-
-    def summary(self) -> None:
-        """ Give a concise summary of the execution """
-        tests = fmf.utils.listed(self.results(), 'test')
-        self.info('summary', f'{tests} executed', 'green', shift=1)
-
-    def go(self) -> None:
-        """ Execute tests """
-        super().go()
-
-        # Nothing more to do if already done
-        if self.status() == 'done':
-            self.info('status', 'done', 'green', shift=1)
-            self.summary()
-            self.actions()
-            return
-
-        # Make sure that guests are prepared
-        if not self.plan.provision.guests():
-            raise tmt.utils.ExecuteError("No guests available for execution.")
-
-        # Execute the tests, store results
-        for guest in self.plan.provision.guests():
-            for phase in self.phases(classes=(Action, ExecutePlugin)):
-                if not phase.enabled_on_guest(guest):
-                    continue
-
-                if isinstance(phase, Action):
-                    phase.go()
-
-                elif isinstance(phase, ExecutePlugin):
-                    phase.go(guest)
-
-                    self._results.extend(phase.results())
-
-                else:
-                    raise GeneralError(f'Unexpected phase in execute step: {phase}')
-
-        # Give a summary, update status and save
-        self.summary()
-        self.status('done')
-        self.save()
-
-    def requires(self) -> List[str]:
-        """
-        Packages required for test execution
-
-        Return a list of packages which need to be installed on the
-        guest so that tests can be executed. Used by the prepare step.
-        """
-        requires = set()
-        for plugin in self.phases(classes=ExecutePlugin):
-            requires.update(plugin.requires())
-        return list(requires)
-
-    def results(self) -> List["tmt.base.Result"]:
-        """
-        Results from executed tests
-
-        Return a dictionary with test results according to the spec:
-        https://tmt.readthedocs.io/en/latest/spec/plans.html#execute
-        """
-        return self._results
-
-
 class ExecutePlugin(tmt.steps.Plugin):
     """ Common parent of execute plugins """
 
@@ -516,3 +357,164 @@ class ExecutePlugin(tmt.steps.Plugin):
     def results(self) -> List["tmt.Result"]:
         """ Return test results """
         raise NotImplementedError
+
+
+class Execute(tmt.steps.Step):
+    """
+    Run tests using the specified executor.
+
+    Note that the old execution methods 'shell.tmt' and 'beakerlib.tmt'
+    have been deprecated and the backward-compatible support for them
+    will be dropped in tmt-2.0.
+
+    Use the new L1 metadata attribute 'framework' instead to specify
+    which test framework should be used for execution. This allows to
+    combine tests using different test frameworks in a single plan.
+    """
+
+    # Internal executor is the default implementation
+    DEFAULT_HOW = 'tmt'
+
+    _plugin_base_class = ExecutePlugin
+
+    def __init__(self, plan: "tmt.Plan", data: tmt.steps.StepData) -> None:
+        """ Initialize execute step data """
+        super().__init__(plan=plan, data=data)
+        # List of Result() objects representing test results
+        self._results: List[tmt.Result] = []
+
+        # Default test framework and mapping old methods
+        # FIXME remove when we drop the old execution methods
+        self._framework = DEFAULT_FRAMEWORK
+        # Map old methods now if there is no run (and thus no wake up)
+        if not self.plan.my_run:
+            self._map_old_methods()
+
+    def load(self) -> None:
+        """ Load test results """
+        super().load()
+        try:
+            results = tmt.utils.yaml_to_dict(self.read('results.yaml'))
+            self._results = [
+                tmt.Result(data, name=test) for test, data in results.items()]
+        except tmt.utils.FileError:
+            self.debug('Test results not found.', level=2)
+
+    def save(self) -> None:
+        """ Save test results to the workdir """
+        super().save()
+        results = dict([
+            (result.name, result.export()) for result in self.results()])
+        self.write('results.yaml', tmt.utils.dict_to_yaml(results))
+
+    def _map_old_methods(self) -> None:
+        """ Map the old execute methods in a backward-compatible way """
+        how = self.data[0]['how']
+        matched = re.search(r"^(shell|beakerlib)(\.tmt)?$", how)
+        if not matched:
+            return
+        # Show the old method deprecation warning to users
+        self.warn(f"The '{how}' execute method has been deprecated.")
+        # Map the old syntax to the appropriate executor
+        # shell, beakerlib ---> tmt
+        # shell.tmt, beakerlib.tmt ---> tmt
+        how = 'tmt'
+        self.warn(f"Use 'how: {how}' in the execute step instead (L2).")
+        self.data[0]['how'] = how
+        # Store shell or beakerlib as the default test framework
+        # (used when the framework is not defined in the L1 metadata)
+        framework = matched.group(1)
+        self.warn(f"Set 'framework: {framework}' in test metadata (L1).")
+        self._framework = framework
+        self.warn("Support for old methods will be dropped in tmt-2.0.")
+
+    def wake(self) -> None:
+        """ Wake up the step (process workdir and command line) """
+        super().wake()
+
+        # There should be just a single definition
+        if len(self.data) > 1:
+            raise tmt.utils.SpecificationError(
+                "Multiple execute steps defined in '{}'.".format(self.plan))
+
+        # Choose the right plugin and wake it up
+        self._map_old_methods()
+        executor = ExecutePlugin.delegate(self, self.data[0])
+        executor.wake()
+        self._phases.append(executor)
+
+        # Nothing more to do if already done
+        if self.status() == 'done':
+            self.debug(
+                'Execute wake up complete (already done before).', level=2)
+        # Save status and step data (now we know what to do)
+        else:
+            self.status('todo')
+            self.save()
+
+    def show(self) -> None:
+        """ Show execute details """
+        ExecutePlugin.delegate(self, self.data[0]).show()
+
+    def summary(self) -> None:
+        """ Give a concise summary of the execution """
+        tests = fmf.utils.listed(self.results(), 'test')
+        self.info('summary', f'{tests} executed', 'green', shift=1)
+
+    def go(self) -> None:
+        """ Execute tests """
+        super().go()
+
+        # Nothing more to do if already done
+        if self.status() == 'done':
+            self.info('status', 'done', 'green', shift=1)
+            self.summary()
+            self.actions()
+            return
+
+        # Make sure that guests are prepared
+        if not self.plan.provision.guests():
+            raise tmt.utils.ExecuteError("No guests available for execution.")
+
+        # Execute the tests, store results
+        for guest in self.plan.provision.guests():
+            for phase in self.phases(classes=(Action, ExecutePlugin)):
+                if not phase.enabled_on_guest(guest):
+                    continue
+
+                if isinstance(phase, Action):
+                    phase.go()
+
+                elif isinstance(phase, ExecutePlugin):
+                    phase.go(guest)
+
+                    self._results.extend(phase.results())
+
+                else:
+                    raise GeneralError(f'Unexpected phase in execute step: {phase}')
+
+        # Give a summary, update status and save
+        self.summary()
+        self.status('done')
+        self.save()
+
+    def requires(self) -> List[str]:
+        """
+        Packages required for test execution
+
+        Return a list of packages which need to be installed on the
+        guest so that tests can be executed. Used by the prepare step.
+        """
+        requires = set()
+        for plugin in self.phases(classes=ExecutePlugin):
+            requires.update(plugin.requires())
+        return list(requires)
+
+    def results(self) -> List["tmt.base.Result"]:
+        """
+        Results from executed tests
+
+        Return a dictionary with test results according to the spec:
+        https://tmt.readthedocs.io/en/latest/spec/plans.html#execute
+        """
+        return self._results


### PR DESCRIPTION
(Part of a patchset focusing on a step data conversion to dataclasses.)

There is no functional change, the patch switches order of step class
and its respective base plugin class for each step. The goal is to reach
a state where each step can offer a link to base class of its plugins,
which will become useful in the step data conversion patch.