### PR TITLE
Beakerlibs pruning and merge

### DIFF
--- a/tests/discover/libraries/data/certificate.fmf
+++ b/tests/discover/libraries/data/certificate.fmf
@@ -16,6 +16,7 @@ test: ./certificate.sh
     require:
       - url: https://github.com/beakerlib/openssl
         name: /certgen
+        type: library
 
 /recommend:
     summary: Generate a certificate (recommend)
@@ -36,6 +37,7 @@ test: ./certificate.sh
       - url: https://github.com/beakerlib-libraries/certgen/
         nick: openssl
         name: /certgen
+        type: library
     test: ./certificate.sh tree
 
 /destination:
@@ -47,6 +49,7 @@ test: ./certificate.sh
       - url: https://github.com/beakerlib/openssl
         name: /certgen
         destination: custom
+        type: library
 
 /missing:
     /repository:
@@ -59,8 +62,10 @@ test: ./certificate.sh
         summary: Repository with no fmf metadata
         require:
           - url: https://github.com/psss/try
+            type: library
     /reference:
         summary: Requested reference does not exist
         require:
           - url: https://github.com/beakerlib/epel
             ref: weird
+            type: library

--- a/tests/discover/libraries/data/file.fmf
+++ b/tests/discover/libraries/data/file.fmf
@@ -6,3 +6,4 @@ path: /
 require:
   - url: https://github.com/beakerlib/test
     name: /very/deep/file
+    type: library

--- a/tests/discover/libraries/data/plan.fmf
+++ b/tests/discover/libraries/data/plan.fmf
@@ -71,7 +71,13 @@ execute:
             summary: "Missing reference"
             discover+:
                 test: missing/reference
+
 /querying:
     summary: "Many tests requiring same rpm-only library"
     discover+:
         test: querying
+
+/pruning:
+    summary: "Simple test for library pruning"
+    discover+:
+        test: pruning

--- a/tests/discover/libraries/data/pruning.fmf
+++ b/tests/discover/libraries/data/pruning.fmf
@@ -1,0 +1,9 @@
+summary: A simple test for libraries pruning
+description:
+    Checks that pruning is executed on libraries
+test: ./pruning.sh
+path: /
+require:
+  - url: https://github.com/beakerlib/database
+    name: /mariadb
+    type: library

--- a/tests/discover/libraries/data/pruning.sh
+++ b/tests/discover/libraries/data/pruning.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlAssertRpm "coreutils"
+        rlRun "rlImport database/mariadb"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun "mariadbStart"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/discover/libraries/data/strip_git_suffix.fmf
+++ b/tests/discover/libraries/data/strip_git_suffix.fmf
@@ -14,11 +14,13 @@ test: ./file.sh
     - library(database/mariadb)
     - url: https://github.com/beakerlib/test
       name: /very/deep/file
+      type: library
 /test2:
   require:
     - library(database/mariadb)
     - url: https://github.com/beakerlib/squid.git
       name: /squid
+      type: library
   recommend:
     - url: https://github.com/beakerlib/database
       name: /postgresql

--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -75,6 +75,12 @@ rlJournalStart
         # However we do it all just once
         LINES=$(grep "Repository 'https://github.com/beakerlib/FOOBAR' not found." "$tmp/querying/log.txt" | wc -l)
         rlAssertEquals "Just one attempt on non-existent repository" "1" "$LINES"
+
+    rlPhaseStartTest "Pruning"
+        rlRun -s "tmt run -vv --debug plan --name pruning"
+        lib_path=$(grep 'Library database/mariadb is copied into' "$rlRun_LOG"|rev|cut -d' ' -f1|rev)
+        rlAssertNotExists "${lib_path}/postgresql"
+        rlAssertNotExists "${lib_path}/mysql"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/libraries/local/data/main.fmf
+++ b/tests/libraries/local/data/main.fmf
@@ -12,3 +12,4 @@
     require:
       - path: PATH
         name: /file
+        type: library

--- a/tests/libraries/local/data/test.sh
+++ b/tests/libraries/local/data/test.sh
@@ -13,6 +13,10 @@ rlJournalStart
         rlAssertExists "fooo"
     rlPhaseEnd
 
+    rlPhaseStartTest
+        rlRun "randomFileCreate"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $tmp" 0 "Remove tmp directory"

--- a/tests/unit/test_beakerlib.py
+++ b/tests/unit/test_beakerlib.py
@@ -64,7 +64,7 @@ def test_invalid_url_conflict(root_logger):
         identifier=tmt.base.DependencyFmfId(
             url='https://github.com/teemtee/tmt',
             name='/',
-            path='/tests/libraries/local/data'),
+            path=Path('/tests/libraries/local/data')),
         parent=parent)
     # Library 'tmt' repo is already fetched from different git,
     # however upstream (gh.com/beakerlib/tmt) repo does not exist,

