### PR TITLE
Decouple logging from objects and base classes

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 -   id: tmt-lint
     name: tmt lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(path=\".\").root)')/.fmf/version && tmt lint --source $@" PAD
+    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt lint --source $@" PAD
     files: '.*\.fmf$'
     verbose: true
     pass_filenames: true
@@ -9,7 +9,7 @@
 
 -   id: tmt-tests-lint
     name: tmt tests lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(path=\".\").root)')/.fmf/version && tmt tests lint --source $@" PAD
+    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt tests lint --source $@" PAD
     files: '.*\.fmf$'
     verbose: true
     pass_filenames: true
@@ -18,7 +18,7 @@
 
 -   id: tmt-plans-lint
     name: tmt plans lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(path=\".\").root)')/.fmf/version && tmt plans lint --source $@" PAD
+    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt plans lint --source $@" PAD
     files: '.*\.fmf$'
     verbose: true
     pass_filenames: true
@@ -27,7 +27,7 @@
 
 -   id: tmt-stories-lint
     name: tmt stories lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(path=\".\").root)')/.fmf/version && tmt stories lint --source $@" PAD
+    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt stories lint --source $@" PAD
     files: '.*\.fmf$'
     verbose: true
     pass_filenames: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -254,7 +254,7 @@ MOCK_MODULES = ['testcloud', 'testcloud.image', 'testcloud.instance']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # Generate stories
-tree = tmt.Tree(path='.')
+tree = tmt.Tree(logger=tmt.Logger.create(), path='.')
 
 areas = {
     '/stories/docs': 'Documentation',

--- a/examples/plugins/discover.py
+++ b/examples/plugins/discover.py
@@ -48,7 +48,7 @@ class DiscoverExample(tmt.steps.discover.DiscoverPlugin):
         print("Code should prepare environment for tests.")
 
         # Discover available tests
-        self._tests = tmt.Tree(path=".").tests()
+        self._tests = tmt.Tree(logger=self._logger, path=".").tests()
 
     def tests(self):
         """

--- a/tests/clean/guests/test.sh
+++ b/tests/clean/guests/test.sh
@@ -9,24 +9,24 @@ rlJournalStart
         rlRun "set -o pipefail"
         rlRun "tmt init"
         rlRun "tmt plan create -t mini plan1"
-        rlRun "tmt run --until provision provision -h container | tee run-output"
+        rlRun "tmt run --until provision provision -h container 2>&1 >/dev/null | tee run-output"
         rlRun "runid=\$(head -n 1 run-output)" 0 "Get the run ID"
     rlPhaseEnd
 
     rlPhaseStartTest "Dry mode"
         rlRun "tmt status -vv | tee output"
         rlAssertGrep "(done\s+){2}(todo\s+){4}$runid\s+/plan1" "output" -E
-        rlRun "tmt clean guests --dry -v | tee output"
+        rlRun "tmt clean guests --dry -v 2>&1 >/dev/null | tee output"
         rlAssertGrep "Would stop guests in run '$runid'" "output"
         rlRun "tmt status -vv | tee output"
         rlAssertGrep "(done\s+){2}(todo\s+){4}$runid\s+/plan1" "output" -E
     rlPhaseEnd
 
     rlPhaseStartTest "Specify ID"
-        rlRun "tmt clean guests --dry -v -l | tee output"
+        rlRun "tmt clean guests --dry -v -l 2>&1 >/dev/null | tee output"
         rlAssertGrep "Would stop guests in run '$runid'" "output"
 
-        rlRun "tmt clean guests --dry -v -i $runid | tee output"
+        rlRun "tmt clean guests --dry -v -i $runid 2>&1 >/dev/null | tee output"
         rlAssertGrep "Would stop guests in run '$runid'" "output"
 
         rlRun "tmt status -vv | tee output"
@@ -34,10 +34,10 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Filter by how"
-        rlRun "tmt clean guests --dry -v --how container | tee output"
+        rlRun "tmt clean guests --dry -v --how container 2>&1 >/dev/null | tee output"
         rlAssertGrep "Would stop guests in run '$runid'" "output"
 
-        rlRun "tmt clean guests --dry -v --how virtual | tee output"
+        rlRun "tmt clean guests --dry -v --how virtual 2>&1 >/dev/null | tee output"
         rlAssertNotGrep "Would stop guests in run '$runid'" "output"
 
         rlRun "tmt status -vv | tee output"
@@ -45,7 +45,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Stop the guest"
-        rlRun "tmt clean guests -v -i $runid | tee output"
+        rlRun "tmt clean guests -v -i $runid 2>&1 >/dev/null | tee output"
         rlAssertGrep "Stopping guests in run '$runid'" "output"
         rlRun "tmt status -vv | tee output"
         rlAssertGrep "(done\s+){2}(todo\s+){3}done\s+$runid\s+/plan1" "output" -E
@@ -53,8 +53,8 @@ rlJournalStart
 
     rlPhaseStartTest "Different root"
         rlRun "tmprun=\$(mktemp -d)" 0 "Create a temporary directory for runs"
-        rlRun "tmt run -i $tmprun/run1 --until provision provision -h local | tee run-output"
-        rlRun "tmt run -i $tmprun/run2 --until provision provision -h local | tee run-output"
+        rlRun "tmt run -i $tmprun/run1 --until provision provision -h local 2>&1 >/dev/null | tee run-output"
+        rlRun "tmt run -i $tmprun/run2 --until provision provision -h local 2>&1 >/dev/null | tee run-output"
         rlRun "tmt clean guests --workdir-root $tmprun"
         rlRun "tmt status --workdir-root $tmprun -vv | tee output"
         rlAssertGrep "(done\s+){2}(todo\s+){3}done\s+$tmprun/run1" "output" -E

--- a/tests/clean/runs/test.sh
+++ b/tests/clean/runs/test.sh
@@ -19,7 +19,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Dry mode"
-        rlRun "tmt clean runs --dry -v --workdir-root $tmprun | tee output"
+        rlRun "tmt clean runs --dry -v --workdir-root $tmprun 2>&1 >/dev/null | tee output"
         rlAssertGrep "Would remove workdir '$run1'" "output"
         rlAssertGrep "Would remove workdir '$run2'" "output"
         rlRun "tmt status --workdir-root $tmprun -vv | tee output"
@@ -28,13 +28,13 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Specify ID"
-        rlRun "tmt clean runs -v -i $run1 | tee output"
+        rlRun "tmt clean runs -v -i $run1 2>&1 >/dev/null | tee output"
         rlAssertGrep "Removing workdir '$run1'" "output"
         rlRun "tmt status --workdir-root $tmprun -vv | tee output"
         rlAssertNotGrep "(done\s+){1}(todo\s+){5}$run1\s+/plan1" "output" -E
         rlAssertGrep "(done\s+){1}(todo\s+){5}$run2\s+/plan1" "output" -E
 
-        rlRun "tmt clean runs -v -l | tee output"
+        rlRun "tmt clean runs -v -l 2>&1 >/dev/null | tee output"
         rlAssertGrep "Removing workdir '$run2'" "output"
         rlRun "tmt status --workdir-root $tmprun -vv | tee output"
         rlAssertNotGrep "(done\s+){1}(todo\s+){5}$run2\s+/plan1" "output" -E

--- a/tests/core/debug/test.sh
+++ b/tests/core/debug/test.sh
@@ -8,12 +8,11 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "tmt run -ar prepare -ddd | tee output"
-        rlAssertGrep "Debug message from prepare" "output"
+        rlRun -s "tmt run -ar prepare -ddd"
+        rlAssertGrep "Debug message from prepare" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun "rm -f output"
         rlRun "popd"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/core/env/test.sh
+++ b/tests/core/env/test.sh
@@ -9,35 +9,35 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Check the TMT_DEBUG variable"
-        rlRun "TMT_DEBUG=3 tmt plan show | tee output"
-        rlAssertGrep "Using the 'DiscoverFmf' plugin" 'output'
-        rlRun "TMT_DEBUG=weird tmt plan show 2>&1 | tee output" 2
-        rlAssertGrep "Invalid debug level" 'output'
+        rlRun -s "TMT_DEBUG=3 tmt plan show 2>&1 >/dev/null"
+        rlAssertGrep "Using the 'DiscoverFmf' plugin" $rlRun_LOG
+        rlRun -s "TMT_DEBUG=weird tmt plan show 2>&1 >/dev/null" 2
+        rlAssertGrep "Invalid debug level" $rlRun_LOG
     rlPhaseEnd
 
     for execute in 'tmt'; do
         tmt="tmt run -avvvr execute --how $execute"
 
         rlPhaseStartTest "Variable in L1 ($execute)"
-            rlRun "$tmt plan --name no test --name yes | tee output"
-            rlAssertGrep '>>>L1<<<' 'output'
+            rlRun -s "$tmt plan --name no test --name yes"
+            rlAssertGrep '>>>L1<<<' $rlRun_LOG
         rlPhaseEnd
 
         rlPhaseStartTest "Variable in L2 ($execute)"
-            rlRun "$tmt plan --name yes test --name no | tee output"
-            rlAssertGrep '>>>L2<<<' 'output'
-            rlRun "$tmt plan --name yes test --name yes | tee output"
-            rlAssertGrep '>>>L2<<<' 'output'
+            rlRun -s "$tmt plan --name yes test --name no"
+            rlAssertGrep '>>>L2<<<' $rlRun_LOG
+            rlRun -s "$tmt plan --name yes test --name yes"
+            rlAssertGrep '>>>L2<<<' $rlRun_LOG
         rlPhaseEnd
 
         rlPhaseStartTest "Variable in option ($execute)"
             for plan in yes no; do
                 for test in yes no; do
-                    rlRun "tmt run -avvvr -e STR=O -e INT=0 \
+                    rlRun -s "tmt run -avvvr -e STR=O -e INT=0 \
                         execute --how $execute \
                         plan --name $plan \
-                        test --name $test | tee output"
-                    rlAssertGrep '>>>O0<<<' 'output'
+                        test --name $test"
+                    rlAssertGrep '>>>O0<<<' $rlRun_LOG
                 done
             done
         rlPhaseEnd
@@ -47,18 +47,18 @@ rlJournalStart
         rlPhaseStartTest "Variable in YAML file ($execute)"
             for plan in yes no; do
                 for test in yes no; do
-                    rlRun "tmt run -avvvr -e @vars.yaml \
+                    rlRun -s "tmt run -avvvr -e @vars.yaml \
                         execute --how $execute \
                         plan --name $plan \
-                        test --name $test | tee output"
-                    rlAssertGrep '>>>O0<<<' 'output'
+                        test --name $test"
+                    rlAssertGrep '>>>O0<<<' $rlRun_LOG
                 done
             done
         rlPhaseEnd
 
         rlPhaseStartTest "Empty environment file ($execute)"
             rlRun -s "tmt run -r -e @empty.yaml 2>&1"
-            rlAssertGrep "WARNING.*Empty environment file" $rlRun_LOG
+            rlAssertGrep "warn: Empty environment file" $rlRun_LOG
         rlPhaseEnd
     done
 

--- a/tests/core/environment-file/test.sh
+++ b/tests/core/environment-file/test.sh
@@ -10,8 +10,8 @@ rlJournalStart
     good="plan --name /plan/good"
 
     rlPhaseStartTest "Check environment-file option reads properly"
-        rlRun "tmt run -rvvvddd $good | tee output"
-        rlAssertGrep "total: 1 test passed" 'output'
+        rlRun -s "tmt run -rvvvddd $good"
+        rlAssertGrep "total: 1 test passed" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Check if --environment overwrites --environment-file"
@@ -33,7 +33,7 @@ rlJournalStart
 
     rlPhaseStartTest "Empty environment file"
         rlRun "tmt run -rvvddd discover finish plan -n empty 2>&1 | tee output"
-        rlAssertGrep "WARNING.*Empty environment file" "output"
+        rlAssertGrep "warn: Empty environment file" "output"
     rlPhaseEnd
 
     rlPhaseStartTest "Escape from the tree"

--- a/tests/core/force/test.sh
+++ b/tests/core/force/test.sh
@@ -10,61 +10,61 @@ rlJournalStart
 
     rlPhaseStartTest "Force the whole run - new workdir"
         # The first run, fresh, no results should be found
-        rlRun "tmt run -ddvvi $run discover | tee output" 0 "First run (fresh)"
-        rlAssertGrep "Run data not found." output
-        rlAssertGrep "Discovered tests not found." output
-        rlAssertNotGrep "Discover.*already done" output
-        rlAssertNotGrep "Provision.*already done" output
-        rlAssertGrep "1 test selected" output
-        rlAssertNotGrep "1 guest provisioned" output
+        rlRun -s "tmt run -ddvvi $run discover" 0 "First run (fresh)"
+        rlAssertGrep "Run data not found." $rlRun_LOG
+        rlAssertGrep "Discovered tests not found." $rlRun_LOG
+        rlAssertNotGrep "Discover.*already done" $rlRun_LOG
+        rlAssertNotGrep "Provision.*already done" $rlRun_LOG
+        rlAssertGrep "1 test selected" $rlRun_LOG
+        rlAssertNotGrep "1 guest provisioned" $rlRun_LOG
 
         # Discover step done, no other steps executed
-        rlRun "tmt run -ddvvi $run | tee output" 0 "Second run (done)"
-        rlAssertNotGrep "Run data not found." output
-        rlAssertNotGrep "Discovered tests not found." output
-        rlAssertGrep "Discover.*already done" output
-        rlAssertNotGrep "Provision.*already done" output
-        rlAssertGrep "1 test selected" output
-        rlAssertNotGrep "1 guest provisioned" output
+        rlRun -s "tmt run -ddvvi $run" 0 "Second run (done)"
+        rlAssertNotGrep "Run data not found." $rlRun_LOG
+        rlAssertNotGrep "Discovered tests not found." $rlRun_LOG
+        rlAssertGrep "Discover.*already done" $rlRun_LOG
+        rlAssertNotGrep "Provision.*already done" $rlRun_LOG
+        rlAssertGrep "1 test selected" $rlRun_LOG
+        rlAssertNotGrep "1 guest provisioned" $rlRun_LOG
 
         # Force, all steps should be executed again
-        rlRun "tmt run --scratch -ddvvi $run | tee output" 0 "Third run (force)"
-        rlAssertGrep "Run data not found." output
-        rlAssertGrep "Discovered tests not found." output
-        rlAssertNotGrep "Discover.*already done" output
-        rlAssertNotGrep "Provision.*already done" output
-        rlAssertGrep "1 test selected" output
-        rlAssertGrep "1 guest provisioned" output
+        rlRun -s "tmt run --scratch -ddvvi $run" 0 "Third run (force)"
+        rlAssertGrep "Run data not found." $rlRun_LOG
+        rlAssertGrep "Discovered tests not found." $rlRun_LOG
+        rlAssertNotGrep "Discover.*already done" $rlRun_LOG
+        rlAssertNotGrep "Provision.*already done" $rlRun_LOG
+        rlAssertGrep "1 test selected" $rlRun_LOG
+        rlAssertGrep "1 guest provisioned" $rlRun_LOG
 
         # Finally wake up, everything should be done
-        rlRun "tmt run -ddvvi $run | tee output" 0 "Fourth run (wake)"
-        rlAssertNotGrep "Run data not found." output
-        rlAssertNotGrep "Discovered tests not found." output
-        rlAssertGrep "Discover.*already done" output
-        rlAssertGrep "Provision.*already done" output
-        rlAssertGrep "1 test selected" output
-        rlAssertGrep "1 guest provisioned" output
+        rlRun -s "tmt run -ddvvi $run" 0 "Fourth run (wake)"
+        rlAssertNotGrep "Run data not found." $rlRun_LOG
+        rlAssertNotGrep "Discovered tests not found." $rlRun_LOG
+        rlAssertGrep "Discover.*already done" $rlRun_LOG
+        rlAssertGrep "Provision.*already done" $rlRun_LOG
+        rlAssertGrep "1 test selected" $rlRun_LOG
+        rlAssertGrep "1 guest provisioned" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Force all steps"
         # The first run, start from scratch, no results should be found
-        rlRun "tmt run --scratch -ddvvi $run | tee output" 0 "First run (fresh)"
-        rlAssertGrep "Discovered tests not found." output
-        rlAssertGrep "1 test selected" output
+        rlRun -s "tmt run --scratch -ddvvi $run" 0 "First run (fresh)"
+        rlAssertGrep "Discovered tests not found." $rlRun_LOG
+        rlAssertGrep "1 test selected" $rlRun_LOG
 
         new_file="$run/tmpfile"
         rlRun "touch $new_file" 0 "Create a file in the workdir"
         rlAssertExists $new_file
 
         # Second run, force all enabled steps
-        rlRun "tmt run --force -ddvvi $run | tee output" 0 "Second run (force)"
-        rlAssertGrep "Discovered tests not found." output
-        rlAssertGrep "1 test selected" output
+        rlRun -s "tmt run --force -ddvvi $run" 0 "Second run (force)"
+        rlAssertGrep "Discovered tests not found." $rlRun_LOG
+        rlAssertGrep "1 test selected" $rlRun_LOG
         rlAssertExists $new_file
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun "rm -rf output $run" 0 "Remove run directory"
+        rlRun "rm -rf $run" 0 "Remove run directory"
         rlRun "popd"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/core/order/test.sh
+++ b/tests/core/order/test.sh
@@ -62,24 +62,22 @@ rlJournalStart
 
     rlPhaseStartTest "Tests order with tmt run discover plan"
         order=(negative_2 one two three fourth negative_2 one two three)
-        rlRun "$discover -v plan -n third | grep ' /tests/' | tee $output"
+        rlRun "$discover -v plan -n third 2>&1 >/dev/null | grep ' /tests/' | tee $output"
         check_correct_order order "$output"
     rlPhaseEnd
 
     rlPhaseStartTest "Tests order with tmt run discover plan and test"
         order=(negative_2 one two three negative_2 one two three)
-        rlRun "$discover -v plan -n third test -n third | grep ' /tests/' \
-          | tee $output"
+        rlRun "$discover -v plan -n third test -n third 2>&1 >/dev/null | grep ' /tests/' | tee $output"
         check_correct_order order "$output"
         order=(fourth)
-        rlRun "$discover -v plan -n third test -n fourth | grep ' /tests/' \
-          | tee $output"
+        rlRun "$discover -v plan -n third test -n fourth 2>&1 >/dev/null | grep ' /tests/' | tee $output"
         check_correct_order order "$output"
     rlPhaseEnd
 
     rlPhaseStartTest "Plans order with tmt run discover"
         order=(negative_1 zero third fourth no_order none)
-        rlRun "tmt run -r finish discover -q | grep plan | tee $output"
+        rlRun "tmt run -r finish discover -q 2>&1 >/dev/null | grep -v 'warn:' | grep plan | tee $output"
         check_correct_order order "$output"
     rlPhaseEnd
 

--- a/tests/core/path/test.py
+++ b/tests/core/path/test.py
@@ -1,7 +1,10 @@
 
 import tmt
+import tmt.log
 
-tree = tmt.Tree(path='data')
+logger = tmt.log.Logger.create()
+
+tree = tmt.Tree(logger=logger, path='data')
 
 
 def test_root():

--- a/tests/core/web-link/test.py
+++ b/tests/core/web-link/test.py
@@ -2,7 +2,7 @@ import re
 
 import tmt
 
-tree = tmt.Tree(path='data')
+tree = tmt.Tree(logger=tmt.Logger.create(), path='data')
 prefix = r'https://github.com/.*/tmt/tree/.*/tests/core/web-link/data/'
 
 

--- a/tests/discover/dynamic-ref.sh
+++ b/tests/discover/dynamic-ref.sh
@@ -33,12 +33,12 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest 'Check dynamic ref combined with test plan context parametrization"'
-        rlRun "tmt -c branch=ubuntu run -r $plan_ctx $steps | tee output" 0,2
+        rlRun "tmt -c branch=ubuntu run -r $plan_ctx $steps 2>&1 >/dev/null | tee output" 0,2
         rlAssertGrep 'ref: ubuntu' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'Check dynamic ref combined with test plan envvar parametrization"'
-        rlRun "tmt -c branch=envvar run --environment BRANCH=debian -r $plan_ctx $steps | tee output" 0,2
+        rlRun "tmt -c branch=envvar run --environment BRANCH=debian -r $plan_ctx $steps 2>&1 >/dev/null | tee output" 0,2
         rlAssertGrep 'ref: debian' 'output'
     rlPhaseEnd
 

--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -11,7 +11,7 @@ rlJournalStart
     rlPhaseStartTest "Filter by test name"
         plan='plan --name fmf/nourl/noref/nopath'
         discover='discover --how fmf --test discover1'
-        rlRun "tmt run -dvr $discover $plan finish | tee output"
+        rlRun "tmt run -dvr $discover $plan finish 2>&1 >/dev/null | tee output"
         rlAssertGrep '1 test selected' output
         rlAssertGrep '/tests/discover1' output
         rlAssertNotGrep '/tests/discover2' output
@@ -21,7 +21,7 @@ rlJournalStart
     rlPhaseStartTest "Filter by advanced filter"
         plan='plan --name fmf/nourl/noref/nopath'
         discover='discover --how fmf --filter tier:1,2'
-        rlRun "tmt run -dvr $discover $plan finish | tee output"
+        rlRun "tmt run -dvr $discover $plan finish 2>&1 >/dev/null | tee output"
         rlAssertGrep '2 tests selected' output
         rlAssertGrep '/tests/discover1' output
         rlAssertGrep '/tests/discover2' output
@@ -32,9 +32,9 @@ rlJournalStart
         rlPhaseStartTest "Exclude tests using $exclude <regex>"
             plan='plan --name fmf/nourl/noref/nopath'
             discover='discover --how fmf'
-            rlRun "tmt run -dvr $discover $plan | tee output"
+            rlRun "tmt run -dvr $discover $plan 2>&1 >/dev/null | tee output"
             rlAssertGrep '/tests/discover1' output
-            rlRun "tmt run -dvr $discover $exclude discover1 $plan | tee output"
+            rlRun "tmt run -dvr $discover $exclude discover1 $plan 2>&1 >/dev/null | tee output"
             rlAssertNotGrep '/tests/discover1' output
         rlPhaseEnd
     done
@@ -42,7 +42,7 @@ rlJournalStart
     rlPhaseStartTest "Exclude tests via exclude option within a plan metadata"
         plan='plan --name fmf/exclude'
         discover='discover --how fmf'
-        rlRun "tmt run -dvr $discover $plan | tee output"
+        rlRun "tmt run -dvr $discover $plan 2>&1 >/dev/null | tee output"
         rlAssertNotGrep '/tests/discover1' output
         rlAssertGrep '/tests/discover2' output
     rlPhaseEnd
@@ -51,14 +51,14 @@ rlJournalStart
         plan='plans --default'
         for link_relation in "" "relates:" "rel.*:"; do
             discover="discover -h fmf --link ${link_relation}/tmp/foo"
-            rlRun "tmt run -dvr $discover $plan finish | tee output"
+            rlRun "tmt run -dvr $discover $plan finish 2>&1 >/dev/null | tee output"
             rlAssertGrep '1 test selected' output
             rlAssertGrep '/tests/discover1' output
         done
         for link_relation in "verifies:https://github.com/teemtee/tmt/issues/870" \
             "ver.*:.*/issues/870" ".*/issues/870"; do
             discover="discover -h fmf --link $link_relation --link rubbish"
-            rlRun "tmt run -dvr $discover $plan finish | tee output"
+            rlRun "tmt run -dvr $discover $plan finish 2>&1 >/dev/null | tee output"
             rlAssertGrep '1 test selected' output
             rlAssertGrep '/tests/discover2' output
         done
@@ -69,7 +69,7 @@ rlJournalStart
         rlRun "tmt run -r $plan discover -h fmf --fmf-id finish | tee output"
 
         # check "discover --fmf-id" shows the same tests as "tmt run discover"
-        rlRun "tmt run -v $plan discover | tee discover"
+        rlRun "tmt run -v $plan discover 2>&1 >/dev/null | tee discover"
         tests_list=$(tac discover |
                      sed -n '/summary:/q;p')
         url_discover=$(grep "url:" discover | awk '{print $2}')
@@ -91,8 +91,7 @@ rlJournalStart
 
     rlPhaseStartTest 'fmf-id (w/o url): Show fmf ids for discovered tests'
         plan='plan --name fmf/nourl/noref/nopath'
-        rlRun "tmt run -dvvvr $plan discover -h fmf --fmf-id finish \
-               | tee output"
+        rlRun "tmt run -dvvvr $plan discover -h fmf --fmf-id finish 2>&1 >/dev/null | tee output"
 
         # check "discover --fmf-id" shows the same tests as "tmt run discover"
         tests_list=$(tmt run -v $plan discover |
@@ -129,10 +128,10 @@ rlJournalStart
     # If plan or test weren't explicitly specified then fmf-ids for all tests
     # in all plans should be shown
     rlPhaseStartTest "fmf-id (w/o url): plans were executed if plan/test -n=."
-        ids_amount=$(tmt run -r discover -h fmf --fmf-id finish |
+        ids_amount=$(tmt run -r discover -h fmf --fmf-id finish 2>&1 >/dev/null |
                      grep "name:" |
                      wc -l)
-        tests_amount=$(tmt run -r discover -h fmf finish |
+        tests_amount=$(tmt run -r discover -h fmf finish 2>&1 >/dev/null |
                        grep "summary:" |
                        awk '{print $2}' |
                        awk '{s+=$1} END {print s}')
@@ -146,7 +145,7 @@ rlJournalStart
         rlRun "cd $path"
         rlRun "tmt run -r test --name /tests/unit \
                           plans --default \
-                          discover --how fmf --fmf-id finish | tee output"
+                          discover --how fmf --fmf-id finish 2>&1 >/dev/null | tee output"
         rlAssertNotGrep "path:" output
     rlPhaseEnd
 
@@ -167,22 +166,22 @@ rlJournalStart
         rlRun "cd $tmp_dir"
         rlRun "tmt init --template base"
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 \
-               | tee output" 2
+               2>&1 >/dev/null | tee output" 2
         rlAssertGrep "\`tmt run discover --fmf-id\` without \`url\` option \
 in plan \`/plans/example\` can be used only within git repo." output
 
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id \
-               --url https://github.com/teemtee/fmf finish | tee output" 0
+               --url https://github.com/teemtee/fmf finish 2>&1 >/dev/null | tee output" 0
         rlRun "rm -rf $tmp_dir"
 
         # 1: w/ url in plan: w/o url in CLI - w/ url in CLI
         tmp_dir="$(mktemp -d)"
         rlRun "cd $tmp_dir"
         rlRun "tmt init --template full"
-        rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish | tee output" 0
+        rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 >/dev/null | tee output" 0
 
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id \
-               --url https://github.com/teemtee/fmf finish | tee output" 0
+               --url https://github.com/teemtee/fmf finish 2>&1 >/dev/null | tee output" 0
         rlRun "rm -rf $tmp_dir"
 
         # 2: w/o url in plan AND w/ url in plan: w/o url in CLI - w/ url in CLI
@@ -194,13 +193,13 @@ in plan \`/plans/example\` can be used only within git repo." output
         rlRun "tmt init --template base"
         rlRun "cp plans/example.fmf $tmp_dir1/plans/a-non-url.fmf"
         rlRun "cd $tmp_dir1"
-        rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 \
+        rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 >/dev/null \
                | tee output" 2
         rlAssertGrep "\`tmt run discover --fmf-id\` without \`url\` option \
 in plan \`/plans/a-non-url\` can be used only within git repo." output
 
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id \
-               --url https://github.com/teemtee/fmf finish | tee output" 0
+               --url https://github.com/teemtee/fmf finish 2>&1 >/dev/null | tee output" 0
         rlRun "rm -rf $tmp_dir1 $tmp_dir2"
 
         # 2: w/ url in plan AND w/o url in plan: w/o url in CLI - w/ url in CLI
@@ -212,13 +211,13 @@ in plan \`/plans/a-non-url\` can be used only within git repo." output
         rlRun "tmt init --template base"
         rlRun "cp plans/example.fmf $tmp_dir1/plans/z-non-url.fmf"
         rlRun "cd $tmp_dir1"
-        rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 \
+        rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 >/dev/null \
                | tee output" 2
         rlAssertGrep "\`tmt run discover --fmf-id\` without \`url\` option \
 in plan \`/plans/z-non-url\` can be used only within git repo." output
 
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id \
-               --url https://github.com/teemtee/fmf finish | tee output" 0
+               --url https://github.com/teemtee/fmf finish 2>&1 >/dev/null | tee output" 0
         rlRun "rm -rf $tmp_dir1 $tmp_dir2"
     rlPhaseEnd
 
@@ -227,7 +226,7 @@ in plan \`/plans/z-non-url\` can be used only within git repo." output
         tmp_dir="$(mktemp -d)"
         rlRun "cd $tmp_dir"
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id \
-               --url https://github.com/teemtee/fmf finish | tee output" 0
+               --url https://github.com/teemtee/fmf finish 2>&1 >/dev/null | tee output" 0
         rlRun "rm -rf $tmp_dir"
     rlPhaseEnd
 
@@ -235,7 +234,7 @@ in plan \`/plans/z-non-url\` can be used only within git repo." output
     rlPhaseStartTest "fmf-id (w/o url): current dir doesn't have fmf metadata"
         tmp_dir="$(mktemp -d)"
         rlRun "cd $tmp_dir"
-        rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 \
+        rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 >/dev/null \
                | tee output" 2
         rlAssertGrep "No metadata found in the current directory" output
         rlRun "rm -rf $tmp_dir"

--- a/tests/discover/manual/test.sh
+++ b/tests/discover/manual/test.sh
@@ -8,9 +8,8 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "tmt run --remove discover finish | tee output"
-        rlAssertGrep "0 tests selected" "output"
-        rlRun "rm output"
+        rlRun -s "tmt run --remove discover finish"
+        rlAssertGrep "0 tests selected" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/discover/modified.sh
+++ b/tests/discover/modified.sh
@@ -10,14 +10,14 @@ rlJournalStart
     rlPhaseStartTest 'Command-line'
         rlRun 'tmt run -rdv discover --how fmf --ref 8329db0 \
             --modified-only --modified-ref 8329db0^ \
-            plan -n features/core finish | tee output'
+            plan -n features/core finish 2>&1 >/dev/null | tee output'
         rlAssertGrep 'summary: 1 test selected' output
         rlAssertGrep '/tests/core/adjust' output
     rlPhaseEnd
 
     rlPhaseStartTest 'Plan'
         rlRun 'env -C data tmt run -rdv discover \
-            plan -n fmf/modified finish | tee output'
+            plan -n fmf/modified finish 2>&1 >/dev/null | tee output'
         rlAssertGrep 'summary: 1 test selected' output
         rlAssertGrep '/tests/core/adjust' output
     rlPhaseEnd

--- a/tests/discover/parametrize.sh
+++ b/tests/discover/parametrize.sh
@@ -16,61 +16,61 @@ rlJournalStart
     steps='discover finish'
 
     rlPhaseStartTest 'From environment attribute'
-        rlRun "tmt run -r $plan_env $steps | tee output"
+        rlRun "tmt run -r $plan_env $steps 2>&1 >/dev/null | tee output"
         rlAssertGrep 'url: https://github.com/teemtee/tmt' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'From --environment command line option'
-        rlRun "tmt run -r -e REPO=tmt $plan_noenv $steps | tee output"
+        rlRun "tmt run -r -e REPO=tmt $plan_noenv $steps 2>&1 >/dev/null | tee output"
         rlAssertGrep 'url: https://github.com/teemtee/tmt' 'output'
         # Precedence of option over environment attribute
-        rlRun "tmt run -r -e REPO=fmf $plan_env $steps | tee output"
+        rlRun "tmt run -r -e REPO=fmf $plan_env $steps 2>&1 >/dev/null | tee output"
         rlAssertGrep 'url: https://github.com/teemtee/fmf' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'Process environment should be ignored'
-        rlRun "REPO=fmf tmt run -r $plan_env $steps | tee output"
+        rlRun "REPO=fmf tmt run -r $plan_env $steps 2>&1 >/dev/null | tee output"
         rlAssertGrep 'url: https://github.com/teemtee/tmt' 'output'
         # No substitution should happen
-        rlRun "REPO=tmt tmt run -r $plan_noenv $steps | tee output" 2
+        rlRun "REPO=tmt tmt run -r $plan_noenv $steps 2>&1 >/dev/null | tee output" 2
         rlAssertGrep 'url: https://github.com/teemtee/${REPO}' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'Undefined variable'
-        rlRun "tmt run -r $plan_noenv $steps | tee output" 2
+        rlRun "tmt run -r $plan_noenv $steps 2>&1 >/dev/null | tee output" 2
         rlAssertGrep 'url: https://github.com/teemtee/${REPO}' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'From context attribute'
-        rlRun "tmt run -r $plan_ctx $steps | tee output"
+        rlRun "tmt run -r $plan_ctx $steps 2>&1 >/dev/null | tee output"
         rlAssertGrep 'url: https://github.com/teemtee/tmt' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'From --context command line option'
-        rlRun "tmt -c repo=tmt run -r $plan_noctx $steps | tee output"
+        rlRun "tmt -c repo=tmt run -r $plan_noctx $steps 2>&1 >/dev/null | tee output"
         rlAssertGrep 'url: https://github.com/teemtee/tmt' 'output'
         # Precedence of option over context attribute
-        rlRun "tmt -c repo=fmf run -r $plan_ctx $steps | tee output"
+        rlRun "tmt -c repo=fmf run -r $plan_ctx $steps 2>&1 >/dev/null | tee output"
         rlAssertGrep 'url: https://github.com/teemtee/fmf' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'Undefined context'
-        rlRun "tmt run -r $plan_noctx $steps | tee output" 2
+        rlRun "tmt run -r $plan_noctx $steps 2>&1 >/dev/null | tee output" 2
         rlAssertGrep 'url: https://github.com/teemtee/$@{repo}' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'Combined variable and context defined in a plan'
-        rlRun "tmt run -r $plan_combined $steps | tee output" 2
+        rlRun "tmt run -r $plan_combined $steps 2>&1 >/dev/null | tee output" 2
         rlAssertGrep 'url: https://github.com/teemtee/teemtee' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'Combined variable and context defined on a cmdline'
-        rlRun "tmt -c prefix=foo run --environment SUFFIX=bar -r $plan_combined $steps | tee output" 2
+        rlRun "tmt -c prefix=foo run --environment SUFFIX=bar -r $plan_combined $steps 2>&1 >/dev/null | tee output" 2
         rlAssertGrep 'url: https://github.com/teemtee/foobar' 'output'
     rlPhaseEnd
 
     rlPhaseStartTest 'Using identical name for variable and context'
-        rlRun "tmt run -r $plan_conflict $steps | tee output" 2
+        rlRun "tmt run -r $plan_conflict $steps 2>&1 >/dev/null | tee output" 2
         rlAssertGrep 'url: https://github.com/teemtee/foobar' 'output'
     rlPhaseEnd
 

--- a/tests/discover/references.sh
+++ b/tests/discover/references.sh
@@ -11,7 +11,7 @@ rlJournalStart
 
     plan=fmf/nourl/noref/nopath
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dvr discover plan --name $plan finish | tee output'
+        rlRun 'tmt run -dvr discover plan --name $plan finish 2>&1 >/dev/null | tee output'
         rlAssertNotGrep 'Cloning into' output
         rlAssertNotGrep 'Checkout ref' output
         rlAssertGrep '3 tests selected' output
@@ -24,7 +24,7 @@ rlJournalStart
     path=$(realpath .)
     rlPhaseStartTest $plan
         rlRun 'tmt run -dvr discover --how fmf --path $path plan --name $plan \
-            finish | tee output'
+            finish 2>&1 >/dev/null | tee output'
         rlAssertNotGrep 'Cloning into' output
         rlAssertNotGrep 'Checkout ref' output
         rlAssertGrep '3 tests selected' output
@@ -35,7 +35,7 @@ rlJournalStart
 
     plan=fmf/nourl/ref/nopath
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dvr discover plan --name $plan finish | tee output'
+        rlRun 'tmt run -dvr discover plan --name $plan finish 2>&1 >/dev/null | tee output'
         rlAssertNotGrep 'Cloning into' output
         rlAssertGrep 'Checkout ref.*5407fe5' output
         rlAssertGrep /tests/docs output
@@ -48,7 +48,7 @@ rlJournalStart
     echo $path
     rlPhaseStartTest $plan
         rlRun 'tmt run -dddvr discover --how fmf --path $path \
-            plan --name $plan finish | tee output'
+            plan --name $plan finish 2>&1 >/dev/null | tee output'
         rlAssertNotGrep 'Cloning into' output
         rlAssertGrep 'Checkout ref.*eae4d52' output
         rlAssertGrep '2 tests selected' output
@@ -58,7 +58,7 @@ rlJournalStart
 
     plan=fmf/url/noref/nopath
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dddvr discover plan --name $plan finish | tee output'
+        rlRun 'tmt run -dddvr discover plan --name $plan finish 2>&1 >/dev/null | tee output'
         rlAssertGrep 'Cloning into' output
         rlAssertNotGrep 'Checkout ref.*main' output
         rlAssertGrep /tests/core/docs output
@@ -68,7 +68,7 @@ rlJournalStart
 
     plan=fmf/url/noref/path
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dddvr discover plan --name $plan finish | tee output'
+        rlRun 'tmt run -dddvr discover plan --name $plan finish 2>&1 >/dev/null | tee output'
         rlAssertGrep 'Cloning into' output
         rlAssertNotGrep 'Checkout ref.*main' output
         rlAssertGrep '2 tests selected' output
@@ -78,7 +78,7 @@ rlJournalStart
 
     plan=fmf/url/ref/nopath
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dddvr discover plan --name $plan finish | tee output'
+        rlRun 'tmt run -dddvr discover plan --name $plan finish 2>&1 >/dev/null | tee output'
         rlAssertGrep 'Cloning into' output
         rlAssertGrep 'Checkout ref.*5407fe5' output
         rlAssertGrep 'hash.*5407fe5' output
@@ -90,7 +90,7 @@ rlJournalStart
 
     plan=fmf/url/ref/path
     rlPhaseStartTest $plan
-        rlRun 'tmt run -dddvr discover plan --name $plan finish | tee output'
+        rlRun 'tmt run -dddvr discover plan --name $plan finish 2>&1 >/dev/null | tee output'
         rlAssertGrep 'Cloning into' output
         rlAssertGrep 'Checkout ref.*eae4d52' output
         rlAssertGrep 'hash.*eae4d52' output
@@ -99,7 +99,7 @@ rlJournalStart
         rlAssertGrep /tests/smoke output
         # Before the change was committed
         rlRun "tmt run -i $tmp -d discover --how fmf --ref eae4d52^ plan \
-            --name $plan 2>&1 | tee output" 2
+            --name $plan 2>&1 >/dev/null | tee output" 2
         rlAssertGrep 'Metadata tree path .* not found.' output
     rlPhaseEnd
 

--- a/tests/execute/duration/test.sh
+++ b/tests/execute/duration/test.sh
@@ -16,11 +16,11 @@ rlJournalStart
             rlPhaseEnd
 
             rlPhaseStartTest "Test provision $provision_method, execute $execute_method, long tests"
-                rlRun -s "tmt run --scratch -vfi $tmp -a provision -h $provision_method execute -h $execute_method test --name long" 2
+                rlRun -s "tmt run --scratch -vfi $tmp -a provision -h $provision_method execute -h $execute_method test --name long 2>&1" 2
                 rlAssertNotGrep "00:02:.. errr /test/long/beakerlib (timeout)" $rlRun_LOG
                 rlAssertNotGrep "00:02:.. errr /test/long/shell (timeout)" $rlRun_LOG
 
-                rlRun -s "tmt run --last report -fvvvv" 2
+                rlRun -s "tmt run --last report -fvvvv 2>&1" 2
                 rlAssertGrep "Maximum test time '5s' exceeded." $rlRun_LOG
                 rlAssertGrep "Adjust the test 'duration' attribute" $rlRun_LOG
                 rlAssertGrep "spec/tests.html#duration" $rlRun_LOG

--- a/tests/execute/result/basic.sh
+++ b/tests/execute/result/basic.sh
@@ -9,7 +9,7 @@ run()
     orig=$3 # original result
     ret=$4  # tmt return code
 
-    rlRun -s "tmt run -a --scratch --id \${run} test --name ${tn} provision --how local report -v | grep report -A2 | tail -n 1" \
+    rlRun -s "tmt run -a --scratch --id \${run} test --name ${tn} provision --how local report -v 2>&1 >/dev/null | grep report -A2 | tail -n 1" \
         ${ret} "Result: ${res}, Test name: ${tn}, Original result: '${orig}', tmt return code: ${ret}"
 
     if [ -z "${orig}" ]; then # No original result provided
@@ -47,7 +47,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Verbose execute prints result"
-        rlRun -s "tmt run --id \${run} --scratch --until execute tests --filter tag:-cherry_pick provision --how local execute -v" "2"
+        rlRun -s "tmt run --id \${run} --scratch --until execute tests --filter tag:-cherry_pick provision --how local execute -v 2>&1 >/dev/null" "2"
         while read -r line; do
             if rlIsRHELLike "=8" && [[ $line =~ /test/error-timeout ]]; then
                 # Centos stream 8 doesn't do watchdog properly https://github.com/teemtee/tmt/issues/1387
@@ -75,7 +75,7 @@ EOF
 
     rlPhaseStartTest "Verbose execute prints result - reboot case"
         # Before the reboot results is not known
-        rlRun -s "tmt run --id \${run} --scratch --until execute tests -n /xfail-with-reboot provision --how container execute -v"
+        rlRun -s "tmt run --id \${run} --scratch --until execute tests -n /xfail-with-reboot provision --how container execute -v 2>&1 >/dev/null"
         EXPECTED=$(cat <<EOF
             00:00:00 /test/xfail-with-reboot [1/1]
             00:00:00 pass /test/xfail-with-reboot (original result: fail) [1/1]
@@ -85,7 +85,7 @@ EOF
     rlPhaseEnd
 
     rlPhaseStartTest "Verbose execute prints result - abort case"
-        rlRun -s "tmt run --id \${run} --scratch --until execute tests tests -n /abort provision --how container execute -v" "2"
+        rlRun -s "tmt run --id \${run} --scratch --until execute tests tests -n /abort provision --how container execute -v 2>&1 >/dev/null" "2"
         rlAssertGrep "00:00:00 errr /test/abort (aborted) [1/1" $rlRun_LOG -F
     rlPhaseEnd
 

--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -13,7 +13,7 @@ rlJournalStart
 
     testName="/test/custom-results"
     rlPhaseStartTest "${testName}"
-        rlRun -s "${tmt_command} ${testName}" 1 "Test provides 'results.yaml' file by itself"
+        rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 1 "Test provides 'results.yaml' file by itself"
         rlAssertGrep "00:11:22 pass /test/custom-results/test/passing" $rlRun_LOG
         rlAssertGrep "00:22:33 fail /test/custom-results/test/failing" $rlRun_LOG
         rlAssertGrep "         pass /test/custom-results/test/no_keys \[1/1\]" $rlRun_LOG
@@ -22,31 +22,31 @@ rlJournalStart
 
     testName="/test/missing-custom-results"
     rlPhaseStartTest "${testName}"
-        rlRun -s "${tmt_command} ${testName}" 2 "Test does not provide 'results.yaml' file"
+        rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test does not provide 'results.yaml' file"
         rlAssertGrep "custom results file '/tmp/.*/plans/default/execute/data/test/missing-custom-results/data/results.yaml' not found" $rlRun_LOG
     rlPhaseEnd
 
     testName="/test/empty-custom-results-file"
     rlPhaseStartTest "${testName}"
-        rlRun -s "${tmt_command} ${testName}" 3 "Test provides empty 'results.yaml' file"
+        rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 3 "Test provides empty 'results.yaml' file"
         rlAssertGrep "total: no results found" $rlRun_LOG
     rlPhaseEnd
 
     testName="/test/wrong-yaml-results-file"
     rlPhaseStartTest "${testName}"
-        rlRun -s "${tmt_command} ${testName}" 2 "Test provides 'results.yaml' in valid YAML but wrong results format"
+        rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test provides 'results.yaml' in valid YAML but wrong results format"
         rlAssertGrep "Expected list in yaml data, got 'dict'." $rlRun_LOG
     rlPhaseEnd
 
     testName="/test/invalid-yaml-results-file"
     rlPhaseStartTest "${testName}"
-        rlRun -s "${tmt_command} ${testName}" 2 "Test provides 'results.yaml' not in YAML format"
+        rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test provides 'results.yaml' not in YAML format"
         rlAssertGrep "Invalid yaml syntax:" $rlRun_LOG
     rlPhaseEnd
 
     testName="/test/wrong-yaml-content"
     rlPhaseStartTest "${testName}"
-        rlRun -s "${tmt_command} ${testName}" 2 "Test provides partial result with wrong value"
+        rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test provides partial result with wrong value"
         rlAssertGrep "Invalid partial custom result 'errrrrr'." $rlRun_LOG
     rlPhaseEnd
 

--- a/tests/execute/weird/test.sh
+++ b/tests/execute/weird/test.sh
@@ -12,7 +12,7 @@ rlJournalStart
         rlPhaseStartTest "Test with the $executor executor"
             rlRun "tmt run -i $tmp/$executor -avvvddd \
                 provision -h local \
-                execute -h $executor | tee output"
+                execute -h $executor 2>&1 >/dev/null | tee output"
             rlAssertGrep 'Before: This text is fine.' output
             rlAssertGrep 'Weird: That is the b.*d one!' output
             rlAssertGrep 'After: This text is fine as well.' output

--- a/tests/integration/test_nitrate.py
+++ b/tests/integration/test_nitrate.py
@@ -11,6 +11,7 @@ from ruamel.yaml import YAML
 
 import tmt.base
 import tmt.cli
+import tmt.log
 from tmt.utils import ConvertError
 
 # Prepare path to examples
@@ -325,6 +326,7 @@ extra-task: /tmt/integration
         self.assertEqual(self.runner_output.exit_code, 0)
 
         tree_f36_intel = tmt.Tree(
+            logger=tmt.log.Logger.create(),
             path='.',
             context={
                 'distro': ['fedora-36'],
@@ -338,6 +340,7 @@ extra-task: /tmt/integration
         self.assertEquals(test.node.get('extra-nitrate'), 'TC#0545993')
 
         tree_f35_intel = tmt.Tree(
+            logger=tmt.log.Logger.create(),
             path='.',
             context={
                 'distro': ['fedora-35'],

--- a/tests/libraries/local/test.sh
+++ b/tests/libraries/local/test.sh
@@ -19,7 +19,7 @@ rlJournalStart
 
     rlPhaseStartTest
         rlRun "set -o pipefail"
-        rlRun "tmt run -ar discover -vvvddd report -vvv | tee output"
+        rlRun "tmt run -ar discover -vvvddd report -vvv 2>&1 >/dev/null | tee output"
         rlAssertGrep "Copy local library.*example" "output"
         rlAssertGrep "Create fyle 'fooo'" "output"
     rlPhaseEnd

--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -11,38 +11,38 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "No login"
-        rlRun "$tmt | tee output"
+        rlRun "$tmt 2>&1 >/dev/null | tee output"
         rlAssertNotGrep "interactive" "output"
     rlPhaseEnd
 
     rlPhaseStartTest "Last step"
-        rlRun "$tmt login -c true | tee output"
+        rlRun "$tmt login -c true 2>&1 >/dev/null | tee output"
         rlAssertGrep "interactive" "output"
         rlRun "grep '^    finish$' -A4 output | grep -i interactive"
     rlPhaseEnd
 
     for step in discover provision prepare execute report finish; do
         rlPhaseStartTest "Selected step ($step)"
-            rlRun "$tmt login -c true -s $step | tee output"
+            rlRun "$tmt login -c true -s $step 2>&1 >/dev/null | tee output"
             rlAssertGrep "interactive" "output"
             rlRun "grep '^    $step$' -A4 output | grep -i interactive"
         rlPhaseEnd
     done
 
     rlPhaseStartTest "Failed command"
-        rlRun "$tmt login -c false | tee output"
+        rlRun "$tmt login -c false 2>&1 >/dev/null | tee output"
         rlAssertGrep "interactive" "output"
     rlPhaseEnd
 
     rlPhaseStartTest "Last run"
         rlRun "tmt run -a provision -h local"
-        rlRun "tmt run -rl login -c true | tee output"
+        rlRun "tmt run -rl login -c true 2>&1 >/dev/null | tee output"
         rlAssertGrep "interactive" "output"
     rlPhaseEnd
 
     rlPhaseStartTest "Last run failed"
         rlRun "tmt run provision -h local prepare --how shell --script false" 2
-        rlRun "tmt run -rl login -c true | tee output" 2
+        rlRun "tmt run -rl login -c true 2>&1 >/dev/null | tee output" 2
         rlAssertGrep "interactive" "output"
     rlPhaseEnd
 

--- a/tests/login/when.sh
+++ b/tests/login/when.sh
@@ -11,13 +11,13 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Skipped"
-        rlRun "$tmt true login -w fail -c true | tee output"
+        rlRun "$tmt true login -w fail -c true 2>&1 >/dev/null | tee output"
         rlAssertGrep "Skipping interactive" "output"
         rlAssertNotGrep "Starting interactive" "output"
     rlPhaseEnd
 
     rlPhaseStartTest "Enabled"
-        rlRun "$tmt false login -w fail -c true | tee output" 1
+        rlRun "$tmt false login -w fail -c true 2>&1 >/dev/null | tee output" 1
         rlAssertNotGrep "Skipping interactive" "output"
         rlAssertGrep "Starting interactive" "output"
     rlPhaseEnd

--- a/tests/plan/select/test.sh
+++ b/tests/plan/select/test.sh
@@ -36,10 +36,10 @@ rlJournalStart
     for name in '-n' '--name'; do
         rlPhaseStartTest "tmt run plan $name <name>"
             tmt='tmt run -i $tmp discover'
-            rlRun "$tmt plan $name core | tee $output"
+            rlRun "$tmt plan $name core 2>&1 >/dev/null | tee $output"
             rlAssertGrep "^/plans/features/core" $output
             rlAssertNotGrep "^/plans/features/basic" $output
-            rlRun "$tmt plan $name non-existent 2>&1 | tee $output" 2
+            rlRun "$tmt plan $name non-existent 2>&1 >/dev/null | tee $output" 2
             rlAssertGrep "No plans found." $output
         rlPhaseEnd
     done

--- a/tests/prepare/ansible/test.sh
+++ b/tests/prepare/ansible/test.sh
@@ -24,7 +24,7 @@ rlJournalStart
             rlPhaseEnd
 
             rlPhaseStartTest "Ansible ($method) - check extra-args attribute"
-                rlRun "tmt run -rddd discover provision -h $method prepare finish plan -n /$plan \
+                rlRun "tmt run -rddd discover provision -h $method prepare finish plan -n /$plan 2>&1 >/dev/null \
                     | grep \"ansible-playbook\"\
                     | tee output"
                 rlAssertGrep "-vvv" output

--- a/tests/prepare/basic/test.sh
+++ b/tests/prepare/basic/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "tmt run -dddvvvr | tee output"
+        rlRun "tmt run -dddvvvr 2>&1 >/dev/null | tee output"
         rlAssertGrep "Test Management Tool" "output"
     rlPhaseEnd
 

--- a/tests/prepare/require/test.sh
+++ b/tests/prepare/require/test.sh
@@ -17,7 +17,7 @@ rlJournalStart
         fi
 
         rlPhaseStartTest "Require an available package ($image)"
-            rlRun "$tmt plan --name available | tee output"
+            rlRun "$tmt plan --name available 2>&1 >/dev/null | tee output"
             rlAssertGrep '1 preparation applied' output
         rlPhaseEnd
 

--- a/tests/report/html/test.sh
+++ b/tests/report/html/test.sh
@@ -13,7 +13,7 @@ rlJournalStart
 
     for option in "" "--absolute-paths"; do
         rlPhaseStartTest "Check status (${option:-relative paths})"
-            rlRun -s "tmt run -av --scratch --id $run_dir report -h html $option" 2
+            rlRun -s "tmt run -av --scratch --id $run_dir report -h html $option 2>&1 >/dev/null | tee output" 2
             rlAssertGrep "summary: 2 tests passed, 1 test failed and 2 errors" $rlRun_LOG -F
 
             # Path of the generated file should be shown and the page should exist

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -9,7 +9,7 @@ rlJournalStart
 
     for method in tmt; do
         rlPhaseStartTest "$method"
-            rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml | tee output" 2
+            rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml 2>&1 >/dev/null | tee output" 2
             rlAssertGrep "2 tests passed, 2 tests failed and 2 errors" "output"
             rlAssertGrep '<testsuite disabled="0" errors="2" failures="2" name="/plan" skipped="0" tests="6"' "junit.xml"
             rlAssertGrep 'fail</failure>' "junit.xml"

--- a/tests/report/polarion/test.sh
+++ b/tests/report/polarion/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "tmt run -avr execute report -h polarion --project-id RHELBASEOS --no-upload --file xunit.xml | tee output" 2
+        rlRun "tmt run -avr execute report -h polarion --project-id RHELBASEOS --no-upload --file xunit.xml 2>&1 >/dev/null | tee output" 2
         rlAssertGrep "1 test passed, 1 test failed and 1 error" "output"
         rlAssertGrep '<testsuite disabled="0" errors="1" failures="1" name="/plan" skipped="0" tests="3"' "xunit.xml"
         rlAssertGrep '<property name="polarion-project-id" value="RHELBASEOS" />' "xunit.xml"

--- a/tests/report/summary/test.sh
+++ b/tests/report/summary/test.sh
@@ -8,12 +8,12 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Check summary"
-        rlRun "tmt run -r | tee output" 2 "Run tests in concise mode"
+        rlRun "tmt run -r 2>&1 >/dev/null | tee output" 2 "Run tests in concise mode"
         rlAssertGrep "3 tests passed, 2 tests failed and 1 error" "output"
     rlPhaseEnd
 
     rlPhaseStartTest "Check details"
-        rlRun "tmt run -v | tee output" 2 "Run tests in verbose mode"
+        rlRun "tmt run -v 2>&1 >/dev/null | tee output" 2 "Run tests in verbose mode"
         rlAssertGrep "fail /test/bad/one" "output"
         rlAssertGrep "fail /test/bad/two" "output"
         rlAssertGrep "pass /test/good/one" "output"
@@ -23,9 +23,9 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Check the last run"
-        rlRun "tmt run -l | tee output" 2 "Last run in concise mode "
+        rlRun "tmt run -l 2>&1 >/dev/null | tee output" 2 "Last run in concise mode "
         rlAssertGrep "3 tests passed, 2 tests failed and 1 error" "output"
-        rlRun "tmt run -lvr | tee output" 2 "Last run in verbose mode "
+        rlRun "tmt run -lvr 2>&1 >/dev/null | tee output" 2 "Last run in verbose mode "
         rlAssertGrep "3 tests passed, 2 tests failed and 1 error" "output"
         rlAssertGrep "fail /test/bad/one" "output"
         rlAssertGrep "pass /test/good/one" "output"

--- a/tests/run/default/test.sh
+++ b/tests/run/default/test.sh
@@ -25,7 +25,7 @@ rlJournalStart
 
     rlPhaseStartTest "Explicit default"
         rlRun "tmt plan create -t mini plans/plan"
-        rlRun "tmt run $options plan --default | tee output"
+        rlRun "tmt run $options plan --default 2>&1 >/dev/null | tee output"
         rlAssertGrep "/plans/default" "output"
         rlAssertNotgrep "/plans/plan" "output"
     rlPhaseEnd

--- a/tests/status/base/test.sh
+++ b/tests/status/base/test.sh
@@ -10,7 +10,7 @@ rlJournalStart
         rlRun "tmt init"
         rlRun "tmt plan create -t mini plan1"
         rlRun "tmt plan create -t mini plan2"
-        rlRun "tmt run -a -S report provision -h local | tee run-output"
+        rlRun "tmt run -a -S report provision -h local 2>&1 >/dev/null | tee run-output"
         rlRun "runid=\$(head -n 1 run-output)" 0 "Get the run ID"
     rlPhaseEnd
 
@@ -58,13 +58,13 @@ rlJournalStart
         rlAssertGrep "done\s+$runid" "output" -E
         # Remove the initial run, we do not need it anymore
         rlRun "rm -r $runid"
-        rlRun "tmt run -r provision -h local | tee run-output"
+        rlRun "tmt run -r provision -h local 2>&1 >/dev/null | tee run-output"
         rlRun "runid=\$(head -n 1 run-output)" 0 "Get the run ID"
         rlRun "tmt status --abandoned | tee output"
         rlAssertGrep "done\s+$runid" "output" -E
         rlRun "tmt run -l finish"
 
-        rlRun "tmt run -ar provision -h local prepare -h shell -s false \
+        rlRun "tmt run -ar provision -h local prepare -h shell -s false 2>&1 >/dev/null \
             | tee run-output" 2 "Let the prepare step fail"
         rlRun "runid=\$(head -n 1 run-output)" 0 "Get the run ID"
         rlRun "tmt status --active | tee output"

--- a/tests/steps/select/test.sh
+++ b/tests/steps/select/test.sh
@@ -16,7 +16,7 @@ rlJournalStart
             exitcode=0
             [[ $selected_step == execute ]] && exitcode=2
             [[ $selected_step == report ]] && exitcode=3
-            rlRun "tmt run $options $selected_step | tee output" $exitcode
+            rlRun "tmt run $options $selected_step 2>&1 >/dev/null | tee output" $exitcode
             for step in $steps; do
                 if [[ $step == $selected_step ]]; then
                     rlAssertGrep $step output
@@ -28,14 +28,14 @@ rlJournalStart
     done
 
     rlPhaseStartTest "All steps"
-        rlRun "tmt run $options --all provision -h local | tee output"
+        rlRun "tmt run $options --all provision -h local 2>&1 >/dev/null | tee output"
         for step in $steps; do
             rlAssertGrep $step output
         done
     rlPhaseEnd
 
     rlPhaseStartTest "Skip steps"
-        rlRun "tmt run $options --skip prepare | tee output"
+        rlRun "tmt run $options --skip prepare 2>&1 >/dev/null | tee output"
         for step in $steps; do
             if [[ $step == prepare ]]; then
                 rlAssertNotGrep $step output
@@ -46,7 +46,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Until"
-        rlRun "tmt run $options --until execute discover -h shell | tee output"
+        rlRun "tmt run $options --until execute discover -h shell 2>&1 >/dev/null | tee output"
         for step in discover provision prepare execute; do
             rlAssertGrep $step output
         done
@@ -57,7 +57,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Since"
-        rlRun "tmt run --last --since report finish -h shell | tee output"
+        rlRun "tmt run --last --since report finish -h shell 2>&1 >/dev/null | tee output"
         for step in discover provision prepare execute; do
             rlAssertNotGrep $step output
         done
@@ -68,7 +68,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Before"
-        rlRun "tmt run $options --before report discover -h shell | tee output"
+        rlRun "tmt run $options --before report discover -h shell 2>&1 >/dev/null | tee output"
         for step in discover provision prepare execute; do
             rlAssertGrep $step output
         done
@@ -79,7 +79,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "After"
-        rlRun "tmt run --last --after execute finish -h shell | tee output"
+        rlRun "tmt run --last --after execute finish -h shell 2>&1 >/dev/null | tee output"
         for step in discover provision prepare execute; do
             rlAssertNotGrep $step output
         done
@@ -91,7 +91,7 @@ rlJournalStart
 
     rlPhaseStartTest "Invalid"
         for option in 'since' 'until' 'skip'; do
-            rlRun "tmt run $options --$option invalid 2>&1 | tee output" 2
+            rlRun "tmt run $options --$option invalid 2>&1 >/dev/null | tee output" 2
             rlAssertGrep "Invalid value" output
         done
     rlPhaseEnd

--- a/tests/test/select/test.sh
+++ b/tests/test/select/test.sh
@@ -11,14 +11,14 @@ rlJournalStart
     # Select by name
     for tmt in 'tmt test ls' 'tmt test show'; do
         rlPhaseStartTest "$tmt"
-            rlRun "$tmt | tee $output"
+            rlRun "$tmt | grep -v 'warn: ' | tee $output"
             rlAssertGrep "/tests/enabled/default" $output
             rlAssertGrep "/tests/tag/default" $output
             rlAssertGrep "/tests/tier/default" $output
         rlPhaseEnd
 
         rlPhaseStartTest "$tmt <name>"
-            rlRun "$tmt tier | tee $output"
+            rlRun "$tmt tier | grep -v 'warn: ' | tee $output"
             rlAssertNotGrep "/tests/enabled/default" $output
             rlAssertNotGrep "/tests/tag/default" $output
             rlAssertGrep "/tests/tier/default" $output
@@ -34,16 +34,16 @@ rlJournalStart
         rlPhaseStartTest "tmt run test $name <name>"
             tmt='tmt run -rv discover finish'
             # Existing
-            rlRun "$tmt test $name enabled | tee $output"
+            rlRun "$tmt test $name enabled 2>&1 >/dev/null | grep -v 'warn: ' | tee $output"
             rlAssertGrep "/tests/enabled/default" $output
             rlAssertNotGrep "/tests/enabled/disabled" $output
             rlAssertNotGrep "/tests/tag/default" $output
             rlAssertNotGrep "/tests/tier/default" $output
             # Missing
-            rlRun "$tmt test $name non-existent | tee $output"
+            rlRun "$tmt test $name non-existent 2>&1 >/dev/null | grep -v 'warn: ' | tee $output"
             rlAssertGrep "No tests found" $output
             # Using 'test --name' overrides 'test' in discover
-            rlRun "$tmt test $name tier/one | tee $output"
+            rlRun "$tmt test $name tier/one 2>&1 >/dev/null | grep -v 'warn: ' | tee $output"
             rlAssertGrep "/tests/tier/one" $output
             rlAssertNotGrep "/tests/tier/two" $output
         rlPhaseEnd
@@ -52,44 +52,52 @@ rlJournalStart
     rlPhaseStartTest "Select tests using a filter"
         # Enabled
         for bool in True true; do
-            rlRun "tmt test ls --filter enabled:$bool | tee $output"
+            rlRun "tmt test ls --filter enabled:$bool | grep -v 'warn: ' | tee $output"
             rlAssertGrep '/tests/enabled/default' $output
             rlAssertGrep '/tests/enabled/defined' $output
             rlAssertNotGrep '/tests/enabled/disabled' $output
         done
         for bool in False false; do
-            rlRun "tmt test ls --filter enabled:False | tee $output"
+            rlRun "tmt test ls --filter enabled:False | grep -v 'warn: ' | tee $output"
             rlAssertNotGrep '/tests/enabled/default' $output
             rlAssertNotGrep '/tests/enabled/defined' $output
             rlAssertGrep '/tests/enabled/disabled' $output
         done
 
-        for tmt in 'tmt test ls' 'tmt run -rv discover finish test' \
+        for tmt in 'tmt test ls' \
+            'tmt run -rv discover finish test' \
             'tmt run -rv plans --name /plans/filtered discover finish test'; do
+
+            if [[ "$tmt" == *" run "* ]]; then
+                redirect="2>&1 >/dev/null"
+            else
+                redirect=""
+            fi
+
             # Tag
-            rlRun "$tmt --filter tag:slow | tee $output"
+            rlRun "$tmt --filter tag:slow $redirect | grep -v 'warn: ' | tee $output"
             rlAssertNotGrep '/tests/tag/default' $output
             rlAssertGrep '/tests/tag/defined' $output
             rlAssertNotGrep '/tests/tag/empty' $output
-            rlRun "$tmt --filter tag:-slow | tee $output"
+            rlRun "$tmt --filter tag:-slow $redirect | grep -v 'warn: ' | tee $output"
             rlAssertGrep '/tests/enabled/default' $output
             rlAssertNotGrep '/tests/tag/defined' $output
             rlAssertGrep '/tests/tag/empty' $output
 
             # Tier
-            rlRun "$tmt --filter tier:1 | tee $output"
+            rlRun "$tmt --filter tier:1 $redirect | grep -v 'warn: ' | tee $output"
             rlAssertGrep '/tests/tier/one' $output
             rlAssertNotGrep '/tests/tier/two' $output
             rlAssertNotGrep '/tests/tier/default' $output
-            rlRun "$tmt --filter tier:-1 | tee $output"
+            rlRun "$tmt --filter tier:-1 $redirect | grep -v 'warn: ' | tee $output"
             rlAssertNotGrep '/tests/tier/one' $output
             rlAssertGrep '/tests/tier/two' $output
             rlAssertGrep '/tests/tier/default' $output
-            rlRun "$tmt --filter tier:1,2 | tee $output"
+            rlRun "$tmt --filter tier:1,2 $redirect | grep -v 'warn: ' | tee $output"
             rlAssertGrep '/tests/tier/one' $output
             rlAssertGrep '/tests/tier/two' $output
             rlAssertNotGrep '/tests/tier/default' $output
-            rlRun "$tmt -f tier:-1 -f tier:-2 | tee $output"
+            rlRun "$tmt -f tier:-1 -f tier:-2 $redirect | grep -v 'warn: ' | tee $output"
             rlAssertNotGrep '/tests/tier/one' $output
             rlAssertNotGrep '/tests/tier/two' $output
             rlAssertGrep '/tests/tier/default' $output
@@ -98,32 +106,38 @@ rlJournalStart
 
     rlPhaseStartTest "Select tests using a condition"
         # Enabled
-        rlRun "tmt test ls --condition 'enabled == True' | tee $output"
+        rlRun "tmt test ls --condition 'enabled == True' | grep -v 'warn: ' | tee $output"
         rlAssertGrep '/tests/enabled/default' $output
         rlAssertGrep '/tests/enabled/defined' $output
         rlAssertNotGrep '/tests/enabled/disabled' $output
-        rlRun "tmt test ls --condition 'enabled == False' | tee $output"
+        rlRun "tmt test ls --condition 'enabled == False' | grep -v 'warn: ' | tee $output"
         rlAssertNotGrep '/tests/enabled/default' $output
         rlAssertNotGrep '/tests/enabled/defined' $output
         rlAssertGrep '/tests/enabled/disabled' $output
 
         for tmt in 'tmt test ls' 'tmt run -rv discover finish test'; do
+            if [[ "$tmt" == *" run "* ]]; then
+                redirect="2>&1 >/dev/null"
+            else
+                redirect=""
+            fi
+
             # Tag
-            rlRun "$tmt --condition '\"slow\" in tag' | tee $output"
+            rlRun "$tmt --condition '\"slow\" in tag' $redirect | grep -v 'warn: ' | tee $output"
             rlAssertNotGrep '/tests/tag/default' $output
             rlAssertGrep '/tests/tag/defined' $output
             rlAssertNotGrep '/tests/tag/empty' $output
-            rlRun "$tmt --condition '\"slow\" not in tag' | tee $output"
+            rlRun "$tmt --condition '\"slow\" not in tag' $redirect | grep -v 'warn: ' | tee $output"
             rlAssertGrep '/tests/enabled/default' $output
             rlAssertNotGrep '/tests/tag/defined' $output
             rlAssertGrep '/tests/tag/empty' $output
 
             # Tier
-            rlRun "$tmt --condition 'tier is not None' | tee $output"
+            rlRun "$tmt --condition 'tier is not None' $redirect | grep -v 'warn: ' | tee $output"
             rlAssertGrep '/tests/tier/one' $output
             rlAssertGrep '/tests/tier/two' $output
             rlAssertNotGrep '/tests/tier/default' $output
-            rlRun "$tmt -c 'tier and int(tier) > 1' | tee $output"
+            rlRun "$tmt -c 'tier and int(tier) > 1' $redirect | grep -v 'warn: ' | tee $output"
             rlAssertNotGrep '/tests/tier/one' $output
             rlAssertGrep '/tests/tier/two' $output
             rlAssertNotGrep '/tests/tier/default' $output
@@ -132,16 +146,16 @@ rlJournalStart
 
     rlPhaseStartTest "Select duplicate tests preserving tests ordering"
         # 'tmt test ls' lists test name once
-        rlRun "tmt tests ls tier | tee $output"
+        rlRun "tmt tests ls tier | grep -v 'warn: ' | tee $output"
         rlAssertGrep '/tests/tier/two' $output
         rlAssertEquals "/tests/tier/two is listed only once" 1 $( grep -c 'tier/two' $output )
 
-        rlRun "tmt tests ls tier/two tier/two | tee $output"
+        rlRun "tmt tests ls tier/two tier/two | grep -v 'warn: ' | tee $output"
         rlAssertGrep '/tests/tier/two' $output
         rlAssertEquals "/tests/tier/two is listed only once" 1 $( grep -c 'tier/two' $output )
 
         # 'tmt test show' lists test name once
-        rlRun "tmt tests show tier | tee $output"
+        rlRun "tmt tests show tier | grep -v 'warn: ' | tee $output"
         rlAssertGrep '/tests/tier/two' $output
         rlAssertEquals "/tests/tier/two is listed only once" 1 $( grep -c 'tier/two' $output )
 
@@ -150,7 +164,7 @@ rlJournalStart
         tmt="tmt run --id $run --scratch plans --name duplicate discover -v"
 
         # 'tmt run discover' lists duplicate test names preserving order
-        rlRun "$tmt | tee $output"
+        rlRun "$tmt 2>&1 >/dev/null | grep -v 'warn: ' | tee $output"
         rlAssertGrep 'tests: /tier/two, /tier/one and /tier/two' $output
         rlAssertGrep 'summary: 3 tests selected' $output
         rlRun "grep -A 1 summary $output | tail -1 | grep '/tests/tier/two'"
@@ -158,14 +172,14 @@ rlJournalStart
         rlRun "grep -A 3 summary $output | tail -1 | grep '/tests/tier/two'"
 
         # tests --name filters discovered test names (/two is discovered twice)
-        rlRun "$tmt -h fmf tests --name two | tee $output"
+        rlRun "$tmt -h fmf tests --name two 2>&1 >/dev/null | grep -v 'warn: ' | tee $output"
         rlAssertGrep 'tests: /tier/two, /tier/one and /tier/two' $output
         rlAssertGrep 'summary: 2 tests selected' $output
         rlRun "grep -A 1 summary $output | tail -1 | grep '/tests/tier/two'"
         rlRun "grep -A 2 summary $output | tail -1 | grep '/tests/tier/two'"
 
         # tests --name doesn't effect order of discovered tests
-        rlRun "$tmt -h fmf tests --name one --name two | tee $output"
+        rlRun "$tmt -h fmf tests --name one --name two 2>&1 >/dev/null | grep -v 'warn: ' | tee $output"
         rlAssertGrep 'tests: /tier/two, /tier/one and /tier/two' $output
         rlAssertGrep 'summary: 3 tests selected' $output
         rlRun "grep -A 1 summary $output | tail -1 | grep '/tests/tier/two'"
@@ -173,13 +187,13 @@ rlJournalStart
         rlRun "grep -A 3 summary $output | tail -1 | grep '/tests/tier/two'"
 
         # discover --test redefines duplicate plan so two is discovered just once
-        rlRun "$tmt -h fmf --test two | tee $output"
+        rlRun "$tmt -h fmf --test two 2>&1 >/dev/null | grep -v 'warn: ' | tee $output"
         rlAssertGrep 'tests: two' $output
         rlAssertGrep 'summary: 1 test selected' $output
         rlRun "grep -A 1 summary $output | tail -1 | grep '/tests/tier/two'"
 
         # redefine --test via command line same as was in the plan
-        rlRun "$tmt -h fmf --test two --test two | tee $output"
+        rlRun "$tmt -h fmf --test two --test two 2>&1 >/dev/null | grep -v 'warn: ' | tee $output"
         rlAssertGrep 'tests: two and two' $output
         rlAssertGrep 'summary: 2 tests selected' $output
         rlRun "grep -A 1 summary $output | tail -1 | grep '/tests/tier/two'"
@@ -208,7 +222,7 @@ rlJournalStart
         rlRun "rm -rf $run" 0 "Clean up run"
 
         # Common prefix should not be selected
-        rlRun -s "tmt tests ls ."
+        rlRun -s "tmt tests ls . | grep -v 'warn: '"
         rlAssertGrep "/subdir" "$rlRun_LOG"
         rlAssertNotGrep "/subdir_other" "$rlRun_LOG"
 
@@ -217,14 +231,14 @@ rlJournalStart
 
         # Virtual cases defined in /sub/ (no other tests should be selected)
         rlRun "pushd sub"
-        rlRun -s "tmt tests ls ."
+        rlRun -s "tmt tests ls .| grep -v 'warn: '"
         rlAssertGrep "/sub/first" "$rlRun_LOG"
         rlAssertGrep "/sub/second" "$rlRun_LOG"
         rlAssertNotGrep "/subdir" "$rlRun_LOG"
         rlRun "popd"
 
         # In top dir all tests should be selected
-        rlRun -s "tmt tests ls ."
+        rlRun -s "tmt tests ls .| grep -v 'warn: '"
         rlAssertGrep "/sub/first" "$rlRun_LOG"
         rlAssertGrep "/subdir" "$rlRun_LOG"
         rlAssertGrep "/tests" "$rlRun_LOG"
@@ -232,9 +246,9 @@ rlJournalStart
 
     for exclude in '-x' '--exclude'; do
         rlPhaseStartTest "tmt test ls $exclude <regex>"
-            rlRun "tmt test ls | tee $output"
+            rlRun "tmt test ls | grep -v 'warn: ' | tee $output"
             rlAssertGrep "/tests/enabled/default" $output
-            rlRun "tmt test ls $exclude default | tee $output"
+            rlRun "tmt test ls $exclude default | grep -v 'warn: ' | tee $output"
             rlAssertNotGrep "/tests/enabled/default" $output
         rlPhaseEnd
     done

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,172 @@
+import logging
+import operator
+import re
+from typing import Any, Callable, Iterable, List, Tuple
+
+import _pytest.logging
+
+
+class PatternMatching:
+    def __init__(self, pattern: str, method: str) -> None:
+        self.pattern = pattern
+        self._compiled_pattern = re.compile(pattern)
+        self.method = getattr(self._compiled_pattern, method)
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__}: "{self.pattern}">'
+
+
+class MATCH(PatternMatching):
+    """
+    Wrap a string with this class, to use it as a regular expression when matching log records.
+
+    :py:class:`SEARCH` applies to any place within the string, while ``MATCH`` must match from the
+    beginning of the string.
+
+    .. code-block:: python
+
+       assert_log(message=MATCH('an exception .+ was raised'))
+    """
+
+    def __init__(self, pattern: str) -> None:
+        super().__init__(pattern, 'match')
+
+
+class SEARCH(PatternMatching):
+    """
+    Wrap a string with this class, to use it as a regular expression when searching for log
+    records.
+
+    ``SEARCH`` applies to any place within the string, while :py:class:`MATCH` must match from the
+    beginning of the string.
+
+    .. code-block:: python
+
+       assert_log(message=SEARCH('an exception .+ was raised'))
+    """
+
+    def __init__(self, pattern: str) -> None:
+        super().__init__(pattern, 'search')
+
+
+def _assert_log(
+        caplog: _pytest.logging.LogCaptureFixture,
+        evaluator: Callable[[Iterable[Any]], bool] = any,
+        not_present: bool = False,
+        **tests: Any
+        ) -> None:
+    """
+    Assert log contains a record - logged message - with given properties. Those are specified as
+    keyword parameters: :py:class:`logging.LogRecords` properties are allowed names, parameter
+    values are the expected values.
+
+    .. code-block:: python
+
+       assert_log(message='everything went well', levelno=logging.INFO)
+       assert_log(message='things broke down', levelno=logging.ERROR)
+       assert_log(message=MATCH('user .+ logged in'), levelno=logging.INFO)
+
+    :param caplog: Pytest's `caplog` fixture.
+    :param evaluator: a callable reducing a given list of booleans into a single boolean. It is
+        used to evaluate whether the search for matching record was successfull: each record is
+        tested, and results of these per-record tests are passed to `evaluator` for the final
+        decision.
+    """
+
+    # We are given field_name=expected_value pairs, but we also want to be open to other binary
+    # operators, like "field_name matches pattern". To protect the actual matching from aspects of
+    # different possible operators, we will convert the "tests" into basic building blocks: a
+    # field name, a callable accepting two parameters, and the given (expected) value. With these,
+    # we can reduce the matching into functions calls without worrying what functions we work with.
+
+    operators: List[Tuple[Callable[[Any], Any], str, Callable[[Any, Any], bool], Any]] = []
+
+    for field_name, expected_value in tests.items():
+        if field_name.startswith('details_'):
+            field_name = field_name.replace('details_', '')
+            def field_getter(record, name): return record.details.get(name, None)
+
+        else:
+            def field_getter(record, name): return getattr(record, name)
+
+        # Special case: if the expected value is a pattern matching instance, it represents a
+        # regular expression. We don't modify the field name and "expected" value, but the
+        # function will be a custom lambda calling proper `re` method.
+        if isinstance(expected_value, PatternMatching):
+            operators.append((
+                field_getter,
+                field_name,
+                lambda a, b: a.method(b) is not None,
+                expected_value
+                ))
+
+            continue
+
+        # Python's `operator` package offers operators - `==` or `!=` - in a form of functions,
+        # which is exactly what we need here, so we don't have to build our own
+        # `lambda a, b: a == b`. We might use more than just `eq` in the future, so let's start
+        # with `operator` right away.
+
+        operators.append((
+            field_getter,
+            field_name,
+            operator.eq,
+            expected_value
+            ))
+
+    # Given a logging record, apply all field/operator/value triplets, and make sure all match the
+    # actual record properties.
+    def _cmp(record: logging.LogRecord) -> bool:
+        return all([
+            op(expected_value, field_getter(record, field_name))
+            for field_getter, field_name, op, expected_value in operators
+            ])
+
+    # Final step: apply our "make sure field/operator/value triplets match given record" to each
+    # and every record, and reduce per-record results into a single answer. By default, `any` is
+    # used which means that any record matching all field/operator/value triples yield the final
+    # "yes, such a record exists".
+    outcome = evaluator([_cmp(record) for record in caplog.records])
+
+    def _report(message: str) -> None:
+        formatted_fields = [
+            f'    {field} == {value}'
+            for field, value in tests.items()
+            ]
+
+        for record in caplog.records:
+            for field_getter, field_name, op, expected_value in operators:
+                print(field_name,
+                      field_getter(record, field_name),
+                      expected_value,
+                      op(expected_value, field_getter(record, field_name)))
+
+        assert False, f"""
+{message}:
+
+{chr(10).join(formatted_fields)}
+"""
+
+    # Cannot find log record with these properties
+
+    if not_present is False and not outcome:
+        _report('Could not find log record with these properties when it should exist')
+
+    elif not_present is True and outcome:
+        _report('Found log record with these properties when it should not exist')
+
+
+def assert_log(
+        caplog: _pytest.logging.LogCaptureFixture,
+        evaluator: Callable[[Iterable[Any]], bool] = any,
+        **tests: Any
+        ) -> None:
+    _assert_log(caplog, evaluator=evaluator, not_present=False, **tests)
+
+
+def assert_not_log(
+        caplog: _pytest.logging.LogCaptureFixture,
+        evaluator: Callable[[Iterable[Any]], bool] = any,
+        **tests: Any
+        ) -> None:
+    _assert_log(caplog, evaluator=evaluator, not_present=True, **tests)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,9 @@
+import _pytest.logging
+import pytest
+
+from tmt.log import Logger
+
+
+@pytest.fixture(name='root_logger')
+def fixture_root_logger(caplog: _pytest.logging.LogCaptureFixture) -> Logger:
+    return Logger.create(verbose=0, debug=0, quiet=False)

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -31,9 +31,9 @@ def test_invalid_yaml_syntax():
     shutil.rmtree(tmp)
 
 
-def test_test_defaults():
+def test_test_defaults(root_logger):
     """ Test default test attributes """
-    test = tmt.Test.from_dict(dict(test='./test.sh'), '/smoke')
+    test = tmt.Test.from_dict(logger=root_logger, mapping=dict(test='./test.sh'), name='/smoke')
     assert test.name == '/smoke'
     assert test.component == list()
     assert str(test.test) == './test.sh'
@@ -46,18 +46,23 @@ def test_test_defaults():
     assert test.tag == list()
 
 
-def test_test_invalid():
+def test_test_invalid(root_logger):
     """ Test invalid test """
     # Missing name
     with pytest.raises(tmt.utils.GeneralError):
-        tmt.Test.from_dict({}, '')
+        tmt.Test.from_dict(logger=root_logger, mapping={}, name='')
     # Invalid name
     with pytest.raises(SpecificationError):
-        tmt.Test.from_dict({}, 'bad')
+        tmt.Test.from_dict(logger=root_logger, mapping={}, name='bad')
     # Invalid attributes
     for key in ['component', 'require', 'tag']:
         with pytest.raises(SpecificationError) as exc_context:
-            tmt.Test.from_dict({key: 1}, '/smoke', raise_on_validation_error=True)
+            tmt.Test.from_dict(
+                logger=root_logger,
+                mapping={
+                    key: 1},
+                name='/smoke',
+                raise_on_validation_error=True)
 
         exc = exc_context.value
 
@@ -71,10 +76,17 @@ def test_test_invalid():
             == f'/smoke:{key} - 1 is not valid under any of the given schemas'
 
     with pytest.raises(SpecificationError):
-        tmt.Test.from_dict({'environment': 'string'}, '/smoke', raise_on_validation_error=True)
+        tmt.Test.from_dict(logger=root_logger, mapping={'environment': 'string'},
+                           name='/smoke', raise_on_validation_error=True)
     # Listify attributes
-    assert tmt.Test.from_dict({'test': 'test', 'tag': 'a'}, '/smoke').tag == ['a']
-    assert tmt.Test.from_dict({'test': 'test', 'tag': ['a', 'b']}, '/smoke').tag == ['a', 'b']
+    assert tmt.Test.from_dict(
+        logger=root_logger,
+        mapping={
+            'test': 'test',
+            'tag': 'a'},
+        name='/smoke').tag == ['a']
+    assert tmt.Test.from_dict(logger=root_logger, mapping={'test': 'test', 'tag': [
+                              'a', 'b']}, name='/smoke').tag == ['a', 'b']
 
 
 def test_link():

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -9,10 +9,12 @@ from click.testing import CliRunner
 
 import tmt
 import tmt.cli
+import tmt.log
 from tmt.identifier import ID_KEY, locate_key
 
 runner = CliRunner()
 test_path = Path(__file__).parent / "id"
+root_logger = tmt.log.Logger.create()
 
 
 class IdLocationDefined(TestCase):
@@ -26,7 +28,7 @@ class IdLocationDefined(TestCase):
 
     def test_defined_partially(self):
         node = self.base_tree.find("/partial")
-        test = tmt.Test(node=node)
+        test = tmt.Test(logger=root_logger, node=node)
         self.assertEqual(locate_key(node, ID_KEY), test.node)
 
     def test_not_defined(self):
@@ -71,19 +73,19 @@ class IdEmpty(TestCase):
 
     def test_base(self):
         node = self.base_tree.find("/some/structure")
-        test = tmt.Test(node=node)
+        test = tmt.Test(logger=root_logger, node=node)
         self.assertEqual(test.id, None)
 
     def test_manually_add_id(self):
         node = self.base_tree.find("/some/structure")
-        test = tmt.Test(node=node)
+        test = tmt.Test(logger=root_logger, node=node)
         self.assertEqual(test.id, None)
         identifier = tmt.identifier.add_uuid_if_not_defined(node, dry=False)
         self.assertGreater(len(identifier), 10)
 
         self.base_tree = fmf.Tree(self.path)
         node = self.base_tree.find("/some/structure")
-        test = tmt.Test(node=node)
+        test = tmt.Test(logger=root_logger, node=node)
         self.assertEqual(test.id, identifier)
 
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,174 @@
+import logging
+
+import _pytest.logging
+import pytest
+
+from tmt.log import (DebugLevelFilter, Logger, QuietnessFilter,
+                     VerbosityLevelFilter)
+
+from . import assert_log
+
+
+def test_sanity(caplog: _pytest.logging.LogCaptureFixture, root_logger: Logger) -> None:
+    root_logger.print('this is printed')
+    root_logger.debug('this is a debug message')
+    root_logger.verbose('this is a verbose message')
+    root_logger.info('this is just an info')
+    root_logger.warn('this is a warning')
+    root_logger.fail('this is a failure')
+
+    assert_log(caplog, details_key='this is printed', levelno=logging.INFO)
+    assert_log(caplog, details_key='this is a debug message', levelno=logging.DEBUG)
+    assert_log(caplog, details_key='this is a verbose message', levelno=logging.INFO)
+    assert_log(caplog, details_key='this is just an info', levelno=logging.INFO)
+    assert_log(caplog, details_key='warn', details_value='this is a warning', levelno=logging.WARN)
+    assert_log(
+        caplog,
+        details_key='fail',
+        details_value='this is a failure',
+        levelno=logging.ERROR)
+
+
+def test_creation(caplog: _pytest.logging.LogCaptureFixture, root_logger: Logger) -> None:
+    logger = Logger.create()
+    assert logger._logger.name == 'tmt'
+
+    actual_logger = logging.Logger('3rd-party-app-logger')
+    logger = Logger.create(actual_logger)
+    assert logger._logger is actual_logger
+
+
+def test_descend(caplog: _pytest.logging.LogCaptureFixture, root_logger: Logger) -> None:
+    deeper_logger = root_logger.descend().descend().descend()
+
+    deeper_logger.print('this is printed')
+    deeper_logger.debug('this is a debug message')
+    deeper_logger.verbose('this is a verbose message')
+    deeper_logger.info('this is just an info')
+    deeper_logger.warn('this is a warning')
+    deeper_logger.fail('this is a failure')
+
+    assert_log(caplog, details_key='this is printed', levelno=logging.INFO)
+    assert_log(caplog, details_key='this is a debug message', levelno=logging.DEBUG)
+    assert_log(caplog, details_key='this is a verbose message', levelno=logging.INFO)
+    assert_log(caplog, details_key='this is just an info', levelno=logging.INFO)
+    assert_log(caplog, details_key='warn', details_value='this is a warning', levelno=logging.WARN)
+    assert_log(
+        caplog,
+        details_key='fail',
+        details_value='this is a failure',
+        levelno=logging.ERROR)
+
+
+@pytest.mark.parametrize(
+    ('logger_verbosity', 'message_verbosity', 'filter_outcome'),
+    [
+        # (
+        #   logger verbosity - corresponds to -v, -vv, -vvv CLI options,
+        #   message verbosity - `level` parameter of `verbosity(...)` call,
+        #   expected outcome of `VerbosityLevelFilter.filter()` - returns integer!
+        # )
+        (0, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (3, 1, 1),
+        (4, 1, 1),
+        (0, 2, 0),
+        (1, 2, 0),
+        (2, 2, 1),
+        (3, 2, 1),
+        (4, 2, 1),
+        (0, 3, 0),
+        (1, 3, 0),
+        (2, 3, 0),
+        (3, 3, 1),
+        (4, 3, 1),
+        (0, 4, 0),
+        (1, 4, 0),
+        (2, 4, 0),
+        (3, 4, 0),
+        (4, 4, 1)
+        ]
+    )
+def test_verbosity_filter(
+        logger_verbosity: int,
+        message_verbosity: int,
+        filter_outcome: int
+        ) -> None:
+    filter = VerbosityLevelFilter()
+
+    assert filter.filter(logging.makeLogRecord({
+        'levelno': logging.INFO,
+        'details': {
+            'logger_verbosity_level': logger_verbosity,
+            'message_verbosity_level': message_verbosity
+            }
+        })) == filter_outcome
+
+
+@pytest.mark.parametrize(
+    ('logger_debug', 'message_debug', 'filter_outcome'),
+    [
+        # (
+        #   logger debug level - corresponds to -d, -dd, -ddd CLI options,
+        #   message debug level - `level` parameter of `debug(...)` call,
+        #   expected outcome of `DebugLevelFilter.filter()` - returns integer!
+        # )
+        (0, 1, 0),
+        (1, 1, 1),
+        (2, 1, 1),
+        (3, 1, 1),
+        (4, 1, 1),
+        (0, 2, 0),
+        (1, 2, 0),
+        (2, 2, 1),
+        (3, 2, 1),
+        (4, 2, 1),
+        (0, 3, 0),
+        (1, 3, 0),
+        (2, 3, 0),
+        (3, 3, 1),
+        (4, 3, 1),
+        (0, 4, 0),
+        (1, 4, 0),
+        (2, 4, 0),
+        (3, 4, 0),
+        (4, 4, 1)
+        ]
+    )
+def test_debug_filter(
+        logger_debug: int,
+        message_debug: int,
+        filter_outcome: int
+        ) -> None:
+    filter = DebugLevelFilter()
+
+    assert filter.filter(logging.makeLogRecord({
+        'levelno': logging.DEBUG,
+        'details': {
+            'logger_debug_level': logger_debug,
+            'message_debug_level': message_debug
+            }
+        })) == filter_outcome
+
+
+@pytest.mark.parametrize(
+    ('levelno', 'filter_outcome'),
+    [
+        # (
+        #   log message level,
+        #   expected outcome of `QietnessFilter.filter()` - returns integer!
+        # )
+        (logging.DEBUG, 0),
+        (logging.INFO, 0),
+        (logging.WARNING, 1),
+        (logging.ERROR, 1),
+        (logging.CRITICAL, 1)
+        ]
+    )
+def test_quietness_filter(levelno: int, filter_outcome: int) -> None:
+    filter = QuietnessFilter()
+
+    assert filter.filter(logging.makeLogRecord({
+        'levelno': levelno
+        })) == filter_outcome

--- a/tests/unit/test_report_junit.py
+++ b/tests/unit/test_report_junit.py
@@ -10,7 +10,7 @@ from tmt.steps.report.junit import ReportJUnit, ReportJUnitData
 
 
 @pytest.fixture
-def report_fix(tmpdir):
+def report_fix(tmpdir, root_logger):
     # need to provide genuine workdir paths - mock would break os.path.* calls
     step_mock = MagicMock(workdir=str(tmpdir))
     plan_mock = MagicMock()
@@ -27,6 +27,7 @@ def report_fix(tmpdir):
         return default
 
     report = ReportJUnit(
+        logger=root_logger,
         step=step_mock,
         data=ReportJUnitData(name='x', how='junit'),
         workdir=str(tmpdir.join('junit')))

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -6,11 +6,13 @@ import fmf
 import pytest
 
 import tmt
+import tmt.log
 import tmt.utils
 
 PATH = os.path.dirname(os.path.realpath(__file__))
 ROOTDIR = os.path.join(PATH, "../..")
 
+LOGGER = tmt.log.Logger.create(verbose=0, debug=0, quiet=False)
 
 # This is what `Tree.{tests,plans,stories}`` do internally, but after getting
 # all nodes, these methods would construct tmt objects representing found
@@ -22,13 +24,15 @@ ROOTDIR = os.path.join(PATH, "../..")
 # `Tree` modifies them - use the underlying fmf tree's `prune()` method, and
 # use the right keys to filter out nodes we're interested in (the same `Tree`
 # uses).
+
+
 def _iter_nodes(tree, keys):
     for node in tree.tree.prune(keys=keys):
         yield tree, node
 
 
 def _iter_trees():
-    yield tmt.Tree(path=ROOTDIR)
+    yield tmt.Tree(logger=LOGGER, path=ROOTDIR)
 
     # Ad hoc construction, but here me out: there are small, custom-tailored fmf trees
     # to serve various tests. These are invisible to the top-level tree. Lucky us though,
@@ -177,7 +181,7 @@ def test_plans_schema(tree, plan):
         ]
     )
 def test_hw_schema_examples(hw: str, request) -> None:
-    tree = tmt.Tree()
+    tree = tmt.Tree(logger=LOGGER)
 
     # Our hardware schema is supposed to be referenced from provision plugin schemas.
     # Instead of cutting it out, we can use a provision plugin schema & prepare the

--- a/tmt/__init__.py
+++ b/tmt/__init__.py
@@ -13,8 +13,10 @@ __all__ = [
     'GuestSsh',
     'Result',
     'Status',
-    'Clean']
+    'Clean',
+    'Logger']
 
 from tmt.base import Clean, Plan, Run, Status, Story, Test, Tree
+from tmt.log import Logger
 from tmt.result import Result
 from tmt.steps.provision import Guest, GuestSsh

--- a/tmt/export.py
+++ b/tmt/export.py
@@ -935,7 +935,7 @@ def enabled_for_environment(test: 'tmt.Test', tcms_notes: str) -> bool:
         context = fmf.context.Context(**context_dict)
         test_node = test.node.copy()
         test_node.adjust(context)
-        return tmt.Test(node=test_node).enabled
+        return tmt.Test(node=test_node, logger=test._logger.descend()).enabled
     except BaseException as exception:
         log.debug(f"Failed to process adjust: {exception}")
         return True

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -1,0 +1,581 @@
+"""
+tmt's logging subsystem.
+
+Adds a layer on top of Python's own :py:mod:`logging` subsystem. This layer implements the desired
+verbosity and debug levels, colorization, formatting, verbosity inheritance and other features used
+by tmt commands and code.
+
+The main workhorses are :py:class:`Logger` instances. Each instance wraps a particular
+:py:class:`logging.Logger` instance - usually there's a chain of such instances, with the root one
+having console and logfile handlers attached. tmt's log verbosity/debug/quiet features are handled
+on our side, with the use of :py:class:`logging.Filter` classes.
+
+``Logger`` instances can be cloned and modified, to match various levels of tmt's runtime class
+tree - ``tmt`` spawns a "root logger" from which a new one is cloned - and indented by one extra
+level - for ``Run`` instance, and so on. This way, every object in tmt's hierarchy uses a given
+logger, which may have its own specific settings, and, in the future, possibly also handlers for
+special output channels.
+
+While tmt recognizes several levels of verbosity (``-v``) and debugging (``-d``), all messages
+emitted by :py:meth:`Logger.verbose` and :py:meth:`Logger.debug` use a single logging level,
+``INFO`` or ``DEBUG``, respectively. The level of verbosity and debugging is then handled by a
+special :py:class:`logging.Filter`` classes. This allows different levels when logging to console
+but all-capturing log files while keeping implementation simple - the other option would be
+managing handlers themselves, which would be very messy given the propagation of messages.
+"""
+
+import itertools
+import logging
+import logging.handlers
+import os
+import os.path
+import sys
+from typing import Any, Optional, cast
+
+import click
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+# Log in workdir
+LOG_FILENAME = 'log.txt'
+
+# Hierarchy indent
+INDENT = 4
+
+DEFAULT_VERBOSITY_LEVEL = 0
+DEFAULT_DEBUG_LEVEL = 0
+
+
+def _debug_level_from_global_envvar() -> int:
+    import tmt.utils
+
+    raw_value = os.getenv('TMT_DEBUG', None)
+
+    if raw_value is None:
+        return 0
+
+    try:
+        return int(raw_value)
+
+    except ValueError:
+        raise tmt.utils.GeneralError(f"Invalid debug level '{raw_value}', use an integer.")
+
+
+def indent(
+        key: str,
+        value: Optional[str] = None,
+        color: Optional[str] = None,
+        level: int = 0) -> str:
+    """
+    Indent a key/value message.
+
+    If both ``key`` and ``value`` are specified, ``{key}: {value}``
+    message is rendered. Otherwise, just ``key`` is used alone. If
+    ``value`` contains multiple lines, each but the very first line is
+    indented by one extra level.
+
+    :param value: optional value to print at right side of ``key``.
+    :param color: optional color to apply on ``key``.
+    :param level: number of indentation levels. Each level is indented
+                  by :py:data:`INDENT` spaces.
+    """
+
+    indent = ' ' * INDENT * level
+    deeper = ' ' * INDENT * (level + 1)
+
+    # Colorize
+    if color is not None:
+        key = click.style(key, fg=color)
+
+    # Handle key only
+    if value is None:
+        message = key
+
+    # Handle key + value
+    else:
+        # Multiline content indented deeper
+        if isinstance(value, str):
+            lines = value.splitlines()
+            if len(lines) > 1:
+                value = ''.join([f"\n{deeper}{line}" for line in lines])
+
+        message = f'{key}: {value}'
+
+    return indent + message
+
+
+class LogRecordDetails(TypedDict, total=False):
+    """ tmt's log message components attached to log records """
+
+    key: str
+    value: Optional[str]
+
+    color: Optional[str]
+    shift: int
+
+    logger_verbosity_level: int
+    message_verbosity_level: Optional[int]
+
+    logger_debug_level: int
+    message_debug_level: Optional[int]
+
+    logger_quiet: bool
+    ignore_quietness: bool
+
+
+class LogfileHandler(logging.FileHandler):
+    def __init__(self, filepath: str) -> None:
+        super().__init__(filepath, mode='a')
+
+
+# ignore[type-arg]: StreamHandler is a generic type, but such expression would be incompatible
+# with older Python versions. Since it's not critical to mark the handler as "str only", we can
+# ignore the issue for now.
+class ConsoleHandler(logging.StreamHandler):  # type: ignore[type-arg]
+    pass
+
+
+class _Formatter(logging.Formatter):
+    def __init__(self, fmt: str, apply_colors: bool = False) -> None:
+        super().__init__(fmt, datefmt='%H:%M:%S')
+
+        self.apply_colors = apply_colors
+
+        # TODO: this is an ugly hack, removing colors after they have been added...
+        # Wouldn't it be better to not add them at first place?
+        #
+        # This is needed to deal with the code that colorizes just part of the message, like
+        # tmt.result.Result outcomes: these are colorized, then merged with the number
+        # of such outcomes, for example, and the string is handed over to logging method.
+        # When colors are *not* to be applied, it's too late because colors have been
+        # applied already. Something to fix...
+        self._decolorize = self._dont_decolorize if apply_colors else self._do_decolorize
+
+    def _do_decolorize(self, s: str) -> str:
+        import tmt.utils
+
+        return tmt.utils.remove_color(s)
+
+    def _dont_decolorize(self, s: str) -> str:
+        return s
+
+    def format(self, record: logging.LogRecord) -> str:
+        if self.usesTime():
+            record.asctime = self.formatTime(record, self.datefmt)
+
+        # When message already exists, do nothing - it either some other logging subsystem,
+        # or tmt's own, already rendered message.
+        if hasattr(record, 'message'):
+            pass
+
+        # Otherwise render the message.
+        else:
+            if record.msg and record.args:
+                record.message = record.msg % record.args
+
+            else:
+                record.message = record.msg
+
+        # Original code from Formatter.format() - hard to inherit when overriding
+        # Formatter.format()...
+        s = self._decolorize(self.formatMessage(record))
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            if s[-1:] != "\n":
+                s = s + "\n"
+            s = s + record.exc_text
+        if record.stack_info:
+            if s[-1:] != "\n":
+                s = s + "\n"
+            s = s + self.formatStack(record.stack_info)
+        return s
+
+
+class LogfileFormatter(_Formatter):
+    def __init__(self) -> None:
+        super().__init__('%(asctime)s %(message)s', apply_colors=False)
+
+
+class ConsoleFormatter(_Formatter):
+    def __init__(self, apply_colors: bool = True) -> None:
+        super().__init__('%(message)s', apply_colors=apply_colors)
+
+
+class VerbosityLevelFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno != logging.INFO:
+            return True
+
+        details: Optional[LogRecordDetails] = getattr(record, 'details', None)
+
+        if details is None:
+            return True
+
+        message_verbosity_level = details.get('message_verbosity_level', None)
+
+        if message_verbosity_level is None:
+            return True
+
+        return True if details['logger_verbosity_level'] >= message_verbosity_level else False
+
+
+class DebugLevelFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno != logging.DEBUG:
+            return True
+
+        details: Optional[LogRecordDetails] = getattr(record, 'details', None)
+
+        if details is None:
+            return True
+
+        message_debug_level = details.get('message_debug_level', None)
+
+        if message_debug_level is None:
+            return True
+
+        return True if details['logger_debug_level'] >= message_debug_level else False
+
+
+class QuietnessFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno not in (logging.DEBUG, logging.INFO):
+            return True
+
+        details: Optional[LogRecordDetails] = getattr(record, 'details', None)
+
+        if details is None:
+            return False
+
+        if not details.get('logger_quiet', False):
+            return True
+
+        if details.get('ignore_quietness', False):
+            return True
+
+        return False
+
+
+class Logger:
+    """
+    A logging entry point, representing a certain level of verbosity and handlers.
+
+    Provides actual logging methods plus methods for managing verbosity levels
+    and handlers.
+    """
+
+    def __init__(
+            self,
+            actual_logger: logging.Logger,
+            base_shift: int = 0,
+            verbosity_level: int = DEFAULT_VERBOSITY_LEVEL,
+            debug_level: int = DEFAULT_DEBUG_LEVEL,
+            quiet: bool = False
+            ) -> None:
+        """
+        Create a ``Logger`` instance with given verbosity levels.
+
+        :param actual_logger: a :py:class:`logging.Logger` instance, the _raw logger_
+            to use for logging.
+        :param base_shift: shift applied to all messages processed by this logger.
+        :param verbosity_level: desired verbosity level, usually derived from ``-v``
+            command-line option.
+        :param debug_level: desired debugging level, usually derived from ``-d``
+            command-line option.
+        :param quiet: if set, all messages would be supressed, with the exception of
+            warnings (:py:meth:`warn`), errors (:py:meth:`fail`) and messages emitted
+            with :py:meth:`print`.
+        """
+
+        self._logger = actual_logger
+
+        self._base_shift = base_shift
+
+        self._child_id_counter = itertools.count()
+
+        self.verbosity_level = verbosity_level
+        self.debug_level = debug_level
+        self.quiet = quiet
+
+    def __repr__(self) -> str:
+        return '<Logger:' \
+            f' name={self._logger.name}' \
+            f' verbosity={self.verbosity_level}' \
+            f' debug={self.debug_level}' \
+            f' quiet={self.quiet}>'
+
+    @staticmethod
+    def _normalize_logger(logger: logging.Logger) -> logging.Logger:
+        """ Reset properties of a given :py:class:`logging.Logger` instance """
+
+        logger.propagate = True
+        logger.level = logging.DEBUG
+
+        logger.handlers = []
+
+        return logger
+
+    def clone(self) -> 'Logger':
+        """
+        Create a copy of this logger instance.
+
+        All its settings are propagated to new instance. Settings are **not** shared,
+        and may be freely modified after cloning without affecting the other logger.
+        """
+
+        return Logger(
+            self._logger,
+            base_shift=self._base_shift,
+            verbosity_level=self.verbosity_level,
+            debug_level=self.debug_level,
+            quiet=self.quiet
+            )
+
+    def descend(
+            self,
+            logger_name: Optional[str] = None,
+            extra_shift: int = 1
+            ) -> 'Logger':
+        """
+        Create a copy of this logger instance, but with a new raw logger.
+
+        New :py:class:`logging.Logger` instance is created from our raw logger, forming a
+        parent/child relationship betwen them, and it's then wrapped with ``Logger`` instance.
+        Settings of this logger are copied to new one, with the exception of ``base_shift``
+        which is increased by one, effectively indenting all messages passing through new logger.
+
+        :param logger_name: optional name for the underlying :py:class:`logging.Logger` instance.
+            Useful for debugging. If not set, a generic one is created.
+        :param extra_shift: by how many extra levels should messages be indented by new logger.
+        """
+
+        logger_name = logger_name or f'logger{next(self._child_id_counter)}'
+        actual_logger = self._normalize_logger(self._logger.getChild(logger_name))
+
+        return Logger(
+            actual_logger,
+            base_shift=self._base_shift + extra_shift,
+            verbosity_level=self.verbosity_level,
+            debug_level=self.debug_level,
+            quiet=self.quiet
+            )
+
+    def add_logfile_handler(self, filepath: str) -> None:
+        """ Attach a log file handler to this logger """
+
+        handler = LogfileHandler(filepath)
+
+        handler.setFormatter(LogfileFormatter())
+
+        self._logger.addHandler(handler)
+
+    def add_console_handler(self, apply_colors: bool = False) -> None:
+        """ Attach console handler to this logger """
+
+        handler = ConsoleHandler(stream=sys.stderr)
+
+        handler.setFormatter(ConsoleFormatter(apply_colors=apply_colors))
+
+        handler.addFilter(VerbosityLevelFilter())
+        handler.addFilter(DebugLevelFilter())
+        handler.addFilter(QuietnessFilter())
+
+        self._logger.addHandler(handler)
+
+    def apply_verbosity_options(self, **kwargs: Any) -> 'Logger':
+        """
+        Update logger's settings to match given CLI options.
+
+        Use this method to update logger's settings after :py:meth:`Logger.descend` call,
+        to reflect options given to a tmt subcommand.
+        """
+
+        verbosity_level = cast(Optional[int], kwargs.get('verbose', None))
+        if verbosity_level is None:
+            pass
+
+        elif verbosity_level == 0:
+            pass
+
+        else:
+            self.verbosity_level = verbosity_level
+
+        debug_level_from_global_envvar = _debug_level_from_global_envvar()
+
+        if debug_level_from_global_envvar not in (None, 0):
+            self.debug_level = debug_level_from_global_envvar
+
+        else:
+            debug_level_from_option = cast(Optional[int], kwargs.get('debug', None))
+
+            if debug_level_from_option is None:
+                pass
+
+            elif debug_level_from_option == 0:
+                pass
+
+            else:
+                self.debug_level = debug_level_from_option
+
+        quietness_level = kwargs.get('quiet', False)
+
+        if quietness_level is True:
+            self.quiet = quietness_level
+
+        return self
+
+    @classmethod
+    def create(
+            cls,
+            actual_logger: Optional[logging.Logger] = None,
+            **verbosity_options: Any) -> 'Logger':
+        """
+        Create a (root) tmt logger.
+
+        This method has a very limited set of use cases:
+
+        * CLI bootstrapping right after tmt started.
+        * Unit tests of code that requires logger as one of its inputs.
+        * 3rd party apps treating tmt as a library, i.e. when they wish tmt to
+          use their logger instead of tmt's default one.
+
+        :param actual_logger: a :py:class:`logging.Logger` instance to wrap.
+            If not set, a default logger named ``tmt`` is created.
+        """
+
+        actual_logger = actual_logger or cls._normalize_logger(logging.getLogger('tmt'))
+
+        return Logger(actual_logger) \
+            .apply_verbosity_options(**verbosity_options)
+
+    def _log(
+            self,
+            level: int,
+            details: LogRecordDetails,
+            message: str = ''
+            ) -> None:
+        """
+        Emit a log record describing the message and related properties.
+
+        This method converts tmt's specific logging approach, with keys, values, colors
+        and shifts, to :py:class:`logging.LogRecord` instances compatible with :py:mod:`logging`
+        workflow and carrying extra information for our custom filters and handlers.
+        """
+
+        details['logger_verbosity_level'] = self.verbosity_level
+        details['logger_debug_level'] = self.debug_level
+        details['logger_quiet'] = self.quiet
+
+        details['shift'] = details.get('shift', 0) + self._base_shift
+
+        if not message:
+            message = indent(
+                details['key'],
+                value=details['value'],
+                # Always apply colors - message can be decolorized later.
+                color=details.get('color', None),
+                level=details.get('shift', 0))
+
+        self._logger._log(level, message, tuple(), extra={'details': details})
+
+    def print(
+            self,
+            key: str,
+            value: Optional[str] = None,
+            color: Optional[str] = None,
+            shift: int = 0,
+            ) -> None:
+        self._log(
+            logging.INFO,
+            {
+                'key': key,
+                'value': value,
+                'color': color,
+                'shift': shift,
+                'ignore_quietness': True
+                }
+            )
+
+    def info(
+            self,
+            key: str,
+            value: Optional[str] = None,
+            color: Optional[str] = None,
+            shift: int = 0
+            ) -> None:
+        self._log(logging.INFO, {'key': key, 'value': value, 'color': color, 'shift': shift})
+
+    def verbose(
+            self,
+            key: str,
+            value: Optional[str] = None,
+            color: Optional[str] = None,
+            shift: int = 0,
+            level: int = 1,
+            ) -> None:
+        self._log(
+            logging.INFO,
+            {
+                'key': key,
+                'value': value,
+                'color': color,
+                'shift': shift,
+                'message_verbosity_level': level
+                }
+            )
+
+    def debug(
+            self,
+            key: str,
+            value: Optional[str] = None,
+            color: Optional[str] = None,
+            shift: int = 0,
+            level: int = 1
+            ) -> None:
+        self._log(
+            logging.DEBUG,
+            {
+                'key': key,
+                'value': value,
+                'color': color,
+                'shift': shift,
+                'message_debug_level': level
+                }
+            )
+
+    def warn(
+            self,
+            message: str,
+            shift: int = 0
+            ) -> None:
+        self._log(
+            logging.WARN,
+            {
+                'key': 'warn',
+                'value': message,
+                'color': 'yellow',
+                'shift': shift
+                }
+            )
+
+    def fail(
+            self,
+            message: str,
+            shift: int = 0
+            ) -> None:
+        self._log(
+            logging.ERROR,
+            {
+                'key': 'fail',
+                'value': message,
+                'color': 'red',
+                'shift': shift
+                }
+            )

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -125,9 +125,14 @@ class Discover(tmt.steps.Step):
     _plugin_base_class = DiscoverPlugin
     _preserved_files = ['step.yaml', 'tests.yaml']
 
-    def __init__(self, *, plan: 'tmt.base.Plan', data: tmt.steps.RawStepDataArgument):
+    def __init__(
+            self,
+            *,
+            plan: 'tmt.base.Plan',
+            data: tmt.steps.RawStepDataArgument,
+            logger: tmt.log.Logger) -> None:
         """ Store supported attributes, check for sanity """
-        super().__init__(plan=plan, data=data)
+        super().__init__(plan=plan, data=data, logger=logger)
 
         # List of Test() objects representing discovered tests
         self._tests: List[tmt.Test] = []
@@ -137,8 +142,12 @@ class Discover(tmt.steps.Step):
         super().load()
         try:
             raw_test_data = tmt.utils.yaml_to_dict(self.read('tests.yaml'))
-            self._tests = [tmt.Test.from_dict(data, name, skip_validation=True)
-                           for name, data in raw_test_data.items()]
+            self._tests = [
+                tmt.Test.from_dict(
+                    logger=self._logger,
+                    mapping=data,
+                    name=name,
+                    skip_validation=True) for name, data in raw_test_data.items()]
 
         except tmt.utils.FileError:
             self.debug('Discovered tests not found.', level=2)

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -130,10 +130,11 @@ class ExecutePlugin(tmt.steps.Plugin):
             *,
             step: Step,
             data: StepData,
-            workdir: tmt.utils.WorkdirArgumentType = None) -> None:
-        super().__init__(step=step, data=data, workdir=workdir)
+            workdir: tmt.utils.WorkdirArgumentType = None,
+            logger: tmt.log.Logger) -> None:
+        super().__init__(logger=logger, step=step, data=data, workdir=workdir)
         if tmt.steps.Login._opt('test'):
-            self._login_after_test = tmt.steps.Login(step=self.step, order=90)
+            self._login_after_test = tmt.steps.Login(logger=logger, step=self.step, order=90)
 
     @classmethod
     def base_command(
@@ -418,9 +419,14 @@ class Execute(tmt.steps.Step):
 
     _preserved_files = ['step.yaml', 'results.yaml', 'data']
 
-    def __init__(self, *, plan: "tmt.Plan", data: tmt.steps.RawStepDataArgument) -> None:
+    def __init__(
+            self,
+            *,
+            plan: "tmt.Plan",
+            data: tmt.steps.RawStepDataArgument,
+            logger: tmt.log.Logger) -> None:
         """ Initialize execute step data """
-        super().__init__(plan=plan, data=data)
+        super().__init__(plan=plan, data=data, logger=logger)
         # List of Result() objects representing test results
         self._results: List[tmt.Result] = []
 

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -177,7 +177,7 @@ class ExecuteUpgrade(ExecuteInternal):
 
     def _get_plan(self, upgrades_repo: str) -> tmt.base.Plan:
         """ Get plan based on upgrade path """
-        tree = tmt.base.Tree(path=upgrades_repo)
+        tree = tmt.base.Tree(logger=self._logger, path=upgrades_repo)
         try:
             # We do not want to consider plan -n provided on the command line
             # in the remote repo for finding upgrade path.
@@ -207,7 +207,7 @@ class ExecuteUpgrade(ExecuteInternal):
                 }
             )
 
-        self._discover_upgrade = DiscoverFmf(step=self.step, data=data)
+        self._discover_upgrade = DiscoverFmf(logger=self._logger, step=self.step, data=data)
         self._run_discover_upgrade()
 
     def _run_discover_upgrade(self) -> None:

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -110,6 +110,7 @@ class Finish(tmt.steps.Step):
             # operations inside finish plugins on the guest use the
             # finish step config rather than provision step config.
             guest_copy = copy.copy(guest)
+            guest_copy._logger = guest._logger.clone().apply_verbosity_options(**self._options)
             guest_copy.parent = self
             for phase in self.phases(classes=(Action, FinishPlugin)):
                 if isinstance(phase, Action):

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -88,9 +88,14 @@ class Prepare(tmt.steps.Step):
 
     _plugin_base_class = PreparePlugin
 
-    def __init__(self, *, plan: 'Plan', data: tmt.steps.RawStepDataArgument) -> None:
+    def __init__(
+            self,
+            *,
+            plan: 'Plan',
+            data: tmt.steps.RawStepDataArgument,
+            logger: tmt.log.Logger) -> None:
         """ Initialize prepare step data """
-        super().__init__(plan=plan, data=data)
+        super().__init__(plan=plan, data=data, logger=logger)
         self.preparations_applied = 0
 
     def wake(self) -> None:
@@ -200,6 +205,8 @@ class Prepare(tmt.steps.Step):
             # operations inside prepare plugins on the guest use the
             # prepare step config rather than provision step config.
             guest_copy = copy.copy(guest)
+            guest_copy.inject_logger(
+                guest._logger.clone().apply_verbosity_options(**self._options))
             guest_copy.parent = self
             # Execute each prepare plugin
             for phase in self.phases(classes=(Action, PreparePlugin)):

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -7,6 +7,7 @@ import click
 import requests
 
 import tmt
+import tmt.log
 import tmt.options
 import tmt.steps
 import tmt.steps.prepare
@@ -33,7 +34,7 @@ class PrepareAnsibleData(tmt.steps.prepare.PrepareStepData):
     def pre_normalization(  # type: ignore[override]
             cls,
             raw_data: _RawAnsibleStepData,
-            logger: tmt.utils.Common) -> None:
+            logger: tmt.log.Logger) -> None:
         super().pre_normalization(raw_data, logger)
 
         # Perform `playbook` normalization here, so we could merge `playbooks` to it.

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -567,7 +567,11 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
         if data.ssh_option:
             self.info('ssh options', fmf.utils.listed(data.ssh_option), 'green')
 
-        self._guest = GuestArtemis(data=data, name=self.name, parent=self.step)
+        self._guest = GuestArtemis(
+            logger=self._logger,
+            data=data,
+            name=self.name,
+            parent=self.step)
         self._guest.start()
 
     def guest(self) -> Optional[GuestArtemis]:

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -126,7 +126,11 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
             self.info('ssh options', fmf.utils.listed(data.ssh_option), 'green')
 
         # And finally create the guest
-        self._guest = tmt.GuestSsh(data=data, name=self.name, parent=self.step)
+        self._guest = tmt.GuestSsh(
+            logger=self._logger,
+            data=data,
+            name=self.name,
+            parent=self.step)
 
     def guest(self) -> Optional[tmt.GuestSsh]:
         """ Return the provisioned guest """

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -139,7 +139,7 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
             guest='localhost',
             role=self.get('role')
             )
-        self._guest = GuestLocal(data=data, name=self.name, parent=self.step)
+        self._guest = GuestLocal(logger=self._logger, data=data, name=self.name, parent=self.step)
 
     def guest(self) -> Optional[GuestLocal]:
         """ Return the provisioned guest """

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -307,7 +307,11 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
         data = PodmanGuestData(**data_from_options)
 
         # Create a new GuestTestcloud instance and start it
-        self._guest = GuestContainer(data=data, name=self.name, parent=self.step)
+        self._guest = GuestContainer(
+            logger=self._logger,
+            data=data,
+            name=self.name,
+            parent=self.step)
         self._guest.start()
 
     def guest(self) -> Optional[GuestContainer]:

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -656,7 +656,11 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
                 self.info(key, value, 'green')
 
         # Create a new GuestTestcloud instance and start it
-        self._guest = GuestTestcloud(data=data, name=self.name, parent=self.step)
+        self._guest = GuestTestcloud(
+            logger=self._logger,
+            data=data,
+            name=self.name,
+            parent=self.step)
         self._guest.start()
 
     def guest(self) -> Optional[tmt.Guest]:


### PR DESCRIPTION
Logging is baked into many classes, anything based on `tmt.utils.Common`
has methods like `debug` and `info` that handle verbosity checks,
indentations, colors, and logging into file *and* console. While having
those methods is absolutely handy, the fact code is embedded into every
class makes it much harder to parametrize it, influence, or redirect the
output. I believe this will become painfully visible when we start
cutting into parallelization where observability is crucial, and several
possible modes of output have been suggested already (everything in a
single stream/file vs per thread stream/file, "window" for each thread
on the same screen, interleaving, prefixing, screen or tmux integration,
multitail, etc.) - extending the current implementation of logging might
be near to impossible.

Hence this patch.

* Every object derived from `Common` is given a logger object when
  instantiated. This may very well be the very same logger every time,
  the dependency injection does not mean every `Common` instance would
  have its own logger instance.
* `Common` still provides helper methods in its namespace, proxying
  calls to the given logger.
* Python's own logging subsystem,
  https://docs.python.org/3/library/logging.html
  is very capable, and the patch uses it heavily, adding custom
  handlers, filters, log record details, and so on.
* When needed, code may spawn custom loggers to suit the needs of the
  situation. At this moment, the most needed functionality is
  "indentation", `shift` recognized by tmt's logging methods. In tmt's
  tree of runtime objects, some are expected to have their output
  shifted to the right, reflecting their position (`tmt` -> `Run` ->
  `Plan` -> `discover`/`provision`,...).

  In the future, there will be more features needed, e.g. to redirect
  particular output to different channels, or apply prefix to their
  lines, and so on.
* Distinction between command "output" and "logging" is now more
  visible, with output landing in stdout - no change there -, and all
  logging landing in stderr, and that's new.

This patch tries to implement all of the above, mimicking the current
observed behavior of tmt logging. There might be some minor changes, but
in general the output should be matching our current experience.

The most visible changes would probably be:

* many classes are now given `logger` argument, explicit
  `tmt.log.Logger` object to use for logging.
* logs at stderr - plenty of tests needed a change in what output they
  are checking (`2>&1 >/dev/null`), grepping stdout no longer works.

There are some caveats, though: there are still loggers out there that
tmt uses, but which are out of out control. The most prominent one is
the one from `fmf.utils`, fmf has it's own logging facilities, and may
break our nice little tidy world. The end goal is to teach fmf - and
others, when identified - to play nicely with others.