### PR TITLE
Adds "full name" guest property for multihost logging

### DIFF
--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -1,0 +1,14 @@
+from tmt.log import Logger
+from tmt.steps.provision import Guest, GuestData
+
+
+def test_full_name(root_logger: Logger) -> None:
+    assert Guest(
+        logger=root_logger,
+        name='foo',
+        data=GuestData(guest='bar')).full_name == 'foo'
+
+    assert Guest(
+        logger=root_logger,
+        name='foo',
+        data=GuestData(guest='bar', role='client')).full_name == 'foo (client)'

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -128,6 +128,15 @@ class Guest(tmt.utils.Common):
         return self._random_name(prefix="tmt-{0}-".format(run_id[-3:]))
 
     @property
+    def full_name(self) -> str:
+        """ Return guest's full name, i.e. name and its role """
+
+        if self.role is None:
+            return self.name
+
+        return f'{self.name} ({self.role})'
+
+    @property
     def is_ready(self) -> bool:
         """ Detect guest is ready or not """
 


### PR DESCRIPTION
It's guest name with added role, to better identify the guest among its peers.

Part of the effort in #1790.