### PR TITLE
Define CPU HW components with more granularity

### DIFF
--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -166,9 +166,26 @@ example: |
       - |
         # Processor-related stuff grouped together
         cpu:
-            processors: 2
-            cores: 16
-            model: 37
+            # The total number of various CPU components in the system.
+            socket: 1
+            cores: 4
+            threads: 8
+
+            # Ther number of various CPU components per their parent.
+            cores-per-socket: 4
+            threads-per-core: 2
+
+            # The total number of logical CPUs.
+            processors: 8
+
+            # CPU model name. Usually reported as such by /proc/cpuinfo or lscpu.
+            model-name: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+            # CPU model number.
+            model: 142
+            # CPU family name.
+            family-name: Comet Lake
+            # CPU family number.
+            family: 6
 
       - |
         # Disk group used to allow possible future extensions

--- a/tmt/schemas/provision/hardware.yaml
+++ b/tmt/schemas/provision/hardware.yaml
@@ -33,7 +33,7 @@ definitions:
     type: object
 
     properties:
-      processors:
+      sockets:
         anyOf:
           - type: string
           - type: integer
@@ -41,10 +41,28 @@ definitions:
         anyOf:
           - type: string
           - type: integer
+      threads:
+        anyOf:
+          - type: string
+          - type: integer
+      cores-per-socket:
+        anyOf:
+          - type: string
+          - type: integer
+      threads-per-core:
+        anyOf:
+          - type: string
+          - type: integer
+      processors:
+        anyOf:
+          - type: string
+          - type: integer
       family:
         anyOf:
           - type: string
           - type: integer
+      family-name:
+        type: string
       model:
         anyOf:
           - type: string


### PR DESCRIPTION
As proposed in #1140, CPU components require slight rework to better reflect the hierarchy of sockets, cores and threads. This should allow for more fitting mapping between requirements and real-life services.