### PR TITLE
Support beaker libraries as recommended packages

### DIFF
--- a/tests/unit/test_beakerlib.py
+++ b/tests/unit/test_beakerlib.py
@@ -12,9 +12,9 @@ def test_library():
     """ Fetch a beakerlib library with/without providing a parent """
     parent = tmt.utils.Common(workdir=True)
     library_with_parent = tmt.beakerlib.Library(
-        'library(openssl/certgen)', parent=parent)
+        tmt.base.RequireSimple('library(openssl/certgen)'), parent=parent)
     library_without_parent = tmt.beakerlib.Library(
-        'library(openssl/certgen)')
+        tmt.base.RequireSimple('library(openssl/certgen)'))
 
     for library in [library_with_parent, library_without_parent]:
         assert library.format == 'rpm'
@@ -67,7 +67,9 @@ def test_dependencies():
     """ Check requires for possible libraries """
     parent = tmt.utils.Common(workdir=True)
     requires, recommends, libraries = tmt.beakerlib.dependencies(
-        ['library(httpd/http)', 'wget'], ['forest'], parent=parent)
+        [tmt.base.RequireSimple('library(httpd/http)'), tmt.base.RequireSimple('wget')],
+        [tmt.base.RequireSimple('forest')],
+        parent=parent)
     # Check for correct requires and recommends
     for require in ['httpd', 'lsof', 'mod_ssl']:
         assert require in requires

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -13,12 +13,12 @@ import tmt.base
 import tmt.utils
 
 # A beakerlib identifier type, can be a string or a fmf id (with extra beakerlib keys)
-BeakerlibIdentifierType = Union[str, tmt.base.RequireFmfId]
+BeakerlibIdentifierType = Union[tmt.base.RequireSimple, tmt.base.RequireFmfId]
 ImportedIdentifiersType = Optional[List[BeakerlibIdentifierType]]
 
 # A type for Beakerlib dependencies
 LibraryDependenciesType = Tuple[
-    List[tmt.base.Require], List[str], List['Library']
+    List[tmt.base.Require], List[tmt.base.Require], List['Library']
     ]
 
 # Regular expressions for beakerlib libraries
@@ -86,13 +86,14 @@ class Library:
 
         self.identifier: BeakerlibIdentifierType
         # The 'library(repo/lib)' format
-        if isinstance(identifier, str):
-            identifier = identifier.strip()
+        if isinstance(identifier, tmt.base.RequireSimple):
+            identifier = tmt.base.RequireSimple(identifier.strip())
             self.identifier = identifier
             matched = LIBRARY_REGEXP.search(identifier)
             if not matched:
                 raise LibraryError
-            self.parent.debug(f"Detected library '{identifier}'.", level=3)
+            self.parent.debug(
+                f"Detected library '{identifier.to_minimal_spec()}'.", level=3)
             self.format: str = 'rpm'
             self.repo: str = matched.groups()[0]
             self.name: str = matched.groups()[1]
@@ -105,7 +106,8 @@ class Library:
         # The fmf identifier
         elif isinstance(identifier, tmt.base.RequireFmfId):
             self.identifier = identifier
-            self.parent.debug(f"Detected library '{identifier}'.", level=3)
+            self.parent.debug(
+                f"Detected library '{identifier.to_minimal_spec()}'.", level=3)
             self.format = 'fmf'
             self.url = identifier.url
             self.path = identifier.path
@@ -275,7 +277,7 @@ class Library:
             raise tmt.utils.GeneralError(
                 f"Library '{self.name}' not found in '{self.repo}'.")
         self.require = tmt.base.normalize_require(library_node.get('require', []))
-        self.recommend = tmt.base.normalize_recommend(library_node.get('recommend', []))
+        self.recommend = tmt.base.normalize_require(library_node.get('recommend', []))
 
         # Create a symlink if the library is deep in the structure
         # FIXME: hot fix for https://github.com/beakerlib/beakerlib/pull/72
@@ -296,7 +298,7 @@ class Library:
 
 def dependencies(
     original_require: List[tmt.base.Require],
-    original_recommend: Optional[List[str]] = None,
+    original_recommend: Optional[List[tmt.base.Require]] = None,
     parent: Optional[tmt.utils.Common] = None,
     imported_lib_ids: ImportedIdentifiersType = None,
         ) -> LibraryDependenciesType:
