### PR TITLE
Save a dmesg output after finishing running a test

### DIFF
--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -32,6 +32,9 @@ DEFAULT_FRAMEWORK = 'shell'
 # The main test output filename
 TEST_OUTPUT_FILENAME = 'output.txt'
 
+# Filename to which the dmesg output should be saved after the test execution.
+TEST_POST_DMESG_FILENAME = 'tmt-dmesg.txt'
+
 # Scripts source directory
 SCRIPTS_SRC_DIR = pkg_resources.resource_filename(
     'tmt', 'steps/execute/scripts')

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -15,6 +15,7 @@ import tmt.utils
 from tmt.base import Test
 from tmt.result import Result, ResultOutcome
 from tmt.steps.execute import (SCRIPTS, TEST_OUTPUT_FILENAME,
+                               TEST_POST_DMESG_FILENAME,
                                TMT_FILE_SUBMIT_SCRIPT, TMT_REBOOT_SCRIPT)
 from tmt.steps.provision import Guest
 from tmt.utils import EnvironmentType, ShellScript
@@ -238,6 +239,8 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             self.data_path(test, TEST_OUTPUT_FILENAME, full=True),
             stdout or '', mode='a', level=3)
         test.real_duration = self.test_duration(start, end)
+
+        guest.pull_dmesg(self.data_path(test, TEST_POST_DMESG_FILENAME, full=True))
 
     def check(self, test: Test) -> List[Result]:
         """ Check the test result """

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -454,6 +454,20 @@ class Guest(tmt.utils.Common):
 
         return True
 
+    def get_current_dmesg(self) -> tmt.utils.CommandOutput:
+        return self.execute(Command('dmesg'), friendly_command='dmesg')
+
+    def pull_dmesg(self, filepath: str) -> None:
+        """ Run and save the output of ``dmesg`` """
+
+        timestamp = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+        dmesg_output = self.get_current_dmesg()
+
+        with open(filepath, mode='w') as f:
+            f.write(f'# Acquired at {timestamp}\n')
+            f.write(dmesg_output.stdout or '')
+
     def remove(self) -> None:
         """
         Remove the guest


### PR DESCRIPTION
Output is saved into a file in test's data directory.

Implements #1548.