### PR TITLE
Expose "key address" to normalization callbacks

### DIFF
--- a/tests/core/fmf-id/test.sh
+++ b/tests/core/fmf-id/test.sh
@@ -14,7 +14,7 @@ rlJournalStart
 
         rlRun -s "tmt plan -vvvv show /plan-with-invalid-ref" 2
         rlAssertGrep "warn: /plan-with-invalid-ref:discover .* is not valid under any of the given schemas" $rlRun_LOG
-        rlAssertGrep "Failed to load step data for DiscoverFmfStepData: Field 'DiscoverFmfStepData:ref' can be string, 'int' found." $rlRun_LOG
+        rlAssertGrep "Failed to load step data for DiscoverFmfStepData: Field 'DiscoverFmfStepData:ref' must be string, 'int' found." $rlRun_LOG
 
         rlRun -s "tmt plan -vvvv show /remote-plan-with-valid-ref"
 
@@ -29,7 +29,7 @@ rlJournalStart
 
         rlRun -s "tmt test -vvvv show /test-with-invalid-ref" 2
         rlAssertGrep "warn: /test-with-invalid-ref:require .* is not valid under any of the given schemas" $rlRun_LOG
-        rlAssertGrep "Field 'ref' can be not set or string, 'int' found." $rlRun_LOG
+        rlAssertGrep "Field 'ref' must be unset or a string, 'int' found." $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/core/fmf-id/test.sh
+++ b/tests/core/fmf-id/test.sh
@@ -14,7 +14,7 @@ rlJournalStart
 
         rlRun -s "tmt plan -vvvv show /plan-with-invalid-ref" 2
         rlAssertGrep "warn: /plan-with-invalid-ref:discover .* is not valid under any of the given schemas" $rlRun_LOG
-        rlAssertGrep "Failed to load step data for DiscoverFmfStepData: Field 'DiscoverFmfStepData:ref' must be string, 'int' found." $rlRun_LOG
+        rlAssertGrep "Failed to load step data for DiscoverFmfStepData: Field 'DiscoverFmfStepData:ref' must be a string, 'int' found." $rlRun_LOG
 
         rlRun -s "tmt plan -vvvv show /remote-plan-with-valid-ref"
 

--- a/tests/core/fmf-id/test.sh
+++ b/tests/core/fmf-id/test.sh
@@ -14,7 +14,7 @@ rlJournalStart
 
         rlRun -s "tmt plan -vvvv show /plan-with-invalid-ref" 2
         rlAssertGrep "warn: /plan-with-invalid-ref:discover .* is not valid under any of the given schemas" $rlRun_LOG
-        rlAssertGrep "Failed to load step data for DiscoverFmfStepData: The 'ref' field must be a string, got 'int'." $rlRun_LOG
+        rlAssertGrep "Failed to load step data for DiscoverFmfStepData: Field 'DiscoverFmfStepData:ref' can be string, 'int' found." $rlRun_LOG
 
         rlRun -s "tmt plan -vvvv show /remote-plan-with-valid-ref"
 
@@ -28,7 +28,8 @@ rlJournalStart
         rlAssertGrep "some-package" $rlRun_LOG
 
         rlRun -s "tmt test -vvvv show /test-with-invalid-ref" 2
-        rlAssertGrep "The 'ref' field must be a string, got 'int'." $rlRun_LOG
+        rlAssertGrep "warn: /test-with-invalid-ref:require .* is not valid under any of the given schemas" $rlRun_LOG
+        rlAssertGrep "Field 'ref' can be not set or string, 'int' found." $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -141,7 +141,7 @@ def test_link():
     # Invalid links and relations
     with pytest.raises(
             SpecificationError,
-            match="Field 'link' can be string, fmf id or list of their combinations,"
+            match="Field 'link' must be a string, a fmf id or a list of their combinations,"
                   " 'int' found."):
         Links(data=123)
     with pytest.raises(SpecificationError, match='Multiple relations'):

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -139,7 +139,10 @@ def test_link():
             note=fmf_id['note'])]
 
     # Invalid links and relations
-    with pytest.raises(SpecificationError, match='Invalid link'):
+    with pytest.raises(
+            SpecificationError,
+            match="Field 'link' can be string, fmf id or list of their commbinations,"
+                  " 'int' found."):
         Links(data=123)
     with pytest.raises(SpecificationError, match='Multiple relations'):
         Links(data=dict(verifies='one', blocks='another'))

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -141,7 +141,7 @@ def test_link():
     # Invalid links and relations
     with pytest.raises(
             SpecificationError,
-            match="Field 'link' can be string, fmf id or list of their commbinations,"
+            match="Field 'link' can be string, fmf id or list of their combinations,"
                   " 'int' found."):
         Links(data=123)
     with pytest.raises(SpecificationError, match='Multiple relations'):

