### PR TITLE
Extend the `duration` for tests using containers

### DIFF
--- a/tests/execute/restraint/main.fmf
+++ b/tests/execute/restraint/main.fmf
@@ -1,0 +1,1 @@
+duration: 10m

--- a/tests/execute/upgrade/main.fmf
+++ b/tests/execute/upgrade/main.fmf
@@ -1,3 +1,5 @@
+duration: 10m
+
 /full:
     summary: Perform a full upgrade from F35 to F36
     test: ./full.sh
@@ -17,7 +19,6 @@
 /override:
     summary: Override the filter in remote upgrade path
     test: ./override.sh
-    duration: 10m
 
 /ignore_test:
     summary: Ignore test -n run subcommand in remote repo

--- a/tests/multihost/prepare/main.fmf
+++ b/tests/multihost/prepare/main.fmf
@@ -1,1 +1,2 @@
 summary: Verify that multihost preparation works
+duration: 10m

--- a/tests/pull/main.fmf
+++ b/tests/pull/main.fmf
@@ -1,0 +1,1 @@
+duration: 10m


### PR DESCRIPTION
Several tests which are using containers failed recently because of slow dnf operations. Let's increase their `duration` a bit to prevent these false positives.