### PR TITLE
Apply normalization callback when updating data with CLI input

### DIFF
--- a/tests/unit/test_dataclasses.py
+++ b/tests/unit/test_dataclasses.py
@@ -1,8 +1,116 @@
-import dataclasses  # noqa: F401
+import dataclasses
+from typing import Any, Optional
+from unittest.mock import MagicMock
 
-# TODO: more tests will come for functionality based on dataclasses.
-# As of now, just make sure it's possible to import the package.
+import pytest
+
+import tmt.log
+import tmt.utils
+from tmt.utils import (SerializableContainer, dataclass_field_by_name,
+                       dataclass_field_metadata, dataclass_normalize_field,
+                       field)
 
 
 def test_sanity():
     pass
+
+
+def test_field_normalize_callback(root_logger: tmt.log.Logger) -> None:
+    def _normalize_foo(raw_value: Any, logger: tmt.log.Logger) -> int:
+        if raw_value is None:
+            return None
+
+        try:
+            return int(raw_value)
+
+        except ValueError as exc:
+            raise tmt.utils.SpecificationError(
+                "Field 'foo' can be either unset or integer,"
+                f" '{type(raw_value).__name__}' found.") from exc
+
+    @dataclasses.dataclass
+    class DummyContainer(SerializableContainer):
+        foo: Optional[int] = field(
+            default=1,
+            normalize=_normalize_foo
+            )
+
+    # Initialize a data package
+    data = DummyContainer()
+    assert data.foo == 1
+
+    dataclass_normalize_field(data, 'foo', None, root_logger)
+    assert data.foo is None
+
+    dataclass_normalize_field(data, 'foo', 2, root_logger)
+    assert data.foo == 2
+
+    dataclass_normalize_field(data, 'foo', '3', root_logger)
+    assert data.foo == 3
+
+    with pytest.raises(
+            tmt.utils.SpecificationError,
+            match=r"Field 'foo' can be either unset or integer, 'str' found."):
+        dataclass_normalize_field(data, 'foo', 'will crash', root_logger)
+
+    assert data.foo == 3
+
+
+def test_field_normalize_special_method(root_logger: tmt.log.Logger) -> None:
+    def normalize_foo(cls, raw_value: Any, logger: tmt.log.Logger) -> int:
+        if raw_value is None:
+            return None
+
+        try:
+            return int(raw_value)
+
+        except ValueError as exc:
+            raise tmt.utils.SpecificationError(
+                "Field 'foo' can be either unset or integer,"
+                f" '{type(raw_value).__name__}' found.") from exc
+
+    @dataclasses.dataclass
+    class DummyContainer(SerializableContainer):
+        foo: Optional[int] = field(
+            default=1
+            )
+
+        _normalize_foo = normalize_foo
+
+    # Initialize a data package
+    data = DummyContainer()
+    assert data.foo == 1
+
+    dataclass_normalize_field(data, 'foo', None, root_logger)
+    assert data.foo is None
+
+    dataclass_normalize_field(data, 'foo', 2, root_logger)
+    assert data.foo == 2
+
+    dataclass_normalize_field(data, 'foo', '3', root_logger)
+    assert data.foo == 3
+
+    with pytest.raises(
+            tmt.utils.SpecificationError,
+            match=r"Field 'foo' can be either unset or integer, 'str' found."):
+        dataclass_normalize_field(data, 'foo', 'will crash', root_logger)
+
+    assert data.foo == 3
+
+
+def test_normalize_callback_preferred(root_logger: tmt.log.Logger) -> None:
+    @dataclasses.dataclass
+    class DummyContainer(SerializableContainer):
+        foo: Optional[int] = field(default=1)
+
+        _normalize_foo = MagicMock()
+
+    data = DummyContainer()
+    foo_metadata = dataclass_field_metadata(dataclass_field_by_name(data, 'foo'))
+
+    foo_metadata.normalize_callback = MagicMock()
+
+    dataclass_normalize_field(data, 'foo', 'will crash', root_logger)
+
+    foo_metadata.normalize_callback.assert_called_once_with('will crash', root_logger)
+    data._normalize_foo.assert_not_called()

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -864,7 +864,7 @@ class Test(Core):
         self.ls()
         for key in self.KEYS_SHOW_ORDER:
             value = getattr(self, key)
-            if key == 'link':
+            if key == 'link' and value is not None:
                 value.show()
                 continue
             # No need to show the default order


### PR DESCRIPTION
Before running a plugin, its data package is updated with CLI options, if there were any given by user. Normalization callback must be applied to values tmt extracts from Click options - it is not enough to use normalization callbacks as values for Click's `type=` parameter, because Click treats them in different way, and expects different results. This has unfortunate effects especially when `field(multiple=True)` was used.

Instead, we need to apply them explicitely when moving data from CLI to plugin data packages, but we do have a code ready just for that, therefore after a small refactoring, users of `field()` should be covered.