### PR TITLE
Merge options of report plugins into their step data fields

### DIFF
--- a/tmt/schemas/report/html.yaml
+++ b/tmt/schemas/report/html.yaml
@@ -22,5 +22,8 @@ properties:
   open:
     type: boolean
 
+  absolute-paths:
+    type: boolean
+
 required:
   - how

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -1,9 +1,7 @@
 import dataclasses
 import os
 import types
-from typing import Any, List, Optional, cast, overload
-
-import click
+from typing import Any, Optional, cast, overload
 
 import tmt
 import tmt.base
@@ -11,6 +9,7 @@ import tmt.options
 import tmt.result
 import tmt.steps
 import tmt.steps.report
+from tmt.utils import field
 
 DEFAULT_NAME = "junit.xml"
 
@@ -90,7 +89,12 @@ def make_junit_xml(report: "tmt.steps.report.ReportPlugin") -> JunitTestSuite:
 
 @dataclasses.dataclass
 class ReportJUnitData(tmt.steps.report.ReportStepData):
-    file: Optional[str] = None
+    file: Optional[str] = field(
+        default=None,
+        option='--file',
+        metavar='FILE',
+        help='Path to the file to store junit to.'
+        )
 
 
 @tmt.steps.provides_method('junit')
@@ -103,15 +107,6 @@ class ReportJUnit(tmt.steps.report.ReportPlugin):
     """
 
     _data_class = ReportJUnitData
-
-    @classmethod
-    def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
-        """ Prepare command line options for connect """
-        return [
-            click.option(
-                '--file', metavar='FILE',
-                help='Path to the file to store junit to'),
-            ] + super().options(how)
 
     def prune(self) -> None:
         """ Do not prune generated junit report """

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -2,14 +2,14 @@ import dataclasses
 import datetime
 import os
 import xml.etree.ElementTree as ET
-from typing import List, Optional
+from typing import Optional
 
-import click
 from requests import post
 
 import tmt
 import tmt.steps
 import tmt.steps.report
+from tmt.utils import field
 
 from .junit import make_junit_xml
 
@@ -18,10 +18,33 @@ DEFAULT_NAME = 'xunit.xml'
 
 @dataclasses.dataclass
 class ReportPolarionData(tmt.steps.report.ReportStepData):
-    file: Optional[str] = None
-    upload: bool = True
-    project_id: Optional[str] = None
-    testrun_title: Optional[str] = None
+    file: Optional[str] = field(
+        default=None,
+        option='--file',
+        metavar='FILE',
+        help='Path to the file to store xUnit in.'
+        )
+
+    upload: bool = field(
+        default=True,
+        option=('--upload / --no-upload'),
+        is_flag=True,
+        help="Whether to upload results to Polarion."
+        )
+
+    project_id: Optional[str] = field(
+        default=None,
+        option='--project-id',
+        metavar='ID',
+        help='Use specific Polarion project ID.'
+        )
+
+    testrun_title: Optional[str] = field(
+        default=None,
+        option='--testrun-title',
+        metavar='TITLE',
+        help='Use specific TestRun title.'
+        )
 
 
 @tmt.steps.provides_method('polarion')
@@ -31,21 +54,6 @@ class ReportPolarion(tmt.steps.report.ReportPlugin):
     """
 
     _data_class = ReportPolarionData
-
-    @classmethod
-    def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
-        """ Prepare command line options """
-        return [
-            click.option(
-                '--file', metavar='FILE', help='Path to the file to store xUnit in'),
-            click.option(
-                '--upload / --no-upload', default=True, show_default=True,
-                help="Whether to upload results to Polarion"),
-            click.option(
-                '--project-id', required=True, help='Use specific Polarion project ID'),
-            click.option(
-                '--testrun-title', help='Use specific TestRun title')
-            ] + super().options(how)
 
     def go(self) -> None:
         """ Go through executed tests and report into Polarion """


### PR DESCRIPTION
This builds upon #1558, and merges options and step data fields of report plugins into one structure (to rule them all...).