### PR TITLE
Move the hardware specification into a separate page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -266,6 +266,7 @@ areas = {
     '/spec/plans': 'Plans',
     '/spec/stories': 'Stories',
     '/spec/context': 'Context',
+    '/spec/hardware': 'Hardware',
     }
 
 os.makedirs('stories', exist_ok=True)

--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -53,3 +53,4 @@ Level 3: Stories
     spec/plans
     spec/stories
     spec/context
+    spec/hardware

--- a/spec/hardware/arch.fmf
+++ b/spec/hardware/arch.fmf
@@ -1,0 +1,9 @@
+summary:
+    Select the desired architecture
+example:
+  - |
+    # Architecture (any of well-known short architecture names,
+    # for example aarch64, i386, ppc64, ppc64le, s390x, x86_64)
+    arch: x86_64
+link:
+  - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/hardware/boot.fmf
+++ b/spec/hardware/boot.fmf
@@ -1,0 +1,14 @@
+summary:
+    Features related to machine boot
+example:
+  - |
+    # Guest with BIOS
+    boot:
+        method: bios
+
+  - |
+    # Guest with UEFI
+    boot:
+        method: uefi
+link:
+  - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/hardware/cpu.fmf
+++ b/spec/hardware/cpu.fmf
@@ -1,0 +1,28 @@
+summary:
+    Choose system according to the processor features
+example:
+  - |
+    # Processor-related stuff grouped together
+    cpu:
+        # The total number of various CPU components in the system.
+        sockets: 1
+        cores: 4
+        threads: 8
+
+        # Ther number of various CPU components per their parent.
+        cores-per-socket: 4
+        threads-per-core: 2
+
+        # The total number of logical CPUs.
+        processors: 8
+
+        # CPU model name. Usually reported as such by /proc/cpuinfo or lscpu.
+        model-name: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+        # CPU model number.
+        model: 142
+        # CPU family name.
+        family-name: Comet Lake
+        # CPU family number.
+        family: 6
+link:
+  - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/hardware/disk.fmf
+++ b/spec/hardware/disk.fmf
@@ -1,0 +1,15 @@
+summary:
+    Choose the disk size
+example:
+  - |
+    # Disk group used to allow possible future extensions
+    disk:
+      - size: 500 GB
+
+  - |
+    # Multiple disks can be requested as well
+    disk:
+      - size: '>= 2 GB'
+      - size: '>= 20 GB'
+link:
+  - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/hardware/hostname.fmf
+++ b/spec/hardware/hostname.fmf
@@ -1,0 +1,16 @@
+summary:
+    Select specific guest by its hostname
+example:
+  - |
+    # Choose machine with given hostname
+    hostname: kvm-01.lab.us-east-2.company.com
+
+  - |
+    # Hostname matching a regular expression
+    hostname: "~ kvm-01.*"
+
+  - |
+    # Hostname not matching a regular expression
+    hostname: "!~ kvm-01.*"
+link:
+  - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/hardware/main.fmf
+++ b/spec/hardware/main.fmf
@@ -1,0 +1,127 @@
+story:
+    As a tester I want to specify detailed hardware requirements
+    for the guest on which the tests will be executed.
+
+description: |
+    As part of the :ref:`/spec/plans/provision` step it is
+    possible to use the ``hardware`` key to specify additional
+    requirements for the testing environment. This provides a
+    generic and an extensible way to write down essential hardware
+    requirements. For example one consistent way how to specify
+    `at least 2 GB of RAM` for all supported provisioners.
+
+    Introduction
+    ^^^^^^^^^^^^
+
+    Individual requirements are provided as a simple ``key:
+    value`` pairs, for example the minimum amount of
+    :ref:`/spec/hardware/memory`, or the related information is
+    grouped under a common parent, for example ``cores`` or
+    ``model`` under the :ref:`/spec/hardware/cpu` key.
+
+    Search
+    ------
+
+    Regular expressions can be used for selected fields such as
+    the :ref:`/spec/hardware/cpu` model name or
+    :ref:`/spec/hardware/hostname`. Use ``~`` for positive and
+    ``!~`` for negative regular expressions at the beginning of
+    the string. Any leading or trailing white space from the
+    search string is removed.
+
+    Please note, that the full extent of regular expressions might
+    not be supported across all provision implementations. The
+    ``.*`` notation, however, should be supported everywhere::
+
+        # Search for processors using a cpu model name
+        cpu:
+            model-name: "~ AMD"
+
+        # Select guests with a non-matching hostname
+        hostname: "!~ kvm-01.*"
+
+    Operators
+    ---------
+
+    When multiple environment requirements are provided the
+    provision implementation should attempt to satisfy all of
+    them. It is also possible to write this explicitly using the
+    ``and`` operator containing a list of dictionaries with
+    individual requirements. When the ``or`` operator is used, any
+    of the alternatives provided in the list should be
+    sufficient::
+
+        # Optional operators at the start of the value
+        memory: '> 8 GB'
+        memory: '>= 8 GB'
+        memory: '< 8 GB'
+        memory: '<= 8 GB'
+
+        # By default exact value expected, these are equivalent:
+        cpu:
+            model: 37
+        cpu:
+            model: '= 37'
+
+        # Using advanced logic operators
+        and:
+          - cpu:
+                family: 15
+          - or:
+              - cpu:
+                    model: 65
+              - cpu:
+                    model: 67
+              - cpu:
+                    model: 69
+
+    Units
+    -----
+
+    The `pint`__ library is used for processing various units,
+    both decimal and binary prefixes can be used::
+
+        1 MB = 1 000 000 B
+        1 MiB = 1 048 576 B
+
+    __ https://pint.readthedocs.io/
+
+    Notes
+    -----
+
+    The implementation for this common ``hardware`` key is in
+    progress. Features under this section marked as implemented
+    are already supported by the ``artemis`` plugin. Support in
+    other provision plugins is on the way.  Check individual
+    plugin documentation for additional information on the
+    hardware requirement support.
+
+    .. note::
+
+        Some plugins may require additional configuration. For
+        example, Artemis can provision machines with disks of a
+        particular size, but to do so, Artemis maintainers must
+        configure disk sizes for various AWS / OpenStack / Azure
+        flavors. The constraint is supported and implemented, but
+        it will not deliver the required virtual machine when the
+        plugin's backend, the Artemis deployment, isn't configured
+        correctly.
+
+    .. note::
+
+        Some plugins may support requirements that are impossible
+        to satisfy, e.g. the :ref:`/spec/plans/provision/local`
+        plugin can support the ``cpu.family`` requirement, but it
+        is hard-locked to the CPU of one's own machine.
+
+
+example:
+  - |
+    # Use the artemis plugin to provision the latest Fedora on
+    # a guest with the x86_64 architecture and 8 GB of memory
+    provision:
+        how: artemis
+        image: fedora
+        hardware:
+            arch: x86_64
+            memory: 8 GB

