### PR TITLE
Use own private key for provision.virtual

### DIFF
--- a/tmt/schemas/provision/virtual.yaml
+++ b/tmt/schemas/provision/virtual.yaml
@@ -28,6 +28,9 @@ properties:
   user:
     type: string
 
+  key:
+    $ref: "/schemas/common#/definitions/one_or_more_strings"
+
   memory:
     type: integer
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -530,6 +530,8 @@ class GuestSshData(GuestData):
     password: Optional[str] = None
     ssh_option: List[str] = dataclasses.field(default_factory=list)
 
+    _normalize_key = tmt.utils.NormalizeKeysMixin._normalize_string_list
+
 
 class GuestSsh(Guest):
     """


### PR DESCRIPTION
Makes it easier to login into the VM. No need to change the key parameter every time.

Use case: I'm using one tmt call to spawn VM and (re)use the VM for provision connect later.