### PR TITLE
Support `TMT_WORKDIR_ROOT` environment variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -344,6 +344,10 @@ TMT_PLUGINS
     Path to a directory with additional plugins. Multiple paths
     separated with the ``:`` character can be provided as well.
 
+TMT_WORKDIR_ROOT
+    Path to root directory containing run workdirs. Defaults to
+    ``/var/tmp/tmt``.
+
 NO_COLOR
     Disable colors in the terminal output. Output only plain,
     non-colored text. See https://no-color.org/ for more

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -150,6 +150,16 @@ def test_last_run_race(tmpdir, monkeypatch):
     assert config.last_run(), "Some run was stored as last run"
 
 
+def test_workdir_env_var(tmpdir, monkeypatch):
+    """ Test TMT_WORKDIR_ROOT environment variable """
+    # Cannot use monkeypatch.context() as it is not present for CentOS Stream 8
+    monkeypatch.setenv('TMT_WORKDIR_ROOT', tmpdir)
+    common = Common()
+    common._workdir_init()
+    monkeypatch.delenv('TMT_WORKDIR_ROOT')
+    assert common.workdir == f'{tmpdir}/run-001'
+
+
 def test_workdir_root_full(tmpdir, monkeypatch):
     """ Raise if all ids lower than WORKDIR_MAX are exceeded """
     monkeypatch.setattr(tmt.utils, 'WORKDIR_ROOT', tmpdir)


### PR DESCRIPTION
I am running Silverblue with podman called from outside the container and the default workdir is not working well for me. I would like to override it via an environment variable.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>