### PR TITLE
Documents and corrects use of class conversion methods

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -72,6 +72,113 @@ In a similar way, the ``tree`` property of the ``Tree`` instance
 points to the original ``fmf.Tree`` from which it was initialized.
 
 
+Class Conversions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Various internal objects and classes often need to be converted
+from their Python nature to data that can be saved, loaded or
+exported in different form. To facilitate these conversions, three
+families of helper methods are provided, each with its own set of
+use cases.
+
+``to_spec``/``from_spec``
+------------------------------------------------------------------
+
+This family of methods works with tmt *specification*, i.e. raw
+user-provided data coming from fmf files describing plans, tests,
+stories, or from command-line options. ``from_spec()`` shall be
+called to spawn objects representing the user input, while
+``to_spec()`` should produce output one could find in fmf files.
+
+The default implementation comes from ``tmt.utils.SpecBasedContainer``
+class, all classes based on user input data should include this
+class among their bases.
+
+.. code-block:: python
+
+   # Create an fmf id object from raw data
+   fmf_id = tmt.base.FmfId.from_spec({'url': ..., 'ref': ...})
+
+
+``to_serialized``/``from_serialized``/``unserialize``
+------------------------------------------------------------------
+
+This family of methods is aiming at runtime objects that may be
+saved into and loaded from tmt working files, i.e. files tmt uses
+to store a state in its workdir, like `step.yaml` or `guests.yaml`.
+
+Third member of this family, ``unserialize``, is similar to
+``from_serialized`` - both create an object from its serialized form,
+only ``unserialize`` is capable of detecting the class to instantiate
+while for using ``from_serialized``, one must already know which
+class to work with. ``unserialize`` then uses ``from_serialized``
+under the hood to do the heavy lifting when correct class is
+identified.
+
+The default implementation comes from ``tmt.utils.SerializableContainer``
+class, all classes that are being saved and loaded during tmt run
+should include this class among their bases.
+
+See https://en.wikipedia.org/wiki/Serialization for more details
+on the concept of serialization.
+
+.. code-block:: python
+
+    # tmt.steps.discover.shell.DiscoverShellData wishes to unserialize its
+    # `tests` a list of `TestDescription` objects rather than a list of
+    # dictionaries (the default implementation).
+    @classmethod
+    def from_serialized(cls, serialized: Dict[str, Any]) -> 'DiscoverShellData':
+        obj = super().from_serialized(serialized)
+
+        obj.tests = [TestDescription.from_serialized(
+            serialized_test) for serialized_test in serialized['tests']]
+
+        return obj
+
+   # A step saving its state...
+   content: Dict[str, Any] = {
+       'status': self.status(),
+       'data': [datum.to_serialized() for datum in self.data]
+   }
+   self.write('step.yaml', tmt.utils.dict_to_yaml(content))
+
+   # ... and loading it back.
+   # Note the use of unserialize(): step data may have been serialized from
+   # various different classes (derived from tmt.steps.provision.Guest),
+   # and unserialize() will detect the correct class.
+   raw_step_data: Dict[Any, Any] = tmt.utils.yaml_to_dict(self.read('step.yaml'))
+   self.data = [
+       StepData.unserialize(raw_datum) for raw_datum in raw_step_data['data']
+   ]
+
+
+``to_dict``
+------------------------------------------------------------------
+
+Very special helper method: its use cases are not related to any
+input or output data, and most of the time, when in need of
+iterating over object's keys and/or values, one can use ``keys()``,
+``values()`` or ``items()`` methods. It is used as a source of data
+for serialization and validation, but it usually has no use outside
+of default implementations.
+
+.. warning::
+
+   If you think of using ``to_dict()``, please, think again and be sure
+   you know what are you doing. Despite its output being sometimes
+   perfectly compatible with output of ``to_serialized()`` or ``to_spec()``,
+   it is not generaly true, and using it instead of proper methods may lead
+   to unexpected exceptions.
+
+.. code-block:: python
+
+   # tmt.base.FmfId's specification is basically just a mapping,
+   # therefore `to_dict()` is good enough to produce a specification.
+   def to_spec(self) -> Dict[str, Any]:
+        return self.to_dict()
+
+
 Essential Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -439,7 +439,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
 
         # Check the 'test --link' option first, then from discover
         raw_link_needles = cast(List[str], tmt.Test._opt('links', []) or self.get('link', []))
-        link_needles = [tmt.base.LinkNeedle.from_raw(
+        link_needles = [tmt.base.LinkNeedle.from_spec(
             raw_needle) for raw_needle in raw_link_needles]
 
         for link_needle in link_needles:

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -295,7 +295,7 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
                     raise tmt.utils.SpecificationError(
                         f"Value '{value}' cannot be converted to int for '{int_key}' attribute.")
 
-        for key, value in data.to_dict().items():
+        for key, value in data.items():
             if key == 'memory':
                 self.info('memory', f"{value} MB", 'green')
             elif key == 'disk':


### PR DESCRIPTION
Recently added `{to,from}_{serialized,raw,dict}` methods for various conversions were poorly documented, and sometimes even wrongly used. This patch adds a short summary on when to use them, and fixes some subpar bits around the code.

Fixes #1518.