### PR TITLE
Fix Common class ignoring other branches of multiple inheritance tree

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -18,22 +18,24 @@ Basic
 
 The ``Common`` class is the parent of most of the available
 classes, it provides common methods for logging, running commands
-and workdir handling. The ``Core`` class together with its child
-classes ``Test``, ``Plan`` and ``Story`` cover the
-:ref:`specification`::
+and workdir handling. The ``_CommonBase`` class is an actual root
+of the class tree, makes sure the inheritance works correctly.
+The ``Core`` class together with its child classes ``Test``,
+``Plan`` and ``Story`` cover the :ref:`specification`::
 
-    Common
-    ├── Core
-    │   ├── Plan
-    │   ├── Story
-    │   └── Test
-    ├── Clean
-    ├── Guest
-    ├── Phase
-    ├── Run
-    ├── Status
-    ├── Step
-    └── Tree
+    _CommonBase
+    └── Common
+        ├── Core
+        │   ├── Plan
+        │   ├── Story
+        │   └── Test
+        ├── Clean
+        ├── Guest
+        ├── Phase
+        ├── Run
+        ├── Status
+        ├── Step
+        └── Tree
 
 
 Phases

--- a/tmt/export/__init__.py
+++ b/tmt/export/__init__.py
@@ -64,7 +64,7 @@ class Exporter(Protocol):
         pass
 
 
-class Exportable(Generic[ExportableT]):
+class Exportable(Generic[ExportableT], tmt.utils._CommonBase):
     """ Mixin class adding support for exportability of class instances """
 
     # Declare export plugin registry as a class variable, but do not initialize it. If initialized


### PR DESCRIPTION
`Common` was not calling `super().__init__()` method, which means mixin classes might have been excluded from the chain of `__init__()` calls. Fixing that, and adding a "root" class to handle calls to `object.__init__()`.

### Checklist 
* [x] implement the feature
* [x] adjust module docs