### PR TITLE
Changes Plugin.go() method to accept logger and extra environment

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -970,18 +970,18 @@ class BasePlugin(Phase):
     #
     # Therefore we need a different name, and a way how not to forget to call this
     # method from child classes.
-    def go_prolog(self) -> None:
+    def go_prolog(self, logger: tmt.log.Logger) -> None:
         """ Perform actions shared among plugins when beginning their tasks """
         # Show the method
-        self.info('how', self.get('how'), 'magenta')
+        logger.info('how', self.get('how'), 'magenta')
         # Give summary if provided
         if self.get('summary'):
-            self.info('summary', self.get('summary'), 'magenta')
+            logger.info('summary', self.get('summary'), 'magenta')
         # Show name only if it's not the default one
         if not self.name.startswith(tmt.utils.DEFAULT_NAME):
-            self.info('name', self.name, 'magenta')
+            logger.info('name', self.name, 'magenta')
         # Include order in verbose mode
-        self.verbose('order', str(self.order), 'magenta', level=3)
+        logger.verbose('order', str(self.order), 'magenta', level=3)
 
     def requires(self) -> List[str]:
         """ List of packages required by the plugin on the guest """
@@ -1010,16 +1010,21 @@ class GuestlessPlugin(BasePlugin):
     def go(self) -> None:
         """ Perform actions shared among plugins when beginning their tasks """
 
-        self.go_prolog()
+        self.go_prolog(self._logger)
 
 
 class Plugin(BasePlugin):
     """ Common parent of all step plugins that do work against a particular guest """
 
-    def go(self, guest: 'Guest') -> None:
+    def go(
+            self,
+            *,
+            guest: 'Guest',
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> None:
         """ Perform actions shared among plugins when beginning their tasks """
 
-        self.go_prolog()
+        self.go_prolog(logger)
 
 
 class Action(Phase):

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -168,9 +168,14 @@ class ExecutePlugin(tmt.steps.Plugin):
                 help='Stop execution after the first test failure.'),
             ] + super().options(how)
 
