### PR TITLE
Update log key content of results.yaml examples

### DIFF
--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -58,9 +58,9 @@ description: |
         fail
             Test execution successfully finished and failed.
 
-    ``PATH`` and ``PATH*`` are the test log output paths, relative
-    to the execute step working directory. ``log`` key is a list
-    of strings, even when there is just a single log, the first
+    ``PATH`` or each ``PATH*`` are the test log output paths,
+    relative to the execute step working directory. ``log`` key
+    is a list of strings, even when there is just a single log, the first
     log will be considered as the main one (e.g. presented to the
     user for inspection).
 

--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -24,11 +24,14 @@ description: |
 
         /test/one:
             result: OUTCOME
-            log: PATH
+            log:
+              - PATH
 
         /test/two:
             result: OUTCOME
-            log: PATH
+            log:
+              - PATH1
+              - PATH2
             duration: DURATION
 
     Where ``OUTCOME`` is the result of the test execution. It can
@@ -55,11 +58,11 @@ description: |
         fail
             Test execution successfully finished and failed.
 
-    The ``PATH`` is the test log output path, relative to the
-    execute step working directory. It can be a single string
-    or a list of strings when multiple log files available, in
-    which case the first log will be considered as the main one
-    (e.g. presented to the user for inspection).
+    ``PATH`` and ``PATH*`` are the test log output paths, relative
+    to the execute step working directory. ``log`` key is a list
+    of strings, even when there is just a single log, the first
+    log will be considered as the main one (e.g. presented to the
+    user for inspection).
 
     The ``DURATION`` is an optional section stating how long did
     the test run. Its value is in the ``hh:mm:ss`` format.

--- a/spec/plans/report.fmf
+++ b/spec/plans/report.fmf
@@ -122,7 +122,8 @@ description:
                     tests:
                         /test/one:
                             result: TEST_RESULT
-                            log: LOG_PATH
+                            log:
+                              - LOG_PATH
 
                         /test/two:
                             result: TEST_RESULT
@@ -134,7 +135,8 @@ description:
                     result: PLAN_RESULT
                         /test/one:
                             result: TEST_RESULT
-                            log: LOG_PATH
+                            log:
+                              - LOG_PATH
 
         Where ``OVERALL_RESULT`` is the overall result of all plan
         results. It is counted the same way as ``PLAN_RESULT``.
@@ -165,6 +167,6 @@ description:
               plan result will be error
 
         Where ``LOG_PATH`` is the test log output path, relative
-        to the execute step plan run directory.  The log can be a
-        single log path or a list of log paths, in case the test
-        has produced more log files.
+        to the execute step plan run directory. The ``log`` key
+        will be a list of such paths, even if there is just a single
+        log.

--- a/spec/tests/result.fmf
+++ b/spec/tests/result.fmf
@@ -22,8 +22,10 @@ description: |
     custom
         test needs to create it's own ``results.yaml`` file in the
         ``${TMT_TEST_DATA}`` directory. The ``results.yaml`` contains list of
-        dictionaries. Each dictionary must contain at least ``name`` and
-        ``result`` keys. Optional keys are ``log`` (a list of paths to log
+        dictionaries. Each dictionary must contain at least a ``name`` key,
+        whose value would be appended to the original test name (a special
+        value ``name: "/"`` sets result for the test itself) and a ``result``
+        key. Optional keys are ``log`` (a list of paths to log
         files, each path must be relative to path in ``$TMT_TEST_DATA``
         environment variable), ``duration`` (in HH:MM:SS format) and ``note``.
 

--- a/spec/tests/result.fmf
+++ b/spec/tests/result.fmf
@@ -23,8 +23,9 @@ description: |
         test needs to create it's own ``results.yaml`` file in the
         ``${TMT_TEST_DATA}`` directory. The ``results.yaml`` contains list of
         dictionaries. Each dictionary must contain at least ``name`` and
-        ``result`` keys. Optional keys are ``log`` (contains paths to log
-        files), ``duration`` (in HH:MM:SS format) and ``note``.
+        ``result`` keys. Optional keys are ``log`` (a list of paths to log
+        files, each path must be relative to path in ``$TMT_TEST_DATA``
+        environment variable), ``duration`` (in HH:MM:SS format) and ``note``.
 
 example:
   - |

--- a/spec/tests/result.fmf
+++ b/spec/tests/result.fmf
@@ -23,8 +23,8 @@ description: |
         test needs to create it's own ``results.yaml`` file in the
         ``${TMT_TEST_DATA}`` directory. The ``results.yaml`` contains list of
         dictionaries. Each dictionary must contain at least ``name`` and
-        ``result`` keys. Optional keys are ``log`` (contains path to log file),
-        ``duration`` (in HH:MM:SS format) and ``note``.
+        ``result`` keys. Optional keys are ``log`` (contains paths to log
+        files), ``duration`` (in HH:MM:SS format) and ``note``.
 
 example:
   - |
@@ -37,12 +37,15 @@ example:
     # Example content of results.yaml
     - name: /test/passing
       result: pass
-      log: pass_log
+      log:
+        - pass_log
       duration: 00:11:22
       note: good result
     - name: /test/failing
       result: fail
-      log: fail_log
+      log:
+        - fail_log
+        - another_log
       duration: 00:22:33
       note: fail result
     - name: /test/no_keys


### PR DESCRIPTION
Reflect the change in how `log` key is handled.

Internally, the `tmt.result.Result` object tracks logs as a list of
paths. This leads to `log` always being a list when serialized into
`results.yaml`, even when `log` holds just a single path.

Because of how custom `results.yaml` file (`result: custom`) is loaded,
tests need to produce their custom `results.yaml` compatible with tmt's
own `results.yaml`, i.e. these should also stick to `log` being always a
list.

### Checklist

* [x] implement the feature
* [ ] ~~write documentation~~
* [ ] ~~extend the test coverage~~
* [x] update specification
* [ ] ~~adjust module docs~~
* [ ] ~~add a usage example~~
* [ ] ~~modify json schema~~
* [ ] ~~mention version~~