### PR TITLE
Change common class constructors to use keyword arguments only

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: tmt-lint
     name: tmt lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(\".\").root)')/.fmf/version && tmt lint --source $@" PAD
+    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(path=\".\").root)')/.fmf/version && tmt lint --source $@" PAD
     files: '.*\.fmf$'
     verbose: true
     pass_filenames: true
@@ -9,7 +9,7 @@
 
 -   id: tmt-tests-lint
     name: tmt tests lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(\".\").root)')/.fmf/version && tmt tests lint --source $@" PAD
+    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(path=\".\").root)')/.fmf/version && tmt tests lint --source $@" PAD
     files: '.*\.fmf$'
     verbose: true
     pass_filenames: true
@@ -18,7 +18,7 @@
 
 -   id: tmt-plans-lint
     name: tmt plans lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(\".\").root)')/.fmf/version && tmt plans lint --source $@" PAD
+    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(path=\".\").root)')/.fmf/version && tmt plans lint --source $@" PAD
     files: '.*\.fmf$'
     verbose: true
     pass_filenames: true
@@ -27,7 +27,7 @@
 
 -   id: tmt-stories-lint
     name: tmt stories lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(\".\").root)')/.fmf/version && tmt stories lint --source $@" PAD
+    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(path=\".\").root)')/.fmf/version && tmt stories lint --source $@" PAD
     files: '.*\.fmf$'
     verbose: true
     pass_filenames: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -254,7 +254,7 @@ MOCK_MODULES = ['testcloud', 'testcloud.image', 'testcloud.instance']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # Generate stories
-tree = tmt.Tree('.')
+tree = tmt.Tree(path='.')
 
 areas = {
     '/stories/docs': 'Documentation',

--- a/tests/core/path/test.py
+++ b/tests/core/path/test.py
@@ -1,7 +1,7 @@
 
 import tmt
 
-tree = tmt.Tree('data')
+tree = tmt.Tree(path='data')
 
 
 def test_root():

--- a/tests/integration/test_nitrate.py
+++ b/tests/integration/test_nitrate.py
@@ -325,7 +325,7 @@ extra-task: /tmt/integration
         self.assertEqual(self.runner_output.exit_code, 0)
 
         tree_f36_intel = tmt.Tree(
-            '.',
+            path='.',
             context={
                 'distro': ['fedora-36'],
                 'arch': ['x86_64']})
@@ -338,7 +338,7 @@ extra-task: /tmt/integration
         self.assertEquals(test.node.get('extra-nitrate'), 'TC#0545993')
 
         tree_f35_intel = tmt.Tree(
-            '.',
+            path='.',
             context={
                 'distro': ['fedora-35'],
                 'arch': ['x86_64']})

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -83,31 +83,32 @@ def test_link():
     assert Links().get() == []
 
     # Single string (default relation)
-    assert Links('/fmf/id').get() == [Link(relation='relates', target='/fmf/id')]
+    assert Links(data='/fmf/id').get() == [Link(relation='relates', target='/fmf/id')]
     # Multiple strings (default relation)
-    assert Links(['one', 'two']).get() == [
+    assert Links(data=['one', 'two']).get() == [
         Link(relation='relates', target='one'), Link(relation='relates', target='two')]
     # Multiple string mixed relation
-    assert Links(['implicit', dict(duplicates='explicit')]).get() == [
+    assert Links(data=['implicit', dict(duplicates='explicit')]).get() == [
         Link(relation='relates', target='implicit'),
         Link(relation='duplicates', target='explicit')]
     # Multiple strings (explicit relation)
-    assert Links([dict(parent='mom'), dict(child='son')]).get() == [
+    assert Links(data=[dict(parent='mom'), dict(child='son')]).get() == [
         Link(relation='parent', target='mom'), Link(relation='child', target='son')]
 
     # Single dictionary (default relation)
-    assert Links(dict(name='foo')).get() == [Link(relation='relates', target=FmfId(name='foo'))]
+    assert Links(data=dict(name='foo')).get() == [
+        Link(relation='relates', target=FmfId(name='foo'))]
     # Single dictionary (explicit relation)
-    assert Links(dict(verifies='foo')).get() == [Link(relation='verifies', target='foo')]
+    assert Links(data=dict(verifies='foo')).get() == [Link(relation='verifies', target='foo')]
     # Multiple dictionaries
     family = [dict(parent='mom', note='foo'), dict(child='son')]
-    assert Links(family).get() == [
+    assert Links(data=family).get() == [
         Link(relation='parent', target='mom', note='foo'), Link(relation='child', target='son')
         ]
 
     # Selected relations
-    assert Links(family).get('parent') == [Link(relation='parent', target='mom', note='foo')]
-    assert Links(family).get('child') == [Link(relation='child', target='son')]
+    assert Links(data=family).get('parent') == [Link(relation='parent', target='mom', note='foo')]
+    assert Links(data=family).get('child') == [Link(relation='child', target='son')]
 
     # Full fmf id
     fmf_id = tmt.utils.yaml_to_dict("""
@@ -116,7 +117,7 @@ def test_link():
             name: /stories/select/filter/regexp
         note: Need to get the regexp filter working first.
         """)
-    link = Links(fmf_id)
+    link = Links(data=fmf_id)
     assert link.get() == [
         Link(
             relation='blocked-by',
@@ -127,14 +128,14 @@ def test_link():
 
     # Invalid links and relations
     with pytest.raises(SpecificationError, match='Invalid link'):
-        Links(123)
+        Links(data=123)
     with pytest.raises(SpecificationError, match='Multiple relations'):
-        Links(dict(verifies='one', blocks='another'))
+        Links(data=dict(verifies='one', blocks='another'))
     with pytest.raises(SpecificationError, match='Invalid link relation'):
-        Links(dict(depends='other'))
+        Links(data=dict(depends='other'))
 
     # Searching for links
-    links = Links([dict(parent='mom', note='foo'), dict(child='son', note='bar')])
+    links = Links(data=[dict(parent='mom', note='foo'), dict(child='son', note='bar')])
     assert links.has_link(LinkNeedle())
     assert links.has_link(LinkNeedle(relation='[a-z]+'))
     assert links.has_link(LinkNeedle(relation='en'))

--- a/tests/unit/test_beakerlib.py
+++ b/tests/unit/test_beakerlib.py
@@ -12,9 +12,9 @@ def test_library():
     """ Fetch a beakerlib library with/without providing a parent """
     parent = tmt.utils.Common(workdir=True)
     library_with_parent = tmt.beakerlib.Library(
-        tmt.base.RequireSimple('library(openssl/certgen)'), parent=parent)
+        identifier=tmt.base.RequireSimple('library(openssl/certgen)'), parent=parent)
     library_without_parent = tmt.beakerlib.Library(
-        tmt.base.RequireSimple('library(openssl/certgen)'))
+        identifier=tmt.base.RequireSimple('library(openssl/certgen)'))
 
     for library in [library_with_parent, library_without_parent]:
         assert library.format == 'rpm'
@@ -33,7 +33,7 @@ def test_library():
         ])
 def test_library_from_fmf(url, name, default_branch):
     """ Fetch beakerlib library referenced by fmf identifier """
-    library = tmt.beakerlib.Library(tmt.base.RequireFmfId(url=url, name=name))
+    library = tmt.beakerlib.Library(identifier=tmt.base.RequireFmfId(url=url, name=name))
     assert library.format == 'fmf'
     assert library.ref == default_branch
     assert library.url == url
@@ -49,7 +49,7 @@ def test_invalid_url_conflict():
     parent = tmt.utils.Common(workdir=True)
     # Fetch to cache 'tmt' repo
     tmt.beakerlib.Library(
-        tmt.base.RequireFmfId(
+        identifier=tmt.base.RequireFmfId(
             url='https://github.com/teemtee/tmt',
             name='/',
             path='/tests/libraries/local/data'),
@@ -58,7 +58,7 @@ def test_invalid_url_conflict():
     # however upstream (gh.com/beakerlib/tmt) repo does not exist,
     # so there can't be "already fetched" error
     with pytest.raises(tmt.beakerlib.LibraryError):
-        tmt.beakerlib.Library('library(tmt/foo)', parent=parent)
+        tmt.beakerlib.Library(identifier='library(tmt/foo)', parent=parent)
     shutil.rmtree(parent.workdir)
 
 

--- a/tests/unit/test_report_junit.py
+++ b/tests/unit/test_report_junit.py
@@ -129,8 +129,8 @@ class TestStateMapping:
         results.extend(
             [
                 Result(
-                    ResultData(result=ResultOutcome.PASS),
-                    "/pass")
+                    data=ResultData(result=ResultOutcome.PASS),
+                    name="/pass")
                 ]
             )
 
@@ -149,8 +149,8 @@ class TestStateMapping:
         results.extend(
             [
                 Result(
-                    ResultData(result=ResultOutcome.INFO),
-                    "/info")
+                    data=ResultData(result=ResultOutcome.INFO),
+                    name="/info")
                 ]
             )
         report.go()
@@ -170,8 +170,8 @@ class TestStateMapping:
         results.extend(
             [
                 Result(
-                    ResultData(result=ResultOutcome.WARN),
-                    "/warn")
+                    data=ResultData(result=ResultOutcome.WARN),
+                    name="/warn")
                 ]
             )
         report.go()
@@ -191,8 +191,8 @@ class TestStateMapping:
         results.extend(
             [
                 Result(
-                    ResultData(result=ResultOutcome.ERROR),
-                    "/error")
+                    data=ResultData(result=ResultOutcome.ERROR),
+                    name="/error")
                 ]
             )
         report.go()
@@ -212,8 +212,8 @@ class TestStateMapping:
         results.extend(
             [
                 Result(
-                    ResultData(result=ResultOutcome.FAIL),
-                    "/fail")
+                    data=ResultData(result=ResultOutcome.FAIL),
+                    name="/fail")
                 ]
             )
         report.go()

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -27,7 +27,7 @@ def _iter_nodes(tree, keys):
 
 
 def _iter_trees():
-    yield tmt.Tree(ROOTDIR)
+    yield tmt.Tree(path=ROOTDIR)
 
     # Ad hoc construction, but here me out: there are small, custom-tailored fmf trees
     # to serve various tests. These are invisible to the top-level tree. Lucky us though,
@@ -41,7 +41,7 @@ def _iter_trees():
     if False:
         for dirpath, dirnames, _ in os.walk(os.path.join(ROOTDIR, 'tests')):
             if '.fmf' in dirnames:
-                yield tmt.Tree(dirpath)
+                yield tmt.Tree(path=dirpath)
 
 
 def _iter_tests_in_tree(tree):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -623,7 +623,7 @@ class Test_validate_git_status:
         run(
             'git push'.split(),
             cwd=mine)
-        test = tmt.Tree(str(fmf_root)).tests()[0]
+        test = tmt.Tree(path=str(fmf_root)).tests()[0]
         validation = validate_git_status(test)
         assert validation == (True, '')
 
@@ -638,7 +638,7 @@ class Test_validate_git_status:
             'git commit -m initial_commit'.split(),
             cwd=tmpdir)
 
-        test = tmt.Tree(str(tmpdir)).tests()[0]
+        test = tmt.Tree(path=str(tmpdir)).tests()[0]
         val, msg = validate_git_status(test)
         assert not val
         assert "Failed to get remote branch" in msg
@@ -654,7 +654,7 @@ class Test_validate_git_status:
             'git commit -m missing_fmf_root'.split(),
             cwd=local_git_repo)
 
-        test = tmt.Tree(str(local_git_repo)).tests()[0]
+        test = tmt.Tree(path=str(local_git_repo)).tests()[0]
         validate = validate_git_status(test)
         assert validate == (False, 'Uncommitted changes in .fmf/version')
 
@@ -669,7 +669,7 @@ class Test_validate_git_status:
             'git commit -m main.fmf'.split(),
             cwd=local_git_repo)
 
-        test = tmt.Tree(str(local_git_repo)).tests()[0]
+        test = tmt.Tree(path=str(local_git_repo)).tests()[0]
         validate = validate_git_status(test)
         assert validate == (False, 'Uncommitted changes in main.fmf')
 
@@ -701,7 +701,7 @@ class Test_validate_git_status:
         # Change README but since it is not part of metadata we do not check it
         mine.join("README").write('changed')
 
-        test = tmt.Tree(str(mine_fmf_root)).tests()[0]
+        test = tmt.Tree(path=str(mine_fmf_root)).tests()[0]
         validation_result = validate_git_status(test)
 
         assert validation_result == (
@@ -723,7 +723,7 @@ class Test_validate_git_status:
             'git commit -m changes'.split(),
             cwd=mine)
 
-        test = tmt.Tree(str(fmf_root)).tests()[0]
+        test = tmt.Tree(path=str(fmf_root)).tests()[0]
         validation_result = validate_git_status(test)
 
         assert validation_result == (

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1921,6 +1921,7 @@ class Tree(tmt.utils.Common):
     """ Test Metadata Tree """
 
     def __init__(self,
+                 *,
                  path: str = '.',
                  tree: Optional[fmf.Tree] = None,
                  context: Optional[tmt.utils.FmfContextType] = None) -> None:
@@ -2185,7 +2186,7 @@ class Tree(tmt.utils.Common):
         tree: Optional[Tree] = None
 
         try:
-            tree = Tree(path)
+            tree = Tree(path=path)
             # Are we creating a new tree under the existing one?
             assert tree is not None  # narrow type
             if path == tree.root:
@@ -2206,7 +2207,7 @@ class Tree(tmt.utils.Common):
             else:
                 try:
                     fmf.Tree.init(path)
-                    tree = Tree(path)
+                    tree = Tree(path=path)
                     assert tree.root is not None  # narrow type
                     path = tree.root
                 except fmf.utils.GeneralError as error:
@@ -2251,6 +2252,7 @@ class Run(tmt.utils.Common):
     tree: Optional[Tree]
 
     def __init__(self,
+                 *,
                  id_: Optional[str] = None,
                  tree: Optional[Tree] = None,
                  context: Optional[click.Context] = None) -> None:
@@ -2289,7 +2291,7 @@ class Run(tmt.utils.Common):
         """ Save metadata tree, handle the default plan """
         default_plan = tmt.utils.yaml_to_dict(tmt.templates.DEFAULT_PLAN)
         try:
-            self.tree = tree if tree else tmt.Tree('.')
+            self.tree = tree if tree else tmt.Tree(path='.')
             self.debug(f"Using tree '{self.tree.root}'.")
             # Clear the tree and insert default plan if requested
             if Plan._opt("default"):
@@ -2392,7 +2394,7 @@ class Run(tmt.utils.Common):
         # create a new Tree from the root in run.yaml
         if self._workdir and not self.opt('root'):
             if data.root:
-                self._save_tree(tmt.Tree(data.root))
+                self._save_tree(tmt.Tree(path=data.root))
             else:
                 # The run was used without any metadata, default plan
                 # was used, load it
@@ -2716,6 +2718,7 @@ class Clean(tmt.utils.Common):
     """ A class for cleaning up workdirs, guests or images """
 
     def __init__(self,
+                 *,
                  parent: Optional[tmt.utils.Common] = None,
                  name: Optional[str] = None,
                  workdir: tmt.utils.WorkdirArgumentType = None,
@@ -2728,7 +2731,7 @@ class Clean(tmt.utils.Common):
         # Set the option to skip to initialize the work tree
         if context:
             context.params[tmt.utils.PLAN_SKIP_WORKTREE_INIT] = True
-        super().__init__(parent, name, workdir, context)
+        super().__init__(parent=parent, name=name, workdir=workdir, context=context)
 
     def images(self) -> bool:
         """ Clean images of provision plugins """
@@ -2798,7 +2801,7 @@ class Clean(tmt.utils.Common):
         successful = True
         assert self._context_object is not None  # narrow type
         for abs_path in tmt.utils.generate_runs(root_path, id_):
-            run = Run(abs_path, self._context_object.tree, self._context)
+            run = Run(id_=abs_path, tree=self._context_object.tree, context=self._context)
             if not self._stop_running_guests(run):
                 successful = False
         return successful
@@ -3030,7 +3033,7 @@ class Links(tmt.utils.SpecBasedContainer):
 
     _links: List[Link]
 
-    def __init__(self, data: Optional[_RawLinks] = None):
+    def __init__(self, *, data: Optional[_RawLinks] = None):
         """ Create a collection from raw link data """
 
         # TODO: this should not happen with mandatory validation

--- a/tmt/beakerlib.py
+++ b/tmt/beakerlib.py
@@ -74,6 +74,7 @@ class Library:
 
     def __init__(
             self,
+            *,
             identifier: BeakerlibIdentifierType,
             parent: Optional[tmt.utils.Common] = None
             ) -> None:
@@ -332,7 +333,7 @@ def dependencies(
     for dependency in filter(already_fetched, to_fetch):
         # Library require/recommend
         try:
-            library = Library(dependency, parent=parent)
+            library = Library(identifier=dependency, parent=parent)
             gathered_libraries.append(library)
             imported_lib_ids.append(library.identifier)
             # Recursively check for possible dependent libraries

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -132,7 +132,7 @@ def main(
     tmt.utils.Common._save_context(click_contex)
 
     # Initialize metadata tree (from given path or current directory)
-    tree = tmt.Tree(root or os.curdir)
+    tree = tmt.Tree(path=root or os.curdir)
 
     # TODO: context object details need checks
     click_contex.obj = ContextObject(
@@ -198,7 +198,7 @@ def main(
 def run(context: click.core.Context, id_: str, **kwargs: Any) -> None:
     """ Run test steps. """
     # Initialize
-    run = tmt.Run(id_, context.obj.tree, context=context)
+    run = tmt.Run(id_=id_, tree=context.obj.tree, context=context)
     context.obj.run = run
 
 

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -96,6 +96,7 @@ class Result(tmt.utils.SerializableContainer):
 
     def __init__(
             self,
+            *,
             data: ResultData,
             name: Optional[str] = None,
             test: Optional['tmt.base.Test'] = None) -> None:
@@ -215,7 +216,7 @@ class Result(tmt.utils.SerializableContainer):
 
         name = serialized.pop('name')
         serialized['result'] = ResultOutcome.from_spec(serialized['result'])
-        return cls(ResultData(**serialized), name=name)
+        return cls(data=ResultData(**serialized), name=name)
 
     @staticmethod
     def failures(log: Optional[str], msg_type: str = 'FAIL') -> str:

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -44,10 +44,10 @@ class Phase(tmt.utils.Common):
 
     def __init__(
             self,
+            *,
             order: int = tmt.utils.DEFAULT_PLUGIN_ORDER,
-            *args: Any,
             **kwargs: Any):
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         self.order: int = order
 
     def enabled_on_guest(self, guest: 'Guest') -> bool:
@@ -198,6 +198,7 @@ class Step(tmt.utils.Common):
 
     def __init__(
             self,
+            *,
             plan: 'Plan',
             data: Optional[RawStepDataArgument] = None,
             name: Optional[str] = None,
@@ -608,6 +609,7 @@ class BasePlugin(Phase):
 
     def __init__(
             self,
+            *,
             step: Step,
             data: StepData,
             workdir: tmt.utils.WorkdirArgumentType = None) -> None:
@@ -717,7 +719,7 @@ class BasePlugin(Phase):
                     f'plugin {plugin_class.__name__} ' \
                     f'expects {plugin_data_class.__name__}'
 
-                plugin = plugin_class(step, data)
+                plugin = plugin_class(step=step, data=data)
                 assert isinstance(plugin, BasePlugin)
                 return plugin
 
@@ -1006,7 +1008,7 @@ class Reboot(Action):
     # True if reboot enabled
     _enabled: bool = False
 
-    def __init__(self, step: Step, order: int) -> None:
+    def __init__(self, *, step: Step, order: int) -> None:
         """ Initialize relations, store the reboot order """
         super().__init__(parent=step, name='reboot', order=order)
 
@@ -1036,7 +1038,7 @@ class Reboot(Action):
         """ Return list of reboot instances for given step """
         if not Reboot._enabled:
             return []
-        return [Reboot(step, phase) for phase in cls.phases(step)]
+        return [Reboot(step=step, order=phase) for phase in cls.phases(step)]
 
     def go(self) -> None:
         """ Reboot the guest(s) """
@@ -1058,7 +1060,7 @@ class Login(Action):
     # True if interactive login enabled
     _enabled: bool = False
 
-    def __init__(self, step: Step, order: int):
+    def __init__(self, *, step: Step, order: int):
         """ Initialize relations, store the login order """
         super().__init__(parent=step, name='login', order=order)
 
@@ -1123,7 +1125,7 @@ class Login(Action):
         """ Return list of login instances for given step """
         if not Login._enabled:
             return []
-        return [Login(step, phase) for phase in cls.phases(step)]
+        return [Login(step=step, order=phase) for phase in cls.phases(step)]
 
     def go(self) -> None:
         """ Login to the guest(s) """

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -127,7 +127,7 @@ class Discover(tmt.steps.Step):
 
     _plugin_base_class = DiscoverPlugin
 
-    def __init__(self, plan: 'tmt.base.Plan', data: tmt.steps.RawStepDataArgument):
+    def __init__(self, *, plan: 'tmt.base.Plan', data: tmt.steps.RawStepDataArgument):
         """ Store supported attributes, check for sanity """
         super().__init__(plan=plan, data=data)
 

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -144,7 +144,7 @@ class TestDescription(
         """ Convert from a serialized form loaded from a file """
 
         obj = super().from_serialized(serialized)
-        obj.link = tmt.base.Links(serialized['link'])
+        obj.link = tmt.base.Links(data=serialized['link'])
         obj.require = [
             tmt.base.RequireSimple.from_spec(require)
             if isinstance(require, str) else tmt.base.RequireFmfId.from_spec(require)

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -126,12 +126,13 @@ class ExecutePlugin(tmt.steps.Plugin):
 
     def __init__(
             self,
+            *,
             step: Step,
             data: StepData,
             workdir: tmt.utils.WorkdirArgumentType = None) -> None:
-        super().__init__(step, data, workdir)
+        super().__init__(step=step, data=data, workdir=workdir)
         if tmt.steps.Login._opt('test'):
-            self._login_after_test = tmt.steps.Login(self.step, 90)
+            self._login_after_test = tmt.steps.Login(step=self.step, order=90)
 
     @classmethod
     def base_command(
@@ -251,7 +252,7 @@ class ExecutePlugin(tmt.steps.Plugin):
 
         data = ResultData(result=result, log=[self.data_path(test, TEST_OUTPUT_FILENAME)],
                           note=note, duration=test.real_duration)
-        return [tmt.Result(data, test=test)]
+        return [tmt.Result(data=data, test=test)]
 
     def check_beakerlib(self, test: "tmt.Test") -> List["tmt.Result"]:
         """ Check result of a beakerlib test """
@@ -267,7 +268,7 @@ class ExecutePlugin(tmt.steps.Plugin):
         except tmt.utils.FileError:
             self.debug(f"Unable to read '{beakerlib_results_file}'.", level=3)
             data.note = 'beakerlib: TestResults FileError'
-            return [tmt.Result(data, test=test)]
+            return [tmt.Result(data=data, test=test)]
 
         search_result = re.search('TESTRESULT_RESULT_STRING=(.*)', results)
         # States are: started, incomplete and complete
@@ -279,7 +280,7 @@ class ExecutePlugin(tmt.steps.Plugin):
                 f"No result or state found in '{beakerlib_results_file}'.",
                 level=3)
             data.note = 'beakerlib: Result/State missing'
-            return [tmt.Result(data, test=test)]
+            return [tmt.Result(data=data, test=test)]
 
         result = search_result.group(1)
         state = search_state.group(1)
@@ -296,7 +297,7 @@ class ExecutePlugin(tmt.steps.Plugin):
         # Finally we have a valid result
         else:
             data.result = ResultOutcome.from_spec(result.lower())
-        return [tmt.Result(data, test=test)]
+        return [tmt.Result(data=data, test=test)]
 
     def check_result_file(self, test: "tmt.Test") -> List["tmt.Result"]:
         """
@@ -338,7 +339,7 @@ class ExecutePlugin(tmt.steps.Plugin):
             else:
                 data.result = ResultOutcome.ERROR
                 data.note = f"invalid test result '{result}' in result file"
-        return [tmt.Result(data, test=test)]
+        return [tmt.Result(data=data, test=test)]
 
     def check_custom_results(self, test: "tmt.Test") -> List["tmt.Result"]:
         """
@@ -414,7 +415,7 @@ class Execute(tmt.steps.Step):
 
     _plugin_base_class = ExecutePlugin
 
-    def __init__(self, plan: "tmt.Plan", data: tmt.steps.RawStepDataArgument) -> None:
+    def __init__(self, *, plan: "tmt.Plan", data: tmt.steps.RawStepDataArgument) -> None:
         """ Initialize execute step data """
         super().__init__(plan=plan, data=data)
         # List of Result() objects representing test results

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -45,8 +45,8 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
 
     _data_class = ExecuteInternalData
 
-    def __init__(self, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
         self._previous_progress_message = ""
         self.scripts = SCRIPTS
 

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -110,8 +110,8 @@ class ExecuteUpgrade(ExecuteInternal):
     # FIXME: ignore[assignment]: https://github.com/teemtee/tmt/issues/1540
     _data_class = ExecuteUpgradeData  # type: ignore[assignment]
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
         self._discover_upgrade: Optional[DiscoverFmf] = None
 
     @classmethod
@@ -177,7 +177,7 @@ class ExecuteUpgrade(ExecuteInternal):
 
     def _get_plan(self, upgrades_repo: str) -> tmt.base.Plan:
         """ Get plan based on upgrade path """
-        tree = tmt.base.Tree(upgrades_repo)
+        tree = tmt.base.Tree(path=upgrades_repo)
         try:
             # We do not want to consider plan -n provided on the command line
             # in the remote repo for finding upgrade path.
@@ -207,7 +207,7 @@ class ExecuteUpgrade(ExecuteInternal):
                 }
             )
 
-        self._discover_upgrade = DiscoverFmf(self.step, data)
+        self._discover_upgrade = DiscoverFmf(step=self.step, data=data)
         self._run_discover_upgrade()
 
     def _run_discover_upgrade(self) -> None:

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -87,7 +87,7 @@ class Prepare(tmt.steps.Step):
 
     _plugin_base_class = PreparePlugin
 
-    def __init__(self, plan: 'Plan', data: tmt.steps.RawStepDataArgument) -> None:
+    def __init__(self, *, plan: 'Plan', data: tmt.steps.RawStepDataArgument) -> None:
         """ Initialize prepare step data """
         super().__init__(plan=plan, data=data)
         self.preparations_applied = 0

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -32,7 +32,7 @@ class InstallBase(tmt.utils.Common):
     copr_plugin: Optional[str] = None
     command: Optional[str] = None
 
-    def __init__(self, parent: tmt.steps.prepare.PreparePlugin, guest: Guest) -> None:
+    def __init__(self, *, parent: tmt.steps.prepare.PreparePlugin, guest: Guest) -> None:
         """ Initialize installation data """
         super().__init__(parent=parent, relative_indent=0)
         self.guest = guest

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -91,11 +91,12 @@ class Guest(tmt.utils.Common):
         return list(self._data_class.keys())
 
     def __init__(self,
+                 *,
                  data: GuestData,
                  name: Optional[str] = None,
                  parent: Optional[tmt.utils.Common] = None) -> None:
         """ Initialize guest data """
-        super().__init__(parent, name)
+        super().__init__(parent=parent, name=name)
 
         self.load(data)
 
@@ -1044,7 +1045,7 @@ class Provision(tmt.steps.Step):
 
     _plugin_base_class = ProvisionPlugin
 
-    def __init__(self, plan: 'tmt.Plan', data: tmt.steps.RawStepDataArgument) -> None:
+    def __init__(self, *, plan: 'tmt.Plan', data: tmt.steps.RawStepDataArgument) -> None:
         """ Initialize provision step data """
         super().__init__(plan=plan, data=data)
 

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -519,7 +519,7 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
         super().wake(data=data)
 
         if data:
-            self._guest = GuestArtemis(data, name=self.name, parent=self.step)
+            self._guest = GuestArtemis(data=data, name=self.name, parent=self.step)
 
     def go(self) -> None:
         """ Provision the guest """
@@ -560,7 +560,7 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
             api_retry_backoff_factor=self.get('api-retry-backoff-factor')
             )
 
-        self._guest = GuestArtemis(data, name=self.name, parent=self.step)
+        self._guest = GuestArtemis(data=data, name=self.name, parent=self.step)
         self._guest.start()
 
     def guest(self) -> Optional[GuestArtemis]:

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -83,7 +83,7 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
         """ Wake up the plugin, process data, apply options """
         super().wake(data=data)
         if data:
-            self._guest = tmt.GuestSsh(data, name=self.name, parent=self.step)
+            self._guest = tmt.GuestSsh(data=data, name=self.name, parent=self.step)
 
     def go(self) -> None:
         """ Prepare the connection """
@@ -128,7 +128,7 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
                 data.key = [key]
 
         # And finally create the guest
-        self._guest = tmt.GuestSsh(data, name=self.name, parent=self.step)
+        self._guest = tmt.GuestSsh(data=data, name=self.name, parent=self.step)
 
     def guest(self) -> Optional[tmt.GuestSsh]:
         """ Return the provisioned guest """

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -104,7 +104,7 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
         """ Wake up the plugin, process data, apply options """
         super().wake(data=data)
         if data:
-            self._guest = GuestLocal(data, name=self.name, parent=self.step)
+            self._guest = GuestLocal(data=data, name=self.name, parent=self.step)
 
     def go(self) -> None:
         """ Provision the container """
@@ -115,7 +115,7 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
             guest='localhost',
             role=self.get('role')
             )
-        self._guest = GuestLocal(data, name=self.name, parent=self.step)
+        self._guest = GuestLocal(data=data, name=self.name, parent=self.step)
 
     def guest(self) -> Optional[GuestLocal]:
         """ Return the provisioned guest """

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -237,7 +237,7 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
         super().wake(data=data)
         # Wake up podman instance
         if data:
-            guest = GuestContainer(data, name=self.name, parent=self.step)
+            guest = GuestContainer(data=data, name=self.name, parent=self.step)
             guest.wake()
             self._guest = guest
 
@@ -258,7 +258,7 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
         data = PodmanGuestData(**data_from_options)
 
         # Create a new GuestTestcloud instance and start it
-        self._guest = GuestContainer(data, name=self.name, parent=self.step)
+        self._guest = GuestContainer(data=data, name=self.name, parent=self.step)
         self._guest.start()
 
     def guest(self) -> Optional[GuestContainer]:

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -596,7 +596,7 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
 
         # Wake up testcloud instance
         if data:
-            guest = GuestTestcloud(data, name=self.name, parent=self.step)
+            guest = GuestTestcloud(data=data, name=self.name, parent=self.step)
             guest.wake()
             self._guest = guest
 
@@ -637,7 +637,7 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
                 self.info(key, value, 'green')
 
         # Create a new GuestTestcloud instance and start it
-        self._guest = GuestTestcloud(data, name=self.name, parent=self.step)
+        self._guest = GuestTestcloud(data=data, name=self.name, parent=self.step)
         self._guest.start()
 
     def guest(self) -> Optional[tmt.Guest]:

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -328,6 +328,7 @@ class Common:
 
     def __init__(
             self,
+            *,
             parent: Optional[CommonDerivedType] = None,
             name: Optional[str] = None,
             workdir: WorkdirArgumentType = None,


### PR DESCRIPTION
With the upcoming changes WRT logging and multihost implementations, it will be increasingly difficult to correctly pass arguments to these classes in the positional way. With various mixins and multiple inheritance, positional arguments would become source of endless suffering. Therefore changing tree of ``tmt.utils.Common`` classes to keyword only for safety and sanity reasons.