### PR TITLE
Add flake8 config file for easier integration with IDEs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+max-line-length = 99
+
+# When changing this list, you probably also want to change pre-commit config too.
+filename = examples/,
+           tests/,
+           tmt/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,13 @@ repos:
     hooks:
       - id: flake8
         args:
-          - --max-line-length=99
+          - --config
+          - .flake8
+        # The list of directories and files to check - matches flake8
+        # configuration in setup.cfg, but has a slightly different
+        # purpose. setup.cfg tells flake8 what to check when called e.g.
+        # by pre-commit or IDE linter integration, the list below tells
+        # *pre-commit* to which files to apply flake8 check.
         files: >
           (?x)^(
             examples/.*|


### PR DESCRIPTION
Most IDEs do not understand pre-commit-config.yaml which prevents said IDEs from calling flake8 to report issues while editing files. Extractng flake8 options into a known location understood by all parties we get consistent flake8 experience from when called by pre-commit *and* IDE of your choice.

Unfortunately, the list of directories to check needs to be duplicated, although each instance of the list has different meaning:

* .flake8 - tells `flake8` which files to check,
* pre-commit-config.yaml - tells `pre-commit` for which files to call `flake8` check.

Both list should probably remain in sync, e.g. it wouldn't make much sense to run `flake8` *check* for a directory not listed in `.flake8`.