### PR TITLE
Add support for remote playbooks in prepare

### DIFF
--- a/spec/plans/finish.fmf
+++ b/spec/plans/finish.fmf
@@ -29,16 +29,21 @@ example: |
 /ansible:
     summary:
         Perform finishing tasks using ansible
-    description:
+    description: |
         One or more playbooks can be provided as a list under the
         ``playbook`` attribute.  Each of them will be applied
         using ``ansible-playbook`` in the given order. The path
         must be relative to the metadata tree root.
+
+        Remote playbooks can be referenced as well as the local ones,
+        and both kinds can be used at the same time.
+
     example: |
         finish:
             how: ansible
             playbook:
                 - playbooks/common.yml
                 - playbooks/os/rhel7.yml
+                - https://foo.bar/rhel7-final-touches.yml
     link:
       - implemented-by: /tmt/steps/finish/ansible.py

--- a/spec/plans/prepare.fmf
+++ b/spec/plans/prepare.fmf
@@ -63,15 +63,20 @@ example: |
         Use ``extra-args`` attribute to enable optional arguments for
         ``ansible-playbook``.
 
+        Remote playbooks can be referenced as well as the local ones,
+        and both kinds can be used at the same time.
+
     example: |
         prepare:
             how: ansible
             playbook:
                 - playbooks/common.yml
                 - playbooks/os/rhel7.yml
+                - https://foo.bar/rhel7-final-touches.yml
             extra-args: '-vvv'
     link:
       - implemented-by: /tmt/steps/provision
+      - verified-by: /tests/prepare/ansible
 
 /install:
     summary:

--- a/tests/prepare/ansible/data/plan.fmf
+++ b/tests/prepare/ansible/data/plan.fmf
@@ -5,9 +5,18 @@ environment:
     SPACES: several words with spaces
 provision:
     how: container
-prepare:
-    how: ansible
-    playbook: playbook.yml
-    extra-args: '-vvv'
 execute:
     how: tmt
+
+/local:
+    prepare:
+        how: ansible
+        playbook: playbook.yml
+        extra-args: '-vvv'
+
+/remote:
+    prepare:
+        how: ansible
+        # This is the very same playbook as the local one, just living in tmt's repository.
+        playbook: https://raw.githubusercontent.com/teemtee/tmt/main/tests/prepare/ansible/data/playbook.yml
+        extra-args: '-vvv'

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -1,7 +1,10 @@
+import os.path
 import sys
+import tempfile
 from typing import Any, List, Optional
 
 import click
+import requests
 
 import tmt
 import tmt.steps
@@ -9,6 +12,7 @@ import tmt.steps.prepare
 import tmt.utils
 from tmt.steps import Step
 from tmt.steps.provision import Guest
+from tmt.utils import PrepareError, retry_session
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -45,6 +49,16 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
               - playbook/three.yml
             extra-args: '-vvv'
 
+    Remote playbooks can be referenced as well as local ones, and both
+    kinds can be intermixed:
+
+        prepare:
+            how: ansible
+            playbook:
+              - playbook/one.yml
+              - https://foo.bar/two.yml
+              - playbook/three.yml
+
     The playbook path should be relative to the metadata tree root.
     Use 'order' attribute to select in which order preparation should
     happen if there are multiple configs. Default order is '50'.
@@ -68,7 +82,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
         return [
             click.option(
                 '-p', '--playbook', metavar='PLAYBOOK', multiple=True,
-                help='Path to an ansible playbook to run.'),
+                help='Path or URL of an ansible playbook to run.'),
             click.option(
                 '--extra-args', metavar='EXTRA-ARGS',
                 help='Optional arguments for ansible-playbook.')
@@ -95,4 +109,37 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):  # type: ignore[misc]
         # Apply each playbook on the guest
         for playbook in self.get('playbook'):
             self.info('playbook', playbook, 'green')
-            guest.ansible(playbook, self.get('extra-args'))
+
+            lowercased_playbook = playbook.lower()
+            playbook_path = playbook
+
+            if lowercased_playbook.startswith(
+                    'http://') or lowercased_playbook.startswith('https://'):
+                root_path = self.step.plan.my_run.tree.root
+
+                try:
+                    with retry_session() as session:
+                        response = session.get(playbook)
+
+                    if not response.ok:
+                        raise PrepareError(
+                            f"Failed to fetch remote playbook '{playbook}'.")
+
+                except requests.RequestException as exc:
+                    raise PrepareError(
+                        f"Failed to fetch remote playbook '{playbook}'.", original=exc)
+
+                with tempfile.NamedTemporaryFile(
+                        mode='w+b',
+                        prefix='playbook-',
+                        suffix='.yml',
+                        dir=root_path,
+                        delete=False) as file:
+                    file.write(response.content)
+                    file.flush()
+
+                    playbook_path = os.path.relpath(file.name, root_path)
+
+                self.info('playbook-path', playbook_path, 'green')
+
+            guest.ansible(playbook_path, self.get('extra-args'))


### PR DESCRIPTION
Besides the local ones, `ansible` plugin would also allow remote
playbooks.

Playbooks are fetched and saved, for the record, then given to Ansible
as any other local playbook.