-    def go(self, guest: Guest) -> None:
-        super().go(guest)
-        self.verbose(
+    def go(
+            self,
+            *,
+            guest: 'Guest',
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> None:
+        super().go(guest=guest, environment=environment, logger=logger)
+        logger.verbose(
             'exit-first', self.get('exit-first', default=False),
             'green', level=2)
 
@@ -499,7 +504,10 @@ class Execute(tmt.steps.Step):
                     phase.go()
 
                 elif isinstance(phase, ExecutePlugin):
-                    phase.go(guest)
+                    # TODO: re-injecting the logger already given to the guest,
+                    # with multihost support heading our way this will change
+                    # to be not so trivial.
+                    phase.go(guest=guest, logger=guest._logger)
 
                     self._results.extend(phase.results())
 

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -314,9 +314,14 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             return True
         return False
 
-    def go(self, guest: Guest) -> None:
+    def go(
+            self,
+            *,
+            guest: 'Guest',
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> None:
         """ Execute available tests """
-        super().go(guest)
+        super().go(guest=guest, environment=environment, logger=logger)
         self._results: List[Result] = []
 
         # Nothing to do in dry mode

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -9,6 +9,7 @@ import tmt.result
 import tmt.steps
 import tmt.steps.discover.fmf
 import tmt.steps.execute
+import tmt.steps.provision
 import tmt.utils
 from tmt.steps.discover import DiscoverPlugin
 from tmt.steps.discover.fmf import DiscoverFmf, DiscoverFmfStepData
@@ -142,11 +143,16 @@ class ExecuteUpgrade(ExecuteInternal):
         else:
             return self.step.plan.discover
 
-    def go(self, guest: tmt.steps.provision.Guest) -> None:
+    def go(
+            self,
+            *,
+            guest: 'tmt.steps.provision.Guest',
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> None:
         """ Execute available tests """
         self._results: List[tmt.result.Result] = []
         # Inform about the how, skip the actual execution
-        ExecutePlugin.go(self, guest)
+        ExecutePlugin.go(self, guest=guest, environment=environment, logger=logger)
 
         self.url = self.get('url')
         self.upgrade_path = self.get('upgrade-path')

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -117,7 +117,10 @@ class Finish(tmt.steps.Step):
                     phase.go()
 
                 elif isinstance(phase, FinishPlugin):
-                    phase.go(guest_copy)
+                    # TODO: re-injecting the logger already given to the guest,
+                    # with multihost support heading our way this will change
+                    # to be not so trivial.
+                    phase.go(guest=guest_copy, logger=guest_copy._logger)
 
                 else:
                     raise GeneralError(f'Unexpected phase in finish step: {phase}')

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Optional, cast
 
 import fmf
 
@@ -67,9 +67,14 @@ class FinishShell(tmt.steps.finish.FinishPlugin):
 
     _data_class = FinishShellData
 
-    def go(self, guest: Guest) -> None:
+    def go(
+            self,
+            *,
+            guest: 'Guest',
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> None:
         """ Perform finishing tasks on given guest """
-        super().go(guest)
+        super().go(guest=guest, environment=environment, logger=logger)
 
         # Give a short summary
         scripts: List[tmt.utils.ShellScript] = self.get('script')

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -9,6 +9,7 @@ import fmf
 
 import tmt
 import tmt.steps
+import tmt.steps.provision
 from tmt.steps import Action
 from tmt.utils import GeneralError
 
@@ -62,18 +63,23 @@ class PreparePlugin(tmt.steps.Plugin):
 
         return prepare
 
-    def go(self, guest: tmt.steps.provision.Guest) -> None:
+    def go(
+            self,
+            *,
+            guest: 'tmt.steps.provision.Guest',
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> None:
         """ Prepare the guest (common actions) """
-        super().go(guest)
+        super().go(guest=guest, environment=environment, logger=logger)
 
         # Show guest name first in multihost scenarios
         if self.step.plan.provision.is_multihost:
-            self.info('guest', guest.name, 'green')
+            logger.info('guest', guest.name, 'green')
 
         # Show requested role if defined
         where = self.get('where')
         if where:
-            self.info('where', where, 'green')
+            logger.info('where', where, 'green')
 
 
 class Prepare(tmt.steps.Step):
@@ -217,7 +223,10 @@ class Prepare(tmt.steps.Step):
                     phase.go()
 
                 elif isinstance(phase, PreparePlugin):
-                    phase.go(guest_copy)
+                    # TODO: re-injecting the logger already given to the guest,
+                    # with multihost support heading our way this will change
+                    # to be not so trivial.
+                    phase.go(guest=guest_copy, logger=guest_copy._logger)
 
                     self.preparations_applied += 1
 

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -96,13 +96,18 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
 
     _data_class = PrepareAnsibleData
 
-    def go(self, guest: Guest) -> None:
+    def go(
+            self,
+            *,
+            guest: 'Guest',
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> None:
         """ Prepare the guests """
-        super().go(guest)
+        super().go(guest=guest, environment=environment, logger=logger)
 
         # Apply each playbook on the guest
         for playbook in self.get('playbook'):
-            self.info('playbook', playbook, 'green')
+            logger.info('playbook', playbook, 'green')
 
             lowercased_playbook = playbook.lower()
             playbook_path = playbook
@@ -136,6 +141,6 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
 
                     playbook_path = os.path.relpath(file.name, root_path)
 
-                self.info('playbook-path', playbook_path, 'green')
+                logger.info('playbook-path', playbook_path, 'green')
 
             guest.ansible(playbook_path, self.get('extra-args'))

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -3,7 +3,7 @@ import os
 import re
 import shutil
 import sys
-from typing import List, Tuple, cast
+from typing import List, Optional, Tuple, cast
 
 import fmf
 
@@ -576,9 +576,14 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
 
     _data_class = PrepareInstallData
 
-    def go(self, guest: Guest) -> None:
+    def go(
+            self,
+            *,
+            guest: 'Guest',
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> None:
         """ Perform preparation for the guests """
-        super().go(guest)
+        super().go(guest=guest, environment=environment, logger=logger)
 
         # Nothing to do in dry mode
         if self.opt('dry'):
@@ -588,13 +593,13 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
         try:
             guest.execute(Command('stat', '/run/ostree-booted'), silent=True)
             installer: InstallBase = InstallRpmOstree(
-                logger=self._logger, parent=self, guest=guest)
+                logger=logger, parent=self, guest=guest)
         except tmt.utils.RunError:
             try:
                 guest.execute(Command('rpm', '-q', 'dnf'), silent=True)
-                installer = InstallDnf(logger=self._logger, parent=self, guest=guest)
+                installer = InstallDnf(logger=logger, parent=self, guest=guest)
             except tmt.utils.RunError:
-                installer = InstallYum(logger=self._logger, parent=self, guest=guest)
+                installer = InstallYum(logger=logger, parent=self, guest=guest)
 
         # Enable copr repositories and install packages
         installer.enable_copr()

--- a/tmt/steps/prepare/multihost.py
+++ b/tmt/steps/prepare/multihost.py
@@ -1,9 +1,10 @@
 import dataclasses
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import tmt
 import tmt.steps
 import tmt.steps.prepare
+import tmt.utils
 from tmt.steps.provision import Guest
 from tmt.utils import ShellScript, field
 
@@ -43,15 +44,20 @@ class PrepareMultihost(tmt.steps.prepare.PreparePlugin):
 
     _data_class = PrepareMultihostData
 
-    def go(self, guest: 'Guest') -> None:
+    def go(
+            self,
+            *,
+            guest: 'Guest',
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> None:
         """ Prepare the guests """
-        super().go(guest)
+        super().go(guest=guest, environment=environment, logger=logger)
 
-        self.debug('Export roles.', level=2)
+        logger.debug('Export roles.', level=2)
         for role, corresponding_guests in self.get('roles').items():
             formatted_guests = ','.join(corresponding_guests)
             self.step.plan._environment[f"TMT_ROLE_{role}"] = formatted_guests
-        self.debug("Add hosts to '/etc/hosts'.", level=2)
+        logger.debug("Add hosts to '/etc/hosts'.", level=2)
         for host_name, host_address in self.get('hosts').items():
             if host_address:
                 guest.execute(

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List, Optional, cast
 
 import fmf
 
@@ -70,17 +70,22 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin):
 
     _data_class = PrepareShellData
 
-    def go(self, guest: Guest) -> None:
+    def go(
+            self,
+            *,
+            guest: 'Guest',
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> None:
         """ Prepare the guests """
-        super().go(guest)
+        super().go(guest=guest, environment=environment, logger=logger)
 
         # Give a short summary
         scripts: List[tmt.utils.ShellScript] = self.get('script')
         overview = fmf.utils.listed(scripts, 'script')
-        self.info('overview', f'{overview} found', 'green')
+        logger.info('overview', f'{overview} found', 'green')
 
         # Execute each script on the guest (with default shell options)
         for script in scripts:
-            self.verbose('script', str(script), 'green')
+            logger.verbose('script', str(script), 'green')
             script_with_options = tmt.utils.ShellScript(f'{tmt.utils.SHELL_OPTIONS}; {script}')
             guest.execute(script_with_options, cwd=self.step.plan.worktree)


### PR DESCRIPTION
This is part of the multihost support effort. Since a single phase can be executed on multiple hosts at the same time, the `go()` method may not rely on `self` when it comes to mutable state. Phase configuration - fmf nodes, CLI options, step data - should be fine to *read*, but each call to `go()` might be happening within different context, with a different guest and logging expectations. Therefore the method must become pure-ish, and modify data given to it.

There are probably more instances of this problem, but logging is the first one we hit: to tell which output comes from which incarnation of a single phase, whether it's the one running on guest A or the one on guest B, `self.{info,verbose,...}` are useless, and `go()` must be given a logger. The logger inside `Guest` instance given to `go()` *might* be good enough, at the first glance, but I expect it to prove to be not the case, therefore adding logger as new parameter.

And we already know we need to propagate extra info to tests and other code, at least info about the guest they run on and its peers, therefore we need a way to pass different set of envvars to invocations of `go()`. So throwing `environment` as a parameter into this patch, because it's "just" another parameter added to `go()`, and if we already know it's needed, let's break the API once right away.

Part of the effort in https://github.com/teemtee/tmt/pull/1790.