### PR TITLE
Enable variable expansion for dynamic references

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -697,6 +697,14 @@ Example of a dynamic ``ref`` definition file in ``repo/.tmtref``::
       - when: distro == rhel-9
         ref: rhel-9
 
+The definition file can also be parametrized using environment
+variables or context dimensions::
+
+    ref: main
+    adjust:
+      - when: distro == fedora or distro == rhel
+        ref: $@distro
+
 
 Stories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/discover/data/dynamic-ref.fmf
+++ b/tests/discover/data/dynamic-ref.fmf
@@ -5,3 +5,7 @@ adjust:
     ref: fedora
   - when: "branch == rhel"
     ref: rhel
+  - when: "branch == debian or branch == ubuntu"
+    ref: $@{branch}
+  - when: "branch == envvar"
+    ref: ${BRANCH}

--- a/tests/discover/dynamic-ref.sh
+++ b/tests/discover/dynamic-ref.sh
@@ -30,6 +30,16 @@ rlJournalStart
         rlAssertGrep 'ref: rhel' $rlRun_LOG
     rlPhaseEnd
 
+    rlPhaseStartTest 'Check dynamic ref combined with test plan context parametrization"'
+        rlRun "tmt -c branch=ubuntu run -r $plan_ctx $steps | tee output" 0,2
+        rlAssertGrep 'ref: ubuntu' 'output'
+    rlPhaseEnd
+
+    rlPhaseStartTest 'Check dynamic ref combined with test plan envvar parametrization"'
+        rlRun "tmt -c branch=envvar run --environment BRANCH=debian -r $plan_ctx $steps | tee output" 0,2
+        rlAssertGrep 'ref: debian' 'output'
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun 'popd'
     rlPhaseEnd

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -377,6 +377,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             # Build a dynamic reference tree, adjust ref based on the context
             reference_tree = fmf.Tree(data=data)
             reference_tree.adjust(fmf.context.Context(**self.step.plan._fmf_context()))
+            # Also temporarily build a plan so that env and context variables are expanded
+            tmt.Plan(node=reference_tree, run=self.step.plan.my_run, skip_validation=True)
             ref = reference_tree.get("ref")
 
         # Checkout revision if requested


### PR DESCRIPTION
Adds possibility to use variables inside the `.tmt/ref.fmf` file.