### PR TITLE
Read source from correct directory if ref is used

### DIFF
--- a/tests/discover/distgit.sh
+++ b/tests/discover/distgit.sh
@@ -337,7 +337,7 @@ done
         rlPhaseStartTest "${prefix}path pointing to the fmf root in the extracted sources"
             rlRun 'pushd tmt'
             rlRun -s "tmt run --remove plans --default discover -v --how fmf \
-            --dist-git-source --dist-git-merge --ref e2d36db --dist-git-extract ${prefix}tmt-*/tests/execute/framework/data \
+            --dist-git-source --dist-git-merge --ref e2d36db --dist-git-extract ${prefix}tmt-1.7.0/tests/execute/framework/data \
             tests --name ^/tests/beakerlib/with-framework\$"
             rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
 

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -384,8 +384,9 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         # Fetch and extract distgit sources
         if dist_git_source:
             try:
+                # 'ref' is checked out in self.testdir
                 self.extract_distgit_source(
-                    git_root, sourcedir, self.get('dist-git-type'))
+                    self.testdir if ref else git_root, sourcedir, self.get('dist-git-type'))
             except Exception as error:
                 raise tmt.utils.DiscoverError(
                     "Failed to process 'dist-git-source'.") from error


### PR DESCRIPTION
When 'ref' is not used it is possible to read git_root. However 'ref' is checked out only in testdir.

Fixes: #1683