### PR TITLE
Update all linters to their most recent versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: 'v1.5.7'
+    rev: 'v1.7.0'
     hooks:
       - id: autopep8
         args:
@@ -14,12 +14,12 @@ repos:
           - --max-line-length=99
 
   - repo: https://github.com/PyCQA/isort
-    rev: "5.8.0"
+    rev: "5.10.1"
     hooks:
       - id: isort
 
   - repo: https://github.com/pycqa/flake8
-    rev: "4.0.1"
+    rev: "5.0.4"
     hooks:
       - id: flake8
         args:
@@ -38,14 +38,14 @@ repos:
           )$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v3.4.0"
+    rev: "v4.3.0"
     hooks:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.961"
+    rev: "v0.982"
     hooks:
       - id: mypy
         additional_dependencies: [types-click]
@@ -55,14 +55,14 @@ repos:
           - mypy.ini
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.15.0
+    rev: "0.18.3"
     hooks:
       - id: check-metaschema
         name: "Check JSON schemas validity"
         files: ^tmt/schemas/.*\.yaml
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.3
+    rev: v1.28.0
     hooks:
       - id: yamllint
         files: ^tmt/schemas/.*\.yaml

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ sys.path.insert(0, os.path.abspath('../'))
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-]
+    ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -237,7 +237,7 @@ htmlhelp_basename = 'doc'
 man_pages = [
     (master_man, '', u'tmt Documentation',
      [author], 1)
-]
+    ]
 
 # If true, show URL addresses after external links.
 #man_show_urls = False

--- a/examples/plugins/setup.py
+++ b/examples/plugins/setup.py
@@ -10,4 +10,4 @@ setup(
             'DiscoverExample = discover:DiscoverExample',
             ]
         }
-)
+    )

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ __pkgdata__ = {
         'steps/execute/scripts/*',
         'steps/report/html/*'
         ]
-}
+    }
 __pkgdir__ = {}
 __pkgs__ = [
     'tmt',
@@ -80,7 +80,7 @@ extras_require = {
     'report-junit': ['junit_xml'],
     'report-polarion': ['junit_xml', 'pylero'],
     'export-polarion': ['pylero'],
-}
+    }
 extras_require['all'] = [
     dependency
     for extra in extras_require.values()

--- a/tests/core/environment-file/data/environment_file_data.py
+++ b/tests/core/environment-file/data/environment_file_data.py
@@ -13,7 +13,7 @@ env_vars_parametrization = (
         ("YAML_INT", "1"),
         ("SPECIAL", "/=(;-)"),
         ),
-)
+    )
 
 
 @pytest.mark.parametrize(*env_vars_parametrization)

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -106,9 +106,8 @@ class _RawFmfId(TypedDict):
     path: Optional[str]
     name: Optional[str]
 
+
 # An internal fmf id representation.
-
-
 @dataclasses.dataclass
 class FmfId(tmt.utils.SpecBasedContainer, tmt.utils.SerializableContainer):
     # The list of valid fmf id keys
@@ -199,7 +198,7 @@ _RawLinkRelationName = Literal[
     # Special case: not a relation, but it can appear where relations appear in
     # link data structures.
     'note'
-]
+    ]
 
 # Link target - can be either a string (like test case name or URL), or an fmf id.
 _RawLinkTarget = Union[str, _RawFmfId]
@@ -213,14 +212,14 @@ _RawLink = Union[
     str,
     _RawFmfId,
     _RawLinkRelation
-]
+    ]
 
 # Collection of links - can be either a single link, or a list of links, and all
 # link forms may be used together.
 _RawLinks = Union[
     _RawLink,
     List[_RawLink]
-]
+    ]
 
 
 # A type describing `adjust` content. See
@@ -236,7 +235,8 @@ _RawAdjustRule = TypedDict(
         'continue': Optional[bool],
         'because': Optional[str]
         }
-)
+    )
+
 
 # A type describing content accepted by various require-like keys: - a string, fmf id,
 # or a list with a mixture of these two types.
@@ -245,8 +245,6 @@ _RawAdjustRule = TypedDict(
 # but allows several extra keys that must be stored.
 #
 # See https://tmt.readthedocs.io/en/latest/spec/tests.html#require
-
-
 class _RawRequireFmfId(_RawFmfId):
     destination: Optional[str]
     nick: Optional[str]
@@ -2760,7 +2758,7 @@ RESULT_OUTCOME_COLORS: Dict[ResultOutcome, str] = {
     ResultOutcome.INFO: 'blue',
     ResultOutcome.WARN: 'yellow',
     ResultOutcome.ERROR: 'magenta'
-}
+    }
 
 
 ResultData = Dict[str, Any]

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -76,7 +76,7 @@ PhaseT = TypeVar('PhaseT', bound=Phase)
 _RawStepData = TypedDict('_RawStepData', {
     'how': str,
     'name': str
-}, total=False)
+    }, total=False)
 
 RawStepDataArgument = Union[_RawStepData, List[_RawStepData]]
 

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -99,7 +99,7 @@ GUEST_STATE_COLORS = {
     'preparing': 'cyan',
     'cancelled': 'red',
     'error': 'red'
-}
+    }
 
 
 # Type annotation for Artemis API `GET /guests/$guestname` response.

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1547,8 +1547,9 @@ class SerializableContainer(DataContainer):
         return cls(**serialized)
 
     @staticmethod
-    def unserialize(serialized: Dict[str, Any]
-                    ) -> SerializableContainerDerivedType:
+    def unserialize(
+            serialized: Dict[str, Any]
+            ) -> SerializableContainerDerivedType:  # type: ignore[misc,type-var]
         """
         Convert from a serialized form loaded from a file.
 
@@ -2633,7 +2634,7 @@ class StructuredField:
         else:
             try:
                 dictionary = self._read_section(self._sections[section])
-                del(dictionary[item])
+                del (dictionary[item])
             except KeyError:
                 raise StructuredFieldError(
                     "Unable to remove '{0!r}' from section '{1!r}'".format(
@@ -3131,12 +3132,12 @@ WaitCheckType = Callable[[], T]
 
 
 def wait(
-    parent: Common,
-    check: WaitCheckType[T],
-    timeout: datetime.timedelta,
-    tick: float = DEFAULT_WAIT_TICK,
-    tick_increase: float = DEFAULT_WAIT_TICK_INCREASE
-) -> T:
+        parent: Common,
+        check: WaitCheckType[T],
+        timeout: datetime.timedelta,
+        tick: float = DEFAULT_WAIT_TICK,
+        tick_increase: float = DEFAULT_WAIT_TICK_INCREASE
+        ) -> T:
     """
     Wait for a condition to become true.
 


### PR DESCRIPTION
Before wrapping up the type annotations, make sure we can squeeze the most out out involved tools.