### PR TITLE
Adds a template-backed export plugin

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -631,12 +631,18 @@ _test_export_default = 'yaml'
 @click.option(
     '-d', '--debug', is_flag=True,
     help='Provide as much debugging details as possible.')
+# TODO: move to `template` export plugin options
+@click.option(
+    '--template', metavar='PATH',
+    help="Path to a template to use for rendering the export. Used with '--how=template' only."
+    )
 def tests_export(
         context: Context,
         format: str,
         how: str,
         nitrate: bool,
         bugzilla: bool,
+        template: Optional[str],
         **kwargs: Any) -> None:
     """
     Export test data into the desired format.
@@ -665,13 +671,15 @@ def tests_export(
     if kwargs.get('fmf_id'):
         echo(tmt.base.FmfId.export_collection(
             collection=[test.fmf_id for test in context.obj.tree.tests()],
-            format=how
+            format=how,
+            template=template
             ))
 
     else:
         echo(tmt.Test.export_collection(
             collection=context.obj.tree.tests(),
-            format=how
+            format=how,
+            template=template
             ))
 
 
@@ -834,7 +842,17 @@ _plan_export_default = 'yaml'
 @click.option(
     '-d', '--debug', is_flag=True,
     help='Provide as much debugging details as possible.')
-def plans_export(context: Context, how: str, format: str, **kwargs: Any) -> None:
+# TODO: move to `template` export plugin options
+@click.option(
+    '--template', metavar='PATH',
+    help="Path to a template to use for rendering the export. Used with '--how=template' only."
+    )
+def plans_export(
+        context: Context,
+        how: str,
+        format: str,
+        template: Optional[str],
+        **kwargs: Any) -> None:
     """
     Export plans into desired format.
 
@@ -848,7 +866,11 @@ def plans_export(context: Context, how: str, format: str, **kwargs: Any) -> None
 
         how = format
 
-    echo(tmt.Plan.export_collection(collection=context.obj.tree.plans(), format=how))
+    echo(tmt.Plan.export_collection(
+        collection=context.obj.tree.plans(),
+        format=how,
+        template=template
+        ))
 
 
 @plans.command(name="id")
@@ -1070,6 +1092,11 @@ _story_export_default = 'yaml'
 @click.option(
     '-d', '--debug', is_flag=True,
     help='Provide as much debugging details as possible.')
+# TODO: move to `template` export plugin options
+@click.option(
+    '--template', metavar='PATH',
+    help="Path to a template to use for rendering the export. Used with '--how=template' only."
+    )
 def stories_export(
         context: Context,
         how: str,
@@ -1082,6 +1109,7 @@ def stories_export(
         unverified: bool,
         undocumented: bool,
         uncovered: bool,
+        template: Optional[str],
         **kwargs: Any) -> None:
     """
     Export selected stories into desired format.
@@ -1102,7 +1130,7 @@ def stories_export(
                         undocumented, uncovered)
         ]
 
-    echo(tmt.Story.export_collection(collection=stories, format=how))
+    echo(tmt.Story.export_collection(collection=stories, format=how, template=template))
 
 
 @stories.command(name='lint')

--- a/tmt/export/rst.py
+++ b/tmt/export/rst.py
@@ -1,8 +1,8 @@
-import os.path
 from typing import Any, List, Optional
 
 import tmt.base
 import tmt.export
+import tmt.export.template
 import tmt.utils
 
 
@@ -13,10 +13,9 @@ class RestructuredExporter(tmt.export.ExportPlugin):
                      story: tmt.base.Story,
                      keys: Optional[List[str]] = None,
                      include_title: bool = True) -> str:
-        template_filepath = os.path.join(tmt.export.TEMPLATES_DIRECTORY, 'default-story.rst.j2')
-
-        return tmt.utils.render_template_file(
-            template_filepath,
+        return tmt.export.template.TemplateExporter.render_template(
+            default_template_filename='default-story.rst.j2',
+            keys=keys,
             STORY=story,
             INCLUDE_TITLE=include_title)
 
@@ -26,5 +25,5 @@ class RestructuredExporter(tmt.export.ExportPlugin):
                                 keys: Optional[List[str]] = None,
                                 include_title: bool = True,
                                 **kwargs: Any) -> str:
-        return '\n\n'.join([cls.export_story(story, include_title=include_title)
+        return '\n\n'.join([cls.export_story(story, keys=keys, include_title=include_title)
                            for story in stories])

--- a/tmt/export/template.py
+++ b/tmt/export/template.py
@@ -1,0 +1,88 @@
+import os.path
+from typing import Any, List, Optional
+
+import tmt.base
+import tmt.export
+import tmt.utils
+
+
+@tmt.base.Story.provides_export('template')
+class TemplateExporter(tmt.export.ExportPlugin):
+    @classmethod
+    def render_template(
+            cls,
+            *,
+            template_filepath: Optional[str] = None,
+            default_template_filename: str,
+            keys: Optional[List[str]] = None,
+            **variables: Any
+            ) -> str:
+        return tmt.utils.render_template_file(
+            template_filepath or os.path.join(
+                tmt.export.TEMPLATES_DIRECTORY,
+                default_template_filename),
+            KEYS=keys,
+            **variables
+            )
+
+    @classmethod
+    def export_fmfid_collection(cls,
+                                fmf_ids: List[tmt.base.FmfId],
+                                keys: Optional[List[str]] = None,
+                                template: Optional[str] = None,
+                                **kwargs: Any) -> str:
+        return '\n\n'.join([
+            cls.render_template(
+                template_filepath=template,
+                default_template_filename='default-fmfid.j2',
+                keys=keys,
+                FMF_ID=fmf_id)
+            for fmf_id in fmf_ids
+            ])
+
+    @classmethod
+    def export_test_collection(cls,
+                               tests: List[tmt.base.Test],
+                               keys: Optional[List[str]] = None,
+                               template: Optional[str] = None,
+                               **kwargs: Any) -> str:
+        return '\n\n'.join([
+            cls.render_template(
+                template_filepath=template,
+                default_template_filename='default-test.j2',
+                keys=keys,
+                TEST=test)
+            for test in tests
+            ])
+
+    @classmethod
+    def export_plan_collection(cls,
+                               plans: List[tmt.base.Plan],
+                               keys: Optional[List[str]] = None,
+                               template: Optional[str] = None,
+                               **kwargs: Any) -> str:
+        return '\n\n'.join([
+            cls.render_template(
+                template_filepath=template,
+                default_template_filename='default-plan.j2',
+                keys=keys,
+                PLAN=plan)
+            for plan in plans
+            ])
+
+    @classmethod
+    def export_story_collection(cls,
+                                stories: List[tmt.base.Story],
+                                keys: Optional[List[str]] = None,
+                                template: Optional[str] = None,
+                                include_title: bool = True,
+                                **kwargs: Any) -> str:
+        return '\n\n'.join([
+            cls.render_template(
+                template_filepath=template,
+                default_template_filename='default-story.j2',
+                keys=keys,
+                STORY=story,
+                INCLUDE_TITLE=include_title)
+            for story in stories
+            ])


### PR DESCRIPTION
Does what the original ReST export did, but without preferring any particular format, leaving its selection to the template itself. Can be applied to all base classes.

ReST export for stories still exists, to remain backward compatible, it's using the new template plugin to do the heavy lifting.

Part of the effort to improve exports, see #1679.