### PR TITLE
Artemis API version may contain multiple integers

### DIFF
--- a/tmt/schemas/provision/artemis.yaml
+++ b/tmt/schemas/provision/artemis.yaml
@@ -39,7 +39,7 @@ properties:
 
   api-version:
     type: string
-    pattern: ^[0-9]\.[0-9]\.[0-9]$
+    pattern: ^[0-9]+\.[0-9]+\.[0-9]+$
 
   arch:
     $ref: "/schemas/common#/definitions/arch"


### PR DESCRIPTION
The current one i.e. is 0.0.48.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>