### PR TITLE
Use Require* classes for collection & installation of plugin requirements

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,7 +7,7 @@ import threading
 import time
 import unittest
 import unittest.mock
-from typing import Tuple
+from typing import Any, List, Tuple
 
 import py
 import pytest
@@ -906,3 +906,39 @@ def test_common_base_inheritance(root_logger):
     # And that both classes can be instantiated.
     ClassA(logger=root_logger, foo='bar')
     ClassB(logger=root_logger, foo='bar')
+
+
+@pytest.mark.parametrize(
+    ('values', 'expected'),
+    [
+        ([], []),
+        ([1, 2, 3, 4, 5], [1, 2, 3, 4, 5]),
+        ([1, 2, 1, 2, 3], [1, 2, 3])
+        ],
+    ids=(
+        'empty-list',
+        'no-duplicates',
+        'duplicates'
+        )
+    )
+def test_uniq(values: List[Any], expected: List[Any]) -> None:
+    assert tmt.utils.uniq(values) == expected
+
+
+@pytest.mark.parametrize(
+    ('lists', 'unique', 'expected'),
+    [
+        ([], False, []),
+        ([[], [], []], False, []),
+        ([[], [1, 2, 3], [1, 2, 3], [4, 5], [3, 2, 1]], False, [1, 2, 3, 1, 2, 3, 4, 5, 3, 2, 1]),
+        ([[], [1, 2, 3], [1, 2, 3], [4, 5], [3, 2, 1]], True, [1, 2, 3, 4, 5])
+        ],
+    ids=(
+        'empty-input',
+        'empty-lists',
+        'keep-duplicates',
+        'unique-enabled'
+        )
+    )
+def test_flatten(lists: List[List[Any]], unique: bool, expected: List[Any]) -> None:
+    assert tmt.utils.flatten(lists, unique=unique) == expected

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -408,6 +408,34 @@ def normalize_require(raw_require: Optional[_RawRequire], logger: tmt.log.Logger
         ]
 
 
+def assert_simple_requirements(
+        requires: List[Require],
+        error_message: str,
+        logger: tmt.log.Logger) -> List[RequireSimple]:
+    """
+    Make sure the list of requirements consists of simple ones.
+
+    :param requires: the list of requires.
+    :param error_message: used for a raised exception.
+    :param logger: used for logging.
+    :raises GeneralError: when there is a requirement on the list which
+        is not a subclass of :py:class:`tmt.base.RequireSimple`.
+    """
+
+    non_simple_requirements = list(filter(
+        lambda require: not isinstance(require, RequireSimple),
+        requires
+        ))
+
+    if not non_simple_requirements:
+        return cast(List[RequireSimple], requires)
+
+    for require in non_simple_requirements:
+        logger.fail(f'Invalid requirement: {require}')
+
+    raise tmt.utils.GeneralError(error_message)
+
+
 CoreT = TypeVar('CoreT', bound='Core')
 
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -409,7 +409,7 @@ def normalize_require(raw_require: Optional[_RawRequire], logger: tmt.log.Logger
 
 
 def assert_simple_requirements(
-        requires: List[Require],
+        requirements: List[Require],
         error_message: str,
         logger: tmt.log.Logger) -> List[RequireSimple]:
     """
@@ -424,11 +424,11 @@ def assert_simple_requirements(
 
     non_simple_requirements = list(filter(
         lambda require: not isinstance(require, RequireSimple),
-        requires
+        requirements
         ))
 
     if not non_simple_requirements:
-        return cast(List[RequireSimple], requires)
+        return cast(List[RequireSimple], requirements)
 
     for require in non_simple_requirements:
         logger.fail(f'Invalid requirement: {require}')

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -563,18 +563,6 @@ class Execute(tmt.steps.Step):
         self.status('done')
         self.save()
 
-    def requires(self) -> List[str]:
-        """
-        Packages required for test execution
-
-        Return a list of packages which need to be installed on the
-        guest so that tests can be executed. Used by the prepare step.
-        """
-        requires = set()
-        for plugin in self.phases(classes=ExecutePlugin):
-            requires.update(plugin.requires())
-        return list(requires)
-
     def results(self) -> List["tmt.result.Result"]:
         """
         Results from executed tests

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, cast
 import click
 
 import tmt
+import tmt.base
 import tmt.options
 import tmt.steps
 import tmt.steps.execute
@@ -425,6 +426,6 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
         """ Return test results """
         return self._results
 
-    def requires(self) -> List[str]:
-        """ Return list of required packages """
+    def requires(self) -> List[tmt.base.Require]:
+        """ All requirements of the plugin on the guest """
         return []

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -144,16 +144,3 @@ class Finish(tmt.steps.Step):
         self.summary()
         self.status('done')
         self.save()
-
-    def requires(self) -> List[str]:
-        """
-        Packages required by all enabled finish plugins
-
-        Return a list of packages which need to be installed on the
-        provisioned guest so that the finishing tasks work well.
-        Used by the prepare step.
-        """
-        requires = set()
-        for plugin in self.phases(classes=FinishPlugin):
-            requires.update(plugin.requires())
-        return list(requires)

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -25,6 +25,7 @@ from tmt.steps import Action
 from tmt.utils import BaseLoggerFnType, Command, Path, ShellScript
 
 if TYPE_CHECKING:
+    import tmt.base
     import tmt.cli
 
 
@@ -514,8 +515,8 @@ class Guest(tmt.utils.Common):
         return CheckRsyncOutcome.INSTALLED
 
     @classmethod
-    def requires(cls) -> List[str]:
-        """ No extra requires needed """
+    def requires(cls) -> List['tmt.base.Require']:
+        """ All requirements of the guest implementation """
         return []
 
 
@@ -1134,14 +1135,17 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin):
         """
         raise NotImplementedError()
 
-    def requires(self) -> List[str]:
+    def requires(self) -> List['tmt.base.Require']:
         """