@@ -326,7 +328,7 @@ def dependencies(
             return True
         return lib not in imported_lib_ids
 
-    to_fetch = original_require + cast(List[tmt.base.Require], original_recommend)
+    to_fetch = original_require + original_recommend
     for dependency in filter(already_fetched, to_fetch):
         # Library require/recommend
         try:

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -345,7 +345,7 @@ def dependencies(
         except LibraryError:
             if dependency in original_require:
                 processed_require.add(dependency)
-            if isinstance(dependency, str) and dependency in original_recommend:
+            if dependency in original_recommend:
                 processed_recommend.add(dependency)
 
     # Convert to list and return the results

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -66,7 +66,6 @@ class TestDescription(
     _normalize_tag = tmt.utils.LoadFmfKeysMixin._normalize_string_list
     _normalize_contact = tmt.utils.LoadFmfKeysMixin._normalize_string_list
     _normalize_component = tmt.utils.LoadFmfKeysMixin._normalize_string_list
-    _normalize_recommend = tmt.utils.LoadFmfKeysMixin._normalize_string_list
 
     def _normalize_order(self, value: Optional[int]) -> int:
         if value is None:
@@ -94,6 +93,11 @@ class TestDescription(
     def _normalize_require(self, value: Optional[tmt.base._RawRequire]) -> List[tmt.base.Require]:
         return tmt.base.normalize_require(value)
 
+    def _normalize_recommend(
+            self,
+            value: Optional[tmt.base._RawRequire]) -> List[tmt.base.Require]:
+        return tmt.base.normalize_require(value)
+
     # ignore[override]: expected, we do want to accept more specific
     # type than the one declared in superclass.
     @classmethod
@@ -114,10 +118,8 @@ class TestDescription(
 
         data = super().to_spec()
         data['link'] = self.link.to_spec() if self.link else None
-        data['require'] = [
-            require if isinstance(require, str) else require.to_spec()
-            for require in self.require
-            ]
+        data['require'] = [require.to_spec() for require in self.require]
+        data['recommend'] = [recommend.to_spec() for recommend in self.recommend]
 
         return data
 
@@ -131,10 +133,8 @@ class TestDescription(
         # can use existing `to_spec()` method, and undo it with a simple
         # `Links(...)` call.
         data['link'] = self.link.to_spec() if self.link else None
-        data['require'] = [
-            require if isinstance(require, str) else require.to_serialized()
-            for require in self.require
-            ]
+        data['require'] = [require.to_spec() for require in self.require]
+        data['recommend'] = [recommend.to_spec() for recommend in self.recommend]
 
         return data
 
@@ -146,8 +146,13 @@ class TestDescription(
         obj.link = tmt.base.Links(serialized['link'])
         obj.require = [
             tmt.base.RequireSimple.from_spec(require)
-            if isinstance(require, str) else tmt.base.RequireFmfId.from_serialized(require)
+            if isinstance(require, str) else tmt.base.RequireFmfId.from_spec(require)
             for require in serialized['require']
+            ]
+        obj.recommend = [
+            tmt.base.RequireSimple.from_spec(recommend)
+            if isinstance(recommend, str) else tmt.base.RequireFmfId.from_spec(recommend)
+            for recommend in serialized['recommend']
             ]
 
         return obj

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -58,7 +58,7 @@ class TestDescription(
     framework: Optional[str] = None
     manual: bool = False
     require: List[tmt.base.Require] = dataclasses.field(default_factory=list)
-    recommend: List[str] = dataclasses.field(default_factory=list)
+    recommend: List[tmt.base.Require] = dataclasses.field(default_factory=list)
     environment: tmt.utils.EnvironmentType = dataclasses.field(default_factory=dict)
     duration: str = '1h'
     result: str = 'respect'
@@ -145,7 +145,8 @@ class TestDescription(
         obj = super().from_serialized(serialized)
         obj.link = tmt.base.Links(serialized['link'])
         obj.require = [
-            require if isinstance(require, str) else tmt.base.RequireFmfId.from_serialized(require)
+            tmt.base.RequireSimple.from_spec(require)
+            if isinstance(require, str) else tmt.base.RequireFmfId.from_serialized(require)
             for require in serialized['require']
             ]
 


### PR DESCRIPTION
This functionality has been removed by patches annotating `base.py`, but it is allowed by specification.