### PR TITLE
Update Fedora versions in `upgrade` tests

### DIFF
--- a/tests/execute/upgrade/data/plan.fmf
+++ b/tests/execute/upgrade/data/plan.fmf
@@ -2,7 +2,7 @@ discover:
     how: fmf
 provision:
     how: virtual
-    image: fedora-35
+    image: fedora-36
 execute:
     how: upgrade
     url: https://github.com/teemtee/upgrade
@@ -12,4 +12,4 @@ execute:
 /path:
     summary: Basic upgrade test with upgrade path
     execute+:
-        upgrade-path: /paths/fedora35to36
+        upgrade-path: /paths/fedora36to37

--- a/tests/execute/upgrade/ignore_test.sh
+++ b/tests/execute/upgrade/ignore_test.sh
@@ -13,7 +13,7 @@ rlJournalStart
             plan -n /plan/no-path \
             test -n /test \
             execute -h upgrade -t '/tasks/prepare' \
-            provision -h container -i fedora:35" 0 "Run a single upgrade task"
+            provision -h container -i fedora:36" 0 "Run a single upgrade task"
         # 1 test before + 1 upgrade tasks + 1 test after
         rlAssertGrep "3 tests passed" $rlRun_LOG
         # Check that the IN_PLACE_UPGRADE variable was set
@@ -21,7 +21,7 @@ rlJournalStart
         rlAssertGrep "IN_PLACE_UPGRADE=old" "$data/old/test/output.txt"
         rlAssertGrep "IN_PLACE_UPGRADE=new" "$data/new/test/output.txt"
         # No upgrade path -> no environment variable
-        rlAssertNotGrep "VERSION_ID=35" "$data/upgrade/tasks/prepare/output.txt"
+        rlAssertNotGrep "VERSION_ID=36" "$data/upgrade/tasks/prepare/output.txt"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/execute/upgrade/override.sh
+++ b/tests/execute/upgrade/override.sh
@@ -16,7 +16,7 @@ rlJournalStart
             rlRun -s "tmt run --scratch -avvvdddi $run --rm --before finish \
                 plan -n /plan/path -c '$condition' \
                 execute -h upgrade -F 'path:/tasks/prepare' \
-                provision -h container -i fedora:35" 0 "Run a single upgrade task"
+                provision -h container -i fedora:36" 0 "Run a single upgrade task"
             # 1 test before + 1 upgrade tasks + 1 test after
             rlAssertGrep "3 tests passed" $rlRun_LOG
             # Check that the IN_PLACE_UPGRADE variable was set
@@ -24,7 +24,7 @@ rlJournalStart
             rlAssertGrep "IN_PLACE_UPGRADE=old" "$data/old/test/output.txt"
             rlAssertGrep "IN_PLACE_UPGRADE=new" "$data/new/test/output.txt"
             # Environment of plan was passed
-            rlAssertGrep "VERSION_ID=35" "$data/upgrade/tasks/prepare/output.txt"
+            rlAssertGrep "VERSION_ID=36" "$data/upgrade/tasks/prepare/output.txt"
         rlPhaseEnd
     done
 

--- a/tests/execute/upgrade/simple.sh
+++ b/tests/execute/upgrade/simple.sh
@@ -12,7 +12,7 @@ rlJournalStart
         rlRun -s "tmt run --scratch -avvvdddi $run --rm --before finish \
             plan -n /plan/no-path \
             execute -h upgrade -t '/tasks/prepare' \
-            provision -h container -i fedora:35" 0 "Run a single upgrade task"
+            provision -h container -i fedora:36" 0 "Run a single upgrade task"
         # 1 test before + 1 upgrade tasks + 1 test after
         rlAssertGrep "3 tests passed" $rlRun_LOG
         # Check that the IN_PLACE_UPGRADE variable was set
@@ -20,7 +20,7 @@ rlJournalStart
         rlAssertGrep "IN_PLACE_UPGRADE=old" "$data/old/test/output.txt"
         rlAssertGrep "IN_PLACE_UPGRADE=new" "$data/new/test/output.txt"
         # No upgrade path -> no environment variable
-        rlAssertNotGrep "VERSION_ID=35" "$data/upgrade/tasks/prepare/output.txt"
+        rlAssertNotGrep "VERSION_ID=36" "$data/upgrade/tasks/prepare/output.txt"
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
As Fedora 35 is now EOL we need to refresh versions. Just a hotfix for now to get rid of the failing tests. Should detect the latest released Fedora instead to prevent the need for these changes.