### PR TITLE
Fix one integer-looking ref in test

### DIFF
--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -74,7 +74,7 @@ execute:
         summary: Integer reference
         discover:
             how: fmf
-            ref: 21962777
+            ref: "21962777"
 
     /distgit:
         summary: Extract distgit sources


### PR DESCRIPTION
`ref` should be a string, and integer-looking ref not being encapsulated with quotes would be parsed as an integer.