### PR TITLE
Correct the path of Ansible playbook

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -492,7 +492,7 @@ and detailed plan information, respectively::
           filter tier: 0,1
          prepare
              how ansible
-        playbook plans/packages.yml
+        playbook ansible/packages.yml
 
     /plans/helps
          summary Check help messages
@@ -596,7 +596,7 @@ step could look like this::
     prepare:
       - name: packages
         how: ansible
-        playbook: plans/packages.yml
+        playbook: ansible/packages.yml
       - name: services
         how: shell
         script: systemctl start service

--- a/examples/multiple/basic.fmf
+++ b/examples/multiple/basic.fmf
@@ -19,7 +19,7 @@ discover:
 prepare:
   - how: ansible
     name: packages
-    playbook: plans/packages.yml
+    playbook: ansible/packages.yml
   - how: shell
     name: services
     script: systemctl start service

--- a/tests/lint/data/plans/bad.fmf
+++ b/tests/lint/data/plans/bad.fmf
@@ -4,6 +4,6 @@ discovery:
     url: https://github.com/teemtee/tmt
 prepareahoj:
     how: ansible
-    playbook: plans/packages.yml
+    playbook: ansible/packages.yml
 execute:
     how: tmt

--- a/tests/lint/data/plans/good.fmf
+++ b/tests/lint/data/plans/good.fmf
@@ -4,6 +4,6 @@ discover:
     url: https://github.com/teemtee/tmt
 prepare:
     how: ansible
-    playbook: plans/packages.yml
+    playbook: ansible/packages.yml
 execute:
     how: tmt

--- a/tmt/templates.py
+++ b/tmt/templates.py
@@ -97,7 +97,7 @@ discover:
     url: https://github.com/teemtee/tmt
 prepare:
     how: ansible
-    playbook: plans/packages.yml
+    playbook: ansible/packages.yml
 execute:
     how: tmt
 """.lstrip()


### PR DESCRIPTION
In some documents and templates, the path of Ansible playbook is set as `plans/packages.yml`, which should be `ansible/packages.yml`.