### PR TITLE
Hardcode tmt git URL so test won't fail for PRs

### DIFF
--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -170,11 +170,13 @@ execute:
     /dynamic-ref:
         /no-context:
             discover:
+                url: https://github.com/teemtee/tmt
                 how: fmf
                 ref: "@tests/discover/data/dynamic-ref.fmf"
         /with-context:
             context:
                 branch: fedora
             discover:
+                url: https://github.com/teemtee/tmt
                 how: fmf
                 ref: "@tests/discover/data/dynamic-ref.fmf"


### PR DESCRIPTION
If repo from PR is used as a target in a test then a test can fail if branches from the respective forked repo are not up to date.