### PR TITLE
Fix recommended packages handling for rpm-ostree

### DIFF
--- a/tests/prepare/recommend/main.fmf
+++ b/tests/prepare/recommend/main.fmf
@@ -3,3 +3,14 @@ description:
     Run a simple test which recommends two packages. Check that
     the existing one is installed and the other one is ignored. No
     error should be reported.
+environment:
+    METHODS: container
+adjust:
+  - when: trigger == commit
+    environment:
+        METHODS: container local
+    because: the pipeline does not support nested virtualization
+  - when: how == full
+    environment:
+        METHODS: container virtual local
+    because: local/virtual provision needs root/full virtualization

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -292,7 +292,7 @@ class InstallRpmOstree(InstallBase):
 
     def prepare_command(self) -> None:
         """ Prepare installation command for rpm-ostree"""
-        missing = cast(tmt.steps.prepare.PreparePlugin, self.parent).get("package")
+        missing = cast(tmt.steps.prepare.PreparePlugin, self.parent).get("missing")
         self.skip = True if missing == 'skip' else False
         self.command = f"{self.sudo}rpm-ostree"
         self.options = '--apply-live --idempotent --allow-inactive'


### PR DESCRIPTION
fix for recommends fmf request missing should retrieve parent.missing attribute not packages
 
extend test for recommend against coreos