### PR TITLE
Adds an extra level of step data classes for provisioning and report

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -42,8 +42,15 @@ class CheckRsyncOutcome(enum.Enum):
     INSTALLED = 'installed'
 
 
+@dataclasses.dataclass
+class ProvisionStepData(tmt.steps.StepData):
+    pass
+
+
 class ProvisionPlugin(tmt.steps.GuestlessPlugin):
     """ Common parent of provision plugins """
+
+    _data_class = ProvisionStepData
 
     # Default implementation for provision is a virtual machine
     how = 'virtual'

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -86,7 +86,7 @@ class ArtemisGuestData(tmt.steps.provision.GuestSshData):
 
 
 @dataclasses.dataclass
-class ProvisionArtemisData(ArtemisGuestData, tmt.steps.StepData):
+class ProvisionArtemisData(ArtemisGuestData, tmt.steps.provision.ProvisionStepData):
     pass
 
 

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -18,7 +18,7 @@ class ConnectGuestData(tmt.steps.provision.GuestSshData):
 
 
 @dataclasses.dataclass
-class ProvisionConnectData(ConnectGuestData, tmt.steps.StepData):
+class ProvisionConnectData(ConnectGuestData, tmt.steps.provision.ProvisionStepData):
     pass
 
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -8,7 +8,7 @@ import tmt.utils
 
 
 @dataclasses.dataclass
-class ProvisionLocalData(tmt.steps.provision.GuestData, tmt.steps.StepData):
+class ProvisionLocalData(tmt.steps.provision.GuestData, tmt.steps.provision.ProvisionStepData):
     pass
 
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -27,7 +27,7 @@ class PodmanGuestData(tmt.steps.provision.GuestData):
 
 
 @dataclasses.dataclass
-class ProvisionPodmanData(PodmanGuestData, tmt.steps.StepData):
+class ProvisionPodmanData(PodmanGuestData, tmt.steps.provision.ProvisionStepData):
     pass
 
 

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -184,7 +184,7 @@ class TestcloudGuestData(tmt.steps.provision.GuestSshData):
 
 
 @dataclasses.dataclass
-class ProvisionTestcloudData(TestcloudGuestData, tmt.steps.StepData):
+class ProvisionTestcloudData(TestcloudGuestData, tmt.steps.provision.ProvisionStepData):
     pass
 
 

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Any, List, Optional, Type, Union, cast
 
 import click
@@ -7,8 +8,15 @@ import tmt.steps
 from tmt.steps import Action
 
 
+@dataclasses.dataclass
+class ReportStepData(tmt.steps.StepData):
+    pass
+
+
 class ReportPlugin(tmt.steps.GuestlessPlugin):
     """ Common parent of report plugins """
+
+    _data_class = ReportStepData
 
     # Default implementation for report is display
     how = 'display'

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -34,7 +34,7 @@ def import_jinja2() -> None:
 
 
 @dataclasses.dataclass
-class ReportHtmlData(tmt.steps.StepData):
+class ReportHtmlData(tmt.steps.report.ReportStepData):
     open: bool = False
 
 

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -89,7 +89,7 @@ def make_junit_xml(report: "tmt.steps.report.ReportPlugin") -> JunitTestSuite:
 
 
 @dataclasses.dataclass
-class ReportJUnitData(tmt.steps.StepData):
+class ReportJUnitData(tmt.steps.report.ReportStepData):
     file: Optional[str] = None
 
 

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -17,7 +17,7 @@ DEFAULT_NAME = 'xunit.xml'
 
 
 @dataclasses.dataclass
-class ReportPolarionData(tmt.steps.StepData):
+class ReportPolarionData(tmt.steps.report.ReportStepData):
     file: Optional[str] = None
     upload: bool = True
     project_id: Optional[str] = None


### PR DESCRIPTION
These classes do not do anything, yet, but they 1. balance the structure of `StepData` classes, other steps do have their step-specific base classes for plugins to use, and 2. there are overlaps between various provision and report plugins (e.g. `user` or `file` keys), which should land in these bases classes, in the future.