### PR TITLE
Adds more controls for output colorization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -348,10 +348,25 @@ TMT_WORKDIR_ROOT
     Path to root directory containing run workdirs. Defaults to
     ``/var/tmp/tmt``.
 
-NO_COLOR
-    Disable colors in the terminal output. Output only plain,
-    non-colored text. See https://no-color.org/ for more
+NO_COLOR, TMT_NO_COLOR
+    Disable colors in the output, both the actual output and
+    logging messages. Output only plain, non-colored text.
+
+    Two variables are accepted, one with the usual ``TMT_``
+    prefix, but tmt accepts also ``NO_COLOR`` to support the
+    NO_COLOR effort, see https://no-color.org/ for more
     information.
+
+TMT_FORCE_COLOR
+    Enforce colors in the output, both the actual output and
+    logging messages. Might come handy when tmt's output streams
+    are not terminal-like, yet its output would be displayed by
+    tools with ANSI color support. This is often the case of
+    various CI systems.
+
+    Note that ``TMT_FORCE_COLOR`` takes priority over ``NO_COLOR``
+    and ``TMT_NO_COLOR``. If user tries both to disable and enable
+    colorization, output would be colorized.
 
 The following environment variables are provided to the environment
 during ``prepare``, ``execute`` and ``finish`` steps:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,12 +1,18 @@
 # coding: utf-8
 
+import dataclasses
 import os
 import shutil
+import sys
 import tempfile
+from typing import Tuple
 
+import _pytest.monkeypatch
+import pytest
 from click.testing import CliRunner
 
 import tmt.cli
+import tmt.log
 
 # Prepare path to examples
 PATH = os.path.dirname(os.path.realpath(__file__))
@@ -124,3 +130,132 @@ def test_systemd():
         tmt.cli.main, ['--root', example('systemd'), 'plan', 'show'])
     assert result.exit_code == 0
     assert 'Tier two functional tests' in result.output
+
+
+@dataclasses.dataclass
+class DecideColorizationTestcase:
+    """ A single test case for :py:func:`tmt.log.decide_colorization` """
+
+    # Name of the testcase and expected outcome of decide_colorization()
+    name: str
+    expected: Tuple[bool, bool]
+
+    # Testcase environment setup to perform before calling decide_colorization()
+    set_no_color_option: bool = False
+    set_force_color_option: bool = False
+    set_no_color_envvar: bool = False
+    set_tmt_no_color_envvar: bool = False
+    set_tmt_force_color_envvar: bool = False
+    simulate_tty: bool = False
+
+
+_DECIDE_COLORIZATION_TESTCASES = [
+    # With TTY simulated
+    DecideColorizationTestcase(
+        'tty, autodetection',
+        (True, True),
+        simulate_tty=True),
+    DecideColorizationTestcase(
+        'tty, disable with option',
+        (False, False),
+        set_no_color_option=True,
+        simulate_tty=True),
+    DecideColorizationTestcase(
+        'tty, disable with NO_COLOR',
+        (False, False),
+        set_no_color_envvar=True,
+        simulate_tty=True),
+    DecideColorizationTestcase(
+        'tty, disable with TMT_NO_COLOR',
+        (False, False),
+        set_tmt_no_color_envvar=True,
+        simulate_tty=True),
+    DecideColorizationTestcase(
+        'tty, force with option',
+        (True, True),
+        set_force_color_option=True,
+        simulate_tty=True),
+    DecideColorizationTestcase(
+        'tty, force with TMT_FORCE_COLOR',
+        (True, True),
+        set_tmt_force_color_envvar=True,
+        simulate_tty=True),
+
+    DecideColorizationTestcase(
+        'tty, force with TMT_FORCE_COLOR over NO_COLOR',
+        (True, True),
+        set_tmt_force_color_envvar=True,
+        set_no_color_envvar=True),
+    DecideColorizationTestcase(
+        'tty, force with TMT_FORCE_COLOR over --no-color',
+        (True, True),
+        set_tmt_force_color_envvar=True,
+        set_no_color_option=True),
+
+    # With TTY not simulated, streams are captured
+    DecideColorizationTestcase(
+        'not tty, autodetection',
+        (False, False)),
+    DecideColorizationTestcase(
+        'not tty, disable with option',
+        (False, False),
+        set_no_color_option=True),
+    DecideColorizationTestcase(
+        'not tty, disable with NO_COLOR',
+        (False, False),
+        set_no_color_envvar=True),
+    DecideColorizationTestcase(
+        'not tty, disable with TMT_NO_COLOR',
+        (False, False),
+        set_tmt_no_color_envvar=True),
+    DecideColorizationTestcase(
+        'not tty, force with option',
+        (True, True),
+        set_force_color_option=True),
+    DecideColorizationTestcase(
+        'not tty, force with TMT_FORCE_COLOR',
+        (True, True),
+        set_tmt_force_color_envvar=True),
+
+    DecideColorizationTestcase(
+        'not tty, force with TMT_FORCE_COLOR over NO_COLOR',
+        (True, True),
+        set_tmt_force_color_envvar=True,
+        set_tmt_no_color_envvar=True),
+    DecideColorizationTestcase(
+        'not tty, force with TMT_FORCE_COLOR over --no-color',
+        (True, True),
+        set_tmt_force_color_envvar=True,
+        set_no_color_option=True),
+    ]
+
+
+@pytest.mark.parametrize(
+    ('testcase',),
+    [(testcase,) for testcase in _DECIDE_COLORIZATION_TESTCASES],
+    ids=[testcase.name for testcase in _DECIDE_COLORIZATION_TESTCASES]
+    )
+def test_decide_colorization(
+        testcase: DecideColorizationTestcase,
+        monkeypatch: _pytest.monkeypatch.MonkeyPatch
+        ) -> None:
+    monkeypatch.delenv('NO_COLOR', raising=False)
+    monkeypatch.delenv('TMT_NO_COLOR', raising=False)
+    monkeypatch.delenv('TMT_FORCE_COLOR', raising=False)
+
+    no_color = True if testcase.set_no_color_option else False
+    force_color = True if testcase.set_force_color_option else False
+
+    if testcase.set_no_color_envvar:
+        monkeypatch.setenv('NO_COLOR', '')
+
+    if testcase.set_tmt_no_color_envvar:
+        monkeypatch.setenv('TMT_NO_COLOR', '')
+
+    if testcase.set_tmt_force_color_envvar:
+        monkeypatch.setenv('TMT_FORCE_COLOR', '')
+
+    monkeypatch.setattr(sys.stdout, 'isatty', lambda: testcase.simulate_tty)
+    monkeypatch.setattr(sys.stderr, 'isatty', lambda: testcase.simulate_tty)
+
+    assert tmt.log.decide_colorization(no_color, force_color) == testcase.expected

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -4,7 +4,6 @@
 
 import collections
 import dataclasses
