### PR TITLE
Do not prune `html` and `junit` reports

### DIFF
--- a/tests/finish/prune/data/plan.fmf
+++ b/tests/finish/prune/data/plan.fmf
@@ -13,7 +13,20 @@ discover:
         test: echo test > $TMT_PLAN_DATA/out-plan.txt
 
 provision:
-  how: local
+    how: local
 
 execute:
-  how: tmt
+    how: tmt
+
+report:
+  - name: display
+    how: display
+  - name: html
+    how: html
+  - name: junit
+    how: junit
+
+finish:
+  - script: touch ../finish/file
+  - script: ln -s . ../finish/link
+  - script: mkdir ../finish/directory

--- a/tests/finish/prune/test.sh
+++ b/tests/finish/prune/test.sh
@@ -9,7 +9,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Check pruning"
-        rlRun "tmt run -i $tmp1 -a"
+        rlRun -s "tmt run -i $tmp1 -a finish -ddd"
         rlAssertNotExists $tmp1/plan/tree
         rlAssertNotExists $tmp1/plan/discover/default-0
         rlAssertNotExists $tmp1/plan/discover/default-1
@@ -18,10 +18,21 @@ rlJournalStart
         for step in discover execute finish prepare provision report; do
             rlAssertExists $tmp1/plan/$step/step.yaml
         done
+
+        # Interesting output from the report plugins should be kept
+        rlAssertExists $tmp1/plan/report/html/index.html
+        rlAssertExists $tmp1/plan/report/junit/junit.xml
+        rlAssertNotExists $tmp1/plan/report/display
+
+        # Successfully removes files, symlinks and directories
+        for kind in file link directory; do
+            rlAssertGrep "Remove.*/finish/$kind" $rlRun_LOG
+            rlAssertNotExists $tmp1/plan/finish/$kind
+        done
     rlPhaseEnd
 
     rlPhaseStartTest "Check Keeping"
-        rlRun "tmt run --keep -i $tmp2 -a"
+        rlRun "tmt run --keep -i $tmp2 -a finish -ddd"
         rlAssertExists $tmp2/plan/tree
         rlAssertExists $tmp2/plan/discover/default-0
         rlAssertExists $tmp2/plan/discover/default-1

--- a/tests/report/html/test.sh
+++ b/tests/report/html/test.sh
@@ -8,65 +8,63 @@ rlJournalStart
         rlRun "pushd data"
         rlRun "set -o pipefail"
         rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "run_dir=$tmp/original"
     rlPhaseEnd
 
-    for method in tmt; do
-        for absolute_paths in "" "--absolute-paths"; do
-            rlPhaseStartTest "$method $absolute_paths"
+    for option in "" "--absolute-paths"; do
+        rlPhaseStartTest "Check status (${option:-relative paths})"
+            rlRun -s "tmt run -av --scratch --id $run_dir report -h html $option" 2
+            rlAssertGrep "summary: 2 tests passed, 1 test failed and 2 errors" $rlRun_LOG -F
 
-                run_dir="$tmp/$method"
-                rlRun "mkdir -p $tmp/$method"
+            # Path of the generated file should be shown and the page should exist
+            rlAssertGrep "output: .*/index.html" $rlRun_LOG
+            HTML=$(grep "output:" $rlRun_LOG | sed 's/.*output: //')
+            rlAssertExists "$HTML" || rlDie "Report file '$HTML' not found, nothing to check."
 
-                rlRun "tmt run --keep -av --scratch --id $run_dir execute -h $method report -h html $absolute_paths | tee output" 2
-                rlAssertGrep "summary: 2 tests passed, 1 test failed and 2 errors" output -F
+            test_name_suffix=error
+            grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix
+            rlAssertGrep 'class="result error">error</td>' $tmp/$test_name_suffix -F
 
-                HTML="${run_dir}${PATH_INDEX}"
+            test_name_suffix=fail
+            grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix
+            rlAssertGrep 'class="result fail">fail</td>' $tmp/$test_name_suffix -F
 
-                test_name_suffix=error
-                grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix
-                rlAssertGrep 'class="result error">error</td>' $tmp/$test_name_suffix -F
+            test_name_suffix=pass
+            grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix
+            rlAssertGrep 'class="result pass">pass</td>' $tmp/$test_name_suffix -F
 
