### PR TITLE
Refactored metadata linting

### DIFF
--- a/tests/lint/test.sh
+++ b/tests/lint/test.sh
@@ -33,18 +33,31 @@ rlJournalStart
         rlAssertGrep "plans/bad" $rlRun_LOG
         rlAssertGrep "stories/bad" $rlRun_LOG
         # linting story
-        rlAssertGrep "warn summary should not exceed 50 characters" $rlRun_LOG
-        rlAssertGrep "fail unknown attribute 'exampleee' is used" $rlRun_LOG
+        rlAssertGrep "warn C000 key \"exampleee\" not recognized by schema /schemas/story" $rlRun_LOG
+        rlAssertGrep "warn C001 summary should not exceed 50 characters" $rlRun_LOG
+        rlAssertGrep "fail S001 unknown key \"exampleee\" is used" $rlRun_LOG
+        rlAssertGrep "pass S002 story key is defined" $rlRun_LOG
         # linting test
-        rlAssertGrep "pass test script must be defined" $rlRun_LOG
-        rlAssertGrep "pass directory path must be absolute" $rlRun_LOG
-        rlAssertGrep "pass directory path must exist" $rlRun_LOG
-        rlAssertGrep "warn summary is very useful for quick inspection"   \
-            $rlRun_LOG
-        rlAssertGrep "fail unknown attribute 'summarrry' is used" $rlRun_LOG
+        rlAssertGrep "warn C000 key \"summarrry\" not recognized by schema, and does not match \"^extra-\" pattern" $rlRun_LOG
+        rlAssertGrep "warn C001 summary key is missing" $rlRun_LOG
+        rlAssertGrep "fail T001 unknown key \"summarrry\" is used" $rlRun_LOG
+        rlAssertGrep "pass T002 test script is defined" $rlRun_LOG
+        rlAssertGrep "pass T003 directory path is absolute" $rlRun_LOG
+        rlAssertGrep "pass T004 test path '.*/tests/lint/data/tests/bad' does exist" $rlRun_LOG
+        rlAssertGrep "skip T005 legacy relevancy not detected" $rlRun_LOG
+        rlAssertGrep "skip T006 legacy 'coverage' field not detected" $rlRun_LOG
+        rlAssertGrep "skip T007 not a manual test" $rlRun_LOG
+        rlAssertGrep "skip T008 not a manual test" $rlRun_LOG
         #linting plan
-        rlAssertGrep "fail unknown attribute 'discovery' is used" $rlRun_LOG
-        rlAssertGrep "fail unknown attribute 'prepareahoj' is used" $rlRun_LOG
+        rlAssertGrep "warn C000 key \"discovery\" not recognized by schema /schemas/plan" $rlRun_LOG
+        rlAssertGrep "warn C000 key \"prepareahoj\" not recognized by schema /schemas/plan" $rlRun_LOG
+        rlAssertGrep "pass C001 summary key is set and is reasonably long" $rlRun_LOG
+        rlAssertGrep "fail P001 unknown key \"discovery\" is used" $rlRun_LOG
+        rlAssertGrep "fail P001 unknown key \"prepareahoj\" is used" $rlRun_LOG
+        rlAssertGrep "pass P002 execute step defined with \"how\"" $rlRun_LOG
+        rlAssertGrep "pass P003 execute step methods are all known" $rlRun_LOG
+        rlAssertGrep "skip P004 discover step is not defined" $rlRun_LOG
+        rlAssertGrep "skip P005 no remote fmf ids defined" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Check --fix for tests"

--- a/tests/plan/lint/main.fmf
+++ b/tests/plan/lint/main.fmf
@@ -1,1 +1,10 @@
-summary: Checks whether plan linting works correctly
+/implicit-root:
+  summary: Checks whether plan linting works correctly
+  environment:
+    EXPLICIT_ROOT: no
+
+/explicit-root:
+  summary: Checks whether plan linting works correctly with explicit --root
+
+  environment:
+    EXPLICIT_ROOT: yes

--- a/tests/plan/lint/test.sh
+++ b/tests/plan/lint/test.sh
@@ -3,64 +3,71 @@
 
 rlJournalStart
     rlPhaseStartSetup
-        rlRun "pushd data"
+        if [ "$EXPLICIT_ROOT" = "yes" ]; then
+            tmt="tmt --root data"
+        else
+            tmt="tmt"
+            rlRun "pushd data"
+        fi
     rlPhaseEnd
 
     rlPhaseStartTest "Good"
-        rlRun -s "tmt plan lint good"
+        rlRun -s "$tmt plan lint good"
         rlAssertGrep "/good" $rlRun_LOG
-        rlAssertNotGrep 'warn summary ' $rlRun_LOG
+        rlAssertNotGrep 'warn ' $rlRun_LOG
         rlRun "rm $rlRun_LOG"
 
-        rlRun -s "tmt plan lint valid_fmf"
-        rlAssertGrep "pass fmf remote id in 'default-0' is valid" $rlRun_LOG
-        rlAssertNotGrep 'warn summary ' $rlRun_LOG
+        rlRun -s "$tmt plan lint valid_fmf"
+        rlAssertGrep "pass P005 remote fmf id in \"default-0\" is valid" $rlRun_LOG
+        rlAssertNotGrep 'warn ' $rlRun_LOG
         rlRun "rm $rlRun_LOG"
 
-        rlRun -s "tmt plan lint multi_execute"
+        rlRun -s "$tmt plan lint multi_execute"
         rlAssertGrep "/multi_execute" $rlRun_LOG
-        rlAssertNotGrep 'fail' $rlRun_LOG
+        rlAssertNotGrep 'fail ' $rlRun_LOG
         rlRun "rm $rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartTest "Bad"
-        rlRun -s "tmt plan lint bad" 1
-        rlAssertGrep 'fail execute step must be defined' $rlRun_LOG
-        rlAssertGrep 'warn summary is very useful' $rlRun_LOG
-        rlRun "rm $rlRun_LOG"
+        rlRun -s "$tmt plan lint bad" 1
+        rlAssertGrep "warn C000 fmf node failed schema validation" $rlRun_LOG
+        rlAssertGrep "warn C001 summary key is missing" $rlRun_LOG
+        rlAssertGrep "fail P002 execute step must be defined with \"how\"" $rlRun_LOG
 
