### PR TITLE
Update test data for the debuginfo install test

### DIFF
--- a/tests/prepare/install/data/debuginfo.fmf
+++ b/tests/prepare/install/data/debuginfo.fmf
@@ -4,11 +4,11 @@ prepare:
   - name: debuginfo
     how: install
     package:
-      - bash-debuginfo
+      - grep-debuginfo
       - elfutils-debuginfod-debuginfo
 execute:
     script:
-      - rpm -q bash-debuginfo bash-debugsource
+      - rpm -q grep-debuginfo grep-debugsource
       - rpm -q elfutils-debuginfo elfutils-debugsource
 
 /fedora:
@@ -34,6 +34,6 @@ execute:
         image: centos:7
     prepare:
         how: install
-        package: bash-debuginfo
+        package: grep-debuginfo
     execute:
-        script: rpm -q bash-debuginfo
+        script: rpm -q grep-debuginfo


### PR DESCRIPTION
Seems `bash` debuginfo packages are broken for `centos:stream8`. Not sure how long the fix will take. Let's use `grep` instead to prevent the constant noise in pull requests.