### PR TITLE
Remove default for dynamic ref evaluation

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -689,9 +689,8 @@ stored in a default branch of a tests repository. That special file
 should contain rules assigning attribute ``ref`` in an ``adjust``
 block depending on the context.
 
-Dynamic ``ref`` assignment is enabled whenever ``.tmt/ref.fmf`` file
-exists in a test repository or the actual test plan reference has
-a format ``ref: @FILEPATH``.
+Dynamic ``ref`` assignment is enabled whenever a test plan reference
+has the format ``ref: @FILEPATH``.
 
 Example of a test plan::
 

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -112,10 +112,8 @@ description: |
             in an `adjust` block, for example depending on a test
             run context.
 
-            Dynamic ``ref`` assignment is enabled whenever
-            ``.tmt/ref.fmf`` file exists in a test repository or
-            the actual test plan reference has a format
-            ``ref: @FILEPATH``.
+            Dynamic ``ref`` assignment is enabled whenever a test
+            plan reference has the format ``ref: @FILEPATH``.
         path
             Path to the metadata tree root. Must be relative to
             the git repository root if url provided, absolute


### PR DESCRIPTION
It turns out that the default doesn't work well with our pipelines yet and therefore it seems safer to disable it and require explicit reference to dynamic ref file in a plan.