### PR TITLE
Bump pre-commit linters - Flake8, Mypy, JSON schema, YAML lint & pygrep

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/pycqa/flake8
-    rev: "5.0.4"
+    rev: "6.0.0"
     hooks:
       - id: flake8
         args:
@@ -40,31 +40,34 @@ repos:
           )$
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.3.0"
+    rev: "v4.4.0"
     hooks:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.982"
+    rev: "v0.991"
     hooks:
       - id: mypy
-        additional_dependencies: [types-click]
+        # Do not install *types-click* - it's not recommended with Click 8 & newer,
+        # which is the version a developer encounters given the requirements are not
+        # frozen.
+        additional_dependencies: [click]
         pass_filenames: false
         args:
           - --config-file
           - mypy.ini
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.18.3"
+    rev: "0.20.0"
     hooks:
       - id: check-metaschema
         name: "Check JSON schemas validity"
         files: ^tmt/schemas/.*\.yaml
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.28.0
+    rev: v1.29.0
     hooks:
       - id: yamllint
         files: ^tmt/schemas/.*\.yaml
@@ -73,7 +76,7 @@ repos:
   # process Python code, and offer interesting "metalinters", checks for
   # what we do to appease flake8 and mypy linters.
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       # Enforce `noqa` and `type: ignore` to always appear with specific
       # error code(s).

--- a/mypy.ini
+++ b/mypy.ini
@@ -24,9 +24,6 @@ files = bin/tmt,
 [mypy-bugzilla.*]
 ignore_missing_imports = True
 
-[mypy-click.*]
-ignore_missing_imports = True
-
 [mypy-gssapi.*]
 ignore_missing_imports = True
 
