### PR TITLE
Use generator instead of list comprehension with any/all

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1524,8 +1524,8 @@ class Tree(tmt.utils.Common):
             filter_vars.update(bool_vars)
             # Conditions
             try:
-                if not all([fmf.utils.evaluate(condition, cond_vars, node)
-                            for condition in conditions]):
+                if not all(fmf.utils.evaluate(condition, cond_vars, node)
+                           for condition in conditions):
                     continue
             except fmf.utils.FilterError:
                 # Handle missing attributes as if condition failed
@@ -1535,8 +1535,8 @@ class Tree(tmt.utils.Common):
                     f"Invalid --condition raised exception: {error}")
             # Filters
             try:
-                if not all([fmf.utils.filter(filter_, filter_vars, regexp=True)
-                            for filter_ in filters]):
+                if not all(fmf.utils.filter(filter_, filter_vars, regexp=True)
+                           for filter_ in filters):
                     continue
             except fmf.utils.FilterError:
                 # Handle missing attributes as if filter failed
@@ -1544,14 +1544,13 @@ class Tree(tmt.utils.Common):
             # Links
             try:
                 # Links are in OR relation
-                if links and all([not node.has_link(link_)
-                                 for link_ in links]):
+                if links and all(not node.has_link(link_) for link_ in links):
                     continue
             except BaseException:
                 # Handle broken link as not matching
                 continue
             # Exclude
-            if any([node for expr in excludes if re.search(expr, node.name)]):
+            if any(node for expr in excludes if re.search(expr, node.name)):
                 continue
             result.append(node)
         return result
@@ -1600,7 +1599,7 @@ class Tree(tmt.utils.Common):
                 return nodes
             return [
                 node for node in nodes
-                if any([re.search(name, node.name) for name in cmd_line_names])]
+                if any(re.search(name, node.name) for name in cmd_line_names)]
 
         # Append post filter to support option --enabled or --disabled
         if Test._opt('enabled'):
@@ -1892,14 +1891,14 @@ class Run(tmt.utils.Common):
 
         # Filter plans by name unless specified on the command line
         plan_options = ['names', 'filters', 'conditions', 'links', 'default']
-        if not any([Plan._opt(option) for option in plan_options]):
+        if not any(Plan._opt(option) for option in plan_options):
             self._plans = [
                 plan for plan in self.tree.plans(run=self)
                 if plan.name in data['plans']]
 
         # Initialize steps only if not selected on the command line
         step_options = 'all since until after before skip'.split()
-        selected = any([self.opt(option) for option in step_options])
+        selected = any(self.opt(option) for option in step_options)
         if not selected and not self._context.obj.steps:
             self._context.obj.steps = set(data['steps'])
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1633,7 +1633,7 @@ def format(
         # Make sure everything is string, prepare list, check for spaces
         value = [str(item) for item in value]
         listed_text = fmf.utils.listed(value)
-        has_spaces = any([item.find(' ') > -1 for item in value])
+        has_spaces = any(item.find(' ') > -1 for item in value)
         # Use listed output only for short lists without spaces
         if len(listed_text) < width - indent and not has_spaces:
             output += listed_text
@@ -1649,9 +1649,7 @@ def format(
     elif isinstance(value, str):
         # In 'auto' mode enable wrapping when long lines present
         if wrap == 'auto':
-            wrap = any(
-                [len(line) + indent - 7 > width
-                 for line in value.split('\n')])
+            wrap = any(len(line) + indent - 7 > width for line in value.split('\n'))
         if wrap:
             output += (wrap_text(
                 value, width=width,
@@ -2541,7 +2539,7 @@ class DistGitHandler:
 
     def its_me(self, remotes: List[str]) -> bool:
         """ True if self can work with remotes """
-        return any([self.remote_substring.search(item) for item in remotes])
+        return any(self.remote_substring.search(item) for item in remotes)
 
 
 class FedoraDistGit(DistGitHandler):


### PR DESCRIPTION
Construction whole list is not necessary, both `all` and `any` can short-circuit & return as soon as they spot an invalid item. Trivial and cheap optimization.