### PR TITLE
Adds a missing import to polarion plugin

### DIFF
--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -9,6 +9,7 @@ from requests import post
 
 import tmt
 import tmt.steps
+import tmt.steps.report
 
 from .junit import make_junit_xml
 


### PR DESCRIPTION
tmt.steps.report is imported, but common IDE does not "see" it because it is missing from the file.