--- a/spec/hardware/memory.fmf
+++ b/spec/hardware/memory.fmf
@@ -1,0 +1,11 @@
+summary:
+    Select the desired amount of memory
+example:
+  - |
+    # Require an exact amount of memory
+    memory: 8 GB
+  - |
+    # Pick a guest with at least 8 GB
+    memory: ">= 8 GB"
+link:
+  - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/hardware/network.fmf
+++ b/spec/hardware/network.fmf
@@ -1,0 +1,9 @@
+summary:
+    Select guests with given network devices
+example:
+  - |
+    # Select by vendor and device name
+    network:
+      - type: eth
+        vendor-name: ~ ^Broadcom
+        device-name: ~ ^NetXtreme II BCM

--- a/spec/hardware/tpm.fmf
+++ b/spec/hardware/tpm.fmf
@@ -1,0 +1,9 @@
+summary:
+    Require the `Trusted Platform Module` features
+description:
+    Use the ``version`` key to select the desired ``tpm`` version,
+    its value must be a ``string``.
+example:
+  - |
+    tpm:
+        version: "2.0"

--- a/spec/hardware/virtualization.fmf
+++ b/spec/hardware/virtualization.fmf
@@ -1,0 +1,19 @@
+summary:
+    Features related to virtualization
+description:
+    This section allows to select guests which are virtualized or
+    support virtualization. Use the ``hypervisor`` key to select
+    specific implementation, for example ``hyperv``, ``kvm``,
+    ``nitro``, ``powerkvm``, ``powervm``, ``vmware`` or ``xen``.
+example:
+  - |
+    # Require a guest which supports virtualization
+    virtualization:
+        is-supported: true
+  - |
+    # Ask for a virtualized guest using kvm hypervisor
+    virtualization:
+        is-virtualized: true
+        hypervisor: kvm
+link:
+  - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -2,17 +2,26 @@ summary: Provision a system for testing
 
 description: |
     Describes what environment is needed for testing and how it
