### PR TITLE
Add logging `labels` used for prefixing messages

### DIFF
--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -136,10 +136,10 @@ def _assert_log(
 
         for record in caplog.records:
             for field_getter, field_name, op, expected_value in operators:
-                print(field_name,
-                      field_getter(record, field_name),
-                      expected_value,
-                      op(expected_value, field_getter(record, field_name)))
+                print(f'field={field_name}',
+                      f'current=>>>{field_getter(record, field_name)}<<<',
+                      f'expected=>>>{expected_value}<<<',
+                      f'comparison={op(expected_value, field_getter(record, field_name))}')
 
         assert False, f"""
 {message}:


### PR DESCRIPTION
Each logger can now attach a list of strings representing an optional "context" to each message generated by the said logger. The list would then be added to each message as a prefix.

The goal is to "taint" messages generated by various logger in the multithreaded environment dictated by multihost support. At the beginning, messages produced by phases running on different guests would be prefixed by the guest name, to allow later inspection.

Part of the effort in https://github.com/teemtee/tmt/pull/1790.