### PR TITLE
Define pull request Copr build job in Packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,13 +19,21 @@ srpm_build_deps:
   - python3-docutils
 
 jobs:
-- job: tests
+
+- job: copr_build
   trigger: pull_request
   targets:
   - fedora-all
   - epel-8
   - epel-9
   enable_net: False
+
+- job: tests
+  trigger: pull_request
+  targets:
+  - fedora-all
+  - epel-8
+  - epel-9
 
 - job: tests
   trigger: pull_request


### PR DESCRIPTION
Hi! As described in https://github.com/teemtee/tmt/pull/1760#issuecomment-1370113865, Packit is planning to require explicit build job definition for the testing jobs (see https://github.com/packit/packit-service/issues/1775). Adding the explicit Copr build job should also prevent the current bug in Packit related to the usage of implicit build job + identifiers, which was brought up in the linked PR.