### PR TITLE
Drop various guest `wake()` methods in favor of parent class

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1037,6 +1037,9 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin):
     # List of all supported methods aggregated from all plugins of the same step.
     _supported_methods: List[tmt.steps.Method] = []
 
+    # TODO: Generics would provide a better type, https://github.com/teemtee/tmt/issues/1437
+    _guest: Optional[Guest] = None
+
     @classmethod
     def base_command(
             cls,
@@ -1082,6 +1085,11 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin):
         Wake up the guest based on provided guest data.
         """
         super().wake()
+
+        if data is not None:
+            guest = self._guest_class(data=data, name=self.name, parent=self.step)
+            guest.wake()
+            self._guest = guest
 
     def guest(self) -> Optional[Guest]:
         """

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -523,15 +523,6 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
                 ),
             ] + super().options(how)
 
-    # FIXME: ignore - https://github.com/teemtee/tmt/issues/1437
-    def wake(self, data: Optional[ArtemisGuestData] = None) -> None:  # type: ignore[override]
-        """ Wake up the plugin, process data, apply options """
-
-        super().wake(data=data)
-
-        if data:
-            self._guest = GuestArtemis(data=data, name=self.name, parent=self.step)
-
     def go(self) -> None:
         """ Provision the guest """
         super().go()

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -8,7 +8,6 @@ import tmt
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
-from tmt.steps.provision import GuestSshData
 
 DEFAULT_USER = "root"
 
@@ -78,13 +77,6 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
                 '-p', '--password', metavar='PASSWORD',
                 help='Password for login into the guest system.'),
             ] + super().options(how)
-
-    # FIXME: ignore - https://github.com/teemtee/tmt/issues/1437
-    def wake(self, data: Optional[GuestSshData] = None) -> None:  # type: ignore[override]
-        """ Wake up the plugin, process data, apply options """
-        super().wake(data=data)
-        if data:
-            self._guest = tmt.GuestSsh(data=data, name=self.name, parent=self.step)
 
     def go(self) -> None:
         """ Prepare the connection """

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -121,12 +121,6 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
     # Guest instance
     _guest = None
 
-    def wake(self, data: Optional[tmt.steps.provision.GuestData] = None) -> None:
-        """ Wake up the plugin, process data, apply options """
-        super().wake(data=data)
-        if data:
-            self._guest = GuestLocal(data=data, name=self.name, parent=self.step)
-
     def go(self) -> None:
         """ Provision the container """
         super().go()

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -256,15 +256,6 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
 
         return super().default(option, default=default)
 
-    def wake(self, data: Optional[tmt.steps.provision.GuestData] = None) -> None:
-        """ Wake up the plugin, process data, apply options """
-        super().wake(data=data)
-        # Wake up podman instance
-        if data:
-            guest = GuestContainer(data=data, name=self.name, parent=self.step)
-            guest.wake()
-            self._guest = guest
-
     def go(self) -> None:
         """ Provision the container """
         super().go()

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -615,17 +615,6 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
                 help="What architecture to virtualize, host arch by default."),
             ] + super().options(how)
 
-    # FIXME: ignore - https://github.com/teemtee/tmt/issues/1437
-    def wake(self, data: Optional[TestcloudGuestData] = None) -> None:  # type: ignore[override]
-        """ Wake up the plugin, process data, apply options """
-        super().wake(data=data)
-
-        # Wake up testcloud instance
-        if data:
-            guest = GuestTestcloud(data=data, name=self.name, parent=self.step)
-            guest.wake()
-            self._guest = guest
-
     def go(self) -> None:
         """ Provision the testcloud instance """
         super().go()


### PR DESCRIPTION
They all do the same things anyway: instantiate a guest class, with given data, pass parent and name down the stream. A base clas can do all of this.