### PR TITLE
Skip missing debuginfo packages in `recommend`

### DIFF
--- a/tests/prepare/recommend/data/plan.fmf
+++ b/tests/prepare/recommend/data/plan.fmf
@@ -10,6 +10,11 @@ execute:
     discover+:
         test: mixed
 
+/debuginfo:
+    summary: One debuginfo package found, one not available
+    discover+:
+        test: debuginfo
+
 /weird:
     summary: No recommended package found
     discover+:

--- a/tests/prepare/recommend/data/test.fmf
+++ b/tests/prepare/recommend/data/test.fmf
@@ -2,6 +2,10 @@
     test: rpm -q tree
     recommend: [tree, forest]
 
+/debuginfo:
+    test: rpm -q grep-debuginfo
+    recommend: [grep-debuginfo, forest-debuginfo]
+
 /weird:
     test: /bin/true
     recommend: weird-package

--- a/tests/prepare/recommend/test.sh
+++ b/tests/prepare/recommend/test.sh
@@ -8,17 +8,29 @@ rlJournalStart
 
     for method in ${METHODS:-container}; do
         tmt="tmt run --all --remove provision --how $method"
+        basic="plan --name 'mixed|weird'"
+        debuginfo="plan --name debuginfo"
 
         # Verify against the default provision image
         rlPhaseStartTest "Test the default image ($method)"
-            rlRun "$tmt"
+            rlRun "$tmt $basic"
         rlPhaseEnd
 
         # Check CentOS images for container provision
         if [[ "$method" == "container" ]]; then
             for image in centos:7 centos:stream8; do
                 rlPhaseStartTest "Test $image ($method)"
-                    rlRun "$tmt --image $image"
+                    rlRun "$tmt --image $image $basic"
+                rlPhaseEnd
+            done
+        fi
+
+        # Check debuginfo install (only for supported distros)
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1964505
+        if [[ "$method" == "container" ]]; then
+            for image in fedora centos:7; do
+                rlPhaseStartTest "Test $image ($method) [debuginfo]"
+                    rlRun "$tmt --image $image $debuginfo"
                 rlPhaseEnd
             done
         fi
@@ -26,7 +38,7 @@ rlJournalStart
         # Add one extra CoreOS run for virtual provision
         if [[ "$method" == "virtual" ]]; then
             rlPhaseStartTest "Test fedora-coreos ($method)"
-                rlRun "$tmt --image fedora-coreos"
+                rlRun "$tmt --image fedora-coreos $basic"
             rlPhaseEnd
         fi
     done

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -254,7 +254,10 @@ class InstallDnf(InstallBase):
         packages = self.list_packages(self.debuginfo_packages, title="debuginfo")
         # Make sure debuginfo-install is present on the target system
         self.guest.execute(f"{self.command} install -y /usr/bin/debuginfo-install")
-        self.guest.execute(f"debuginfo-install -y {packages}")
+        # FIXME: cast() - https://github.com/teemtee/tmt/issues/1372
+        parent = cast(tmt.steps.prepare.PreparePlugin, self.parent)
+        skip = "--skip-broken " if parent.get("missing") == "skip" else ""
+        self.guest.execute(f"debuginfo-install -y {skip}{packages}")
 
 
 class InstallYum(InstallDnf):


### PR DESCRIPTION
Use `debuginfo-install --skip-broken` for debuginfo packages requested under the `recommend` key. Add corresponding test coverage.

Fix #1113.