### PR TITLE
Support logging "topics" to allow lower unnecessary verbosity

### DIFF
--- a/tests/core/logging/main.fmf
+++ b/tests/core/logging/main.fmf
@@ -1,0 +1,1 @@
+summary: Verify the basic logging behavior

--- a/tests/core/logging/test.sh
+++ b/tests/core/logging/test.sh
@@ -7,11 +7,11 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Logging topics"
-        rlRun -s "tmt -dddd plan show > /dev/null"
+        rlRun -s "tmt -dddd plan show /plans/features/core > /dev/null"
         rlAssertNotGrep "key source" $rlRun_LOG
         rlAssertNotGrep "normalized fields" $rlRun_LOG
 
-        rlRun -s "tmt --log-topic=key-normalization -dddd plan show > /dev/null"
+        rlRun -s "tmt --log-topic=key-normalization -dddd plan show /plans/features/core > /dev/null"
         rlAssertGrep "key source" $rlRun_LOG
         rlAssertGrep "normalized fields" $rlRun_LOG
     rlPhaseEnd

--- a/tests/core/logging/test.sh
+++ b/tests/core/logging/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Logging topics"
+        rlRun -s "tmt -dddd plan show > /dev/null"
+        rlAssertNotGrep "key source" $rlRun_LOG
+        rlAssertNotGrep "normalized fields" $rlRun_LOG
+
+        rlRun -s "tmt --log-topic=key-normalization -dddd plan show > /dev/null"
+        rlAssertGrep "key source" $rlRun_LOG
+        rlAssertGrep "normalized fields" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -324,11 +324,19 @@ def test_indent(key, value, color, level, labels, labels_padding, expected):
             Topic.KEY_NORMALIZATION,
             True
             ),
+        (
+            {Topic.KEY_NORMALIZATION},
+            None,
+            True
+            ),
         ],
     ids=(
         'no logger topics, no message topic',
         'no logger topics, message has topic',
-        'message for enabled topic'
+        'message for enabled topic',
+        'logger topic, no message topic'
+        # TODO: enable once we have more than one topic
+        # 'message for disabled topic'
         )
     )
 def test_topic_filter(

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -524,6 +524,8 @@ class Logger:
 
         handler.setFormatter(LogfileFormatter())
 
+        handler.addFilter(TopicFilter())
+
         self._logger.addHandler(handler)
 
     def add_console_handler(self, apply_colors: bool = False) -> None:

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -56,7 +56,7 @@ VERBOSITY_OPTIONS: List[ClickOptionDecoratorType] = [
         metavar=f'[{"|".join(topic.value for topic in tmt.log.Topic)}]',
         multiple=True,
         type=str,
-        help='If specified, --debug and --verbose would emit logs only for these topics.')
+        help='If specified, --debug and --verbose would emit logs also for these topics.')
     ]
 
 # Force and dry actions

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type
 
 import click
 
+import tmt.log
 import tmt.utils
 
 # When dealing with older Click packages (I'm looking at you, Python 3.6),
@@ -50,6 +51,12 @@ VERBOSITY_OPTIONS: List[ClickOptionDecoratorType] = [
     click.option(
         '-q', '--quiet', is_flag=True,
         help='Be quiet. Exit code is just enough for me.'),
+    click.option(
+        '--log-topic',
+        metavar=f'[{"|".join(topic.value for topic in tmt.log.Topic)}]',
+        multiple=True,
+        type=str,
+        help='If specified, --debug and --verbose would emit logs only for these topics.')
     ]
 
 # Force and dry actions

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -9,6 +9,7 @@ import click
 
 import tmt
 import tmt.base
+import tmt.log
 import tmt.options
 import tmt.steps
 import tmt.steps.execute
@@ -170,7 +171,8 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             value: Optional[str] = None,
             color: Optional[str] = None,
             shift: int = 2,
-            level: int = 3) -> None:
+            level: int = 3,
+            topic: Optional[tmt.log.Topic] = None) -> None:
         """ Custom logger for test output with shift 2 and level 3 defaults """
         self.verbose(key=key, value=value, color=color, shift=shift, level=level)
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -179,7 +179,8 @@ class BaseLoggerFnType(Protocol):
             value: Optional[str] = None,
             color: Optional[str] = None,
             shift: int = 0,
-            level: int = 1) -> None:
+            level: int = 1,
+            topic: Optional[tmt.log.Topic] = None) -> None:
         pass
 
 
@@ -888,13 +889,14 @@ class Common(_CommonBase):
             value: Optional[str] = None,
             color: Optional[str] = None,
             shift: int = 0,