-    should be provisioned. Provides a generic and an extensible
-    way to write down essential hardware requirements. For example
-    one consistent way how to specify "at least 2 GB of RAM" for
-    all supported provisioners. Might fail if it cannot provision
-    according to the constraints.
+    should be provisioned. There are several provision plugins
+    supporting multiple ways to provision the environment for
+    testing, for example
+    :ref:`/spec/plans/provision/virtual`,
+    :ref:`/spec/plans/provision/container`,
+    :ref:`/spec/plans/provision/connect` or
+    :ref:`/spec/plans/provision/local`.
+    See individual plugin documentation for details about
+    supported options.
+
+    As part of the provision step it is also possible to specify
+    detailed hardware requirements for the testing environment.
+    See the :ref:`/spec/hardware` specification section for
+    details.
 
 example: |
+    # Provision a local virtual machine with the latest Fedora
     provision:
         how: virtual
         image: fedora
-        memory: 8 GB
 
 /virtual:
     summary: Provision a virtual machine (default)
@@ -104,162 +113,6 @@ example: |
             guest: hostname or ip address
             key: private-key-path
 
-
-/hardware:
-    summary: Hardware specification
-
-    description: |
-        As part of the provision step it is possible to specify
-        additional requirements for the testing environment.
-        Individual requirements are provided as a simple ``key:
-        value`` pairs, for example the minimum amount of
-        ``memory`` or the related information is grouped under a
-        common parent, for example ``cores`` or ``model`` under
-        the ``cpu`` key.
-
-        When multiple environment requirements are provided the
-        provision implementation should attempt to satisfy all of
-        them. It is also possible to write this explicitly using
-        the ``and`` operator containing a list of dictionaries
-        with individual requirements. When the ``or`` operator is
-        used, any of the alternatives provided in the list should
-        be sufficient.
-
-        Regular expressions can be used for selected fields such
-        as the ``model-name``. Please note, that the full extent
-        of regular expressions might not be supported across all
-        provision implementations. The ``.*`` notation, however,
-        should be supported everywhere.
-
-        The `pint`__ library is used for processing various units,
-        both decimal and binary prefixes can be used::
-
-            1 MB = 1 000 000 B
-            1 MiB = 1 048 576 B
-
-        __ https://pint.readthedocs.io/
-
-        .. note::
-
-            Although the hardware specification is not implemented
-            yet we do not expect any significant changes to the
-            currently proposed format.
-
-    example:
-      - |
-        # Here's a full provision step example
-        provision:
-            how: virtual
-            image: fedora-35
-            hardware:
-                arch: x86_64
-                memory: 8 GB
-      - |
-        # Basic key-value format used to specify the memory size
-        memory: 8 GB
-
-      - |
-        # Architecture (any of well-known short architecture names,
-        # for example aarch64, i386, ppc64, ppc64le, s390x, x86_64)
-        arch: x86_64
-
-      - |
-        # Processor-related stuff grouped together
-        cpu:
-            # The total number of various CPU components in the system.
-            sockets: 1
-            cores: 4
-            threads: 8
-
-            # Ther number of various CPU components per their parent.
-            cores-per-socket: 4
-            threads-per-core: 2
-
-            # The total number of logical CPUs.
-            processors: 8
-
-            # CPU model name. Usually reported as such by /proc/cpuinfo or lscpu.
-            model-name: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
-            # CPU model number.
-            model: 142
-            # CPU family name.
-            family-name: Comet Lake
-            # CPU family number.
-            family: 6
-
-      - |
-        # Disk group used to allow possible future extensions
-        disk:
-          - size: 500 GB
-
-        # Multiple disks can be requested as well
-        disk:
-          - size: '>= 2 GB'
-          - size: '>= 20 GB'
-
-      - |
-        # Optional operators at the start of the value
-        memory: '> 8 GB'
-        memory: '>= 8 GB'
-        memory: '< 8 GB'
-        memory: '<= 8 GB'
-
-      - |
-        # By default exact value expected, these are equivalent:
-        cpu:
-            model: 37
-        cpu:
-            model: '= 37'
-
-      - |
-        # Enable regular expression search
-        cpu:
-            model-name: =~ .*AMD.*
-
-      - |
-        # Network interface
-        network:
-          - type: eth
-            vendor-name: =~ Broadcom.*
-            device-name: =~ NetXtreme II BCM.*
-
-      - |
-        # Features related to virtualization
-        virtualization:
-            is-virtualized: true
-            is-supported: false
-            hypervisor: kvm
-
-      - |
-        # Features related to machine boot modes
-        boot:
-            method: bios
-
-        boot:
-            method: uefi
-
-      - |
-        # Choose machine with given hostname
-        hostname: kvm-01.lab.us-east-2.company.com
-
-        # Hostname matching a regular expression
-        hostname: "~ kvm-01.*"
-
-        # Hostname not matching a regular expression
-        hostname: "!~ kvm-01.*"
-
-      - |
-        # Using advanced logic operators
-        and:
-          - cpu:
-                family: 15
-          - or:
-              - cpu:
-                    model: 65
-              - cpu:
-                    model: 67
-              - cpu:
-                    model: 69
 
 /multihost:
     summary: Multihost testing specification

