### PR TITLE
Protect args in rsync call

### DIFF
--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -168,7 +168,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
         guest.push(
             source=test_wrapper_filepath,
             destination=test_wrapper_filepath,
-            options=["-p", "--chmod=755"])
+            options=["-s", "-p", "--chmod=755"])
 
         # Prepare the actual remote command
         remote_command = f'./{TEST_WRAPPER_FILENAME}'

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -31,10 +31,10 @@ RECONNECT_WAIT_TICK_INCREASE = 1.0
 
 # Default rsync options
 DEFAULT_RSYNC_OPTIONS = [
-    "-R", "-r", "-z", "--links", "--safe-links", "--delete"]
+    "-s", "-R", "-r", "-z", "--links", "--safe-links", "--delete"]
 
-DEFAULT_RSYNC_PUSH_OPTIONS = ["-R", "-r", "-z", "--links", "--safe-links", "--delete"]
-DEFAULT_RSYNC_PULL_OPTIONS = ["-R", "-r", "-z", "--links", "--safe-links", "--protect-args"]
+DEFAULT_RSYNC_PUSH_OPTIONS = ["-s", "-R", "-r", "-z", "--links", "--safe-links", "--delete"]
+DEFAULT_RSYNC_PULL_OPTIONS = ["-s", "-R", "-r", "-z", "--links", "--safe-links", "--protect-args"]
 
 
 class CheckRsyncOutcome(enum.Enum):


### PR DESCRIPTION
Otherwise on older rsync tmt-wrapper isn't synced to the SUT