--- a/tmt/libraries/__init__.py
+++ b/tmt/libraries/__init__.py
@@ -152,12 +152,6 @@ def dependencies(
             if isinstance(library, BeakerLib):
                 # Recursively check for possible dependent libraries
                 assert parent is not None  # narrow type
-                if library.hostname == 'local':
-                    library_path = library.path
-                else:  # TODO: Change with pruning for libraries
-                    assert parent.workdir is not None  # narrow type
-                    library_path = parent.workdir / library.dest / library.repo
-
                 assert parent.workdir is not None  # narrow type
                 requires, recommends, libraries = dependencies(
                     original_require=library.require,
@@ -165,8 +159,8 @@ def dependencies(
                     parent=parent,
                     imported_lib_ids=imported_lib_ids,
                     logger=logger,
-                    source_location=library_path,
-                    target_location=parent.workdir / library.dest / library.repo)
+                    source_location=library.source_directory,
+                    target_location=Path(library.tree.root))
                 processed_require.update(set(requires))
                 processed_recommend.update(set(recommends))
                 gathered_libraries.extend(libraries)

--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -20,7 +20,6 @@ LIBRARY_REGEXP = re.compile(r'^library\(([^/]+)(/[^)]+)\)$')
 # Default beakerlib libraries location and destination directory
 DEFAULT_REPOSITORY_TEMPLATE = 'https://github.com/beakerlib/{repository}'
 DEFAULT_DESTINATION = 'libs'
-DEFAULT_CLONE_DIR = None  # filled on first usage, {discover.workdir}/libs/clone
 
 # List of git forges for which the .git suffix should be stripped
 STRIP_SUFFIX_FORGES = [
@@ -256,11 +255,8 @@ class BeakerLib(Library):
                     if self.url in self._nonexistent_url:
                         raise tmt.utils.GitUrlError(
                             f"Already know that '{self.url}' does not exist.")
-                    global DEFAULT_CLONE_DIR
-                    if not DEFAULT_CLONE_DIR:
-                        DEFAULT_CLONE_DIR = os.path.join(
-                            self.parent.workdir, DEFAULT_DESTINATION, 'clone')
-                    clone_dir = os.path.join(DEFAULT_CLONE_DIR, self.hostname, self.repo)
+                    clone_dir = os.path.join(
+                        self.parent.clone_dirpath, self.hostname, self.repo)
                     # Shallow clone to speed up testing and
                     # minimize data transfers if ref is not provided
                     if not os.path.exists(clone_dir):

--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -290,7 +290,7 @@ class BeakerLib(Library):
                     # Copy only the required library
                     library_path: str = os.path.join(clone_dir, self.fmf_node_path.strip('/'))
                     local_library_path: str = os.path.join(
-                        directory, os.path.basename(self.fmf_node_path.strip('/')))
+                        directory, self.fmf_node_path.strip('/'))
                     if not os.path.exists(library_path):
                         self.parent.debug(f"Failed to find library {self} at {self.url}")
                         raise LibraryError
@@ -352,7 +352,7 @@ class BeakerLib(Library):
             self._library_cache[str(self)] = self
 
         # Get the library node, check require and recommend
-        library_node = self.tree.find(str(self)[str(self).rfind('/'):])
+        library_node = self.tree.find(self.name)
         if not library_node:
             # Fallback to install during the prepare step if in rpm format
             if self.format == 'rpm':

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -556,10 +556,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         if self.clone_dirpath.exists():
             shutil.rmtree(self.clone_dirpath, ignore_errors=True)
 
-        # Cleanup clone directories
-        if os.path.exists(self.clone_dirpath):
-            shutil.rmtree(self.clone_dirpath, ignore_errors=True)
-
         # Add TMT_SOURCE_DIR variable for each test
         if dist_git_source:
             for test in self._tests:

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -557,8 +557,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             shutil.rmtree(self.clone_dirpath, ignore_errors=True)
 
         # Cleanup clone directories
-        if tmt.beakerlib.DEFAULT_CLONE_DIR:
-            shutil.rmtree(tmt.beakerlib.DEFAULT_CLONE_DIR, ignore_errors=True)
+        if os.path.exists(self.clone_dirpath):
+            shutil.rmtree(self.clone_dirpath, ignore_errors=True)
 
         # Add TMT_SOURCE_DIR variable for each test
         if dist_git_source:

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -556,6 +556,10 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         if self.clone_dirpath.exists():
             shutil.rmtree(self.clone_dirpath, ignore_errors=True)
 
+        # Cleanup clone directories
+        if tmt.beakerlib.DEFAULT_CLONE_DIR:
+            shutil.rmtree(tmt.beakerlib.DEFAULT_CLONE_DIR, ignore_errors=True)
+
         # Add TMT_SOURCE_DIR variable for each test
         if dist_git_source:
             for test in self._tests:

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1693,7 +1693,7 @@ def copytree(
     return dst
 
 
-def get_full_metadata(fmf_tree_path: str, node_path: str) -> Any:
+def get_full_metadata(fmf_tree_path: Path, node_path: str) -> Any:
     """
     Get full metadata for a node in any fmf tree
 


### PR DESCRIPTION
Only thing pulled in now is the requested library, not the rest of the repo.
tmt now accepts different libraries from the same repo with different url
and those library files are merged under the same repo name directory.

example libs directory:
```
/var/tmp/tmt/run-224/plans/default/discover/default-0/libs/
├── certgen
│   └── certgen <--- pulled in as a dependency of openssl/certgen
│       ├── lib.sh
│       ├── main.fmf
│       ├── Makefile
│       └── runtest.sh
├── crypto
│   └── fips <------ pulled with library(crypto/fips)
│       ├── lib.sh
│       ├── main.fmf
│       ├── Makefile
│       ├── rstrnt-package-workaround.sh
│       └── runtest.sh
└── openssl
    ├── certgen <--- pulled in with library(openssl/certgen)
    │   ├── lib.sh
    │   └── main.fmf
    └── tls-1-3-interoperability-gnutls-openssl <--- pulled in with fmf id (url+path)
        └── more files                               this one would fail as the repo is also openssl, but there is a different url
```

part of #1690 