### PR TITLE
Adds a ruff linter to pre-commit checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ MANIFEST
 # Testing
 .mypy_cache
 .pytest_cache
+.ruff_cache
 
 # Virtual environment
 .env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,3 +87,21 @@ repos:
       # - id: python-no-log-warn
       # - id: python-use-type-annotations
       # - id: text-unicode-replacement-char
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version.
+    rev: 'v0.0.215'
+    hooks:
+      - id: ruff
+        # Respect `exclude` and `extend-exclude` settings.
+        args:
+          - "--config"
+          - "ruff.toml"
+        files: >
+          (?x)^(
+            bin/.*|
+            examples/.*|
+            tests/.*|
+            tmt/.*|
+            setup.py
+          )$

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,16 @@
+src = ["tmt"]
+
+# select = ["E", "F"]
+select = ["A", "ANN", "ARG", "B", "BLE", "C", "D", "E", "ERA", "F", "FBT", "I", "ICN", "N", "PGH", "PLC", "PLE", "PLR", "PLW", "Q", "RET", "RUF", "S", "T", "TID", "UP", "W", "YTT"]
+ignore = [
+    # Missing type annotation for self in method
+    "ANN101",
+    # Missing type annotation for cls in classmethod
+    "ANN102",
+    # All documentation related checks
+    "D",
+    # Single quotes found but double quotes preferred
+    "Q000",
+]
+target-version = "py36"
+line-length = 99


### PR DESCRIPTION
Ruff [1] seems to be one of the freshly emerging linters, possibly covering multiple other tools. Why?

* should be much faster that other linters,
* caching (nice for local development),
* suggests fixes,
* different perspective - just like with other human endeavours, tools bring their slightly different views, and may report issues other tools happily ignore.

[1] https://github.com/charliermarsh/ruff