### PR TITLE
Fix guest distro detection, do not throw results away

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -416,7 +416,7 @@ class Guest(tmt.utils.Common):
 
         # Distro
         distro_commands = [
-            # check os-release first)
+            # Check os-release first
             ('cat /etc/os-release', r'PRETTY_NAME="(.*)"'),
             # Check for lsb-release
             ('cat /etc/lsb-release', r'DISTRIB_DESCRIPTION="(.*)"'),
@@ -426,11 +426,10 @@ class Guest(tmt.utils.Common):
 
         for command, pattern in distro_commands:
             try:
-                distro = _fetch_detail(command, pattern)
-
+                distro: Optional[str] = _fetch_detail(command, pattern)
+                break
             except tmt.utils.RunError:
                 continue
-
         else:
             distro = None
 


### PR DESCRIPTION
While annotating `tmt.steps.provision`, a regression has been introduced: code detecting guest distro works as it used to, but its result was overwritten, efefctively throwing the result away.