--- a/tmt/schemas/provision/hardware.yaml
+++ b/tmt/schemas/provision/hardware.yaml
@@ -132,6 +132,17 @@ definitions:
     items:
       "$ref": "#/definitions/network"
 
+  # HW requirements: `tpm` block
+  tpm:
+    type: object
+
+    properties:
+      version:
+        type: string
+
+    additionalProperties: false
+    minProperties: 1
+
   # HW requirements: `virtualization` block
   virtualization:
     type: object
@@ -179,6 +190,9 @@ definitions:
       network:
         "$ref": "#/definitions/networks"
 
+      tpm:
+        "$ref": "#/definitions/tpm"
+
       virtualization:
         "$ref": "#/definitions/virtualization"
 
@@ -200,6 +214,7 @@ definitions:
             - "$ref": "#/definitions/cpu"
             - "$ref": "#/definitions/disks"
             - "$ref": "#/definitions/networks"
+            - "$ref": "#/definitions/tpm"
             - "$ref": "#/definitions/virtualization"
             - "$ref": "#/definitions/block"
             - "$ref": "#/definitions/and"
@@ -219,6 +234,7 @@ definitions:
             - "$ref": "#/definitions/cpu"
             - "$ref": "#/definitions/disks"
             - "$ref": "#/definitions/networks"
+            - "$ref": "#/definitions/tpm"
             - "$ref": "#/definitions/virtualization"
             - "$ref": "#/definitions/block"
             - "$ref": "#/definitions/and"
@@ -233,6 +249,7 @@ definitions:
       - "$ref": "#/definitions/cpu"
       - "$ref": "#/definitions/disks"
       - "$ref": "#/definitions/networks"
+      - "$ref": "#/definitions/tpm"
       - "$ref": "#/definitions/virtualization"
       - "$ref": "#/definitions/block"
       - "$ref": "#/definitions/and"


### PR DESCRIPTION
The number of supported `hardware` keys has grown, it's becoming hard to track what has been already implemented. Let's create a dedicated page for the hardware requirements and create stories for each key to allow direct docs links to individual features.