### PR TITLE
Ignore plan -n when searching for upgrade path

### DIFF
--- a/tests/execute/upgrade/override.sh
+++ b/tests/execute/upgrade/override.sh
@@ -8,20 +8,25 @@ rlJournalStart
         rlRun "run=/var/tmp/tmt/run-upgrade"
     rlPhaseEnd
 
-    rlPhaseStartTest
-        rlRun -s "tmt run --scratch -avvvdddi $run --rm --before finish \
-            plan -n /plan/path \
-            execute -h upgrade -F 'path:/tasks/prepare' \
-            provision -h container -i fedora:35" 0 "Run a single upgrade task"
-        # 1 test before + 1 upgrade tasks + 1 test after
-        rlAssertGrep "3 tests passed" $rlRun_LOG
-        # Check that the IN_PLACE_UPGRADE variable was set
-        data="$run/plan/path/execute/data"
-        rlAssertGrep "IN_PLACE_UPGRADE=old" "$data/old/test/output.txt"
-        rlAssertGrep "IN_PLACE_UPGRADE=new" "$data/new/test/output.txt"
-        # Environment of plan was passed
-        rlAssertGrep "VERSION_ID=35" "$data/upgrade/tasks/prepare/output.txt"
-    rlPhaseEnd
+    # Test that plan conditions are not applied to the remote repo
+    # If it was applied, the second condition would prevent selection
+    # of a plan, resulting in a failure.
+    for condition in 'True' '"Basic upgrade test" in summary'; do
+        rlPhaseStartTest "Plan condition $condition"
+            rlRun -s "tmt run --scratch -avvvdddi $run --rm --before finish \
+                plan -n /plan/path -c '$condition' \
+                execute -h upgrade -F 'path:/tasks/prepare' \
+                provision -h container -i fedora:35" 0 "Run a single upgrade task"
+            # 1 test before + 1 upgrade tasks + 1 test after
+            rlAssertGrep "3 tests passed" $rlRun_LOG
+            # Check that the IN_PLACE_UPGRADE variable was set
+            data="$run/plan/path/execute/data"
+            rlAssertGrep "IN_PLACE_UPGRADE=old" "$data/old/test/output.txt"
+            rlAssertGrep "IN_PLACE_UPGRADE=new" "$data/new/test/output.txt"
+            # Environment of plan was passed
+            rlAssertGrep "VERSION_ID=35" "$data/upgrade/tasks/prepare/output.txt"
+        rlPhaseEnd
+    done
 
     rlPhaseStartCleanup
         rlRun "tmt run -l finish" 0 "Stop the guest and remove the workdir"

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -174,7 +174,14 @@ class ExecuteUpgrade(ExecuteInternal):
     def _get_plan(self, upgrades_repo):
         """ Get plan based on upgrade path """
         tree = tmt.base.Tree(upgrades_repo)
-        plans = tree.plans(names=[self.upgrade_path])
+        try:
+            # We do not want to consider plan -n provided on the command line
+            # in the remote repo for finding upgrade path.
+            tmt.base.Plan.ignore_class_options = True
+            plans = tree.plans(names=[self.upgrade_path])
+        finally:
+            tmt.base.Plan.ignore_class_options = False
+
         if len(plans) == 0:
             raise tmt.utils.ExecuteError(
                 f"No matching upgrade path found for '{self.upgrade_path}'.")


### PR DESCRIPTION
Previously, options from the plan command on the terminal would also be propagated to the remote upgrade repo. This is not desired, the plan should only filter in the local repository, since otherwise it could cause incorrect upgrade path to be selected (or an error to be thrown due to multiple upgrade paths being matched).