### PR TITLE
Require jinja2 always, not only with report-html subpackage/extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ install_requires = [
     'click',
     'requests',
     'ruamel.yaml',
+    'jinja2',
     ]
 
 # typing_extensions is needed with Python 3.7 and older, types imported
@@ -79,7 +80,6 @@ extras_require = {
         'markdown',
         'python-bugzilla',
         'html2text'],
-    'report-html': ['jinja2'],
     'report-junit': ['junit_xml'],
     'report-polarion': ['junit_xml', 'pylero'],
     'export-polarion': ['pylero'],

--- a/tmt.spec
+++ b/tmt.spec
@@ -48,6 +48,7 @@ BuildRequires: python%{python3_pkgversion}-testcloud >= 0.8.2
 BuildRequires: python%{python3_pkgversion}-markdown
 BuildRequires: python%{python3_pkgversion}-junit_xml
 BuildRequires: python%{python3_pkgversion}-ruamel-yaml
+BuildRequires: python%{python3_pkgversion}-jinja2
 # Only needed for rhel-8 (it has python3.6)
 %if 0%{?rhel} == 8
 BuildRequires: python%{python3_pkgversion}-typing-extensions
@@ -104,7 +105,6 @@ Additional dependencies needed for test metadata import and export.
 %package report-html
 Summary: Report plugin with support for generating web pages
 Requires: tmt == %{version}-%{release}
-Requires: python3-jinja2
 
 %description report-html
 Generate test results in the html format. Quickly review test

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -1,11 +1,11 @@
 import dataclasses
 import os
 import os.path
-import types
 import webbrowser
 from typing import List, Optional
 
 import click
+import jinja2
 import pkg_resources
 
 import tmt
@@ -15,22 +15,6 @@ import tmt.steps.report
 
 HTML_TEMPLATE_PATH = pkg_resources.resource_filename(
     'tmt', 'steps/report/html/template.html.j2')
-
-jinja2: Optional[types.ModuleType] = None
-
-
-def import_jinja2() -> None:
-    """
-    Import jinja2 module only when needed
-
-    Until we have a separate package for each plugin.
-    """
-    global jinja2
-    try:
-        import jinja2
-    except ImportError:
-        raise tmt.utils.ReportError(
-            "Missing 'jinja2', fixable by 'pip install tmt[report-html]'")
 
 
 @dataclasses.dataclass
@@ -72,9 +56,6 @@ class ReportHtml(tmt.steps.report.ReportPlugin):
     def go(self) -> None:
         """ Process results """
         super().go()
-
-        import_jinja2()
-        assert jinja2
 
         # Prepare the template
         environment = jinja2.Environment()


### PR DESCRIPTION
Part of the effort to improve exports, see https://github.com/teemtee/tmt/issues/1679.