-                test_name_suffix=fail
-                grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix
-                rlAssertGrep 'class="result fail">fail</td>' $tmp/$test_name_suffix -F
+            test_name_suffix=timeout
+            grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix
+            rlAssertGrep 'class="result error">error</td>' $tmp/$test_name_suffix -F
+            sed -e "/name\">\/test\/$test_name_suffix/,/\/tr/!d" $HTML | tee $tmp/$test_name_suffix-note
+            rlAssertGrep '<td class="note">timeout</td>' $tmp/$test_name_suffix-note -F
 
-                test_name_suffix=pass
-                grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix
-                rlAssertGrep 'class="result pass">pass</td>' $tmp/$test_name_suffix -F
+            test_name_suffix=xfail
+            grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix
+            rlAssertGrep 'class="result pass">pass</td>' $tmp/$test_name_suffix -F
+            sed -e "/name\">\/test\/$test_name_suffix/,/\/tr/!d" $HTML | tee $tmp/$test_name_suffix-note
+            rlAssertGrep '<td class="note">original result: fail</td>' $tmp/$test_name_suffix-note -F
+        rlPhaseEnd
 
-                test_name_suffix=timeout
-                grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix
-                rlAssertGrep 'class="result error">error</td>' $tmp/$test_name_suffix -F
-                sed -e "/name\">\/test\/$test_name_suffix/,/\/tr/!d" $HTML | tee $tmp/$test_name_suffix-note
-                rlAssertGrep '<td class="note">timeout</td>' $tmp/$test_name_suffix-note -F
-
-                test_name_suffix=xfail
-                grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix
-                rlAssertGrep 'class="result pass">pass</td>' $tmp/$test_name_suffix -F
-                sed -e "/name\">\/test\/$test_name_suffix/,/\/tr/!d" $HTML | tee $tmp/$test_name_suffix-note
-                rlAssertGrep '<td class="note">original result: fail</td>' $tmp/$test_name_suffix-note -F
+        if [ "$option" = "" ]; then
+            rlPhaseStartTest "Check relative links"
+                moved_dir="$tmp/moved"
+                rlRun "mv $run_dir $moved_dir"
+                rlRun "pushd $(dirname ${HTML/original/moved})"
+                grep -Po '(?<=href=")[^"]+' "index.html" | while read f_path; do
+                    [[ $f_path == /* ]] && rlFail "Path $f_path is not a relative path"
+                    rlAssertExists $f_path
+                done
+                rlRun "popd"
             rlPhaseEnd
-
-            if [ "$absolute_paths" = "" ]; then
-                rlPhaseStartTest "$method - valid links"
-                    moved_dir="$tmp/moved"
-                    rlRun "mv $run_dir $moved_dir"
-                    rlRun "pushd $(dirname ${moved_dir}${PATH_INDEX})"
-                    grep -Po '(?<=href=")[^"]+' "index.html" | while read f_path; do
-                        [[ $f_path == /* ]] && rlFail "Path $f_path is not a relative path"
-                        rlAssertExists $f_path
-                    done
-                    rlRun "popd"
-                rlPhaseEnd
-            else
-                rlPhaseStartTest "$method - valid absolute links"
-                    grep -Po '(?<=href=")[^"]+' "${run_dir}${PATH_INDEX}" | while read f_path; do
-                        [[ $f_path == /* ]] || rlFail "Path $f_path is not an absolute path"
-                        rlAssertExists $f_path
-                    done
-                rlPhaseEnd
-            fi
-        done
+        else
+            rlPhaseStartTest "Check absolute links"
+                grep -Po '(?<=href=")[^"]+' "$HTML" | while read f_path; do
+                    [[ $f_path == /* ]] || rlFail "Path $f_path is not an absolute path"
+                    rlAssertExists $f_path
+                done
+            rlPhaseEnd
+        fi
     done
 
     rlPhaseStartCleanup

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -65,6 +65,10 @@ class ReportHtml(tmt.steps.report.ReportPlugin):
                 help='Make paths absolute rather than relative to working directory.')
             ] + super().options(how)
 
+    def prune(self) -> None:
+        """ Do not prune generated html report """
+        pass
+
     def go(self) -> None:
         """ Process results """
         super().go()

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -113,6 +113,10 @@ class ReportJUnit(tmt.steps.report.ReportPlugin):
                 help='Path to the file to store junit to'),
             ] + super().options(how)
 
+    def prune(self) -> None:
+        """ Do not prune generated junit report """
+        pass
+
     def go(self) -> None:
         """ Read executed tests and write junit """
         super().go()


### PR DESCRIPTION
Files generated during the `report` step are usually needed after the run is finished. Implement a new `prune()` method so that each `BasePlugin` class can decide what needs to be pruned and what should be kept. Also fix removal of regular files and symlinks. Extend the test coverage accordingly.