### PR TITLE
Add message to failure tags in junit

### DIFF
--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -12,6 +12,7 @@ rlJournalStart
             rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml | tee output" 2
             rlAssertGrep "2 tests passed, 2 tests failed and 2 errors" "output"
             rlAssertGrep '<testsuite disabled="0" errors="2" failures="2" name="/plan" skipped="0" tests="6"' "junit.xml"
+            rlAssertGrep 'fail</failure>' "junit.xml"
         rlPhaseEnd
     done
 

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -75,13 +75,13 @@ def make_junit_xml(report: "tmt.steps.report.ReportPlugin") -> JunitTestSuite:
             stdout=main_log)
         # Map tmt OUTCOME to JUnit states
         if result.result == tmt.result.ResultOutcome.ERROR:
-            case.add_error_info(result.result.value)
+            case.add_error_info(result.result.value, output=result.failures(main_log))
         elif result.result == tmt.result.ResultOutcome.FAIL:
-            case.add_failure_info(result.result.value)
+            case.add_failure_info(result.result.value, output=result.failures(main_log))
         elif result.result == tmt.result.ResultOutcome.INFO:
-            case.add_skipped_info(result.result.value)
+            case.add_skipped_info(result.result.value, output=result.failures(main_log))
         elif result.result == tmt.result.ResultOutcome.WARN:
-            case.add_error_info(result.result.value)
+            case.add_error_info(result.result.value, output=result.failures(main_log))
         # Passed state is the default
         suite.test_cases.append(case)
 


### PR DESCRIPTION
This is useful for both RP and Polarion to have correct failure messages.

The matching is not great but it works for beakerlib fine, other issues should be matched as well and if nothing is found whole output is dumped there.