### PR TITLE
Create container images from the latest non-dev copr build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -137,8 +137,6 @@ jobs:
     dist_git_branches:
       - fedora-all
       - epel-9
-    actions:
-        post-upstream-clone: []
 
   - job: koji_build
     trigger: commit

--- a/containers/Containerfile.full
+++ b/containers/Containerfile.full
@@ -9,7 +9,7 @@ RUN set -x && \
 RUN set -x && \
     dnf install -y dnf-plugins-core && \
     dnf copr enable -y psss/tmt && \
-    dnf install -y tmt-all beakerlib && \
+    dnf install -y tmt+all-[0-9].[0-9][0-9].[0-9]* beakerlib && \
     dnf autoremove -y && \
     dnf clean all
 

--- a/containers/Containerfile.mini
+++ b/containers/Containerfile.mini
@@ -9,7 +9,7 @@ RUN set -x && \
 RUN set -x && \
     dnf install -y dnf-plugins-core && \
     dnf copr enable -y psss/tmt && \
-    dnf install -y tmt && \
+    dnf install -y tmt-[0-9].[0-9][0-9].[0-9]* && \
     dnf autoremove -y && \
     dnf clean all
 

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -384,9 +384,9 @@ Release a new package to Fedora and EPEL repositories:
 Finally, if everything went well:
 
 * Close the corresponding release milestone
-* Once the `copr build`__ is completed, move the ``quay`` branch
-  to point to the release commit as well to build fresh container
-  images.
+* Once the non development `copr build`__ is completed, move the
+  ``quay`` branch to point to the release commit as well to build
+  fresh container images.
 
 Handle manually what did not went well:
 
@@ -396,12 +396,8 @@ Handle manually what did not went well:
 * If there was a problem with creating Fedora pull requests, you
   can trigger them manually using ``/packit propose-downstream``
   in any open issue.
-* If running `packit propose-downstream`__ from your laptop make
-  sure that the ``post-upstream-clone`` action is disabled in
-  ``.packit.yaml`` to prevent bumping the devel version.
 
 __ https://github.com/teemtee/tmt/releases/
 __ https://src.fedoraproject.org/rpms/tmt/pull-requests
-__ https://copr.fedorainfracloud.org/coprs/psss/tmt/builds/
+__ https://copr.fedorainfracloud.org/coprs/g/teemtee/tmt/builds/
 __ https://pypi.org/project/tmt/
-__ https://packit.dev/docs/cli/propose-downstream/


### PR DESCRIPTION
Packit is producing y+1.dev versions however we want to have one with matching release in the container.

No idea yet how to avoid the manual 'copr build' step :/