-            level: int = 1) -> None:
+            level: int = 1,
+            topic: Optional[tmt.log.Topic] = None) -> None:
         """
         Show message if in requested verbose mode level
 
         In quiet mode verbose messages are not displayed.
         """
-        self._logger.verbose(key, value=value, color=color, shift=shift, level=level)
+        self._logger.verbose(key, value=value, color=color, shift=shift, level=level, topic=topic)
 
     def debug(
             self,
@@ -902,13 +904,14 @@ class Common(_CommonBase):
             value: Optional[str] = None,
             color: Optional[str] = None,
             shift: int = 0,
-            level: int = 1) -> None:
+            level: int = 1,
+            topic: Optional[tmt.log.Topic] = None) -> None:
         """
         Show message if in requested debug mode level
 
         In quiet mode debug messages are not displayed.
         """
-        self._logger.debug(key, value=value, color=color, shift=shift, level=level)
+        self._logger.debug(key, value=value, color=color, shift=shift, level=level, topic=topic)
 
     def warn(self, message: str, shift: int = 0) -> None:
         """ Show a yellow warning message on info level, send to stderr """
@@ -924,14 +927,15 @@ class Common(_CommonBase):
             value: Optional[str] = None,
             color: Optional[str] = None,
             shift: int = 1,
-            level: int = 3) -> None:
+            level: int = 3,
+            topic: Optional[tmt.log.Topic] = None) -> None:
         """
         Reports the executed command in verbose mode.
 
         This is a tailored verbose() function used for command logging where
         default parameters are adjusted (to preserve the function type).
         """
-        self.verbose(key=key, value=value, color=color, shift=shift, level=level)
+        self.verbose(key=key, value=value, color=color, shift=shift, level=level, topic=topic)
 
     def run(self,
             command: Command,

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -3955,17 +3955,37 @@ def dataclass_normalize_field(
         logger.debug(
             'field normalized to false-ish value',
             f'{container.__class__.__name__}.{keyname}',
-            level=4)
+            level=4,
+            topic=tmt.log.Topic.KEY_NORMALIZATION)
 
         with_getattr = getattr(container, keyname, None)
         with_dict = container.__dict__.get(keyname, None)
 
-        logger.debug('value', str(value), level=4, shift=1)
-        logger.debug('current value (getattr)', str(with_getattr), level=4, shift=1)
-        logger.debug('current value (__dict__)', str(with_dict), level=4, shift=1)
+        logger.debug(
+            'value',
+            str(value),
+            level=4,
+            shift=1,
+            topic=tmt.log.Topic.KEY_NORMALIZATION)
+        logger.debug(
+            'current value (getattr)',
+            str(with_getattr),
+            level=4,
+            shift=1,
+            topic=tmt.log.Topic.KEY_NORMALIZATION)
+        logger.debug(
+            'current value (__dict__)',
+            str(with_dict),
+            level=4,
+            shift=1,
+            topic=tmt.log.Topic.KEY_NORMALIZATION)
 
         if value != with_getattr or with_getattr != with_dict:
-            logger.debug('known values do not match', level=4, shift=2)
+            logger.debug(
+                'known values do not match',
+                level=4,
+                shift=2,
+                topic=tmt.log.Topic.KEY_NORMALIZATION)
 
     # Set attribute by adding it to __dict__ directly. Messing with setattr()
     # might cause re-use of mutable values by other instances.
@@ -4216,8 +4236,16 @@ class NormalizeKeysMixin(_CommonBase):
 
         LOG_SHIFT, LOG_LEVEL = 2, 4
 
-        debug_intro = functools.partial(logger.debug, shift=LOG_SHIFT - 1, level=LOG_LEVEL)
-        debug = functools.partial(logger.debug, shift=LOG_SHIFT, level=LOG_LEVEL)
+        debug_intro = functools.partial(
+            logger.debug,
+            shift=LOG_SHIFT - 1,
+            level=LOG_LEVEL,
+            topic=tmt.log.Topic.KEY_NORMALIZATION)
+        debug = functools.partial(
+            logger.debug,
+            shift=LOG_SHIFT,
+            level=LOG_LEVEL,
+            topic=tmt.log.Topic.KEY_NORMALIZATION)
 
         debug_intro('key source')
         for k, v in key_source.items():


### PR DESCRIPTION
Many verbose and debug messages are not interesting until a very specific kind of error appears. This is especially true for key normalization or command timestamps - both were added recently, both increased verbosity a lot. This patch allows splitting debug and verbose messages into "topics" that can be enabled when needed, e.g. when reproducing an issue or debugging a user report.

```shell
$ tmt -vvdd run ...
$ tmt -vvdd --log-topic key-normalization run ...
```