### PR TITLE
Fixes use of variable before assignment in Plan.go

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1435,8 +1435,8 @@ class Plan(Core):
 
         # Run enabled steps except 'finish'
         self.debug('go', color='cyan', shift=0, level=2)
+        abort = False
         try:
-            abort = False
             for step in self.steps(skip=['finish']):
                 step.go()
                 # Finish plan if no tests found (except dry mode)


### PR DESCRIPTION
`abort` is declared at the very first line of `try` block, also used in `finally` block, which may look safe. In theory, it is still possible for an exception to raise *after* entering `try` bug *before* defining `abort` name. in such a case, testing `abort` in `finally` block would raise yet another exception, possibly making investigation harder.