### PR TITLE
Adds flake8 coverage for bin/ directory

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,7 @@
 max-line-length = 99
 
 # When changing this list, you probably also want to change pre-commit config too.
-filename = examples/,
+filename = bin/,
+           examples/,
            tests/,
            tmt/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
         # *pre-commit* to which files to apply flake8 check.
         files: >
           (?x)^(
+            bin/.*|
             examples/.*|
             tests/.*|
             tmt/.*


### PR DESCRIPTION
This has been missing for some time, `bin/tmt` is a Python code and deserves flake8's care.