### PR TITLE
Remove support for the obsoleted `detach` executor

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -743,21 +743,8 @@ class Test(tmt.utils.ValidateFmfMixin, tmt.utils.LoadFmfKeysMixin, Core):
         (test-name, test-data) tuples.
         """
 
-        # Prepare special format for the executor
-        if format_ == 'execute':
-            data = dict()
-            data['test'] = self.test
-            data['path'] = self.path
-            data['framework'] = self.framework
-            if self.duration is not None:
-                data['duration'] = self.duration
-            if self.environment:
-                data['environment'] = ' '.join(
-                    tmt.utils.shell_variables(self.environment))
-            return data
-
         # Export to Nitrate test case management system
-        elif format_ == 'nitrate':
+        if format_ == 'nitrate':
             tmt.export.export_to_nitrate(self)
 
         # Export to Polarion test case management system

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -158,15 +158,6 @@ class Discover(tmt.steps.Step):
 
         self.write('tests.yaml', tmt.utils.dict_to_yaml(raw_test_data))
 
-        # Create 'run.yaml' with the list of tests for the executor
-        if not self.tests():
-            return
-        raw_test_data = {
-            test.name: test.export(format_='execute')
-            for test in self.tests()
-            }
-        self.write('run.yaml', tmt.utils.dict_to_yaml(raw_test_data, width=1000000))
-
     def _discover_from_execute(self) -> None:
         """ Check the execute step for possible shell script tests """
 


### PR DESCRIPTION
The old `detach` executor needed a special `run.yaml` file with a simplified format of test metadata for shell execution. As the `detach` plugin has been obsoleted we don't need these anymore.