### PR TITLE
Enhance ClickOptionDecorator type to announce identity

### DIFF
--- a/tmt/options.py
+++ b/tmt/options.py
@@ -9,11 +9,31 @@ import click
 
 import tmt.utils
 
+# When deling with older Click packages (I'm looking at you, Python 3.6),
+# we need to define FC on our own.
+try:
+    from click.decorators import FC  # type: ignore[attr-defined]
+
+except ImportError:
+    from typing import TypeVar, Union
+
+    FC = TypeVar('FC', bound=Union[Callable[..., Any], click.Command])  # type: ignore[misc]
+
+
 MethodDictType = Dict[str, click.core.Command]
+
 # Originating in click.decorators, an opaque type describing "decorator" functions
-# produced by click.option() calls: not options, but rather functions that attach
+# produced by click.option() calls: not options, but decorators, functions that attach
 # options to a given command.
-ClickOptionDecoratorType = Callable[[Callable[..., Any]], Any]
+# Since click.decorators does not have a dedicated type for this purpose, we need
+# to construct it on our own, but we can re-use a typevar click.decorators has.
+_ClickOptionDecoratorType = Callable[[FC], FC]
+# The type above is a generic type, `FC` being a typevar, so we have two options:
+# * each place using the type would need to fill the variable, i.e. add [foo]`, or
+# * we could do that right here, because right now, we don't care too much about
+# what this `foo` type actually is - what's important is the identity, return type
+# matches the type of the argument.
+ClickOptionDecoratorType = _ClickOptionDecoratorType[Any]  # type: ignore[misc]
 
 # Verbose, debug and quiet output
 verbose_debug_quiet: List[ClickOptionDecoratorType] = [

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -67,8 +67,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for given method """
-        options = super().options(how)
-        options[:0] = [
+        return [
             click.option(
                 '--dist-git-source',
                 is_flag=True,
@@ -78,8 +77,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin):
                 type=click.Choice(tmt.utils.get_distgit_handler_names()),
                 help='Use the provided DistGit handler '
                      'instead of the auto detection.'),
-            ]
-        return options
+            ] + super().options(how)
 
     def tests(self) -> List['tmt.Test']:
         """

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -155,8 +155,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for given method """
-        options = super().options(how)
-        options[:0] = [
+        return [
             click.option(
                 '-u', '--url', metavar='REPOSITORY',
                 help='URL of the git repository with fmf metadata.'),
@@ -207,8 +206,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                      'supported. Defaults to the top fmf root if it is '
                      'present, otherwise top directory (shortcut "/").'
                 ),
-            ]
-        return options
+            ] + super().options(how)
 
     @property
     def is_in_standalone_mode(self) -> bool:

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -148,13 +148,11 @@ class ExecutePlugin(tmt.steps.Plugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         # Add option to exit after the first test failure
-        options = super().options(how)
-        options[:0] = [
+        return [
             click.option(
                 '-x', '--exit-first', is_flag=True,
                 help='Stop execution after the first test failure.'),
-            ]
-        return options
+            ] + super().options(how)
 
     def go(self, guest: Guest) -> None:
         super().go(guest)

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -51,8 +51,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for given method """
-        options = super().options(how)
-        options[:0] = [
+        return [
             click.option(
                 '-s', '--script', metavar='SCRIPT', multiple=True,
                 help='Shell script to be executed as a test.'),
@@ -64,8 +63,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             click.option(
                 '--no-progress-bar', is_flag=True,
                 help='Disable interactive progress bar showing the current test.')
-            ]
-        return options
+            ] + super().options(how)
 
     # TODO: consider switching to utils.updatable_message() - might need more
     # work, since use of _show_progress is split over several methods.

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -116,8 +116,7 @@ class ExecuteUpgrade(ExecuteInternal):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for given method """
-        options = super().options(how)
-        options[:0] = [
+        return [
             click.option(
                 '--url', '-u', metavar='REPOSITORY',
                 help='URL of the git repository with upgrade tasks.'),
@@ -129,8 +128,7 @@ class ExecuteUpgrade(ExecuteInternal):
             DiscoverFmf.TEST_OPTION,
             DiscoverFmf.FILTER_OPTION,
             DiscoverFmf.EXCLUDE_OPTION
-            ]
-        return options
+            ] + super().options(how)
 
     @property
     def discover(self) -> Union[tmt.steps.discover.Discover, DiscoverFmf]:  # type:ignore[override]

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -39,14 +39,12 @@ class FinishShell(tmt.steps.finish.FinishPlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Finish command line options """
-        options = super().options(how)
-        options[:0] = [
+        return [
             click.option(
                 '-s', '--script', metavar='SCRIPT',
                 multiple=True,
                 help='Shell script to be executed, can be used multiple times.')
-            ]
-        return options
+            ] + super().options(how)
 
     def go(self, guest: Guest) -> None:
         """ Perform finishing tasks on given guest """

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -1,7 +1,7 @@
 import dataclasses
 import os.path
 import tempfile
-from typing import List, Optional, Union, cast
+from typing import List, Optional, Union
 
 import click
 import requests
@@ -82,19 +82,17 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
 
     _data_class = PrepareAnsibleData
 
-    # TODO: fix types once superclass gains its annotations
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options """
-        # FIXME: cast() - https://github.com/teemtee/tmt/pull/1529
-        return cast(List[tmt.options.ClickOptionDecoratorType], [
+        return [
             click.option(
                 '-p', '--playbook', metavar='PLAYBOOK', multiple=True,
                 help='Path or URL of an ansible playbook to run.'),
             click.option(
                 '--extra-args', metavar='EXTRA-ARGS',
                 help='Optional arguments for ansible-playbook.')
-            ]) + super().options(how)
+            ] + super().options(how)
 
     def go(self, guest: Guest) -> None:
         """ Prepare the guests """

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -416,8 +416,7 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options """
-        # FIXME: cast() - https://github.com/teemtee/tmt/pull/1529
-        return cast(List[tmt.options.ClickOptionDecoratorType], [
+        return [
             click.option(
                 '-p', '--package', metavar='PACKAGE', multiple=True,
                 help='Package name or path to rpm to be installed.'),
@@ -434,7 +433,7 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
                 '-m', '--missing', metavar='ACTION',
                 type=click.Choice(['fail', 'skip']),
                 help='Action on missing packages, fail (default) or skip.'),
-            ]) + super().options(how)
+            ] + super().options(how)
 
     def go(self, guest: Guest) -> None:
         """ Perform preparation for the guests """

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import List, Optional, cast
+from typing import List, Optional
 
 import click
 import fmf
