### PR TITLE
Convert story ReST export to use a Jinja2 template

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -284,3 +284,4 @@ for area in areas:
         for story in tree.stories(names=[area], whole=True):
             if story.enabled:
                 doc.write(story.export(format='rst', include_title=story.name != area))
+                doc.write('\n\n')

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ __pkg__ = 'tmt'
 __pkgdata__ = {
     'tmt': [
         'py.typed',
+        'export/templates/*',
         'schemas/*.yaml',
         'schemas/*/*.yaml',
         'steps/execute/scripts/*',

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1692,6 +1692,22 @@ class Story(Core, tmt.export.Exportable['Story']):
         """ Return links to relevant source code """
         return self.link.get('implemented-by') if self.link else []
 
+    @property
+    def status(self) -> List[str]:
+        """ Aggregate story status from implemented-, verified- and documented-by links """
+        status = []
+
+        if self.implemented:
+            status.append('implemented')
+
+        if self.verified:
+            status.append('verified')
+
+        if self.documented:
+            status.append('documented')
+
+        return status
+
     def _match(
             self, implemented: bool, verified: bool, documented: bool, covered: bool,
             unimplemented: bool, unverified: bool, undocumented: bool, uncovered: bool) -> bool:

--- a/tmt/export/__init__.py
+++ b/tmt/export/__init__.py
@@ -21,6 +21,8 @@ else:
     from typing_extensions import Protocol
 
 import fmf
+import fmf.utils
+import pkg_resources
 from click import echo, style
 
 import tmt
@@ -28,6 +30,8 @@ import tmt.utils
 
 if TYPE_CHECKING:
     import tmt.base
+
+TEMPLATES_DIRECTORY = pkg_resources.resource_filename('tmt', 'export/templates')
 
 bugzilla: Optional[types.ModuleType] = None
 

--- a/tmt/export/rst.py
+++ b/tmt/export/rst.py
@@ -1,7 +1,5 @@
-import re
+import os.path
 from typing import Any, List, Optional
-
-import fmf.utils
 
 import tmt.base
 import tmt.export
@@ -15,55 +13,12 @@ class RestructuredExporter(tmt.export.ExportPlugin):
                      story: tmt.base.Story,
                      keys: Optional[List[str]] = None,
                      include_title: bool = True) -> str:
-        output = ''
+        template_filepath = os.path.join(tmt.export.TEMPLATES_DIRECTORY, 'default-story.rst.j2')
 
-        # Title and its anchor
-        if include_title:
-            depth = len(re.findall('/', story.name)) - 1
-            if story.title and story.title != story.node.parent.get('title'):
-                title = story.title
-            else:
-                title = re.sub('.*/', '', story.name)
-            output += f'\n.. _{story.name}:\n'
-            output += '\n{}\n{}\n'.format(title, '=~^:-><'[depth] * len(title))
-
-        # Summary, story and description
-        if story.summary and story.summary != story.node.parent.get('summary'):
-            output += '\n{}\n'.format(story.summary)
-        if story.story != story.node.parent.get('story'):
-            output += '\n*{}*\n'.format(story.story.strip())
-        # Insert note about unimplemented feature (leaf nodes only)
-        if not story.node.children and not story.implemented:
-            output += '\n.. note:: This is a draft, '
-            output += 'the story is not implemented yet.\n'
-        if (story.description and
-                story.description != story.node.parent.get('description')):
-            output += '\n{}\n'.format(story.description)
-
-        # Examples
-        if story.example and story.example != story.node.parent.get('example'):
-            examples = tmt.utils.listify(story.example)
-            first = True
-            for example in examples:
-                if first:
-                    output += '\nExamples::\n\n'
-                    first = False
-                else:
-                    output += '\n::\n\n'
-                output += tmt.utils.format(
-                    '', example, wrap=False, indent=4,
-                    key_color=None, value_color=None) + '\n'
-
-        # Status
-        if not story.node.children:
-            status = []
-            for coverage in ['implemented', 'verified', 'documented']:
-                if getattr(story, coverage):
-                    status.append(coverage)
-            output += "\nStatus: {}\n".format(
-                fmf.utils.listed(status) if status else 'idea')
-
-        return output
+        return tmt.utils.render_template_file(
+            template_filepath,
+            STORY=story,
+            INCLUDE_TITLE=include_title)
 
     @classmethod
     def export_story_collection(cls,
@@ -71,5 +26,5 @@ class RestructuredExporter(tmt.export.ExportPlugin):
                                 keys: Optional[List[str]] = None,
                                 include_title: bool = True,
                                 **kwargs: Any) -> str:
-        return '\n'.join([cls.export_story(story, include_title=include_title)
-                         for story in stories])
+        return '\n\n'.join([cls.export_story(story, include_title=include_title)
+                           for story in stories])

--- a/tmt/export/templates/default-story.rst.j2
+++ b/tmt/export/templates/default-story.rst.j2
@@ -1,0 +1,55 @@
+{% if INCLUDE_TITLE %}
+{% set depth = STORY.name | findall('/') | length - 1 %}
+{% set title_underline = '=~^:-><'[depth] %}
+{% if STORY.title and STORY.title != STORY.node.parent.get('title') %}
+    {% set title = STORY.title %}
+{% else %}
+    {% set title = STORY.name | regex_replace('.*/', '') %}
+{% endif %}
+
+.. _{{ STORY.name | strip }}:
+
+{{ title | strip }}
+{{ title_underline * title | length }}
+{% endif %}
+
+{# Summary, story and description #}
+{% if STORY.summary and STORY.summary != STORY.node.parent.get('summary') %}
+{{ STORY.summary | strip }}
+{% endif %}
+
+{% if STORY.story != STORY.node.parent.get('story') %}
+*{{ STORY.story | strip }}*
+{% endif %}
+
+{# Insert note about unimplemented feature (leaf nodes only) #}
+{% if not STORY.node.children and not STORY.implemented %}
+.. note:: This is a draft, the story is not implemented yet.
+{% endif %}
+
+{% if STORY.description and STORY.description != STORY.node.parent.get('description') %}
+{{ STORY.description }}
+{% endif %}
+
+{# Examples #}
+{% if STORY.example and STORY.example != STORY.node.parent.get('example') %}
+    {% for example in STORY.example %}
+        {% if example == STORY.example | first %}
+Examples::
+        {% else %}
+::
+        {% endif %}
+
+{{ example | indent(width=4, first=True, blank=True) }}
+
+    {% endfor %}
+{% endif %}
+
+{# Status #}
+{% if not STORY.node.children %}
+    {% if STORY.status %}
+Status: {{ STORY.status | listed }}
+    {% else %}
+Status: idea
+    {% endif %}
+{% endif %}


### PR DESCRIPTION
The template - a default one - is bundled with tmt, and mimics the output emitted by the original Python code.

In next patches, it would become possible to use custom templates via CLI options.

Part of the effort to improve exports, see #1679.