### PR TITLE
Replace GeneralError's "origin" with Python's "raise from"

### DIFF
--- a/bin/tmt
+++ b/bin/tmt
@@ -27,6 +27,6 @@ except tmt.utils.RunError as error:
 except tmt.utils.GeneralError as error:
     click.echo(click.style(str(error), fg='red'), err=True)
     # Mention also the original exception if provided
-    if error.original:
-        click.echo(f"The exception was: {error.original}", err=True)
+    if error.__cause__:
+        click.echo(f"The exception was: {error.__cause__}", err=True)
     raise SystemExit(2)

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -62,8 +62,7 @@ def test_test_invalid():
         exc = exc_context.value
 
         assert isinstance(exc, SpecificationError)
-        assert exc.args[0] \
-            == 'fmf node /smoke failed validation'
+        assert exc.message == 'fmf node /smoke failed validation'
 
         validation_error, error_message = exc.validation_errors[0]
 

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -85,7 +85,7 @@ def import_polarion() -> None:
         from pylero.work_item import _WorkItem as PolarionWorkItem
     except PolarionException as exc:
         log.debug(traceback.format_exc())
-        raise ConvertError("Failed to login with pylero", original=exc)
+        raise ConvertError("Failed to login with pylero") from exc
 
 
 def get_bz_instance() -> Any:
@@ -100,8 +100,7 @@ def get_bz_instance() -> Any:
         bz_instance = bugzilla.Bugzilla(url=BUGZILLA_XMLRPC_URL)
     except Exception as exc:
         log.debug(traceback.format_exc())
-        raise ConvertError(
-            "Couldn't initialize the Bugzilla client.", original=exc)
+        raise ConvertError("Couldn't initialize the Bugzilla client.") from exc
 
     if not bz_instance.logged_in:
         raise ConvertError(

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -80,7 +80,7 @@ def import_member(module_name: str, member_name: str) -> Any:
     try:
         import_(module_name)
     except SystemExit as exc:
-        raise tmt.utils.GeneralError(f"Failed to import module '{module_name}'.", original=exc)
+        raise tmt.utils.GeneralError(f"Failed to import module '{module_name}'.") from exc
 
     # Now the module should be available in `sys.modules` like any
     # other, and we can go and grab the class we need from it.

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -728,8 +728,8 @@ class BasePlugin(Phase, metaclass=PluginIndex):
 
                     except Exception as exc:
                         raise tmt.utils.GeneralError(
-                            f'Failed to load step data for {plugin_data_class.__name__}: {exc}',
-                            original=exc)
+                            f'Failed to load step data for {plugin_data_class.__name__}: {exc}') \
+                            from exc
 
                 assert data is not None
                 assert data.__class__ is plugin_data_class, \

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -367,7 +367,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                     git_root, sourcedir, self.get('dist-git-type'))
             except Exception as error:
                 raise tmt.utils.DiscoverError(
-                    "Failed to process 'dist-git-source'.", original=error)
+                    "Failed to process 'dist-git-source'.") from error
 
             # Check what should be extracted from the sources
             if dist_git_extract:

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -307,7 +307,7 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
                     git_root, sourcedir, self.get('dist-git-type'))
             except Exception as error:
                 raise tmt.utils.DiscoverError(
-                    "Failed to process 'dist-git-source'.", original=error)
+                    "Failed to process 'dist-git-source'.") from error
 
         # Use a tmt.Tree to apply possible command line filters
         tests = tmt.Tree(tree=tests).tests(conditions=["manual is False"])

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -304,7 +304,7 @@ class ExecutePlugin(tmt.steps.Plugin):
 
         # Nothing to do if there's no result file
         if not os.path.exists(report_result_path):
-            raise tmt.utils.FileError
+            raise tmt.utils.FileError(f"Results file '{report_result_path}' does not exist.")
 
         # Prepare the log path and duration
         data = {'log': self.data_path(test, TEST_OUTPUT_FILENAME),

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -121,7 +121,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
 
                 except requests.RequestException as exc:
                     raise PrepareError(
-                        f"Failed to fetch remote playbook '{playbook}'.", original=exc)
+                        f"Failed to fetch remote playbook '{playbook}'.") from exc
 
                 with tempfile.NamedTemporaryFile(
                         mode='w+b',

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -546,12 +546,12 @@ class GuestTestcloud(tmt.GuestSsh):
             self._image.prepare()
         except FileNotFoundError as error:
             raise ProvisionError(
-                f"Image '{self._image.local_path}' not found.", original=error)
+                f"Image '{self._image.local_path}' not found.") from error
         except (testcloud.exceptions.TestcloudPermissionsError,
                 PermissionError) as error:
             raise ProvisionError(
                 f"Failed to prepare the image. Check the '{TESTCLOUD_IMAGES}' "
-                f"directory permissions.", original=error)
+                f"directory permissions.") from error
 
         # Create instance
         self.instance_name = self._tmt_name()


### PR DESCRIPTION
`GeneralError` was accepting a parameter named `original` which seems to be a dulication of existing Python functionality, `raise ... from ...`. Patch changes exceptions to use `raise .. from ...` instead when there is a original/follow-up relation between exceptions. This is a step towards using standardized features of the language, giving Python's own error reporting and 3rd party libraries a chance to understand the relationship between exceptions - to do so with `original` attribute, extra code would be needed.

Thanks to this, I was able to drop `GeneralError.__init__`, which wouldn't be needed anymore, but it turned out this would break "error message" existence, with some exceptions having `message` attribute, some using `args[0]`, some having none of these. So I added `__init__` back, this time with different content: no more `original` field handling, but explicit `self.message` is now set for all exceptions derived from `GeneralError`.