### PR TITLE
Add default envvar to plugin options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -448,6 +448,62 @@ SERVERS
     to make multihost prototype support easier to verify as many current
     tests were developed with Restraint.
 
+Plugin options
+--------------
+
+.. note::
+
+   The following applies to situations when a plugin is specified
+   on the command line only. Keys of plugins specified in fmf files
+   would not be modified. This is a limit of the current implementation,
+   and will be addressed in the future.
+
+      # Here the verbosity will not be increased since the plugin is
+      # not mentioned on the command line:
+      $ TMT_PLUGIN_DISCOVER_FMF_VERBOSE=2 tmt run -a
+
+      # Here the environment variable will take effect:
+      $ TMT_PLUGIN_DISCOVER_FMF_VERBOSE=2 tmt run -a discover -h fmf ...
+
+Each plugin option can be also specified via environment variable.
+Variables follow a naming scheme utilizing plugin name, step it
+belongs to, and the option name:
+
+    ``TMT_PLUGIN_${STEP}_${PLUGIN}_${OPTION}``
+
+All values are upper-cased, with dashes (``-``) replaced by
+underscores (``_``).
+
+For example, an execute plugin "tmt" would run with verbosity
+equal to ``-vvv``::
+
+    TMT_PLUGIN_EXECUTE_TMT_VERBOSE=3 tmt run ... execute -h tmt ...
+
+Command-line takes precedence over environment variables, therefore
+``-v`` would undo the effect of environment variable, and reduce
+verbosity to one level only::
+
+    TMT_PLUGIN_EXECUTE_TMT_VERBOSE=3 tmt run ... execute -h tmt -v ...
+
+Environment variables - just like command-line options - take
+precedence over values stored in files. For example, consider the
+following discover step::
+
+    discover:
+        how: fmf
+        url: https://example.org/
+
+The following commands would override the URL::
+
+    tmt run ... discover -h fmf --url https://actual.org/ ...
+
+    TMT_PLUGIN_DISCOVER_FMF_URL=https://actual.org/ tmt run ...
+
+For setting flag-like option, 0 and 1 are the expected value. For
+example, an interactive mode would be enabled in this run::
+
+    TMT_PLUGIN_EXECUTE_TMT_INTERACTIVE=1 tmt run ... execute -h tmt ...
+
 Links
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -341,6 +341,13 @@ and only check for the exit code.
 Variables
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The list of available environment variables which can be used to
+adjust the execution.
+
+
+Command Variables
+-----------------
+
 The following environment variables can be used to modify
 behaviour of the ``tmt`` command.
 
@@ -377,6 +384,10 @@ TMT_FORCE_COLOR
     and ``TMT_NO_COLOR``. If user tries both to disable and enable
     colorization, output would be colorized.
 
+
+Step Variables
+--------------
+
 The following environment variables are provided to the environment
 during ``prepare``, ``execute`` and ``finish`` steps:
 
@@ -390,6 +401,10 @@ TMT_PLAN_DATA
     artifacts related to the whole plan execution. It is pulled
     back from the guest and available for inspection after the
     plan is completed.
+
+
+Test Variables
+--------------
 
 The following environment variables are provided to the test
 during the execution:
@@ -448,22 +463,9 @@ SERVERS
     to make multihost prototype support easier to verify as many current
     tests were developed with Restraint.
 
-Plugin options
---------------
 
-.. note::
-
-   The following applies to situations when a plugin is specified
-   on the command line only. Keys of plugins specified in fmf files
-   would not be modified. This is a limit of the current implementation,
-   and will be addressed in the future.
-
-      # Here the verbosity will not be increased since the plugin is
-      # not mentioned on the command line:
-      $ TMT_PLUGIN_DISCOVER_FMF_VERBOSE=2 tmt run -a
-
-      # Here the environment variable will take effect:
-      $ TMT_PLUGIN_DISCOVER_FMF_VERBOSE=2 tmt run -a discover -h fmf ...
+Plugin Variables
+----------------
 
 Each plugin option can be also specified via environment variable.
 Variables follow a naming scheme utilizing plugin name, step it
@@ -503,6 +505,21 @@ For setting flag-like option, 0 and 1 are the expected value. For
 example, an interactive mode would be enabled in this run::
 
     TMT_PLUGIN_EXECUTE_TMT_INTERACTIVE=1 tmt run ... execute -h tmt ...
+
+.. note::
+
+   The following applies to situations when a plugin is specified
+   on the command line only. Keys of plugins specified in fmf files
+   would not be modified. This is a limit of the current implementation,
+   and will be addressed in the future::
+
+      # Here the verbosity will not be increased since the plugin is
+      # not mentioned on the command line:
+      $ TMT_PLUGIN_DISCOVER_FMF_VERBOSE=2 tmt run -a
+
+      # Here the environment variable will take effect:
+      $ TMT_PLUGIN_DISCOVER_FMF_VERBOSE=2 tmt run -a discover -h fmf ...
+
 
 Links
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -774,7 +774,7 @@ class BasePlugin(Phase):
                 else:
                     raise tmt.utils.GeneralError(
                         f"Envvar property of '{param.name}' option "
-                        f"set to unexpected type {type(param.envvar)}")
+                        f"set to unexpected type '{type(param.envvar)}'.")
 
         # Create base command with common options using method class
         method_class = tmt.options.create_method_class(commands)


### PR DESCRIPTION
Click supports consuming option values from environment variables, see [1] for details.

Each plugin option gains an environment variable named `TMT_PLUGIN_${step_name}_${plugin_name}_${option_name}`. There is no change in how values are processed, only now Click would extract values from respective envvars when command-line option is not specified.

[1] https://click.palletsprojects.com/en/8.1.x/options/#values-from-environment-variables

* [x] documentation
* [x] how `envvar` and `is_flag` interacts? shall we add also `NO_...` envvar? Or does something like `TMT_FOO=0|1` work?
* [ ] a test or two