-import os
 import subprocess
 import sys
 from typing import TYPE_CHECKING, Any, DefaultDict, List, Optional, Set
@@ -140,7 +139,6 @@ remote_plan_options = create_options_decorator(tmt.options.REMOTE_PLAN_OPTIONS)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #  Main
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 @click.group(invoke_without_command=True, cls=CustomGroup)
 @click.pass_context
 @click.option(
@@ -155,10 +153,20 @@ remote_plan_options = create_options_decorator(tmt.options.REMOTE_PLAN_OPTIONS)
 @click.option(
     '--version', is_flag=True,
     help='Show tmt version and commit hash.')
+@click.option(
+    '--no-color', is_flag=True, default=False,
+    help='Forces tmt to not use any colors in the output or logging.'
+    )
+@click.option(
+    '--force-color', is_flag=True, default=False,
+    help='Forces tmt to use colors in the output and logging.'
+    )
 def main(
         click_contex: Context,
         root: str,
         context: List[str],
+        no_color: bool,
+        force_color: bool,
         **kwargs: Any) -> None:
     """ Test Management Tool """
     # Show current tmt version and exit
@@ -166,15 +174,13 @@ def main(
         print(f"tmt version: {tmt.__version__}")
         raise SystemExit(0)
 
-    # Disable coloring if NO_COLOR is set
-    # TODO: wouldn't it be nice to support --color/--no-color options?
-    apply_colors = sys.stderr.isatty() and 'NO_COLOR' not in os.environ
+    apply_colors_output, apply_colors_logging = tmt.log.decide_colorization(no_color, force_color)
 
     logger = tmt.log.Logger.create(**kwargs)
-    logger.add_console_handler(apply_colors=apply_colors)
+    logger.add_console_handler(apply_colors=apply_colors_logging)
 
     # Propagate color setting to Click as well.
-    click_contex.color = apply_colors
+    click_contex.color = apply_colors_output
 
     # Save click context and fmf context for future use
     tmt.utils.Common._save_context(click_contex)


### PR DESCRIPTION
Besides the already supported ``NO_COLOR`` envvar, the patch adds new controls:

* `--no-color` CLI option, for the same purpose but when one likes CLI more than envvars,
* enforcing colors via `--force-color` and `TMT_FORCE_COLOR` envvar, and
* new `TMT_NO_COLOR` envvar - same effect as `NO_COLOR`, but with well-established `TMT_*` prefix, to be consistent.