### PR TITLE
Add `compatible` as a new hardware specification key

### DIFF
--- a/spec/hardware/compatible.fmf
+++ b/spec/hardware/compatible.fmf
@@ -1,0 +1,14 @@
+summary:
+    Select guest based on given compatibility
+description:
+    Pick only guests compatible with given operating system
+    distribution. See the context :ref:`/spec/context/dimension`
+    definitions for the list of supported values of the ``distro``
+    key. Must be a list of strings.
+example:
+  - |
+    # Select a guest compatible with both rhel-8 and rhel-9
+    compatible:
+        distro:
+          - rhel-8
+          - rhel-9

--- a/tmt/schemas/provision/hardware.yaml
+++ b/tmt/schemas/provision/hardware.yaml
@@ -28,6 +28,19 @@ definitions:
     # empty `boot`.
     minProperties: 1
 
+  # HW requirements: `compatible` block
+  compatible:
+    type: object
+
+    properties:
+      distro:
+        type: array
+        items:
+          type: string
+
+    additionalProperties: false
+    minProperties: 1
+
   # HW requirements: `cpu` block
   cpu:
     type: object
@@ -175,6 +188,9 @@ definitions:
       boot:
         "$ref": "#/definitions/boot"
 
+      compatible:
+        "$ref": "#/definitions/compatible"
+
       cpu:
         "$ref": "#/definitions/cpu"
 
@@ -211,6 +227,7 @@ definitions:
         items:
           anyOf:
             - "$ref": "#/definitions/boot"
+            - "$ref": "#/definitions/compatible"
             - "$ref": "#/definitions/cpu"
             - "$ref": "#/definitions/disks"
             - "$ref": "#/definitions/networks"
@@ -231,6 +248,7 @@ definitions:
         items:
           anyOf:
             - "$ref": "#/definitions/boot"
+            - "$ref": "#/definitions/compatible"
             - "$ref": "#/definitions/cpu"
             - "$ref": "#/definitions/disks"
             - "$ref": "#/definitions/networks"
@@ -246,6 +264,7 @@ definitions:
   hardware:
     anyOf:
       - "$ref": "#/definitions/boot"
+      - "$ref": "#/definitions/compatible"
       - "$ref": "#/definitions/cpu"
       - "$ref": "#/definitions/disks"
       - "$ref": "#/definitions/networks"


### PR DESCRIPTION
The new key allows to select guests by feature compatibility. As for now we're only adding ``distro`` for which there is a clear use case, but let's keep the field open for possible future extensions.

Fix #1582.