-        rlRun -s "tmt plan lint invalid_how" 1
-        rlAssertGrep "fail unknown discover method 'somehow'" $rlRun_LOG
-        rlAssertGrep "fail unsupported execute method 'somehow'" $rlRun_LOG
-        rlRun "rm $rlRun_LOG"
+        rlRun -s "$tmt plan lint invalid_how" 1
+        rlAssertGrep "warn C000 value of \"how\" is not \"shell\"" $rlRun_LOG
+        rlAssertGrep "warn C000 value of \"how\" is not \"fmf\"" $rlRun_LOG
+        rlAssertGrep "warn C000 value of \"how\" is not \"tmt\"" $rlRun_LOG
+        rlAssertGrep "warn C000 key \"name\" not recognized by schema /schemas/execute/upgrade" $rlRun_LOG
+        rlAssertGrep "warn C000 value of \"how\" is not \"upgrade\"" $rlRun_LOG
+        rlAssertGrep "warn C000 fmf node failed schema validation" $rlRun_LOG
+        rlAssertGrep "fail P003 unknown execute method \"somehow\" in \"default-0\"" $rlRun_LOG
+        rlAssertGrep "fail P004 unknown discover method \"somehow\" in \"default-0\"" $rlRun_LOG
 
-        rlRun -s "tmt plan lint invalid_url" 1
-        rlAssertGrep "fail repo 'http://invalid-url' cannot be cloned" \
-            $rlRun_LOG
-        rlRun "rm $rlRun_LOG"
+        rlRun -s "$tmt plan lint invalid_url" 1
+        rlAssertGrep "fail P005 remote fmf id in \"default-0\" is invalid, repo 'http://invalid-url' cannot be cloned" $rlRun_LOG
 
-        rlRun -s "tmt plan lint invalid_ref" 1
-        rlAssertGrep "fail git ref 'invalid-ref-123456' is invalid" $rlRun_LOG
-        rlRun "rm $rlRun_LOG"
+        rlRun -s "$tmt plan lint invalid_ref" 1
+        rlAssertGrep "fail P005 remote fmf id in \"default-0\" is invalid, git ref 'invalid-ref-123456' is invalid" $rlRun_LOG
 
-        rlRun -s "tmt plan lint invalid_path" 1
-        rlAssertGrep "fail path '/invalid-path-123456' is invalid" $rlRun_LOG
-        rlRun "rm $rlRun_LOG"
+        rlRun -s "$tmt plan lint invalid_path" 1
+        rlAssertGrep "fail P005 remote fmf id in \"default-0\" is invalid, path '/invalid-path-123456' is invalid" $rlRun_LOG
 
-        rlRun -s "tmt plan lint multi_discover" 1
-        rlAssertGrep "pass fmf remote id in 'a' is valid" $rlRun_LOG
-        rlAssertGrep "fail repo 'http://invalid-url' cannot be cloned" \
-            $rlRun_LOG
-        rlRun "rm $rlRun_LOG"
+        rlRun -s "$tmt plan lint multi_discover" 1
+        rlAssertGrep "pass P005 remote fmf id in \"a\" is valid" $rlRun_LOG
+        rlAssertGrep "fail P005 remote fmf id in \"b\" is invalid, repo 'http://invalid-url' cannot be cloned" $rlRun_LOG
 
-        rlRun -s "tmt plan lint invalid_attr" 1
-        rlAssertGrep "fail unknown attribute 'discove' is used" $rlRun_LOG
-        rlAssertGrep "fail unknown attribute 'environmen' is used" $rlRun_LOG
-        rlAssertGrep "fail unknown attribute 'summaryABCDEF' is used" $rlRun_LOG
-        rlRun "rm $rlRun_LOG"
+        rlRun -s "$tmt plan lint invalid_attr" 1
+        rlAssertGrep "warn C000 fmf node failed schema validation" $rlRun_LOG
+        rlAssertGrep "warn C001 summary key is missing" $rlRun_LOG
+        rlAssertGrep "fail P001 unknown key \"discove\" is used" $rlRun_LOG
+        rlAssertGrep "fail P001 unknown key \"environmen\" is used" $rlRun_LOG
+        rlAssertGrep "fail P001 unknown key \"summaryABCDEF\" is used" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun "popd"
+        if [ "$EXPLICIT_ROOT" != "yes" ]; then
+            rlRun "popd"
+        fi
     rlPhaseEnd
 rlJournalEnd

--- a/tests/precommit/test.sh
+++ b/tests/precommit/test.sh
@@ -74,7 +74,7 @@ EOF
         rlRun -s "git commit -m wrong" "1"
         # Test uses invalid attribute
         rlAssertGrep "$expected_command.*Failed" $rlRun_LOG
-        rlAssertGrep 'fail unknown attribute' $rlRun_LOG
+        rlAssertGrep 'fail .001 unknown key "foo" is used' $rlRun_LOG
 
         # Force broken test into repo
         rlRun -s "git commit --no-verify -m wrong" "0"

--- a/tests/story/lint/test.sh
+++ b/tests/story/lint/test.sh
@@ -9,25 +9,26 @@ rlJournalStart
 
     rlPhaseStartTest "Correct story"
         rlRun -s "tmt stories lint good" 0
-        rlAssertGrep "pass correct attributes are used" $rlRun_LOG
-        rlAssertNotGrep "warn summary" $rlRun_LOG
+        rlAssertGrep "pass C000 fmf node passes schema validation" $rlRun_LOG
+        rlAssertGrep "pass S001 correct keys are used" $rlRun_LOG
+        rlAssertNotGrep "warn" $rlRun_LOG
         rlAssertNotGrep "fail" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Incorrect story"
         rlRun -s "tmt stories lint long_summary" 0
-        rlAssertGrep "warn summary should not exceed 50 characters" $rlRun_LOG
-        rlRun "rm $rlRun_LOG"
+        rlAssertGrep "warn C001 summary should not exceed 50 characters" $rlRun_LOG
 
         rlRun -s "tmt stories lint typo_in_key" 1
-        rlAssertGrep "fail unknown attribute '.*' is used" $rlRun_LOG
-        rlAssertNotGrep "pass correct attributes are used" $rlRun_LOG
-        rlRun "rm $rlRun_LOG"
+        rlAssertGrep "warn C000 fmf node failed schema validation" $rlRun_LOG
+        rlAssertGrep "warn C001 summary key is missing" $rlRun_LOG
+        rlAssertGrep "fail S001 unknown key \"exampleGG\" is used" $rlRun_LOG
 
         rlRun -s "tmt stories lint missing_story" 1
-        rlAssertGrep "fail story is required" $rlRun_LOG
-        rlAssertGrep "pass correct attributes are used" $rlRun_LOG
-        rlRun "rm $rlRun_LOG"
+        rlAssertGrep "warn C000 fmf node failed schema validation" $rlRun_LOG
+        rlAssertGrep "warn C001 summary key is missing" $rlRun_LOG
+        rlAssertGrep "pass S001 correct keys are used" $rlRun_LOG
+        rlAssertGrep "fail S002 story is required" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -10,18 +10,20 @@ import shutil
 import sys
 import time
 from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Dict, Generator,
