### PR TITLE
Fixes isort 5.10.1 installation issue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
           - --max-line-length=99
 
   - repo: https://github.com/PyCQA/isort
-    rev: "5.10.1"
+    rev: "5.12.0"
     hooks:
       - id: isort
 


### PR DESCRIPTION
There seem to be issues with isort installation via pre-commit, apparently related to Poetry. Even though we do not use it directly, it was somehow involved, and bumping isort to 5.12.0 fixes the issue. See https://github.com/PyCQA/isort/commit/0d219a6e0b49b7f84ef0702b2387d5e14299bb8e.