### PR TITLE
Add `kickstart` section as a new specification key

### DIFF
--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -17,6 +17,11 @@ description: |
     See the :ref:`/spec/hardware` specification section for
     details.
 
+    As part of the provision step it is also possible to specify
+    kickstart file used during the installation.
+    See the :ref:`/spec/plans/provision/kickstart` specification
+    section for details.
+
 example: |
     # Provision a local virtual machine with the latest Fedora
     provision:

--- a/spec/plans/provision/kickstart.fmf
+++ b/spec/plans/provision/kickstart.fmf
@@ -1,0 +1,76 @@
+story:
+    As a tester I want to specify detailed installation of a guest
+    using the kickstart script.
+
+description: |
+    As part of the :ref:`/spec/plans/provision` step it is possible to
+    use the ``kickstart`` key to specify additional requirements for the
+    installation of a guest. It is possible to specify a kickstart
+    script that will for example specify specific partitioning.
+
+    The structure of a kickstart file is separated into several
+    sections.
+
+    pre-install
+        Corresponds to the ``%pre`` section of a file.  It can contain
+        ``bash`` commands, this part is run before the installation of a
+        guest.
+
+    post-install
+        Corresponds to the ``%post`` section of a file.  It can contain
+        ``bash`` commands, this part is run after the installation of a
+        guest.
+
+    script
+        Contains the kickstart specific commands that are run during the
+        installation of a guest.
+
+    It is also possible to specify ``metadata``. This part may be
+    interpreted differently for each of the pools that the guest is
+    created from. For example, in Beaker this section can be used to
+    modify the default kickstart template used by Beaker.  Similarly
+    works the ``kernel-options`` and ``kernel-options-post``.  Kernel
+    options are passed on the kernel command line when the installer is
+    booted.  Post-install kernel options are set in the boot loader
+    configuration, to be passed on the kernel command line after
+    installation.
+
+    .. note::
+
+        The implementation for the ``kickstart`` key is in progress.
+        Support of a kickstart file is currently limited to Beaker
+        provisioning, as implemented by tmt's beaker and artemis
+        plugins, and may not be fully supported by other provisioning
+        plugins in the future.  Check individual plugin documentation
+        for additional information on the kickstart support.
+
+example:
+  - |
+    # Use the artemis plugin to provision a guest from Beaker.
+    # The following `kickstart` specification will be run
+    # during the guest installation.
+    provision:
+        how: artemis
+        pool: beaker
+        image: rhel-7
+        kickstart:
+            pre-install: |
+                %pre --log=/dev/console
+                disk=$(lsblk | grep disk | awk '{print $1}')
+                echo $disk
+                %end
+            script: |
+                lang en_US.UTF-8
+                zerombr
+                clearpart --all --initlabel
+                part /boot --fstype="xfs" --size=200
+                part swap --fstype="swap" --size=4096
+                part / --fstype="xfs" --size=10000 --grow
+            post-install: |
+                %post
+                systemctl disable firewalld
+                %end
+            metadata: |
+                "no-autopart harness=restraint"
+            kernel-options: "ksdevice=eth1"
+            kernel-options-post: "quiet"

--- a/tmt/schemas/provision/artemis.yaml
+++ b/tmt/schemas/provision/artemis.yaml
@@ -50,6 +50,9 @@ properties:
   hardware:
     $ref: "/schemas/provision/hardware#/definitions/hardware"
 
+  kickstart:
+    $ref: "/schemas/provision/kickstart#/definitions/kickstart"
+
   pool:
     type: string
 

--- a/tmt/schemas/provision/kickstart.yaml
+++ b/tmt/schemas/provision/kickstart.yaml
@@ -1,0 +1,40 @@
+---
+
+#
+# JSON Schema definition for kickstart specification
+#
+# https://tmt.readthedocs.io/en/stable/spec/plans.html#kickstart
+#
+
+$id: /schemas/provision/kickstart
+$schema: http://json-schema.org/draft-07/schema
+
+definitions:
+  kickstart:
+    type: object
+
+    properties:
+
+      kernel-options:
+        type: string
+
+      kernel-options-post:
+        type: string
+
+      metadata:
+        type: string
+
+      post-install:
+        type: string
+
+      pre-install:
+        type: string
+
+      script:
+        type: string
+
+    additionalProperties: false
+
+    # Enforce at least one property - we don't care which one, but we don't want
+    # empty `kickstart`.
+    minProperties: 1

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -168,6 +168,12 @@ WorkdirType = Optional[Path]
 # Option to skip to initialize work tree in plan
 PLAN_SKIP_WORKTREE_INIT = 'plan_skip_worktree_init'
 
+# List of schemas that need to be ignored in a plan
+PLAN_SCHEMA_IGNORED_IDS: List[str] = [
+    '/schemas/provision/hardware',
+    '/schemas/provision/kickstart'
+    ]
+
 
 class BaseLoggerFnType(Protocol):
     def __call__(
@@ -3415,7 +3421,7 @@ def _patch_plan_schema(schema: Schema, store: SchemaStore) -> None:
         step_schema_prefix = f'/schemas/{step}/'
 
         step_plugin_schema_ids = [schema_id for schema_id in store.keys() if schema_id.startswith(
-            step_schema_prefix) and schema_id != '/schemas/provision/hardware']
+            step_schema_prefix) and schema_id not in PLAN_SCHEMA_IGNORED_IDS]
 
         refs: List[Schema] = [
             {'$ref': schema_id} for schema_id in step_plugin_schema_ids


### PR DESCRIPTION
For some of our tests in Leapp we need to run a specific kickstart section before/during the installation of a guest.
 
Allow a tester to specify a kickstart section that can contain several blocks representing the structure of a kickstart file.

Fix: https://github.com/teemtee/tmt/issues/1282.