### PR TITLE
Convert provision plugins' step data to our field implementation

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -848,17 +848,37 @@ class GuestSshData(GuestData):
     reached over SSH.
     """
 
-    # port to connect to
-    port: Optional[int] = None
-    # user name to log in
-    user: Optional[str] = None
-    # path to the private key
-    key: List[str] = dataclasses.field(default_factory=list)
-    # password
-    password: Optional[str] = None
-    ssh_option: List[str] = dataclasses.field(default_factory=list)
-
-    _normalize_key = tmt.utils.NormalizeKeysMixin._normalize_string_list
+    port: Optional[int] = field(
+        default=None,
+        option=('-P', '--port'),
+        metavar='PORT',
+        help='Use specific port to connect to.',
+        normalize=tmt.utils.normalize_optional_int)
+    user: Optional[str] = field(
+        default=None,
+        option=('-u', '--user'),
+        metavar='USERNAME',
+        help='Username to use for all guest operations.')
+    key: List[str] = field(
+        default_factory=list,
+        option=('-k', '--key'),
+        metavar='PATH',
+        help='Private key for login into the guest system.',
+        normalize=tmt.utils.normalize_string_list)
+    password: Optional[str] = field(
+        default=None,
+        option=('-p', '--password'),
+        metavar='PASSWORD',
+        help='Password for login into the guest system.')
+    ssh_option: List[str] = field(
+        default_factory=list,
+        option='--ssh-option',
+        metavar="OPTION",
+        multiple=True,
+        help="Specify additional SSH option. "
+        "Value is passed to SSH's -o option, see ssh_config(5) for "
+        "supported options. Can be specified multiple times.",
+        normalize=tmt.utils.normalize_string_list)
 
 
 class GuestSsh(Guest):
@@ -957,15 +977,6 @@ class GuestSsh(Guest):
         self._ssh_master_connection(command)
 
         return command + self._ssh_options()
-
-    @classmethod
-    def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
-        """ Prepare command line options related to SSH-capable guests """
-        return [*super().options(how=how),
-                option('--ssh-option', metavar="OPTION", multiple=True, default=[],
-                       help="Specify additional SSH option. "
-                       "Value is passed to SSH's -o option, see ssh_config(5) for "
-                       "supported options. Can be specified multiple times.")]
 
     def ansible(self, playbook: Path, extra_args: Optional[str] = None) -> None:
         """ Prepare guest using ansible playbook """

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -875,7 +875,7 @@ class GuestSshData(GuestData):
         option='--ssh-option',
         metavar="OPTION",
         multiple=True,
-        help="Specify additional SSH option. "
+        help="Specify an additional SSH option. "
         "Value is passed to SSH's -o option, see ssh_config(5) for "
         "supported options. Can be specified multiple times.",
         normalize=tmt.utils.normalize_string_list)

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -1,18 +1,29 @@
 import dataclasses
-from typing import List, Optional
+from typing import Optional
 
 import tmt
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
-from tmt.options import option
+from tmt.utils import field
 
 DEFAULT_USER = "root"
 
 
 @dataclasses.dataclass
 class ConnectGuestData(tmt.steps.provision.GuestSshData):
-    user: str = DEFAULT_USER
+    guest: Optional[str] = field(
+        default=None,
+        option=('-g', '--guest'),
+        metavar='GUEST',
+        help='Select remote host to connect to (hostname or ip).'
+        )
+    user: Optional[str] = field(
+        default=DEFAULT_USER,
+        option=('-u', '--user'),
+        metavar='USERNAME',
+        help='Username to use for all guest operations.'
+        )
 
 
 @dataclasses.dataclass
@@ -54,27 +65,6 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
 
     # Guest instance
     _guest = None
-
-    @classmethod
-    def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
-        """ Prepare command line options for connect """
-        return [
-            option(
-                '-g', '--guest', metavar='GUEST',
-                help='Select remote host to connect to (hostname or ip).'),
-            option(
-                '-P', '--port', metavar='PORT',
-                help='Use specific port to connect to.'),
-            option(
-                '-k', '--key', metavar='PRIVATE_KEY',
-                help='Private key for login into the guest system.'),
-            option(
-                '-u', '--user', metavar='USER',
-                help='Username to use for all guest operations.'),
-            option(
-                '-p', '--password', metavar='PASSWORD',
-                help='Password for login into the guest system.'),
-            *super().options(how)]
 
     def go(self) -> None:
         """ Prepare the connection """

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -9,8 +9,7 @@ import tmt.log
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
-from tmt.options import option
-from tmt.utils import Command, Path, ShellScript
+from tmt.utils import Command, Path, ShellScript, field
 
 # Timeout in seconds of waiting for a connection
 CONNECTION_TIMEOUT = 60
@@ -22,11 +21,28 @@ DEFAULT_USER = "root"
 
 @dataclasses.dataclass
 class PodmanGuestData(tmt.steps.provision.GuestData):
-    image: str = DEFAULT_IMAGE
-    user: str = DEFAULT_USER
-    force_pull: bool = False
+    image: str = field(
+        default=DEFAULT_IMAGE,
+        option=('-i', '--image'),
+        metavar='IMAGE',
+        help='Select image to use. Short name or complete url.')
+    user: Optional[str] = field(
+        default=DEFAULT_USER,
+        option=('-u', '--user'),
+        metavar='USERNAME',
+        help='Username to use for all container operations.')
 
-    container: Optional[str] = None
+    force_pull: bool = field(
+        default=False,
+        option=('-p', '--pull', '--force-pull'),
+        is_flag=True,
+        help='Force pulling a fresh container image.')
+
+    container: Optional[str] = field(
+        default=None,
+        option=('-c', '--container'),
+        metavar='NAME',
+        help='Name or id of an existing container to be used.')
 
 
 @dataclasses.dataclass
@@ -269,24 +285,6 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
 
     # Guest instance
     _guest = None
-
-    @classmethod
-    def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
-        """ Prepare command line options for connect """
-        return [
-            option(
-                '-i', '--image', metavar='IMAGE',
-                help='Select image to use. Short name or complete url.'),
-            option(
-                '-c', '--container', metavar='NAME',
-                help='Name or id of an existing container to be used.'),
-            option(
-                '-p', '--pull', 'force_pull', is_flag=True,
-                help='Force pulling a fresh container image.'),
-            option(
-                '-u', '--user', metavar='USER',
-                help='User to use for all container operations.'),
-            *super().options(how)]
 
     def default(self, option: str, default: Any = None) -> Any:
         """ Return default data for given option """

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -4350,6 +4350,66 @@ def dataclass_normalize_field(
     return value
 
 
+def normalize_int(
+        key_address: str,
+        value: Any,
+        logger: tmt.log.Logger) -> int:
+    """
+    Normalize an integer.
+
+    For a field that takes an integer input. The field might be also
+    left out, but it does have a default value.
+    """
+
+    if isinstance(value, int):
+        return value
+
+    try:
+        return int(value)
+
+    except ValueError as exc:
+        raise NormalizationError(key_address, value, 'an integer') from exc
+
+
+def normalize_optional_int(
+        key_address: str,
+        value: Optional[str],
+        logger: tmt.log.Logger) -> Optional[int]:
+    """
+    Normalize an integer that may be unset as well.
+
+    For a field that takes an integer input, but might be also left out,
+    and has no default value.
+    """
+
+    if value is None:
+        return None
+
+    if isinstance(value, int):
+        return value
+
+    try:
+        return int(value)
+
+    except ValueError as exc:
+        raise NormalizationError(key_address, value, 'unset or an integer') from exc
+
+
+def normalize_storage_size(
+        key_address: str,
+        value: Any,
+        logger: tmt.log.Logger) -> int:
+    """
+    Normalize a storage size.
+
+    As of now, it's just a simple integer with units interpreted by the owning
+    plugin. In the future, we want this function to switch to proper units
+    and return ``ping.Quantity`` instead.
+    """
+
+    return normalize_int(key_address, value, logger)
+
+
 def normalize_string_list(
         key_address: str,
         value: Union[None, str, List[str]],

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -4373,7 +4373,7 @@ def normalize_int(
 
 def normalize_optional_int(
         key_address: str,
-        value: Optional[str],
+        value: Any,
         logger: tmt.log.Logger) -> Optional[int]:
     """
     Normalize an integer that may be unset as well.
@@ -4404,7 +4404,7 @@ def normalize_storage_size(
 
     As of now, it's just a simple integer with units interpreted by the owning
     plugin. In the future, we want this function to switch to proper units
-    and return ``ping.Quantity`` instead.
+    and return ``pint.Quantity`` instead.
     """
 
     return normalize_int(key_address, value, logger)


### PR DESCRIPTION
This unites options with plugin *and* guest data, and with inheritance, we also get some options shared among plugins through the step data instead of overriden `options()` methods.