### PR TITLE
Include the new web link in verbose `show` mode

### DIFF
--- a/tests/core/web-link/test.py
+++ b/tests/core/web-link/test.py
@@ -1,21 +1,21 @@
+import re
+
 import tmt
 
 tree = tmt.Tree(path='data')
+prefix = r'https://github.com/.*/tmt/tree/.*/tests/core/web-link/data/'
 
 
 def test_stories():
     url = tree.stories(names=['/story'])[0].web_link()
-    assert url.startswith('https://github.com/teemtee/tmt/tree/')
-    assert url.endswith('/tests/core/web-link/data/story.fmf')
+    assert re.match(prefix + 'story.fmf', url)
 
 
 def test_plans():
     url = tree.plans(names=['/plan'])[0].web_link()
-    assert url.startswith('https://github.com/teemtee/tmt/tree/')
-    assert url.endswith('/tests/core/web-link/data/plan.fmf')
+    assert re.match(prefix + 'plan.fmf', url)
 
 
 def test_tests():
     url = tree.tests(names=['/test'])[0].web_link()
-    assert url.startswith('https://github.com/teemtee/tmt/tree/')
-    assert url.endswith('/tests/core/web-link/data/test.fmf')
+    assert re.match(prefix + 'test.fmf', url)

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -449,8 +449,9 @@ class Core(
         """ Show source files """
         if self.id is not None:
             echo(tmt.utils.format('id', self.id, key_color='magenta'))
-        echo(tmt.utils.format(
-            'sources', self.node.sources, key_color='magenta'))
+        echo(tmt.utils.format('sources', self.node.sources, key_color='magenta'))
+        self._fmf_id()
+        echo(tmt.utils.format('web', self.web_link(), key_color='magenta', wrap=False))
 
     def _fmf_id(self) -> None:
         """ Show fmf identifier """
@@ -834,7 +835,6 @@ class Test(Core):
                 echo(tmt.utils.format(key, value))
         if self.opt('verbose'):
             self._show_additional_keys()
-            self._fmf_id()
         if self.opt('verbose', 0) >= 2:
             # Print non-empty unofficial attributes
             for key in sorted(self.node.get().keys()):


### PR DESCRIPTION
Show the clickable web link when showing tests, plans and stories in verbose mode. Also include fmf-id in the story and plan output. Allows to quickly access the source code from the web browser.

Also fix the test so that it works fine also for pull requests from forked repositories.