@@ -45,13 +45,12 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options """
-        # FIXME: cast() - https://github.com/teemtee/tmt/pull/1529
-        return cast(List[tmt.options.ClickOptionDecoratorType], [
+        return [
             click.option(
                 '-s', '--script', metavar='SCRIPT',
                 multiple=True,
                 help='Shell script to be executed, can be used multiple times.')
-            ]) + super().options(how)
+            ] + super().options(how)
 
     def go(self, guest: Guest) -> None:
         """ Prepare the guests """

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -283,8 +283,7 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for Artemis """
-        # FIXME: cast() - https://github.com/teemtee/tmt/pull/1529
-        return cast(List[tmt.options.ClickOptionDecoratorType], [
+        return [
             click.option(
                 '--api-url', metavar='URL',
                 help="Artemis API URL.",
@@ -348,7 +347,7 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
                 help=f'A factor for exponential API retry backoff, '
                      f'{DEFAULT_RETRY_BACKOFF_FACTOR} by default.',
                 ),
-            ]) + super().options(how)
+            ] + super().options(how)
 
     # More specific type is a violation of Liskov substitution principle, and mypy
     # complains about it - rightfully so. Ignoring the issue which should be resolved

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -59,8 +59,7 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for connect """
-        options = super().options(how)
-        options[:0] = [
+        return [
             click.option(
                 '-g', '--guest', metavar='GUEST',
                 help='Select remote host to connect to (hostname or ip).'),
@@ -76,8 +75,7 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
             click.option(
                 '-p', '--password', metavar='PASSWORD',
                 help='Password for login into the guest system.'),
-            ]
-        return options
+            ] + super().options(how)
 
     def wake(self, data: Optional[GuestSshData] = None) -> None:  # type: ignore[override]
         """ Wake up the plugin, process data, apply options """

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -56,8 +56,7 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for connect """
-        options = super().options(how)
-        options[:0] = [
+        return [
             click.option(
                 '-i', '--image', metavar='IMAGE',
                 help='Select image to use. Short name or complete url.'),
@@ -70,8 +69,7 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
             click.option(
                 '-u', '--user', metavar='USER',
                 help='User to use for all container operations.')
-            ]
-        return options
+            ] + super().options(how)
 
     def default(self, option: str, default: Any = None) -> Any:
         """ Return default data for given option """

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -239,8 +239,7 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for testcloud """
-        options = super().options(how)
-        options[:0] = [
+        return [
             click.option(
                 '-i', '--image', metavar='IMAGE',
                 help='Select image to be used. Provide a short name, '
@@ -262,8 +261,7 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
                 '-a', '--arch',
                 type=click.Choice(['x86_64', 'aarch64', 's390x', 'ppc64le']),
                 help="What architecture to virtualize, host arch by default."),
-            ]
-        return options
+            ] + super().options(how)
 
     # TODO: Revisit this `type: ignore` once `Guest` becomes a generic type
     def wake(self, data: Optional[TestcloudGuestData] = None) -> None:  # type: ignore[override]

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -55,13 +55,11 @@ class ReportHtml(tmt.steps.report.ReportPlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for the html report """
-        options = super().options(how)
-        options[:0] = [
+        return [
             click.option(
                 '-o', '--open', is_flag=True,
                 help='Open results in your preferred web browser.'),
-            ]
-        return options
+            ] + super().options(how)
 
     def go(self) -> None:
         """ Process results """

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -107,13 +107,11 @@ class ReportJUnit(tmt.steps.report.ReportPlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for connect """
-        options = super().options(how)
-        options[:0] = [
+        return [
             click.option(
                 '--file', metavar='FILE',
                 help='Path to the file to store junit to'),
-            ]
-        return options
+            ] + super().options(how)
 
     def go(self) -> None:
         """ Read executed tests and write junit """

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -35,8 +35,7 @@ class ReportPolarion(tmt.steps.report.ReportPlugin):
     @classmethod
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options """
-        options = super().options(how)
-        options[:0] = [
+        return [
             click.option(
                 '--file', metavar='FILE', help='Path to the file to store xUnit in'),
             click.option(
@@ -46,8 +45,7 @@ class ReportPolarion(tmt.steps.report.ReportPlugin):
                 '--project-id', required=True, help='Use specific Polarion project ID'),
             click.option(
                 '--testrun-title', help='Use specific TestRun title')
-            ]
-        return options
+            ] + super().options(how)
 
     def go(self) -> None:
         """ Go through executed tests and report into Polarion """


### PR DESCRIPTION
Current type works, but is not perfect - namely, it lacks any notion of identity between argument and return value of `click.option` decorators. This makes it incompatible with how `mypy` sees `click.option`, and forces us to use a suboptimal code when overriding `options()` method. We can re-use bits of `click.decorators` code to improve the situation, and children's `options()` becomes more straightforward.