### PR TITLE
Add Polarion as a source for test case import

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -245,8 +245,9 @@ Import Tests
 Use ``tmt tests import`` to gather old metadata stored in
 different sources and convert them into the new ``fmf`` format.
 By default ``Makefile`` and ``PURPOSE`` files in the current
-directory are inspected and the ``Nitrate`` test case management
-system is contacted to gather all related metadata.
+directory are inspected plus the ``Nitrate`` and ``Polarion`` test
+case management systems are contacted to gather all related
+metadata.
 
 In order to fetch data from Nitrate you need to have ``nitrate``
 module installed. For each test case found in Nitrate separate fmf
@@ -255,6 +256,16 @@ found in all test cases are stored in ``main.fmf``. You can use
 ``--no-nitrate`` to disable Nitrate integration, ``--no-makefile``
 and ``--no-purpose`` switches to disable the other two metadata
 sources.
+
+To read data from Polarion you need to install and setup
+``pylero`` library (described in `Export tests`_) and enable it
+with the ``--polarion`` flag.  If you are importing a single test
+case you can specify ``--polarion-case-id`` instead of searching
+by values pulled from other sources and you can specify
+``--no-link-polarion`` to not save Polarion links.  It reads
+summary, description, enabled status, assignee, id, component,
+tags and links. If ``id`` is not found in Polarion it's generated
+and exported.
 
 Manual test cases can be imported from Nitrate using the
 ``--manual`` option. Provide either ``--case ID`` or ``--plan ID``

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -516,20 +516,29 @@ def tests_create(
 @click.argument('paths', nargs=-1, metavar='[PATH]...')
 @click.option(
     '--nitrate / --no-nitrate', default=True,
-    help='Import test metadata from Nitrate')
+    help='Import test metadata from Nitrate.')
+@click.option(
+    '--polarion / --no-polarion', default=False,
+    help='Import test metadata from Polarion.')
 @click.option(
     '--purpose / --no-purpose', default=True,
-    help='Migrate description from PURPOSE file')
+    help='Migrate description from PURPOSE file.')
 @click.option(
     '--makefile / --no-makefile', default=True,
-    help='Convert Beaker Makefile metadata')
+    help='Convert Beaker Makefile metadata.')
 @click.option(
     '--restraint / --no-restraint', default=False,
-    help='Convert restraint metadata file')
+    help='Convert restraint metadata file.')
 @click.option(
     '--general / --no-general', default=True,
     help='Detect components from linked nitrate general plans '
          '(overrides Makefile/restraint component).')
+@click.option(
+    '--polarion-case-id',
+    help='Polarion Test case ID to import data from.')
+@click.option(
+    '--link-polarion / --no-link-polarion', default=True,
+    help='Add Polarion link to fmf testcase metadata.')
 @click.option(
     '--type', 'types', metavar='TYPE', default=['multihost'], multiple=True,
     show_default=True,
@@ -560,6 +569,9 @@ def tests_import(
         general: bool,
         types: List[str],
         nitrate: bool,
+        polarion: bool,
+        polarion_case_id: Optional[str],
+        link_polarion: bool,
         purpose: bool,
         disabled: bool,
         manual: bool,
@@ -576,11 +588,10 @@ def tests_import(
 
     \b
     makefile ..... summary, component, duration, require
-    restraint .... name, description, entry_point, owner,
-                   max_time, repoRequires
+    restraint .... name, description, entry_point, owner, max_time, repoRequires
     purpose ...... description
-    nitrate ...... contact, component, tag,
-                   environment, relevancy, enabled
+    nitrate ...... contact, component, tag, environment, relevancy, enabled
+    polarion ..... summary, enabled, assignee, id, component, tag, description, link
     """
     tmt.Test._save_context(context)
 
@@ -602,8 +613,8 @@ def tests_import(
                 "Path '{0}' is not a directory.".format(path))
         # Gather old metadata and store them as fmf
         common, individual = tmt.convert.read(
-            path, makefile, restraint, nitrate, purpose, disabled, types,
-            general)
+            path, makefile, restraint, nitrate, polarion, polarion_case_id, link_polarion,
+            purpose, disabled, types, general)
         # Add path to common metadata if there are virtual test cases
         if individual:
             root = fmf.Tree(path).root


### PR DESCRIPTION
Doesn't import anything new (compared to other methods) however some teams have cases only in Polarion and this provides an easy way to pull data with --polarion-case-id, when other methods of searching (id, extra-nitrate, extra-task) would not work.
Also pulls id from Polarion if it is present or generates (and exports) a new one if it is not.