### PR TITLE
Fix getting CentOS via --how virtual

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -423,10 +423,9 @@ class GuestTestcloud(tmt.GuestSsh):
         elif name == 'fedora-coreos':
             url = testcloud.util.get_fedora_image_url("stable", self.arch)
         elif name == 'centos':
-            url = testcloud.util.get_centos_image_url("latest", self.arch)
+            url = testcloud.util.get_centos_image_url("latest", stream=False, arch=self.arch)
         elif name == 'centos-stream':
-            url = testcloud.util.get_centos_image_url(
-                "latest", stream=True, arch=self.arch)
+            url = testcloud.util.get_centos_image_url("latest", stream=True, arch=self.arch)
         elif name == 'ubuntu':
             url = testcloud.util.get_ubuntu_image_url("latest", self.arch)
         elif name == 'debian':
@@ -440,7 +439,7 @@ class GuestTestcloud(tmt.GuestSsh):
                 matched_fedora_coreos.group(2), self.arch)
         elif matched_centos[0]:
             url = testcloud.util.get_centos_image_url(
-                matched_centos[0].group(2), self.arch)
+                matched_centos[0].group(2), stream=False, arch=self.arch)
         elif matched_centos[1]:
             url = testcloud.util.get_centos_image_url(
                 matched_centos[1].group(2), stream=True, arch=self.arch)


### PR DESCRIPTION
* fixes #1638
* when asking for CentOS with virtual provision method, the testcloud.util.get_centos_image_url() always results to CentOS Stream
* centos == stream latest, centos-9 == stream 9, centos-8 == stream 8, centos-7 cannot be mapped to a compose

Signed-off-by: Daniel Diblik <ddiblik@redhat.com>