### PR TITLE
Fixes plan schema to allow custom context dimensions

### DIFF
--- a/tmt/schemas/plan.yaml
+++ b/tmt/schemas/plan.yaml
@@ -48,7 +48,7 @@ properties:
   # https://tmt.readthedocs.io/en/stable/spec/context.html#spec-context
   context:
     type: object
-    additionalProperties: false
+    additionalProperties: true
 
     properties:
       arch:


### PR DESCRIPTION
As documented, schema should allow dimensions - represented as keys of `context` mapping - beside the official ones.