### PR TITLE
Support step data definitions carrying CLI options

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -658,7 +658,14 @@ class BasePlugin(Phase):
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for given method """
         # Include common options supported across all plugins
-        return tmt.options.VERBOSITY_OPTIONS + tmt.options.FORCE_DRY_OPTIONS
+        return [
+            metadata.option
+            for metadata in (
+                tmt.utils.dataclass_field_metadata(field)
+                for field in dataclasses.fields(cls._data_class)
+                )
+            if metadata.option is not None
+            ] + tmt.options.VERBOSITY_OPTIONS + tmt.options.FORCE_DRY_OPTIONS
 
     @classmethod
     def command(cls) -> click.Command:

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -21,9 +21,20 @@ from tmt.utils import GeneralError
 
 @dataclasses.dataclass
 class DiscoverStepData(tmt.steps.StepData):
-    dist_git_source: bool = False
+    dist_git_source: bool = tmt.utils.field(
+        default=False,
+        option='--dist-git-source',
+        is_flag=True,
+        help='Extract DistGit sources.'
+        )
+
     # TODO: use enum!
-    dist_git_type: Optional[str] = None
+    dist_git_type: Optional[str] = tmt.utils.field(
+        default=None,
+        option='--dist-git-type',
+        choices=tmt.utils.get_distgit_handler_names,
+        help='Use the provided DistGit handler instead of the auto detection.'
+        )
 
 
 class DiscoverPlugin(tmt.steps.GuestlessPlugin):
@@ -64,21 +75,6 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin):
             Discover._save_context(context)
 
         return discover
-
-    @classmethod
-    def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
-        """ Prepare command line options for given method """
-        return [
-            click.option(
-                '--dist-git-source',
-                is_flag=True,
-                help='Extract DistGit sources.'),
-            click.option(
-                '--dist-git-type',
-                type=click.Choice(tmt.utils.get_distgit_handler_names()),
-                help='Use the provided DistGit handler '
-                     'instead of the auto detection.'),
-            ] + super().options(how)
 
     def tests(self) -> List['tmt.Test']:
         """

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -1,20 +1,25 @@
 import dataclasses
-from typing import List, Optional
+from typing import List
 
-import click
 import fmf
 
 import tmt
 import tmt.steps
 import tmt.steps.finish
+import tmt.utils
 from tmt.steps.provision import Guest
 
 
 @dataclasses.dataclass
 class FinishShellData(tmt.steps.finish.FinishStepData):
-    script: List[str] = dataclasses.field(default_factory=list)
-
-    _normalize_script = tmt.utils.NormalizeKeysMixin._normalize_string_list
+    script: List[str] = tmt.utils.field(
+        default_factory=list,
+        option=('-s', '--script'),
+        multiple=True,
+        metavar='SCRIPT',
+        help='Shell script to be executed. Can be used multiple times.',
+        normalize=tmt.utils.normalize_string_list
+        )
 
 
 @tmt.steps.provides_method('shell')
@@ -35,16 +40,6 @@ class FinishShell(tmt.steps.finish.FinishPlugin):
     """
 
     _data_class = FinishShellData
-
-    @classmethod
-    def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
-        """ Finish command line options """
-        return [
-            click.option(
-                '-s', '--script', metavar='SCRIPT',
-                multiple=True,
-                help='Shell script to be executed, can be used multiple times.')
-            ] + super().options(how)
 
     def go(self, guest: Guest) -> None:
         """ Perform finishing tasks on given guest """


### PR DESCRIPTION
To reduce places one has too modify when adding new step data fields,
the patch adds a custom variant of `dataclasses.field` helper, which
accepts objects useful when defining fields:

* CLI option properties,
* normalization callback,
* field default values.

Our custom wrapper then takes care of creating the proper `click.option`
callable for the described CLI option, the normalization callbacks would
be used correctly when loading data from fmf nodes, and fields would
have their default values just like hen defined with the original
`dataclasses.field`.

The advantage is the fact all this info is in a single function call,
instead of spread across the step data class (default values plus
normalization callbacks as methods) and special plugin method (options).

And since the normalization callback should be perfectly able to handle
data delivered by click, both input streams - fmf nodes and CLI - would
be treated in the same way.

The patch adds a few basic helpers, and changes a discover step data
base class to demonstrate how new tools are to be used.