### PR TITLE
Create symlink pointing to workdir of the last test run

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -852,6 +852,11 @@ the execution is finished::
     tmt run --rm
     tmt run -r
 
+Execution of test run also creates symlink ``last`` pointing to the
+workdir of last run with numeric id, so content from exaple above
+``/var/tmp/tmt/run-581`` can be also accessed via following path:
+``/var/tmp/tmt/last``.
+
 
 Select Plans
 ------------------------------------------------------------------

--- a/tests/run/default/test.sh
+++ b/tests/run/default/test.sh
@@ -30,6 +30,12 @@ rlJournalStart
         rlAssertNotgrep "/plans/plan" "output"
     rlPhaseEnd
 
+    rlPhaseStartTest "Symlink pointing to last run is created"
+        rlRun "tmt run --dry"
+        rlRun "find /var/tmp/tmt/ -name last -type l | tee output"
+        rlAssertGrep "/var/tmp/tmt/last" "output"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -rf $tmp" 0 "Removing tmp directory"

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -748,9 +748,16 @@ class Common:
                 try:
                     # Call is atomic, no race possible
                     os.makedirs(workdir)
+                    symlink = os.path.join(WORKDIR_ROOT, "last")
+                    if os.path.exists(symlink):
+                        os.remove(symlink)
+                    os.symlink(directory, symlink)
                     break
                 except FileExistsError:
                     pass
+                except OSError as error:
+                    log.warn(f"Unable to create symlink to last run '{symlink}'.\n{error}")
+                    break
             else:
                 raise GeneralError(
                     f"Workdir full. Cleanup the '{WORKDIR_ROOT}' directory.")


### PR DESCRIPTION
Minor change intended to simplify checking of logs from the last run (e.g. in case with large number of test runs is present).