### PR TITLE
Add /root/.local/bin to PATH on Centos Stream 8 in CI

### DIFF
--- a/plans/features/advanced.fmf
+++ b/plans/features/advanced.fmf
@@ -6,7 +6,7 @@ description:
 discover:
     how: fmf
     filter: 'tier: 3'
-adjust:
+adjust+:
 -   when: distro == centos-stream, rhel
     because: pre-commit is not available from epel, use pip instead
     prepare+:

--- a/plans/features/main.fmf
+++ b/plans/features/main.fmf
@@ -13,3 +13,11 @@ prepare+:
       # have to run as root to do that, and who's running tmt test suite
       # as root?
       - pip3 install --user yq || pip3 install yq
+      - yq --help
+
+adjust+:
+  - when: distro == centos-stream-8 and trigger == commit
+    environment+:
+      # Default PATH, spiked with ~/.local/bin for Python packages installed with --user.
+      # This is needed on Centos Stream 8 where the user-specific path is not in PATH.
+      PATH: "/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"


### PR DESCRIPTION
This path is missing, therefore tests do not have access to Python packages installed with `--user`. Local development on Centos Stream should not be affected as it should be using virtualenv anyway.