-        Provide a list of packages required for the workdir sync.
+        All requirements of the guest implementation.
 
-        By default, plugin's guest class - :py:attr:`ProvisionPlugin._guest_class` - is asked to
-        provide the list of required packages via :py:meth:`Guest.requires` method.
+        Provide a list of requirements for the workdir sync.
 
-        :returns: a list of package names.
+        By default, plugin's guest class, :py:attr:`ProvisionPlugin._guest_class`,
+        is asked to provide the list of required packages via
+        :py:meth:`Guest.requires` method.
+
+        :returns: a list of requirements.
         """
 
         return self._guest_class.requires()
@@ -1315,16 +1319,3 @@ class Provision(tmt.steps.Step):
     def guests(self) -> List[Guest]:
         """ Return the list of all provisioned guests """
         return self._guests
-
-    def requires(self) -> List[str]:
-        """
-        Packages required by all enabled provision plugins
-
-        Return a list of packages which need to be installed on the
-        provisioned guest so that the workdir can be synced to it.
-        Used by the prepare step.
-        """
-        requires = set()
-        for plugin in self.phases(classes=ProvisionPlugin):
-            requires.update(plugin.requires())
-        return list(requires)

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -2,6 +2,7 @@ import dataclasses
 from typing import Any, List, Optional, Union
 
 import tmt
+import tmt.base
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -6,6 +6,7 @@ from typing import Any, List, Optional, Union
 import click
 
 import tmt
+import tmt.base
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -108,16 +108,3 @@ class Report(tmt.steps.Step):
         self.summary()
         self.status('done')
         self.save()
-
-    def requires(self) -> List[str]:
-        """
-        Packages required by all enabled report plugins
-
-        Return a list of packages which need to be installed on the
-        provisioned guest so that the full report can be successfully
-        generated. Used by the prepare step.
-        """
-        requires = set()
-        for plugin in self.phases(classes=ReportPlugin):
-            requires.update(plugin.requires())
-        return list(requires)

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1203,6 +1203,27 @@ class FinishError(GeneralError):
 #  Utilities
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+
+def uniq(values: List[T]) -> List[T]:
+    """ Return a list of all unique items from ``values`` """
+    return list(set(values))
+
+
+def flatten(lists: Generator[List[T], None, None], unique: bool = False) -> List[T]:
+    """
+    "Flatten" a list of lists into a single-level list.
+
+    :param lists: an iterable of lists to flatten.
+    :param unique: if set, duplicate items would be removed, leaving only
+        a single instance in the final list.
+    :returns: list of items from all given lists.
+    """
+
+    flattened: List[T] = sum(lists, [])
+
+    return uniq(flattened) if unique else flattened
+
+
 def quote(string: str) -> str:
     """ Surround a string with double quotes """
     return f'"{string}"'


### PR DESCRIPTION
These classes - `RequireSimple` and `RequireFmf` - are used to represent test requirements (and recommended packages, too). On the other hand, packages required on a guest by various plugins were still expressed as strings. The nature of these is the same as tests' requirements, therefore let's use the same types for both.

As a side-effect, collection of plugin requirements is now slightly simpler, using base class implementation of `Step.requires()` when possible, and step data of `prepare/install` plugin annotates its `package` field with `RequireSimple` as well.

Note 1: `RequireFmf` is not supported by `prepare/install` - beakerlib libraries are processed by the step itself, fetched & replaced with their *simple* requirements.

Note 2: adding two primitives for list flattening & uniqueness handling, to improve readability fo these two common actions in the land of requirements.

### Checklist

* [ ] implement the feature
* [ ] write documentation
* [ ] extend the test coverage
* [ ] update specification
* [ ] adjust module docs
* [ ] add a usage example
* [ ] modify json schema
* [ ] mention version