### PR TITLE
Polish workdir pruning - pathlib transition & logging

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1742,7 +1742,7 @@ class Plan(Core, tmt.export.Exportable['Plan']):
     def prune(self) -> None:
         """ Remove all uninteresting files from the plan workdir """
 
-        logger = self._logger.descend(extra_shift=2)
+        logger = self._logger.descend(extra_shift=1)
 
         logger.verbose(
             f"Prune '{self.name}' plan workdir '{self.workdir}'.",
@@ -1754,7 +1754,7 @@ class Plan(Core, tmt.export.Exportable['Plan']):
             shutil.rmtree(self.worktree)
 
         for step in self.steps(disabled=True):
-            step.prune(logger)
+            step.prune(logger=step._logger)
 
 
 class StoryPriority(enum.Enum):

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1741,13 +1741,20 @@ class Plan(Core, tmt.export.Exportable['Plan']):
 
     def prune(self) -> None:
         """ Remove all uninteresting files from the plan workdir """
-        self.verbose(
-            "prune", f"Prune plan workdir '{self.workdir}'.", color="magenta", level=3, shift=2)
+
+        logger = self._logger.descend(extra_shift=2)
+
+        logger.verbose(
+            f"Prune '{self.name}' plan workdir '{self.workdir}'.",
+            color="magenta",
+            level=3)
+
         if self.worktree:
-            self.debug(f"Prune worktree '{self.worktree}'.", level=3, shift=2)
+            logger.debug(f"Prune '{self.name}' worktree '{self.worktree}'.", level=3)
             shutil.rmtree(self.worktree)
+
         for step in self.steps(disabled=True):
-            step.prune()
+            step.prune(logger)
 
 
 class StoryPriority(enum.Enum):

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -28,7 +28,7 @@ import enum
 import itertools
 import logging
 import logging.handlers
-import os.path
+import os
 import sys
 from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple, cast
 

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -122,7 +122,7 @@ class Discover(tmt.steps.Step):
     """ Gather information about test cases to be executed. """
 
     _plugin_base_class = DiscoverPlugin
-    _preserved_files = ['step.yaml', 'tests.yaml']
+    _preserved_workdir_members = ['step.yaml', 'tests.yaml']
 
     def __init__(
             self,

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -496,7 +496,7 @@ class Execute(tmt.steps.Step):
 
     _plugin_base_class = ExecutePlugin
 
-    _preserved_files = ['step.yaml', 'results.yaml', 'data']
+    _preserved_workdir_members = ['step.yaml', 'results.yaml', 'data']
 
     def __init__(
             self,

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1187,7 +1187,7 @@ class Provision(tmt.steps.Step):
 
     _plugin_base_class = ProvisionPlugin
 
-    _preserved_files = ['step.yaml', 'guests.yaml']
+    _preserved_workdir_members = ['step.yaml', 'guests.yaml']
 
     def __init__(
             self,

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -55,7 +55,7 @@ class ReportHtml(tmt.steps.report.ReportPlugin):
 
     _data_class = ReportHtmlData
 
-    def prune(self) -> None:
+    def prune(self, logger: tmt.log.Logger) -> None:
         """ Do not prune generated html report """
         pass
 

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -107,7 +107,7 @@ class ReportJUnit(tmt.steps.report.ReportPlugin):
 
     _data_class = ReportJUnitData
 
-    def prune(self) -> None:
+    def prune(self, logger: tmt.log.Logger) -> None:
         """ Do not prune generated junit report """
         pass
 

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -117,7 +117,7 @@ class ReportPolarion(tmt.steps.report.ReportPlugin):
 
     _data_class = ReportPolarionData
 
-    def prune(self) -> None:
+    def prune(self, logger: tmt.log.Logger) -> None:
         """ Do not prune generated xunit report """
         pass
 


### PR DESCRIPTION
It started as switching `prune()` chain of calls to `Path`, but when I started, I also tried to improve few other aspects that were puzzling for me when looking at paths:

* "preserved files" => "preserved workdir members" - it's not just files, directories also appear;
* `Path` instead of `os.path` (`os.listdir()` => `workdir.iterdir()` and so on);
* logging improvements, removed some quote incosistencies and added more hierarchy with loggers & `logger.descend()`:

```
        Prune '/plans/features/core' plan workdir '/var/tmp/tmt/run-187/plans/features/core'.
        Prune '/plans/features/core' worktree '/var/tmp/tmt/run-187/plans/features/core/tree'.
        Prune 'discover' step workdir '/var/tmp/tmt/run-187/plans/features/core/discover'.
            Remove 'default-0' workdir '/var/tmp/tmt/run-187/plans/features/core/discover/default-0'.
            Preserve 'step.yaml'.
            Preserve 'tests.yaml'.
        Prune 'provision' step workdir '/var/tmp/tmt/run-187/plans/features/core/provision'.
            Remove 'default-0' workdir '/var/tmp/tmt/run-187/plans/features/core/provision/default-0'.
            Preserve 'step.yaml'.
            Preserve 'guests.yaml'.
```

Follow up of https://github.com/teemtee/tmt/pull/1776.