### PR TITLE
Use custom subclass of click.Context for better annotations

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -8,10 +8,10 @@ import re
 import shutil
 import sys
 import time
-from typing import (Any, ClassVar, Dict, Generator, Iterable, List, Optional,
-                    Sequence, Tuple, TypeVar, Union, cast, overload)
+from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generator,
+                    Iterable, List, Optional, Sequence, Tuple, TypeVar, Union,
+                    cast, overload)
 
-import click
 import fmf
 import fmf.base
 import fmf.utils
@@ -38,6 +38,10 @@ if sys.version_info >= (3, 8):
     from typing import Literal, TypedDict
 else:
     from typing_extensions import Literal, TypedDict
+
+if TYPE_CHECKING:
+    import tmt.cli
+
 
 T = TypeVar('T')
 
@@ -464,7 +468,7 @@ class Core(
         return tmt.utils.fmf_id(self.name, self.node.root)
 
     @classmethod
-    def _save_context(cls, context: click.Context) -> None:
+    def _save_context(cls, context: 'tmt.cli.Context') -> None:
         """ Save provided command line context for future use """
         super(Core, cls)._save_context(context)
 
@@ -2255,7 +2259,7 @@ class Run(tmt.utils.Common):
                  *,
                  id_: Optional[str] = None,
                  tree: Optional[Tree] = None,
-                 context: Optional[click.Context] = None) -> None:
+                 context: Optional['tmt.cli.Context'] = None) -> None:
         """ Initialize tree, workdir and plans """
         # Use the last run id if requested
         self.config = tmt.utils.Config()
@@ -2714,6 +2718,9 @@ class Status(tmt.utils.Common):
             self.process_run(run)
 
 
+CleanCallback = Callable[[], bool]
+
+
 class Clean(tmt.utils.Common):
     """ A class for cleaning up workdirs, guests or images """
 
@@ -2722,7 +2729,7 @@ class Clean(tmt.utils.Common):
                  parent: Optional[tmt.utils.Common] = None,
                  name: Optional[str] = None,
                  workdir: tmt.utils.WorkdirArgumentType = None,
-                 context: Optional[click.Context] = None) -> None:
+                 context: Optional['tmt.cli.Context'] = None) -> None:
         """
         Initialize name and relation with the parent object
 

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -22,6 +22,7 @@ from tmt.options import show_step_method_hints
 
 if TYPE_CHECKING:
     import tmt.base
+    import tmt.cli
     from tmt.base import Plan
     from tmt.steps.provision import Guest
 
@@ -1026,7 +1027,7 @@ class Reboot(Action):
         @click.option(
             '--hard', is_flag=True,
             help='Hard reboot of the machine. Unsaved data may be lost.')
-        def reboot(context: click.Context, **kwargs: Any) -> None:
+        def reboot(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             """ Reboot the guest. """
             Reboot._save_context(context)
             Reboot._enabled = True
@@ -1089,7 +1090,7 @@ class Login(Action):
         @click.option(
             '-t', '--test', is_flag=True,
             help='Log into the guest after each executed test in the execute phase.')
-        def login(context: click.Context, **kwargs: Any) -> None:
+        def login(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             """
             Provide user with an interactive shell on the guest.
 

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -8,6 +8,7 @@ from fmf.utils import listed
 import tmt
 
 if TYPE_CHECKING:
+    import tmt.cli
     import tmt.steps
     import tmt.options
 
@@ -50,7 +51,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin):
         @click.option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method to discover tests.')
