### PR TITLE
Modify rpm-ostree options for new parameter

### DIFF
--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -397,7 +397,7 @@ def _parametrize_test_install() -> \
             yield container, \
                 package_manager_class, \
                 Package('tree'), \
-                r"rpm -q --whatprovides tree \|\| rpm-ostree install --apply-live --idempotent --allow-inactive  tree", \
+                r"rpm -q --whatprovides tree \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes tree", \
                 'Installing: tree'  # noqa: E501
 
         elif package_manager_class is tmt.package_managers.apk.Apk:
@@ -582,7 +582,7 @@ def _parametrize_test_install_nonexistent() -> \
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
             yield container, \
                 package_manager_class, \
-                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| rpm-ostree install --apply-live --idempotent --allow-inactive  tree-but-spelled-wrong", \
+                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes tree-but-spelled-wrong", \
                 'no package provides tree-but-spelled-wrong'  # noqa: E501
 
         elif package_manager_class is tmt.package_managers.apk.Apk:
@@ -676,7 +676,7 @@ def _parametrize_test_install_nonexistent_skip() -> \
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
             yield container, \
                 package_manager_class, \
-                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| rpm-ostree install --apply-live --idempotent --allow-inactive  tree-but-spelled-wrong \|\| /bin/true", \
+                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes tree-but-spelled-wrong \|\| /bin/true", \
                 'no package provides tree-but-spelled-wrong'  # noqa: E501
 
         elif package_manager_class is tmt.package_managers.apk.Apk:
@@ -774,8 +774,8 @@ def _parametrize_test_install_dont_check_first() -> \
             yield container, \
                 package_manager_class, \
                 Package('tree'), \
-                r"rpm-ostree install --apply-live --idempotent --allow-inactive  tree", \
-                'Installing: tree'
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes tree", \
+                'Installing: tree'  # noqa: E501
 
         elif package_manager_class is tmt.package_managers.apk.Apk:
             yield container, \
@@ -1359,7 +1359,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
             yield container, \
                 package_manager_class, \
                 FileSystemPath('/usr/bin/dos2unix'), \
-                r"rpm -qf /usr/bin/dos2unix \|\| rpm-ostree install --apply-live --idempotent --allow-inactive  /usr/bin/dos2unix", \
+                r"rpm -qf /usr/bin/dos2unix \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes /usr/bin/dos2unix", \
                 "Installing 1 packages:\n  dos2unix-"  # noqa: E501
 
         elif package_manager_class is tmt.package_managers.apk.Apk:
@@ -1476,7 +1476,7 @@ def _parametrize_test_install_multiple() -> \
             yield container, \
                 package_manager_class, \
                 (Package('tree'), Package('nano')), \
-                r"rpm -q --whatprovides tree nano \|\| rpm-ostree install --apply-live --idempotent --allow-inactive  tree nano", \
+                r"rpm -q --whatprovides tree nano \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes tree nano", \
                 'Installing: tree'  # noqa: E501
 
         elif package_manager_class is tmt.package_managers.apk.Apk:
@@ -1606,7 +1606,7 @@ def _parametrize_test_install_downloaded() -> \
                 package_manager_class, \
                 (Package('tree'), Package('cowsay')), \
                 ('tree*.x86_64.rpm', 'cowsay*.noarch.rpm'), \
-                r"rpm-ostree install --apply-live --idempotent --allow-inactive  /tmp/tree.rpm /tmp/cowsay.rpm", \
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes /tmp/tree.rpm /tmp/cowsay.rpm", \
                 'Installing: tree'  # noqa: E501
 
         elif package_manager_class is tmt.package_managers.apt.Apt:

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -31,7 +31,7 @@ class RpmOstree(tmt.package_managers.PackageManager):
 
         command += Command('rpm-ostree')
 
-        options = Command('--apply-live', '--idempotent', '--allow-inactive')
+        options = Command('--apply-live', '--idempotent', '--allow-inactive', '--assumeyes')
 
         return (command, options)
 


### PR DESCRIPTION
rpm-ostree behavior has been modified, and implemented an assume yes param ie -y, implementing here as in later releases this will be required for invoking non interactive 