### PR TITLE
Respect `TMT_WORKDIR_ROOT` variable in `testcloud`

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -48,7 +48,7 @@ def import_testcloud() -> None:
 
 
 # Testcloud cache to our tmt's workdir root
-TESTCLOUD_DATA = os.path.join(WORKDIR_ROOT, 'testcloud')
+TESTCLOUD_DATA = os.path.join(os.getenv('TMT_WORKDIR_ROOT', WORKDIR_ROOT), 'testcloud')
 TESTCLOUD_IMAGES = os.path.join(TESTCLOUD_DATA, 'images')
 
 # Userdata for cloud-init


### PR DESCRIPTION
Just a quick fix to prevent `testcloud` storing the downloaded images in the default location. Would be nice to have something like `tmt.utils.get_constant()` which would handle the check for possible environment variable override.