### PR TITLE
Simplify the `Result` class implementation

### DIFF
--- a/tests/execute/result/custom/wrong_results.yaml
+++ b/tests/execute/result/custom/wrong_results.yaml
@@ -1,5 +1,5 @@
 # TODO: Make also this test working - JSON scheme needs to be defined for
-# ResultData to prevent invalid key 'foo'
+# Result to prevent invalid key 'foo'
 #
 #- name: /test/wrong-key
 #  result: pass

--- a/tests/unit/test_report_junit.py
+++ b/tests/unit/test_report_junit.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 
-from tmt.result import Result, ResultData, ResultOutcome
+from tmt.result import Result, ResultOutcome
 from tmt.steps.report.junit import ReportJUnit, ReportJUnitData
 from tmt.utils import Path
 
@@ -128,13 +128,7 @@ def assert_xml(actual_filepath, expected):
 class TestStateMapping:
     def test_pass(self, report_fix):
         report, results, out_file_path = report_fix
-        results.extend(
-            [
-                Result(
-                    data=ResultData(result=ResultOutcome.PASS),
-                    name="/pass")
-                ]
-            )
+        results.append(Result(result=ResultOutcome.PASS, name="/pass"))
 
         report.go()
 
@@ -148,13 +142,7 @@ class TestStateMapping:
 
     def test_info(self, report_fix):
         report, results, out_file_path = report_fix
-        results.extend(
-            [
-                Result(
-                    data=ResultData(result=ResultOutcome.INFO),
-                    name="/info")
-                ]
-            )
+        results.append(Result(result=ResultOutcome.INFO, name="/info"))
         report.go()
 
         assert_xml(out_file_path, """<?xml version="1.0" ?>
@@ -169,13 +157,7 @@ class TestStateMapping:
 
     def test_warn(self, report_fix):
         report, results, out_file_path = report_fix
-        results.extend(
-            [
-                Result(
-                    data=ResultData(result=ResultOutcome.WARN),
-                    name="/warn")
-                ]
-            )
+        results.append(Result(result=ResultOutcome.WARN, name="/warn"))
         report.go()
 
         assert_xml(out_file_path, """<?xml version="1.0" ?>
@@ -190,13 +172,7 @@ class TestStateMapping:
 
     def test_error(self, report_fix):
         report, results, out_file_path = report_fix
-        results.extend(
-            [
-                Result(
-                    data=ResultData(result=ResultOutcome.ERROR),
-                    name="/error")
-                ]
-            )
+        results.append(Result(result=ResultOutcome.ERROR, name="/error"))
         report.go()
 
         assert_xml(out_file_path, """<?xml version="1.0" ?>
@@ -211,13 +187,7 @@ class TestStateMapping:
 
     def test_fail(self, report_fix):
         report, results, out_file_path = report_fix
-        results.extend(
-            [
-                Result(
-                    data=ResultData(result=ResultOutcome.FAIL),
-                    name="/fail")
-                ]
-            )
+        results.append(Result(result=ResultOutcome.FAIL, name="/fail"))
         report.go()
 
         assert_xml(out_file_path, """<?xml version="1.0" ?>

--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -334,3 +334,26 @@ definitions:
   # https://tmt.readthedocs.io/en/stable/spec/plans.html#multihost
   where:
     $ref: "/schemas/common#/definitions/one_or_more_strings"
+
+  result_outcome:
+    type: string
+    enum:
+      - pass
+      - fail
+      - info
+      - warn
+      - error
+
+  # https://tmt.readthedocs.io/en/stable/spec/tests.html#result
+  result_interpret:
+    type: string
+
+    enum:
+      - respect
+      - xfail
+      - pass
+      - info
+      - warn
+      - error
+      - fail
+      - custom

--- a/tmt/schemas/results.yaml
+++ b/tmt/schemas/results.yaml
@@ -1,0 +1,59 @@
+---
+
+#
+# JSON Schema definition for tmt `results.yaml` file
+#
+# https://tmt.readthedocs.io/en/stable/spec/plans.html#execute
+#
+
+$id: /schemas/results
+$schema: https://json-schema.org/draft-07/schema
+
+type: array
+items:
+  type: object
+  additionalProperties: false
+
+  properties:
+    guest:
+      type: object
+      additionalProperties: false
+
+      properties:
+        name:
+          type: string
+
+        role:
+          $ref: "/schemas/common#/definitions/role"
+
+      required: []
+      minProperties: 1
+
+    name:
+      type: string
+      pattern: "^/.*"
+
+    result:
+      $ref: "/schemas/common#/definitions/result_outcome"
+
+    note:
+      type: string
+
+    duration:
+      type: string
+      pattern: "^[0-9]{2,}:[0-5][0-9]:[0-5][0-9]$"
+
+    ids:
+      type: object
+      patternProperties:
+        ^.*$:
+          type: string
+
+    log:
+      type: array
+      items:
+        type: string
+
+  required:
+    - name
+    - result

--- a/tmt/schemas/test.yaml
+++ b/tmt/schemas/test.yaml
@@ -89,17 +89,7 @@ properties:
 
   # https://tmt.readthedocs.io/en/stable/spec/tests.html#result
   result:
-    type: string
-
-    enum:
-      - respect
-      - xfail
-      - pass
-      - info
-      - warn
-      - error
-      - fail
-      - custom
+    $ref: "/schemas/common#/definitions/result_interpret"
 
   # https://tmt.readthedocs.io/en/stable/spec/core.html#summary
   summary:


### PR DESCRIPTION
* drop `ResultData`, it's no longer needed and `Result` can handle all the work;
* add `guest` key as proposed in [1];
* add schema for validation of (custom) `results.yaml`;
* `execute` step saves `results.yaml` as a list of results rather than a mapping, to allow one test being executed multiple times. See [2].

[1] https://github.com/teemtee/tmt/issues/1614#issuecomment-1406346209 [2] https://github.com/teemtee/tmt/issues/1614