### PR TITLE
Add `SpecBasedContainer.to_minimal_spec()` method

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -81,7 +81,7 @@ exported in different form. To facilitate these conversions, three
 families of helper methods are provided, each with its own set of
 use cases.
 
-``to_spec``/``to_minimal_dict``/``from_spec``
+``to_spec``/``to_minimal_spec``/``from_spec``
 ------------------------------------------------------------------
 
 This family of methods works with tmt *specification*, i.e. raw
@@ -94,9 +94,9 @@ The default implementation comes from ``tmt.utils.SpecBasedContainer``
 class, all classes based on user input data should include this
 class among their bases.
 
-``to_minimal_dict`` performs the identical operation as ``to_dict``,
-but its result should not include keys that optional and not set,
-while ``to_dict`` should always include all keys, even when set to
+``to_minimal_spec`` performs the identical operation as ``to_spec``,
+but its result should not include keys that are optional and not set,
+while ``to_spec`` should always include all keys, even when set to
 default values or not set at all.
 
 .. code-block:: python

--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -81,7 +81,7 @@ exported in different form. To facilitate these conversions, three
 families of helper methods are provided, each with its own set of
 use cases.
 
-``to_spec``/``from_spec``
+``to_spec``/``to_minimal_dict``/``from_spec``
 ------------------------------------------------------------------
 
 This family of methods works with tmt *specification*, i.e. raw
@@ -93,6 +93,11 @@ called to spawn objects representing the user input, while
 The default implementation comes from ``tmt.utils.SpecBasedContainer``
 class, all classes based on user input data should include this
 class among their bases.
+
+``to_minimal_dict`` performs the identical operation as ``to_dict``,
+but its result should not include keys that optional and not set,
+while ``to_dict`` should always include all keys, even when set to
+default values or not set at all.
 
 .. code-block:: python
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -137,6 +137,11 @@ class FmfId(tmt.utils.SpecBasedContainer, tmt.utils.SerializableContainer):
 
         return self.to_dict()
 
+    # ignore[override]: expected, we do want to return more specific
+    # type than the one declared in superclass.
+    def to_minimal_spec(self) -> _RawFmfId:  # type: ignore[override]
+        return cast(_RawFmfId, super().to_minimal_spec())
+
     @classmethod
     def from_spec(cls, raw: _RawFmfId) -> 'FmfId':
         """ Convert from a specification file or from a CLI option """
@@ -530,7 +535,7 @@ class Core(
             # of export() cleanup comes.
             elif key == 'require' and value:
                 data[key] = [
-                    require.to_minimal_dict() if isinstance(
+                    require.to_minimal_spec() if isinstance(
                         require, RequireFmfId) else require for require in cast(
                         List[Require], value)]
 
@@ -767,7 +772,7 @@ class Test(Core):
                 continue
             if key == 'require':
                 value = [
-                    require if isinstance(require, str) else require.to_minimal_dict()
+                    require if isinstance(require, str) else require.to_minimal_spec()
                     for require in self.require
                     ]
             if value not in [None, list(), dict()]:
@@ -907,10 +912,10 @@ class Test(Core):
         # Export the fmf identifier
         if keys == ['fmf-id']:
             if format_ == ExportFormat.DICT:
-                return self.fmf_id.to_minimal_dict()
+                return self.fmf_id.to_minimal_spec()
 
             if format_ == ExportFormat.YAML:
-                return tmt.utils.dict_to_yaml(self.fmf_id.to_minimal_dict())
+                return tmt.utils.dict_to_yaml(self.fmf_id.to_minimal_spec())
 
             raise tmt.utils.GeneralError(f"Invalid test export format '{format_}'.")
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -140,6 +140,7 @@ class FmfId(tmt.utils.SpecBasedContainer, tmt.utils.SerializableContainer):
     # ignore[override]: expected, we do want to return more specific
     # type than the one declared in superclass.
     def to_minimal_spec(self) -> _RawFmfId:  # type: ignore[override]
+        """ Convert to specification, skip default values """
         return cast(_RawFmfId, super().to_minimal_spec())
 
     @classmethod

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -283,7 +283,7 @@ class Discover(tmt.steps.Step):
             if self.tests():
                 fmf_id_list = [
                     tmt.utils.dict_to_yaml(
-                        test.fmf_id.to_minimal_dict(),
+                        test.fmf_id.to_minimal_spec(),
                         start=True) for test in self.tests() if test.fmf_id.url]
                 click.echo(''.join(fmf_id_list), nl=False)
             return

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1511,6 +1511,17 @@ class SpecBasedContainer(DataContainer):
 
         return self.to_dict()
 
+    def to_minimal_spec(self) -> Dict[str, Any]:
+        """
+        Convert to a form suitable for saving in a specification file.
+
+        See https://tmt.readthedocs.io/en/stable/classes.html#class-conversions for more details.
+
+        See :py:meth:`from_spec` for its counterpart.
+        """
+
+        return self.to_minimal_dict()
+
 
 SerializableContainerDerivedType = TypeVar(
     'SerializableContainerDerivedType',

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1513,7 +1513,7 @@ class SpecBasedContainer(DataContainer):
 
     def to_minimal_spec(self) -> Dict[str, Any]:
         """
-        Convert to a form suitable for saving in a specification file.
+        Convert to specification, skip default values
 
         See https://tmt.readthedocs.io/en/stable/classes.html#class-conversions for more details.
 


### PR DESCRIPTION
It originated as `to_minimal_dict()`, but to avoid confusion, adding `to_minimal_spec()` as well, to be aligned with "don't use `to_dict()`" rule from documentation. `to_minimal_spec()` makes it clear what kind of output is requested.