### PR TITLE
Update specification of the `where` multihost key

### DIFF
--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -213,3 +213,75 @@ description: |
             dist-git-source: true
     link:
       - implemented-by: /tmt/steps/discover/fmf.py
+
+/where:
+    summary: Execute tests on selected guests
+    description: |
+        In the :ref:`/spec/plans/provision/multihost` scenarios it
+        is often necessary to execute test code on selected guests
+        only or execute different test code on individual guests.
+        The ``where`` key allows to select guests where the tests
+        should be executed by providing their ``name`` or the
+        ``role`` they play in the scenario. Use a list to specify
+        multiple names or roles. By default, when the ``where`` key
+        is not defined, tests are executed on all provisioned
+        guests.
+
+        There is also an alternative to the syntax using a ``where``
+        dictionary encapsulating the ``discover`` config under keys
+        corresponding to guest names or roles. This can result in
+        much more concise config especially when defining several
+        shell scripts for each guest or role.
+
+    example:
+      - |
+        # Run different script for each guest or role
+        discover:
+            how: shell
+            tests:
+              - name: run-the-client-code
+                test: client.py
+                where: client
+              - name: run-the-server-code
+                test: server.py
+                where: server
+
+      - |
+        # Filter different set of tests for each guest or role
+        discover:
+          - how: fmf
+            filter: tag:client-tests
+            where: client
+          - how: fmf
+            filter: tag:server-tests
+            where: server
+
+      - |
+        # Alternative syntax using the 'where' dictionary
+        # encapsulating for tests defined by fmf
+        discover:
+            where:
+                client:
+                  - how: fmf
+                    filter: tag:client-tests
+                server:
+                  - how: fmf
+                    filter: tag:server-tests
+
+      - |
+        # Alternative syntax using the 'where' dictionary
+        # encapsulating for shell script tests
+        discover:
+            where:
+                server:
+                    how: shell
+                    tests:
+                      - test: first server script
+                      - test: second server script
+                      - test: third server script
+                client:
+                    how: shell
+                    tests:
+                      - test: first client script
+                      - test: second client script
+                      - test: third client script

--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -247,33 +247,6 @@ description: |
       - implemented-by: /tmt/steps/execute/internal.py
       - verified-by: /tests/execute/framework
 
-/where:
-    summary: Execute tests on selected guests
-    description: |
-        In the :ref:`/spec/plans/provision/multihost` scenarios it
-        is often necessary to execute test code on selected guests
-        only or execute different test code on individual guests.
-        The ``where`` key allows to select guests where the tests
-        should be executed by providing their ``name`` or the
-        ``role`` they play in the scenario. Use a list to specify
-        multiple names or roles. By default, when the ``where`` key
-        is not defined, tests are executed on all provisioned
-        guests.
-    example: |
-        # Execute discovered tests on the client (already supported)
-        execute:
-          - how: tmt
-            where: client
-
-        # Run different script for each role (not supported yet)
-        execute:
-          - name: run-the-client-code
-            script: client.py
-            where: client
-          - name: run-the-server-code
-            script: server.py
-            where: server
-
 /script:
     summary: Execute shell scripts
     story: As a user I want to easily run shell script as a test.

--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -132,7 +132,7 @@ example: |
         ``where`` key to select guests on which the
         :ref:`preparation</spec/plans/prepare/where>`
         tasks should be applied or where the test
-        :ref:`execution</spec/plans/execute/where>` should
+        :ref:`execution</spec/plans/discover/where>` should
         take place.
 
         If guests need to be synchronized during the environment


### PR DESCRIPTION
Updating specification related to #1545.