### PR TITLE
Fix forgotten guest when Artemis provisioning times out

### DIFF
--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -354,6 +354,10 @@ class GuestArtemis(tmt.GuestSsh):
                         seconds=self.provision_timeout), tick=self.provision_tick)
 
             except tmt.utils.WaitingTimedOutError:
+                # The provisioning chain has been already started, make sure we
+                # remove the guest.
+                self.remove()
+
                 raise ProvisionError(
                     f'Failed to provision in the given amount '
                     f'of time (--provision-timeout={self.provision_timeout}).')


### PR DESCRIPTION
The request has been submitted, and even when it fails to materialize, plugin needs to remove it before bailing out.