-        def discover(context: click.Context, **kwargs: Any) -> None:
+        def discover(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             # TODO: This part should go into the 'fmf.py' module
             if kwargs.get('fmf_id'):
                 # Set quiet, disable debug and verbose to avoid logging

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -18,6 +18,7 @@ from tmt.steps.provision import Guest
 from tmt.utils import GeneralError
 
 if TYPE_CHECKING:
+    import tmt.cli
     import tmt.options
     import tmt.steps.discover
     import tmt.steps.provision
@@ -151,7 +152,7 @@ class ExecutePlugin(tmt.steps.Plugin):
         @click.option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method for test execution.')
-        def execute(context: click.Context, **kwargs: Any) -> None:
+        def execute(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             context.obj.steps.add('execute')
             Execute._save_context(context)
 

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -1,6 +1,6 @@
 import copy
 import dataclasses
-from typing import Any, List, Optional, Type, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Type, cast
 
 import click
 import fmf
@@ -9,6 +9,9 @@ import tmt
 import tmt.steps
 from tmt.steps import Action, Method, StepData
 from tmt.utils import GeneralError
+
+if TYPE_CHECKING:
+    import tmt.cli
 
 
 @dataclasses.dataclass
@@ -41,7 +44,7 @@ class FinishPlugin(tmt.steps.Plugin):
         @click.option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method for finishing tasks.')
-        def finish(context: click.Context, **kwargs: Any) -> None:
+        def finish(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             context.obj.steps.add('finish')
             Finish._save_context(context)
 

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -13,6 +13,7 @@ from tmt.steps import Action
 from tmt.utils import GeneralError
 
 if TYPE_CHECKING:
+    import tmt.cli
     from tmt.base import Plan
 
 
@@ -55,7 +56,7 @@ class PreparePlugin(tmt.steps.Plugin):
         @click.option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method for environment preparation.')
-        def prepare(context: click.core.Context, **kwargs: Any) -> None:
+        def prepare(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             context.obj.steps.add('prepare')
             Prepare._save_context(context)
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -10,7 +10,7 @@ import string
 import subprocess
 import tempfile
 from shlex import quote
-from typing import Any, Dict, List, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union, cast
 
 import click
 import fmf
@@ -20,6 +20,10 @@ import tmt.plugins
 import tmt.steps
 import tmt.utils
 from tmt.steps import Action
+
+if TYPE_CHECKING:
+    import tmt.cli
+
 
 # Timeout in seconds of waiting for a connection after reboot
 CONNECTION_TIMEOUT = 5 * 60
@@ -1003,7 +1007,7 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin):
         @click.option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method for provisioning.')
-        def provision(context: click.Context, **kwargs: Any) -> None:
+        def provision(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             context.obj.steps.add('provision')
             Provision._save_context(context)
 

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -1,11 +1,14 @@
 import dataclasses
-from typing import Any, List, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Type, Union, cast
 
 import click
 
 import tmt
 import tmt.steps
 from tmt.steps import Action
+
+if TYPE_CHECKING:
+    import tmt.cli
 
 
 @dataclasses.dataclass
@@ -41,7 +44,7 @@ class ReportPlugin(tmt.steps.GuestlessPlugin):
         @click.option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method for results reporting.')
-        def report(context: click.Context, **kwargs: Any) -> None:
+        def report(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             context.obj.steps.add('report')
             Report._save_context(context)
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -306,7 +306,7 @@ class Common:
     """
 
     # Command line context, options and workdir
-    _context: Optional[click.Context] = None
+    _context: Optional['tmt.cli.Context'] = None
     # When set to true, _opt will be ignored (default will be returned)
     ignore_class_options: bool = False
     _options: Dict[str, Any] = dict()
@@ -332,7 +332,7 @@ class Common:
             parent: Optional[CommonDerivedType] = None,
             name: Optional[str] = None,
             workdir: WorkdirArgumentType = None,
-            context: Optional[click.Context] = None,
+            context: Optional['tmt.cli.Context'] = None,
             relative_indent: int = 1,
             **kwargs: Any) -> None:
         """
@@ -367,12 +367,12 @@ class Common:
         return self.name
 
     @classmethod
-    def _save_context(cls, context: click.Context) -> None:
+    def _save_context(cls, context: 'tmt.cli.Context') -> None:
         """ Save provided command line context and options for future use """
         cls._context = context
         cls._options = context.params
 
-    def _save_context_to_instance(self, context: click.Context) -> None:
+    def _save_context_to_instance(self, context: 'tmt.cli.Context') -> None:
         """ Save provided command line context and options to the instance """
         self._context = context
         self._options = context.params


### PR DESCRIPTION
Thanks to a subclass, we can provide more narrower type of `context.obj` attribute, and that allows `mypy` follow the breadcrumbs even better. The original class and `obj` had to be `cast()`-ed, to `mypy` it was simply an `Any` object.