### PR TITLE
Draft: Add `partition` as a new hw specification key

### DIFF
--- a/spec/hardware/partition.fmf
+++ b/spec/hardware/partition.fmf
@@ -1,0 +1,37 @@
+summary:
+    Specify disk partitions that need to be created on the disk.
+description:
+    Use the ``type`` key to select the desired type of partition method.
+    Possible methods are ``part`` for classical hard disk partition containing
+    filesystem or ``lvm`` for physical partition with a separate LVM volume
+    group containing a single LVM logical volume containing a filesystem.
+    Default value is ``part``.
+
+    The ``device`` specifies which disk to apply partitioning, if this parameter
+    is omitted it's selected automatically. Use ``fs`` to select
+    desired filesystem (for example ``ext4``, ``xfs`, ``btrfs``).
+
+    Required parameters are: ``device``, ``size``, and ``fs``
+example:
+  - |
+    # Create additional partition
+    partition:
+      - type: part
+        size: 5 GB
+        device: /dev/sdf
+        fs: ext4
+        mount: /var/tmp
+
+  - |
+    # Multiple partitions can be specified as well
+    partition:
+      - type: part
+        size: 5 GB
+        device: /dev/sdf
+        fs: xfs
+        mount: /var/log
+      - type: part
+        size: 200 GB
+        device: /dev/sdg
+        fs: xfs
+        mount: /custom-partition-name

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -146,6 +146,15 @@ def test_plans_schema(tree, plan):
             network:
                 - type: eth
                 - type: eth
+            partition:
+                - type: part
+                  size: 5 GB
+                  device: /dev/sdf
+                  fs: xfs
+                  mount: /var/log
+                - size: 200 GB
+                  fs: xfs
+                  mount: /custom-partition-name
             system:
                 vendor: HPE
                 model: ProLiant DL385 Gen10

--- a/tmt/schemas/provision/hardware.yaml
+++ b/tmt/schemas/provision/hardware.yaml
@@ -148,6 +148,46 @@ definitions:
     items:
       "$ref": "#/definitions/network"
 
+  # HW requirements: single `partition` item
+  partition:
+    type: object
+
+    properties:
+      type:
+        type: string
+        enum:
+          - part
+          - lvm
+        default: "part"
+
+      size:
+        anyOf:
+          - type: string
+          - type: integer
+
+      device:
+        type: string
+
+      fs:
+        type: string
+
+      mount:
+        type: string
+
+    additionalProperties: false
+
+    # Enforce the user to fill `size`, `mount` and `fs` properties
+    required:
+      - size
+      - mount
+      - fs
+
+  # HW requirements: `partitions` block
+  partitions:
+    type: array
+    items:
+      "$ref": "#/definitions/partition"
+
   # HW requirements: single `system` item
   system:
     type: object
@@ -232,6 +272,9 @@ definitions:
 
       network:
         "$ref": "#/definitions/networks"
+
+      partition:
+        "$ref": "#/definitions/partitions"
 
       system:
         "$ref": "#/definitions/system"


### PR DESCRIPTION
Allow the user to specify the `partition` parameter. This will create custom partitions on
the disk(s). It should be possible to select the size, mountpoint, filesystem, disk and type of the
partition. 

The `type` can be either classical or LVM (https://www.redhat.com/sysadmin/lvm-vs-partitioning). 

Fix: https://github.com/teemtee/tmt/issues/1243.