-                    Iterable, Iterator, List, Optional, Sequence, Tuple,
+                    Iterable, Iterator, List, Optional, Sequence, Tuple, Type,
                     TypeVar, Union, cast)
 
 import fmf
 import fmf.base
 import fmf.utils
+import jsonschema
 from click import confirm, echo, style
 from fmf.utils import listed
 from ruamel.yaml.error import MarkedYAMLError
 
 import tmt.export
 import tmt.identifier
+import tmt.lint
 import tmt.log
 import tmt.plugins
 import tmt.steps
@@ -33,6 +35,7 @@ import tmt.steps.provision
 import tmt.steps.report
 import tmt.templates
 import tmt.utils
+from tmt.lint import LinterOutcome, LinterReturn
 from tmt.result import Result, ResultOutcome
 from tmt.utils import (Command, EnvironmentType, FmfContextType, Path,
                        ShellScript, WorkdirArgumentType, verdict)
@@ -539,6 +542,20 @@ class Core(
         """ Node name """
         return self.name
 
+    @classmethod
+    def from_tree(cls: Type[T], tree: 'tmt.Tree') -> List[T]:
+        """
+        Gather list of instances of this class in a given tree.
+
+        Helpful when looking for objects of a class derived from :py:class:`Core`
+        in a given tree, encapsulating the mapping between core classes and tree
+        search methods.
+
+        :param tree: tree to search for objects.
+        """
+
+        return cast(List[T], getattr(tree, f'{cls.__name__.lower()}s')())
+
     def _update_metadata(self) -> None:
         """ Update the _metadata attribute """
         self._metadata.update(self._export())
@@ -690,19 +707,111 @@ class Core(
 
         return data
 
-    def lint_keys(self, additional_keys: List[str]) -> List[str]:
+    def _lint_keys(self, additional_keys: List[str]) -> List[str]:
         """ Return list of invalid keys used, empty when all good """
         known_keys = additional_keys + self._keys()
         return [key for key in self.node.get().keys() if key not in known_keys]
 
-    def _lint_summary(self) -> bool:
-        """ Lint summary attribute """
-        # Summary is advised with a resonable length
-        if self.summary is None:
-            verdict(None, "summary is very useful for quick inspection")
-        elif len(self.summary) > 50:
-            verdict(None, "summary should not exceed 50 characters")
-        return True
+    def lint_validate(self) -> LinterReturn:
+        """ C000: fmf node should pass the schema validation """
+
+        schema_name = self.__class__.__name__.lower()
+
+        errors = tmt.utils.validate_fmf_node(self.node, f'{schema_name}.yaml', self._logger)
+
+        if errors:
+            # A bit of error formatting. It is possible to use str(error), but the result
+            # is a bit too JSON-ish. Let's present an error message in a way that helps
+            # users to point finger on each and every issue.
+
+            def detect_unallowed_properties(error: jsonschema.ValidationError) -> LinterReturn:
+                match = re.search(
+                    r"(?mi)Additional properties are not allowed \(([a-zA-Z0-9', \-]+) (?:was|were) unexpected\)",  # noqa: E501
+                    str(error))
+
+                if not match:
+                    return
+
+                for bad_property in match.group(1).replace("'", '').replace(' ', '').split(','):
+                    yield LinterOutcome.WARN, \
+                        f'key "{bad_property}" not recognized by schema {error.schema["$id"]}'
+
+            # A key not recognized, but when patternProperties are allowed. In that case,
+            # the key is both not listed and not matching the pattern.
+            def detect_unallowed_properties_with_pattern(
+                    error: jsonschema.ValidationError) -> LinterReturn:
+                match = re.search(
+                    r"(?mi)'([a-zA-Z0-9', \-]+)' (?:does|do) not match any of the regexes: '([a-zA-Z0-9\-\^\+\*]+)'",  # noqa: E501
+                    str(error))
+
+                if not match:
+                    return
+
+                for bad_property in match.group(1).replace("'", '').replace(' ', '').split(','):
+                    yield LinterOutcome.WARN, \
+                        f'key "{bad_property}" not recognized by schema,' \
+                        f' and does not match "{match.group(2)}" pattern'
+
+            # A key value is not recognized. This is often a case with keys whose values are
+            # limited by an enum, like `how`. Unfortunatelly, validator will record every mismatch
+            # between a value and enum even if eventually a match is found. So it might be tempting
+            # to ignore this particular kind of error - it may also indicate a genuine typo in
+            # key name or completely misplaced key, so it's still necessary to report the error.
+            def detect_enum_violations(error: jsonschema.ValidationError) -> LinterReturn:
+                match = re.search(
+                    r"(?mi)'([a-z\-]+)' is not one of \['([a-zA-Z\-]+)'\]",
+                    str(error))
+
+                if not match:
+                    return
+
+                # Older jsonpatch packages may lack this attribute
+                if not hasattr(error, 'json_path'):
+                    json_path = '$'
+
+                    for elem in error.absolute_path:
+                        if isinstance(elem, int):
+                            json_path += f'[{elem}]'
+                        else:
+                            json_path += f'.{elem}'
+
+                else:
+                    json_path = error.json_path
+
+                yield LinterOutcome.WARN, \
+                    f'value of "{json_path.split(".")[-1]}" is not "{match.group(2)}"'
+
+            for error, _ in errors:
+                yield from detect_unallowed_properties(error)
+                yield from detect_unallowed_properties_with_pattern(error)
+                yield from detect_enum_violations(error)
+
+                # Validation errors can have "context", a list of "sub" errors encountered during
+                # validation. Interesting ones are identified & added to our error message.
+                if error.context:
+                    for suberror in error.context:
+                        yield from detect_unallowed_properties(suberror)
+                        yield from detect_unallowed_properties_with_pattern(suberror)
+                        yield from detect_enum_violations(suberror)
+
+            yield LinterOutcome.WARN, 'fmf node failed schema validation'
+
+            return
+
+        yield LinterOutcome.PASS, 'fmf node passes schema validation'
+
+    def lint_summary_exists(self) -> LinterReturn:
+        """ C001: summary key should be set and should be reasonably long """
+
+        if not self.summary:
+            yield LinterOutcome.WARN, 'summary key is missing'
+            return
+
+        if len(self.summary) > 50:
+            yield LinterOutcome.WARN, 'summary should not exceed 50 characters'
+            return
+
+        yield LinterOutcome.PASS, 'summary key is set and is reasonably long'
 
     def has_link(self, needle: 'LinkNeedle') -> bool:
         """ Whether object contains specified link """
@@ -716,7 +825,10 @@ class Core(
 Node = Core
 
 
-class Test(Core, tmt.export.Exportable['Test']):
+class Test(
+        Core,
+        tmt.export.Exportable['Test'],
+        tmt.lint.Lintable['Test']):
     """ Test object (L1 Metadata) """
 
     # Basic test information
@@ -941,6 +1053,14 @@ class Test(Core, tmt.export.Exportable['Test']):
             path=script_path, content=content,
             name='test script', dry=dry, force=force, mode=0o755)
 
+    @property
+    def manual_test_path(self) -> Path:
+        assert self.manual, 'Test is not manual yet path to manual instructions was requested'
+
+        assert self.path
+
+        return Path(self.node.root) / self.path.unrooted() / str(self.test)
+
     def show(self) -> None:
         """ Show test details """
         self.ls()
@@ -972,88 +1092,139 @@ class Test(Core, tmt.export.Exportable['Test']):
                 if value not in [None, list(), dict()]:
                     echo(tmt.utils.format(key, value, key_color='blue'))
 
-    def _lint_manual(self, test_path: Path) -> bool:
-        """ Check that the manual instructions respect the specification """
-        # Manual tests should store a path to a document describing the test case steps.
-        manual_test = test_path / str(self.test)
+    # FIXME - Make additional attributes configurable
+    def lint_unknown_keys(self) -> LinterReturn:
+        """ T001: all keys are known """
 
-        # File does not exist
-        if not manual_test.exists():
-            return verdict(False, f"file '{self.test}' does not exist")
+        # We don't want adjust in show/export so it is not yet in Test._keys
+        invalid_keys = self._lint_keys(EXTRA_TEST_KEYS + OBSOLETED_TEST_KEYS + ['adjust'])
 
-        # Check syntax for warnings
-        warnings = tmt.export.check_md_file_respects_spec(manual_test)
-        if warnings:
-            for warning in warnings:
-                verdict(False, warning)
-            return False
+        if invalid_keys:
+            for key in invalid_keys:
+                yield LinterOutcome.FAIL, f'unknown key "{key}" is used'
 
-        # Everything looks ok
-        return verdict(True, f"correct manual test syntax in '{self.test}'")
+            return
 
-    def lint(self) -> bool:
-        """
-        Check test against the L1 metadata specification.
+        yield LinterOutcome.PASS, 'correct keys are used'
 
-        Return whether the test is valid.
-        """
-        self.ls()
-        assert self.path is not None  # narrow type
+    def lint_defined_test(self) -> LinterReturn:
+        """ T002: test script must be defined """
 
-        # Check test, path and summary (use bitwise '&' because 'and' is
-        # lazy and would skip all verdicts following the first fail)
-        valid = verdict(
-            bool(self.test), 'test script must be defined')
-        valid &= verdict(
-            self.path.is_absolute(), 'directory path must be absolute')
-        if self.path.is_absolute():
-            assert self.path is not None  # narrow type
-            test_path = Path(self.node.root) / self.path.unrooted()
-        else:
-            test_path = self.path
-        valid &= verdict(
-            test_path.exists(), 'directory path must exist')
-        self._lint_summary()
+        if not self.test:
+            yield LinterOutcome.FAIL, 'test script is not defined'
+            return
 
-        # Check for possible test case relevancy rules
+        yield LinterOutcome.PASS, 'test script is defined'
+
+    def lint_absolute_path(self) -> LinterReturn:
+        """ T003: test directory path must be absolute """
+
+        if not self.path:
+            yield LinterOutcome.FAIL, 'directory path is not set'
+            return
+
+        if not self.path.is_absolute():
+            yield LinterOutcome.FAIL, 'directory path is not absolute'
+            return
+
+        yield LinterOutcome.PASS, 'directory path is absolute'
+
+    def lint_path_exists(self) -> LinterReturn:
+        """ T004: test directory path must exist """
+
+        if not self.path:
+            yield LinterOutcome.FAIL, 'directory path is not set'
+            return
+
+        test_path = Path(self.node.root) / self.path.unrooted()
+
+        if not test_path.exists():
+            yield LinterOutcome.FAIL, f"test path '{test_path}' does not exist"
+            return
+
+        yield LinterOutcome.PASS, f"test path '{test_path}' does exist"
+
+    def lint_legacy_relevancy_rules(self) -> LinterReturn:
+        """ T005: relevancy has been obsoleted by adjust """
+
         filename = self.node.sources[-1]
         metadata = tmt.utils.yaml_to_dict(self.read(filename))
         relevancy = metadata.pop('relevancy', None)
-        if relevancy:
-            # Convert into adjust rules if --fix enabled
-            if self.opt('fix'):
-                metadata['adjust'] = tmt.convert.relevancy_to_adjust(relevancy)
-                self.write(filename, tmt.utils.dict_to_yaml(metadata))
-                verdict(None, 'relevancy converted into adjust')
-            else:
-                valid = verdict(
-                    False, 'relevancy has been obsoleted by adjust')
 
-        # Check for possible coverage attribute
+        if not relevancy:
+            yield LinterOutcome.SKIP, 'legacy relevancy not detected'
+            return
+
+        # Convert into adjust rules if --fix enabled
+        if not self.opt('fix'):
+            yield LinterOutcome.FAIL, 'relevancy has been obsoleted by adjust'
+            return
+
+        metadata['adjust'] = tmt.convert.relevancy_to_adjust(relevancy)
+        self.write(filename, tmt.utils.dict_to_yaml(metadata))
+
+        yield LinterOutcome.FIXED, 'relevancy converted into adjust'
+
+    def lint_legacy_coverage_key(self) -> LinterReturn:
+        """ T006: coverage has been obsoleted by link """
+
+        filename = self.node.sources[-1]
+        metadata = tmt.utils.yaml_to_dict(self.read(filename))
         coverage = metadata.pop('coverage', None)
-        if coverage:
-            valid = verdict(False, 'coverage has been obsoleted by link')
-        # Check for unknown attributes
-        # FIXME - Make additional attributes configurable
-        # We don't want adjust in show/export so it is not yet in Test._keys
-        invalid_keys = self.lint_keys(
-            EXTRA_TEST_KEYS + OBSOLETED_TEST_KEYS + ['adjust'])
-        if invalid_keys:
-            valid = False
-            for key in invalid_keys:
-                verdict(False, f"unknown attribute '{key}' is used")
-        else:
-            verdict(True, "correct attributes are used")
 
-        # Check if the format of Markdown file respects the specification
-        # https://tmt.readthedocs.io/en/latest/spec/tests.html#manual
-        if self.manual:
-            valid &= self._lint_manual(test_path)
+        if coverage is None:
+            yield LinterOutcome.SKIP, "legacy 'coverage' field not detected"
+            return
 
-        return valid
+        yield LinterOutcome.FAIL, "the 'coverage' field has been obsoleted by 'link'"
+
+    # Check if the format of Markdown file respects the specification
+    # https://tmt.readthedocs.io/en/latest/spec/tests.html#manual
+    def lint_manual_test_path_exists(self) -> LinterReturn:
+        """ T007: manual test path is not an actual path """
+
+        if not self.manual:
+            yield LinterOutcome.SKIP, 'not a manual test'
+            return
+
+        if not self.path:
+            yield LinterOutcome.FAIL, 'directory path is not set'
+            return
+
+        if not self.manual_test_path.exists():
+            yield LinterOutcome.FAIL, f'manual test path "{self.manual_test_path}" does not exist'
+            return
+
+        yield LinterOutcome.PASS, f'manual test path "{self.manual_test_path}" does exist'
+
+    def lint_manual_valid_markdown(self) -> LinterReturn:
+        """ T008: manual test should be valid markdown """
+
+        if not self.manual:
+            yield LinterOutcome.SKIP, 'not a manual test'
+            return
+
+        try:
+            warnings = tmt.export.check_md_file_respects_spec(self.manual_test_path)
+
+        except tmt.utils.ConvertError as exc:
+            yield LinterOutcome.FAIL, f'cannot open the manual test path: {exc}'
+            return
+
+        if warnings:
+            for warning in warnings:
+                # replace new-lines with a (single) space
+                yield LinterOutcome.WARN, ' '.join(line.strip() for line in warning.splitlines())
+
+            return
+
+        yield LinterOutcome.PASS, 'correct manual test syntax'
 
 
-class Plan(Core, tmt.export.Exportable['Plan']):
+class Plan(
+        Core,
+        tmt.export.Exportable['Plan'],
+        tmt.lint.Lintable['Plan']):
     """ Plan object (L2 Metadata) """
 
     # `environment` and `environment-file` are NOT promoted to instance variables.
@@ -1503,106 +1674,120 @@ class Plan(Core, tmt.export.Exportable['Plan']):
             for key, value in fmf_id.items():
                 echo(tmt.utils.format(key, value, key_color='green'))
 
-    def _lint_execute(self) -> Optional[bool]:
-        """ Lint execute step """
-        execute = self.node.get('execute')
-        if not execute:
-            return verdict(False, "execute step must be defined with 'how'")
-        if isinstance(execute, dict):
-            execute = [execute]
+    # FIXME - Make additional attributes configurable
+    def lint_unknown_keys(self) -> LinterReturn:
+        """ P001: all keys are known """
 
-        methods = [
-            method.name
-            for method in tmt.steps.execute.ExecutePlugin.methods()]
-        correct = True
-        for configuration in execute:
-            how = configuration.get('how')
-            if how not in methods:
-                name = configuration.get('name')
-                verdict(False,
-                        f"unsupported execute method '{how}' in '{name}'")
-                correct = False
-
-        return correct
-
-    def _lint_discover(self) -> bool:
-        """ Lint discover step """
-        # TODO: can we use self.discover & its data instead? A question to be answered
-        # by better schema & lint cooperation - e.g. unknown methods shall be reported
-        # by schema-based validation already.
-
-        # The discover step is optional
-        # FIXME: cast() - typeless "dispatcher" method
-        discover_data = cast(Optional[tmt.steps.RawStepDataArgument], self.node.get('discover'))
-        if not discover_data:
-            return True
-        if not isinstance(discover_data, list):
-            discover_data = [discover_data]
-
-        methods = [
-            method.name
-            for method in tmt.steps.discover.DiscoverPlugin.methods()]
-        correct = True
-        for discover_datum in discover_data:
-            how = discover_datum.get('how')
-
-            if how not in methods:
-                correct = verdict(False, f"unknown discover method '{how}'")
-                continue
-
-            # FIXME Add check for the shell discover method
-            if how == 'shell':
-                continue
-
-            correct &= self._lint_discover_fmf(discover_datum)
-
-        return correct
-
-    @staticmethod
-    def _lint_discover_fmf(discover: tmt.steps._RawStepData) -> bool:
-        """ Lint fmf discover method """
-        # Validate remote id and translate to human readable errors
-        fmf_id_data = cast(
-            _RawFmfId,
-            {key: value for key, value in discover.items() if key in ['url', 'ref', 'path']}
-            )
-
-        # Skipping `name` on purpose - that belongs to the whole step,
-        # it's not treated as part of fmf id.
-        valid, error = FmfId.from_spec(fmf_id_data).validate()
-
-        if valid:
-            name = discover.get('name')
-            return verdict(True, f"fmf remote id in '{name}' is valid")
-
-        return verdict(False, error)
-
-    def lint(self) -> bool:
-        """
-        Check plan against the L2 metadata specification
-
-        Return whether the plan is valid.
-        """
-        self.ls()
-
-        # Explore all available plugins
-        tmt.plugins.explore(self._logger)
-
-        invalid_keys = self.lint_keys(
-            list(self.step_names(enabled=True, disabled=True)) +
-            self.extra_L2_keys)
+        invalid_keys = self._lint_keys(
+            list(self.step_names(enabled=True, disabled=True)) + self.extra_L2_keys)
 
         if invalid_keys:
             for key in invalid_keys:
-                verdict(False, f"unknown attribute '{key}' is used")
-        else:
-            verdict(True, "correct attributes are used")
+                yield LinterOutcome.FAIL, f'unknown key "{key}" is used'
 
-        return all([
-            self._lint_summary(),
-            self._lint_execute(),
-            self._lint_discover(),
-            len(invalid_keys) == 0])
+            return
+
+        yield LinterOutcome.PASS, 'correct keys are used'
+
+    def lint_execute_not_defined(self) -> LinterReturn:
+        """ P002: execute step must be defined with "how" """
+
+        if not self.node.get('execute'):
+            yield LinterOutcome.FAIL, 'execute step must be defined with "how"'
+            return
+
+        yield LinterOutcome.PASS, 'execute step defined with "how"'
+
+    def _step_phase_nodes(self, step: str) -> List[Dict[str, Any]]:
+        """ List raw fmf nodes for the given step """
+
+        _phases = self.node.get(step)
+
+        if not _phases:
+            return []
+
+        if isinstance(_phases, dict):
+            return [_phases]
+
+        return cast(List[Dict[str, Any]], _phases)
+
+    def _lint_step_methods(
+            self,
+            step: str,
+            plugin_class: Type[tmt.steps.BasePlugin]) -> LinterReturn:
+        """ P003: execute step methods must be known """
+
+        phases = self._step_phase_nodes(step)
+
+        if not phases:
+            yield LinterOutcome.SKIP, f'{step} step is not defined'
+            return
+
+        methods = [method.name for method in plugin_class.methods()]
+
+        invalid_phases = [
+            phase
+            for phase in phases
+            if phase.get('how') not in methods
+            ]
+
+        if invalid_phases:
+            for phase in invalid_phases:
+                yield LinterOutcome.FAIL, \
+                    f'unknown {step} method "{phase.get("how")}" in "{phase.get("name")}"'
+
+            return
+
+        yield LinterOutcome.PASS, f'{step} step methods are all known'
+
+    # TODO: can we use self.discover & its data instead? A question to be answered
+    # by better schema & lint cooperation - e.g. unknown methods shall be reported
+    # by schema-based validation already.
+    def lint_execute_unknown_method(self) -> LinterReturn:
+        """ P003: execute step methods must be known """
+
+        yield from self._lint_step_methods('execute', tmt.steps.execute.ExecutePlugin)
+
+    def lint_discover_unknown_method(self) -> LinterReturn:
+        """ P004: discover step methods must be known """
+
+        yield from self._lint_step_methods('discover', tmt.steps.discover.DiscoverPlugin)
+
+    def lint_fmf_remote_ids_valid(self) -> LinterReturn:
+        """ P005: remote fmf ids must be valid """
+
+        fmf_ids: List[Tuple[FmfId, Dict[str, Any]]] = []
+
+        for phase in self._step_phase_nodes('discover'):
+            if phase.get('how') != 'fmf':
+                continue
+
+            # Skipping `name` on purpose - that belongs to the whole step,
+            # it's not treated as part of fmf id.
+            fmf_id_data = cast(
+                _RawFmfId,
+                {key: value for key, value in phase.items() if key in ['url', 'ref', 'path']}
+                )
+
+            if not fmf_id_data:
+                continue
+
+            fmf_ids.append((FmfId.from_spec(fmf_id_data), phase))
+
+        if fmf_ids:
+            for fmf_id, phase in fmf_ids:
+                valid, error = fmf_id.validate()
+
+                if valid:
+                    yield LinterOutcome.PASS, f'remote fmf id in "{phase.get("name")}" is valid'
+
+                else:
+                    yield LinterOutcome.FAIL, \
+                        f'remote fmf id in "{phase.get("name")}" is invalid, {error}'
+
+            return
+
+        yield LinterOutcome.SKIP, 'no remote fmf ids defined'
 
     def go(self) -> None:
         """ Execute the plan """
@@ -1772,7 +1957,10 @@ class StoryPriority(enum.Enum):
         return self.value
 
 
-class Story(Core, tmt.export.Exportable['Story']):
+class Story(
+        Core,
+        tmt.export.Exportable['Story'],
+        tmt.lint.Lintable['Story']):
     """ User story object """
 
     example: List[str] = []
@@ -1817,6 +2005,11 @@ class Story(Core, tmt.export.Exportable['Story']):
         super().__init__(node=node, logger=logger, skip_validation=skip_validation,
                          raise_on_validation_error=raise_on_validation_error, **kwargs)
         self._update_metadata()
+
+    # Override the parent implementation - it would try to call `Tree.storys()`...
+    @classmethod
+    def from_tree(cls, tree: 'tmt.Tree') -> List['Story']:
+        return tree.stories()
 
     @property
     def documented(self) -> List['Link']:
@@ -1946,30 +2139,33 @@ class Story(Core, tmt.export.Exportable['Story']):
         echo(self)
         return (code, test, docs)
 
-    def _lint_story(self) -> Optional[bool]:
-        story = self.node.get('story')
-        if not story:
-            return verdict(False, "story is required")
-        return True
+    # FIXME - Make additional attributes configurable
+    def lint_unknown_keys(self) -> LinterReturn:
+        """ S001: all keys are known """
 
-    def lint(self) -> bool:
-        """
-        Check story against the L3 metadata specification.
-
-        Return whether the story is valid.
-        """
-        self.ls()
-        invalid_keys = self.lint_keys(EXTRA_STORY_KEYS)
+        invalid_keys = self._lint_keys(EXTRA_STORY_KEYS)
 
         if invalid_keys:
             for key in invalid_keys:
-                verdict(False, f"unknown attribute '{key}' is used")
-        else:
-            verdict(True, "correct attributes are used")
+                yield LinterOutcome.FAIL, f'unknown key "{key}" is used'
 
-        return all([self._lint_summary(),
-                    self._lint_story(),
-                    len(invalid_keys) == 0])
+            return
+
+        yield LinterOutcome.PASS, 'correct keys are used'
+
+    def lint_story(self) -> LinterReturn:
+        """ S002: story key must be defined """
+
+        if not self.node.get('story'):
+            yield LinterOutcome.FAIL, 'story is required'
+            return
+
+        yield LinterOutcome.PASS, 'story key is defined'
+
+
+Test.discover_linters()
+Plan.discover_linters()
+Story.discover_linters()
 
 
 class Tree(tmt.utils.Common):

--- a/tmt/lint.py
+++ b/tmt/lint.py
@@ -1,0 +1,363 @@
+# coding: utf-8
+
+"""
+Metadata linting.
+
+Internal APIs, classes, shared functionality and helpers for linting of
+test, plan and story metadata linting.
+
+A mixin class, :py:class:`Lintable`, provides the required functionality for
+base classes. Namely, it takes care of linter discovery and adds
+:py:meth:`Lintable.lint` method to run them.
+
+Classes spiced with ``Lintable`` define their sets of linters. Consider the
+following examples:
+
+.. code-block:: python
+
+   # Methods whose names start with ``lint_*`` prefix are considered linters.
+   def lint_path_exists(self) -> LinterReturn:
+       # A linter must have a docstring which is then used to generate documentation,
+       # e.g. when ``lint --list-checks`` is called. The docstring must begin with
+       # a linter *id*. The id should match ``[CTPS]\\d\\d\\d`` regular expression:
+       # ``C``ommon, ``T``est, ``P``lan, ``S``tory, plus a three-digit serial number
+       # of the linter among its peers.
+       ''' T004: test directory path must exist '''
+
+       # Linter implements a generator (see :py:member:`LinterReturn`) yielding
+       # two item tuples of :py:class:`LinterOutcome` and string messages.
+
+       if not self.path:
+           yield LinterOutcome.FAIL, 'directory path is not set'
+           return
+
+       test_path = os.path.join(self.node.root, os.path.relpath(self.path.strip(), '/'))
+
+       if not os.path.exists(test_path):
+           yield LinterOutcome.FAIL, f'test path "{test_path}" does not exist'
+           return
+
+       yield LinterOutcome.PASS, f'test path "{test_path}" does exist'
+
+   def lint_manual_valid_markdown(self) -> LinterReturn:
+       ''' T008: manual test should be valid markdown '''
+
+       # Linter should yield `SKIP` outcome when it does not apply, to announce
+       # it did inspect the object but realized it's out of scope.
+       if not self.manual:
+            yield LinterOutcome.SKIP, 'not a manual test'
+            return
+
+       manual_test = os.path.join(self.node.root, self.path.strip())
+
+       warnings = tmt.export.check_md_file_respects_spec(manual_test)
+
+       if warnings:
+           # Linter may yield as many tuples as deems necessary. This allows for
+           # linters iterating over more granular aspects of metadata, providing
+           # more specific hints.
+           for warning in warnings:
+              yield LinterOutcome.WARN, warning
+
+       ...
+"""
+
+import dataclasses
+import enum
+import textwrap
+from typing import (TYPE_CHECKING, Any, Callable, ClassVar, Generator, Generic,
+                    Iterable, List, Optional, Tuple, TypeVar)
+
+from click import style
+
+import tmt
+import tmt.utils
+
+if TYPE_CHECKING:
+    import tmt.base
+
+
+# ignore[type-arg]: bound type vars cannot be generic, and it would create a loop anyway.
+LintableT = TypeVar('LintableT', bound='Lintable')  # type: ignore[type-arg]
+
+
+class LinterOutcome(enum.Enum):
+    SKIP = 'skip'
+    PASS = 'pass'
+    FAIL = 'fail'
+    WARN = 'warn'
+    FIXED = 'fixed'
+
+
+# TODO: these would be cool, but first we should get rid of Result
+# adding color when it shouldn't have.
+#
+# _OUTCOME_TO_MARK = {
+#     LinterOutcome.SKIP: '-',
+#     LinterOutcome.PASS: '\N{heavy check mark}',
+#     LinterOutcome.FAIL: '\N{heavy multiplication x}',
+#     LinterOutcome.WARN: '\N{exclamation mark}',
+#     LinterOutcome.FIXED: '\N{heavy check mark}'
+# }
+
+_OUTCOME_TO_MARK = {
+    LinterOutcome.SKIP: 'skip',
+    LinterOutcome.PASS: 'pass',
+    LinterOutcome.FAIL: 'fail',
+    LinterOutcome.WARN: 'warn',
+    LinterOutcome.FIXED: 'fix '
+    }
+
+_OUTCOME_TO_COLOR = {
+    LinterOutcome.SKIP: 'blue',
+    LinterOutcome.PASS: 'green',
+    LinterOutcome.FAIL: 'red',
+    LinterOutcome.WARN: 'yellow',
+    LinterOutcome.FIXED: 'green'
+    }
+
+
+#: Info on how a linter decided: linter itself, its outcome & the message.
+LinterRuling = Tuple['Linter', LinterOutcome, LinterOutcome, str]
+#: A return value type of a single linter.
+LinterReturn = Generator[Tuple[LinterOutcome, str], None, None]
+#: A linter itself, a callable method.
+LinterCallback = Callable[['Lintable'], LinterReturn]
+
+
+@dataclasses.dataclass(init=False)
+class Linter:
+    """ A single linter """
+
+    callback: LinterCallback
+    id: str
+
+    def __init__(self, callback: LinterCallback) -> None:
+        self.callback = callback
+
+        if not callback.__doc__:
+            raise tmt.utils.GeneralError(f"Linter '{callback}' lacks docstring.")
+
+        id, _ = textwrap.dedent(callback.__doc__).strip().split(':', 1)
+
+        self.id = id.strip()
+
+
+class Lintable(Generic[LintableT]):
+    """ Mixin class adding support for linting of class instances """
+
+    # Declare linter registry as a class variable, but do not initialize it. If initialized
+    # here, the mapping would be shared by all classes, which is not a desirable attribute.
+    # Instead, mapping will be created by `get_linter_registry()`.
+    _linter_registry: ClassVar[List[Linter]]
+
+    # Keep this method around, to correctly support Python's method resolution order.
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+    # Cannot use @property as this must remain classmethod
+    @classmethod
+    def get_linter_registry(cls) -> List[Linter]:
+        """ Return - or initialize - linter registry """
+
+        if not hasattr(cls, '_linter_registry'):
+            cls._linter_registry = []
+
+        return cls._linter_registry
+
+    @classmethod
+    def discover_linters(cls) -> None:
+        """
+        Discover and register all linters implemented by this class.
+
+        A linter is a method whose name starts with ``lint_`` prefix. It must
+        have a docstring which serves as a hint for ``--list-checks`` output.
+        """
+
+        for name in dir(cls):
+            if not name.startswith('lint_'):
+                continue
+
+            cls.get_linter_registry().append(tmt.lint.Linter(getattr(cls, name)))
+
+    @classmethod
+    def resolve_enabled_linters(
+            cls,
+            enable_checks: Optional[List[str]] = None,
+            disable_checks: Optional[List[str]] = None
+            ) -> List[Linter]:
+        """
+        Produce a list of enabled linters from all registered ones.
+
+        Method combines three inputs:
+
+        * registered linters, acquired from the class registry,
+        * list of checks to enable, and
+        * list of checks to disable
+
+        into a single list of checks that are considered as enabled.
+
+        :param enable_checks: if set, only listed checks would be included in
+            the output.
+        :param disable_checks: if set, listed checks would be removed from the
+            output.
+        :returns: list of linters that were registered, enabled and not
+            disabled.
+        """
+
+        linters: List[Linter] = []
+
+        if not enable_checks:
+            linters = cls.get_linter_registry()
+
+        else:
+            linters = []
+
+            for needle in enable_checks:
+                linters += [
+                    linter
+                    for linter in cls.get_linter_registry()
+                    if needle in linter.id
+                    ]
+
+        if disable_checks:
+            linters = [
+                linter for linter in linters
+                if linter.id not in disable_checks
+                ]
+
+        return linters
+
+    def lint(
+            self,
+            enable_checks: Optional[List[str]] = None,
+            disable_checks: Optional[List[str]] = None,
+            enforce_checks: Optional[List[str]] = None) -> Tuple[bool, List[LinterRuling]]:
+        """
+        Check the instance against a battery of linters and report results.
+
+        :param enable_checks: if set, only listed checks would be applied.
+        :param disable_checks: if set, listed checks would not be applied.
+        :param enforce_checks: if set, listed checks would be marked as failed
+            if their outcome is not ``pass``, i.e. even a warning would become
+            a fail.
+        :returns: a tuple of two items: a boolean reporting whether the instance
+            passed the test, and a list of :py:class:`LinterRuling` items, each
+            describing one linter outcome. Note that linters may produce none or
+            more than one outcome.
+        """
+
+        enforce_checks = enforce_checks or []
+
+        linters = self.resolve_enabled_linters(
+            enable_checks=enable_checks,
+            disable_checks=disable_checks)
+
+        valid = True
+        rulings: List[LinterRuling] = []
+
+        for linter in sorted(linters, key=lambda x: x.id):
+            for outcome, message in linter.callback(self):
+                if outcome == LinterOutcome.FAIL:
+                    rulings.append((linter, outcome, outcome, message))
+
+                    valid = False
+
+                elif outcome != LinterOutcome.PASS:
+                    if linter.id in enforce_checks:
+                        rulings.append((linter, outcome, LinterOutcome.FAIL, message))
+
+                        valid = False
+
+                    else:
+                        rulings.append((linter, outcome, outcome, message))
+
+                else:
+                    rulings.append((linter, outcome, outcome, message))
+
+        return valid, rulings
+
+    @classmethod
+    def format_linters(cls) -> str:
+        """
+        Format registered linters for printing or logging.
+
+        :returns: a string description of registered linters, suitable for
+            logging or help texts.
+        """
+
+        hints: List[str] = []
+
+        for linter in sorted(cls.get_linter_registry(), key=lambda x: x.id):
+            # This has been already verified when registering the linter
+            assert linter.callback.__doc__ is not None
+
+            hints.append(textwrap.dedent(linter.callback.__doc__).strip())
+
+        return '\n'.join(hints)
+
+
+def filter_allowed_checks(
+        rulings: Iterable[LinterRuling],
+        outcomes: Optional[List[LinterOutcome]] = None) -> Generator[LinterRuling, None, None]:
+    """
+    Filter only rulings whose outcomes are allowed.
+
+    :param rulings: rulings to process.
+    :param outcomes: a list of allowed ruling outcomes. If not set, all outcomes
+        are allowed.
+    :yields: rulings with allowed outcomes.
+    """
+
+    outcomes = outcomes or []
+
+    for linter, actual_outcome, eventual_outcome, message in rulings:
+        if outcomes and eventual_outcome not in outcomes:
+            continue
+
+        yield (linter, actual_outcome, eventual_outcome, message)
+
+
+def format_rulings(rulings: Iterable[LinterRuling]) -> Generator[str, None, None]:
+    """
+    Format rulings for printing or logging.
+
+    :param rulings: rulings to format.
+    :yields: rulings formatted as separate strings.
+    """
+
+    # Find out whether there is a ruling whose actual outcome is not the same
+    # as its eventual outcome. That means the actual outcome has been overruled,
+    # waived or turned into a failure - if there is any such ruling, we should
+    # display the actual => eventual transition. If there's no such ruling, we
+    # can display just one outcome, they are both same, and indentation and
+    # padding would be simpler.
+    display_eventual = any(
+        actual_outcome != eventual_outcome for _, actual_outcome, eventual_outcome, _ in rulings)
+
+    for linter, actual_outcome, eventual_outcome, message in rulings:
+        assert actual_outcome in _OUTCOME_TO_MARK
+        assert actual_outcome in _OUTCOME_TO_COLOR
+
+        actual_status = style(
+            _OUTCOME_TO_MARK[actual_outcome],
+            fg=_OUTCOME_TO_COLOR[actual_outcome])
+
+        if display_eventual:
+            assert eventual_outcome in _OUTCOME_TO_MARK
+            assert eventual_outcome in _OUTCOME_TO_COLOR
+
+            eventual_status = style(
+                _OUTCOME_TO_MARK[eventual_outcome],
+                fg=_OUTCOME_TO_COLOR[eventual_outcome])
+
+            if actual_outcome == eventual_outcome:
+                eventual = ' ' * 8
+
+            else:
+                eventual = f' -> {eventual_status}'
+
+        else:
+            eventual = ''
+
+        yield f'{actual_status}{eventual} {linter.id} {message}'

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type
 
 import click
 
+import tmt.lint
 import tmt.log
 import tmt.utils
 
@@ -171,6 +172,47 @@ FMF_SOURCE_OPTIONS: List[ClickOptionDecoratorType] = [
 
 REMOTE_PLAN_OPTIONS: List[ClickOptionDecoratorType] = [
     click.option('-s', '--shallow', is_flag=True, help='Do not clone remote plan.')
+    ]
+
+
+_lint_outcomes = [member.value for member in tmt.lint.LinterOutcome.__members__.values()]
+
+LINT_OPTIONS: List[ClickOptionDecoratorType] = [
+    click.option(
+        '--list-checks',
+        is_flag=True,
+        help='List all available checks.'),
+    click.option(
+        '--enable-check',
+        'enable_checks',
+        metavar='CHECK-ID',
+        multiple=True,
+        type=str,
+        help='Run only checks mentioned by this option.'),
+    click.option(
+        '--disable-check',
+        'disable_checks',
+        metavar='CHECK-ID',
+        multiple=True,
+        type=str,
+        help='Do not run checks mentioned by this option.'),
+    click.option(
+        '--enforce-check',
+        'enforce_checks',
+        metavar='CHECK-ID',
+        multiple=True,
+        type=str,
+        help='Consider linting as failed if any of the checks is not a pass.'),
+    click.option(
+        '--failed-only',
+        is_flag=True,
+        help='Display only tests/plans/stories that fail a check.'),
+    click.option(
+        '--outcome-only',
+        metavar='|'.join(_lint_outcomes),
+        multiple=True,
+        type=click.Choice(_lint_outcomes),
+        help='Display only checks with the given outcome.')
     ]
 
 


### PR DESCRIPTION
The existing user-facing API did not change, we still have the CLI commands we're used to, `tmt [test|plan|story] lint` and `tmt lint`. internally, things are not different, with linters split into categories, automagical discovery, formalized internal APIs, and new CLI look (`--list-checks`, `--failed-only`, `--enable-checks` & brand new output).

```
$ tmt story lint /spec/plans/import
/spec/plans/import
pass C000 fmf node passes schema validation
pass C001 summary key is set
pass C002 summary is reasonably long
pass S001 correct key are used
fail S002 story is required
```

Fixes #2006 