--- a/tests/unit/test_dataclasses.py
+++ b/tests/unit/test_dataclasses.py
@@ -24,7 +24,7 @@ def test_field_normalize_callback(root_logger: tmt.log.Logger) -> None:
             return int(raw_value)
 
         except ValueError as exc:
-            raise tmt.utils.NormalizationError(key_address, raw_value, 'not set or integer') \
+            raise tmt.utils.NormalizationError(key_address, raw_value, 'unset or an integer') \
                 from exc
 
     @dataclasses.dataclass
@@ -49,7 +49,7 @@ def test_field_normalize_callback(root_logger: tmt.log.Logger) -> None:
 
     with pytest.raises(
             tmt.utils.SpecificationError,
-            match=r"Field ':foo' can be not set or integer, 'str' found."):
+            match=r"Field ':foo' must be unset or an integer, 'str' found."):
         dataclass_normalize_field(data, ':foo', 'foo', 'will crash', root_logger)
 
     assert data.foo == 3
@@ -64,7 +64,7 @@ def test_field_normalize_special_method(root_logger: tmt.log.Logger) -> None:
             return int(raw_value)
 
         except ValueError as exc:
-            raise tmt.utils.NormalizationError(key_address, raw_value, 'not set or integer') \
+            raise tmt.utils.NormalizationError(key_address, raw_value, 'unset or an integer') \
                 from exc
 
     @dataclasses.dataclass
