### PR TITLE
Merge options of prepare plugins into their step data fields

### DIFF
--- a/tmt/steps/prepare/multihost.py
+++ b/tmt/steps/prepare/multihost.py
@@ -5,7 +5,7 @@ import tmt
 import tmt.steps
 import tmt.steps.prepare
 from tmt.steps.provision import Guest
-from tmt.utils import ShellScript
+from tmt.utils import ShellScript, field
 
 
 # Derived from StepData, not PrepareStepData, on purpose: this is not a plugin
@@ -13,8 +13,8 @@ from tmt.utils import ShellScript
 # defined by this "step" by using `where` key in their own data.
 @dataclasses.dataclass
 class PrepareMultihostData(tmt.steps.prepare.PrepareStepData):
-    roles: Dict[str, List[str]] = dataclasses.field(default_factory=dict)
-    hosts: Dict[str, str] = dataclasses.field(default_factory=dict)
+    roles: Dict[str, List[str]] = field(default_factory=dict)
+    hosts: Dict[str, str] = field(default_factory=dict)
 
 
 @tmt.steps.provides_method('multihost')

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -1,22 +1,27 @@
 import dataclasses
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, cast
 
-import click
 import fmf
 
 import tmt
-import tmt.options
 import tmt.steps
 import tmt.steps.prepare
 import tmt.utils
 from tmt.steps.provision import Guest
-from tmt.utils import ShellScript
+from tmt.utils import ShellScript, field
 
 
 # TODO: remove `ignore` with follow-imports enablement
 @dataclasses.dataclass
 class PrepareShellData(tmt.steps.prepare.PrepareStepData):
-    script: List[ShellScript] = dataclasses.field(default_factory=list)
+    script: List[ShellScript] = field(
+        default_factory=list,
+        option=('-s', '--script'),
+        multiple=True,
+        metavar='SCRIPT',
+        help='Shell script to be executed. Can be used multiple times.',
+        normalize=tmt.utils.normalize_shell_script_list
+        )
 
     # ignore[override] & cast: two base classes define to_spec(), with conflicting
     # formal types.
@@ -64,16 +69,6 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin):
     """
 
     _data_class = PrepareShellData
-
-    @classmethod
-    def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
-        """ Prepare command line options """
-        return [
-            click.option(
-                '-s', '--script', metavar='SCRIPT',
-                multiple=True,
-                help='Shell script to be executed, can be used multiple times.')
-            ] + super().options(how)
 
     def go(self, guest: Guest) -> None:
         """ Prepare the guests """


### PR DESCRIPTION
This builds upon #1558, and merges options and step data fields of report plugins into one structure (to rule them all...).