@@ -64,4 +61,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-testcloud.*]
+ignore_missing_imports = True
+
+[mypy-importlib_metadata]
 ignore_missing_imports = True

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -627,7 +627,7 @@ def read_nitrate(
     except (nitrate.NitrateError,
             nitrate.xmlrpc_driver.NitrateXmlrpcError,
             gssapi.raw.misc.GSSError) as error:
-        raise ConvertError(error)
+        raise ConvertError(str(error))
     if not testcases:
         echo("No {0}testcase found for '{1}'.".format(
             '' if disabled else 'non-disabled ', beaker_task))

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -12,7 +12,7 @@ import tmt.utils
 # When dealing with older Click packages (I'm looking at you, Python 3.6),
 # we need to define FC on our own.
 try:
-    from click.decorators import FC  # type: ignore[attr-defined]
+    from click.decorators import FC
 
 except ImportError:
     from typing import TypeVar, Union
@@ -37,7 +37,7 @@ _ClickOptionDecoratorType = Callable[[FC], FC]
 # * we could do that right here, because right now, we don't care too much about
 # what this `foo` type actually is - what's important is the identity, return type
 # matches the type of the argument.
-ClickOptionDecoratorType = _ClickOptionDecoratorType[Any]  # type: ignore[misc]
+ClickOptionDecoratorType = _ClickOptionDecoratorType[Any]
 
 # Verbose, debug and quiet output
 VERBOSITY_OPTIONS: List[ClickOptionDecoratorType] = [
@@ -274,6 +274,7 @@ def create_method_class(methods: MethodDictType) -> Type[click.Command]:
             if how and self._method is None:
                 # Use run for logging, steps may not be initialized yet
                 assert context.obj.run is not None  # narrow type
+                assert self.name is not None  # narrow type
                 show_step_method_hints(context.obj.run, self.name, how)
                 raise tmt.utils.SpecificationError(
                     f"Unsupported {self.name} method '{how}'.")

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -74,6 +74,20 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
             self.ref = self.revision
 
 
+REF_OPTION = click.option(
+    '-r', '--ref', metavar='REVISION',
+    help='Branch, tag or commit specifying the git revision.')
+TEST_OPTION = click.option(
+    '-t', '--test', metavar='NAMES', multiple=True,
+    help='Select tests by name.')
+FILTER_OPTION = click.option(
+    '-F', '--filter', metavar='FILTERS', multiple=True,
+    help='Include only tests matching the filter.')
+EXCLUDE_OPTION = click.option(
+    '-x', '--exclude', metavar='[REGEXP]', multiple=True,
+    help="Exclude a regular expression from search result.")
+
+
 @tmt.steps.provides_method('fmf')
 class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
     """
@@ -149,19 +163,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
 
     _data_class = DiscoverFmfStepData
 
-    REF_OPTION = click.option(
-        '-r', '--ref', metavar='REVISION',
-        help='Branch, tag or commit specifying the git revision.')
-    TEST_OPTION = click.option(
-        '-t', '--test', metavar='NAMES', multiple=True,
-        help='Select tests by name.')
-    FILTER_OPTION = click.option(
-        '-F', '--filter', metavar='FILTERS', multiple=True,
-        help='Include only tests matching the filter.')
-    EXCLUDE_OPTION = click.option(
-        '-x', '--exclude', metavar='[REGEXP]', multiple=True,
-        help="Exclude a regular expression from search result.")
-
     # Options which require .git to be present for their functionality
     _REQUIRES_GIT = (
         "ref",
@@ -177,7 +178,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             click.option(
                 '-u', '--url', metavar='REPOSITORY',
                 help='URL of the git repository with fmf metadata.'),
-            cls.REF_OPTION,
+            REF_OPTION,
             click.option(
                 '--modified-url', metavar='REPOSITORY',
                 help='URL of the reference git repository with fmf metadata.'),
@@ -192,13 +193,13 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             click.option(
                 '-p', '--path', metavar='ROOT',
                 help='Path to the metadata tree root.'),
-            cls.TEST_OPTION,
+            TEST_OPTION,
             click.option(
                 '--link', metavar="RELATION:TARGET", multiple=True,
                 help="Filter by linked objects (regular expressions are "
                      "supported for both relation and target)."),
-            cls.FILTER_OPTION,
-            cls.EXCLUDE_OPTION,
+            FILTER_OPTION,
+            EXCLUDE_OPTION,
             click.option(
                 '--fmf-id', default=False, is_flag=True,
                 help='Show fmf identifiers for tests discovered in plan.'),

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -7,6 +7,7 @@ import fmf.utils
 import tmt.base
 import tmt.result
 import tmt.steps
+import tmt.steps.discover.fmf
 import tmt.steps.execute
 import tmt.utils
 from tmt.steps.discover import DiscoverPlugin
@@ -125,10 +126,10 @@ class ExecuteUpgrade(ExecuteInternal):
                 '--upgrade-path', '-p', metavar='PLAN_NAME',
                 help='Upgrade path corresponding to a plan name in the repository '
                 'with upgrade tasks.'),
-            DiscoverFmf.REF_OPTION,
-            DiscoverFmf.TEST_OPTION,
-            DiscoverFmf.FILTER_OPTION,
-            DiscoverFmf.EXCLUDE_OPTION
+            tmt.steps.discover.fmf.REF_OPTION,
+            tmt.steps.discover.fmf.TEST_OPTION,
+            tmt.steps.discover.fmf.FILTER_OPTION,
+            tmt.steps.discover.fmf.EXCLUDE_OPTION
             ] + super().options(how)
 
     @property

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -118,17 +118,17 @@ class ReportJUnit(tmt.steps.report.ReportPlugin):
 
         suite = make_junit_xml(self)
 
+        assert junit_xml  # narrow type
+
         assert self.workdir is not None
         f_path = self.get("file", os.path.join(self.workdir, DEFAULT_NAME))
         try:
             with open(f_path, 'w') as fw:
                 if hasattr(junit_xml, 'to_xml_report_file'):
-                    # FIXME: ignore[union-attr]: https://github.com/teemtee/tmt/issues/1616
-                    junit_xml.to_xml_report_file(fw, [suite])  # type: ignore[union-attr]
+                    junit_xml.to_xml_report_file(fw, [suite])
                 else:
                     # For older junit-xml
-                    # FIXME: ignore[union-attr]: https://github.com/teemtee/tmt/issues/1616
-                    junit_xml.TestSuite.to_file(fw, [suite])  # type: ignore[union-attr]
+                    junit_xml.TestSuite.to_file(fw, [suite])
             self.info("output", f_path, 'yellow')
         except Exception as error:
             raise tmt.utils.ReportError(


### PR DESCRIPTION
This improves coverage of some corner cases in tmt & Click integration, and reveals a few more minor issues that were fixed by very small refactoring or proper waivers.