@@ -90,7 +90,7 @@ def test_field_normalize_special_method(root_logger: tmt.log.Logger) -> None:
 
     with pytest.raises(
             tmt.utils.SpecificationError,
-            match=r"Field ':foo' can be not set or integer, 'str' found."):
+            match=r"Field ':foo' must be unset or an integer, 'str' found."):
         dataclass_normalize_field(data, ':foo', 'foo', 'will crash', root_logger)
 
     assert data.foo == 3

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -162,7 +162,7 @@ class FmfId(
         ref = raw.get('ref', None)
         if not isinstance(ref, (type(None), str)):
             # TODO: deliver better key address
-            raise tmt.utils.NormalizationError('ref', ref, 'not set or string')
+            raise tmt.utils.NormalizationError('ref', ref, 'unset or a string')
 
         fmf_id = FmfId()
 
@@ -375,7 +375,7 @@ class DependencyFmfId(FmfId):
         ref = raw.get('ref', None)
         if not isinstance(ref, (type(None), str)):
             # TODO: deliver better key address
-            raise tmt.utils.NormalizationError('ref', ref, 'not set or string')
+            raise tmt.utils.NormalizationError('ref', ref, 'unset or a string')
 
         fmf_id = DependencyFmfId()
 
@@ -504,7 +504,13 @@ def normalize_require(
     if isinstance(raw_require, str) or isinstance(raw_require, dict):
         return [dependency_factory(raw_require)]
 
-    return [dependency_factory(require) for require in raw_require]
+    if isinstance(raw_require, list):
+        return [dependency_factory(require) for require in raw_require]
+
+    raise tmt.utils.NormalizationError(
+        key_address,
+        raw_require,
+        'a string, a library, a file or a list of their combinations')
 
 
 def assert_simple_dependencies(
@@ -1502,7 +1508,7 @@ class Plan(
         environment_files = node.get("environment-file") or []
         if not isinstance(environment_files, list):
             raise tmt.utils.NormalizationError(
-                f'{self.name}:environment-file', environment_files, 'list of paths')
+                f'{self.name}:environment-file', environment_files, 'unset or a list of paths')
         combined = tmt.utils.environment_files_to_dict(
             filenames=environment_files,
             root=Path(node.root) if node.root else None,
@@ -3489,7 +3495,7 @@ class Links(tmt.utils.SpecBasedContainer):
         if data is not None and not isinstance(data, (str, dict, list)):
             # TODO: deliver better key address, needs to know the parent
             raise tmt.utils.NormalizationError(
-                'link', data, 'string, fmf id or list of their combinations')
+                'link', data, 'a string, a fmf id or a list of their combinations')
 
         # Nothing to do if no data provided
         if data is None:

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -567,7 +567,7 @@ class Core(
     enabled: bool = True
     order: int = field(
         default=DEFAULT_ORDER,
-        normalize=lambda key_address, raw_value, logger: 
+        normalize=lambda key_address, raw_value, logger:
             DEFAULT_ORDER if raw_value is None else int(raw_value))
     link: Optional['Links'] = field(
         default=None,

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -3489,7 +3489,7 @@ class Links(tmt.utils.SpecBasedContainer):
         if data is not None and not isinstance(data, (str, dict, list)):
             # TODO: deliver better key address, needs to know the parent
             raise tmt.utils.NormalizationError(
-                'link', data, 'string, fmf id or list of their commbinations')
+                'link', data, 'string, fmf id or list of their combinations')
 
         # Nothing to do if no data provided
         if data is None:

--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -265,9 +265,9 @@ class BeakerLib(Library):
             raise tmt.utils.GeneralError(
                 f"Library '{self.name}' not found in '{self.repo}'.")
         self.require = tmt.base.normalize_require(
-            library_node.get('require', []), self.parent._logger)
+            f'{self.name}:require', library_node.get('require', []), self.parent._logger)
         self.recommend = tmt.base.normalize_require(
-            library_node.get('recommend', []), self.parent._logger)
+            f'{self.name}:recommend', library_node.get('recommend', []), self.parent._logger)
 
         # Create a symlink if the library is deep in the structure
         # FIXME: hot fix for https://github.com/beakerlib/beakerlib/pull/72

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -999,7 +999,8 @@ class BasePlugin(Phase):
             if value is None or value == [] or value == () or value is False:
                 continue
 
-            tmt.utils.dataclass_normalize_field(self.data, keyname, value, self._logger)
+            tmt.utils.dataclass_normalize_field(
+                self.data, f'{self.name}:{keyname}', keyname, value, self._logger)
 
     def wake(self) -> None:
         """

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -57,7 +57,7 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
             return None
 
         if not isinstance(value, str):
-            raise tmt.utils.NormalizationError(key_address, value, 'string')
+            raise tmt.utils.NormalizationError(key_address, value, 'a string')
 
         return value
 

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -50,14 +50,14 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
     # TODO: with mandatory validation, this can go away.
     def _normalize_ref(
             self,
+            key_address: str,
             value: Optional[Any],
             logger: tmt.log.Logger) -> Optional[str]:
         if value is None:
             return None
 
         if not isinstance(value, str):
-            raise tmt.utils.SpecificationError(
-                f"The 'ref' field must be a string, got '{type(value).__name__}'.")
+            raise tmt.utils.NormalizationError(key_address, value, 'string')
 
         return value
 

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -39,7 +39,7 @@ class TestDescription(
     # soon as possible - nobody want's to keep two very same lists of attributes.
     test: ShellScript = field(
         default=ShellScript(''),
-        normalize=lambda raw_value, logger: ShellScript(raw_value),
+        normalize=lambda key_address, raw_value, logger: ShellScript(raw_value),
         serialize=lambda test: str(test),
         unserialize=lambda serialized_test: ShellScript(serialized_test)
         )
@@ -51,11 +51,12 @@ class TestDescription(
     order: int = field(
         # TODO: ugly circular dependency (see tmt.base.DEFAULT_ORDER)
         default=50,
-        normalize=lambda raw_value, logger: 50 if raw_value is None else int(raw_value)
+        normalize=lambda key_address, raw_value, logger:
+            50 if raw_value is None else int(raw_value)
         )
     link: Optional[tmt.base.Links] = field(
         default=None,
-        normalize=lambda raw_value, logger: tmt.base.Links(data=raw_value),
+        normalize=lambda key_address, raw_value, logger: tmt.base.Links(data=raw_value),
         # Using `to_spec()` on purpose: `Links` does not provide serialization
         # methods, because specification of links is already good enough. We
         # can use existing `to_spec()` method, and undo it with a simple
@@ -74,11 +75,12 @@ class TestDescription(
         )
     tier: Optional[str] = field(
         default=None,
-        normalize=lambda raw_value, logger: None if raw_value is None else str(raw_value)
+        normalize=lambda key_address, raw_value, logger:
+            None if raw_value is None else str(raw_value)
         )
     adjust: Optional[List[tmt.base._RawAdjustRule]] = field(
         default=None,
-        normalize=lambda raw_value, logger: [] if raw_value is None else (
+        normalize=lambda key_address, raw_value, logger: [] if raw_value is None else (
             [raw_value] if not isinstance(raw_value, list) else raw_value
             )
         )
@@ -149,7 +151,7 @@ class TestDescription(
 class DiscoverShellData(tmt.steps.discover.DiscoverStepData):
     tests: List[TestDescription] = field(
         default_factory=list,
-        normalize=lambda raw_value, logger: [
+        normalize=lambda key_address, raw_value, logger: [
             TestDescription.from_spec(raw_datum, logger)
             for raw_datum in cast(List[Dict[str, Any]], raw_value)
             ],

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -473,11 +473,10 @@ class PrepareInstallData(tmt.steps.prepare.PrepareStepData):
         multiple=True,
         help='Package name or path to rpm to be installed.',
         # PrepareInstall supports *simple* requirements only
-        normalize=lambda value, logger: tmt.base.assert_simple_dependencies(
-            tmt.base.normalize_require(value, logger),
+        normalize=lambda key_address, value, logger: tmt.base.assert_simple_dependencies(
+            tmt.base.normalize_require(key_address, value, logger),
             "'install' plugin support simple packages only, no fmf links are allowed",
-            logger
-            ),
+            logger),
         serialize=lambda packages: [package.to_spec() for package in packages],
         unserialize=lambda serialized: [
             tmt.base.DependencySimple.from_spec(package)
@@ -522,7 +521,7 @@ class PrepareInstallData(tmt.steps.prepare.PrepareStepData):
         )
 
 
-@tmt.steps.provides_method('install')
+@ tmt.steps.provides_method('install')
 class PrepareInstall(tmt.steps.prepare.PreparePlugin):
     """
     Install packages on the guest

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -637,7 +637,7 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
                     setattr(data, int_key, int(value))
                 except ValueError as exc:
                     raise tmt.utils.NormalizationError(
-                        f'{self.name}:{int_key}', value, 'integer') from exc
+                        f'{self.name}:{int_key}', value, 'an integer') from exc
 
         for key, value in data.items():
             if key == 'memory':

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -635,9 +635,9 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
             if value is not None:
                 try:
                     setattr(data, int_key, int(value))
-                except ValueError:
-                    raise tmt.utils.SpecificationError(
-                        f"Value '{value}' cannot be converted to int for '{int_key}' attribute.")
+                except ValueError as exc:
+                    raise tmt.utils.NormalizationError(
+                        f'{self.name}:{int_key}', value, 'integer') from exc
 
         for key, value in data.items():
             if key == 'memory':

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1350,7 +1350,7 @@ class NormalizationError(SpecificationError):
         """
 
         super().__init__(
-            f"Field '{key_address}' can be {expected_type}, '{type(raw_value).__name__}' found.",
+            f"Field '{key_address}' must be {expected_type}, '{type(raw_value).__name__}' found.",
             *args,
             **kwargs)
 
@@ -4382,7 +4382,7 @@ def normalize_path_list(
     if isinstance(value, (list, tuple)):
         return [Path(path) for path in value]
 
-    raise NormalizationError(key_address, value, 'path or list of paths')
+    raise NormalizationError(key_address, value, 'a path or a list of paths')
 
 
 def normalize_shell_script_list(
@@ -4418,7 +4418,7 @@ def normalize_shell_script_list(
     if isinstance(value, (list, tuple)):
         return [ShellScript(str(item)) for item in value]
 
-    raise NormalizationError(key_address, value, 'string or list of strings')
+    raise NormalizationError(key_address, value, 'a string or a list of strings')
 
 
 def normalize_fmf_context(
@@ -4479,7 +4479,7 @@ class NormalizeKeysMixin(_CommonBase):
         if isinstance(value, (list, tuple)):
             return [item for item in value]
 
-        raise NormalizationError(key_address, value, 'string or list of strings')
+        raise NormalizationError(key_address, value, 'a string or a list of strings')
 
     def _normalize_environment(
             self,


### PR DESCRIPTION
Keys belong to various objects like step phases or fmf ids, and tmt can do better job when reporting unexpected input values. Another step is to expose the location of the key to normalization callbacks and a dedicated exception for reporting the violations in a unified manner.

The key address is already used by schema validation when reporting validation errors, and while it's often subpar, it enhances error messages a bit.

In the follow-up patches, improving the addresses will happen - for example, sometimes a class name is printed instead of a fmf node name, usually because the node name is not available.