### PR TITLE
Define a "plugin registry" class

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -695,7 +695,7 @@ def tests_import(
         tmt.convert.adjust_runtest(path / 'runtest.sh')
 
 
-_test_export_formats = list(tmt.Test.get_export_plugin_registry().keys())
+_test_export_formats = list(tmt.Test.get_export_plugin_registry().iter_plugin_ids())
 _test_export_default = 'yaml'
 
 
@@ -962,7 +962,7 @@ def plans_create(
     tmt.Plan.create(name, template, context.obj.tree.root, force)
 
 
-_plan_export_formats = list(tmt.Plan.get_export_plugin_registry().keys())
+_plan_export_formats = list(tmt.Plan.get_export_plugin_registry().iter_plugin_ids())
 _plan_export_default = 'yaml'
 
 
@@ -1211,7 +1211,7 @@ def stories_coverage(
     echo()
 
 
-_story_export_formats = list(tmt.Story.get_export_plugin_registry().keys())
+_story_export_formats = list(tmt.Story.get_export_plugin_registry().iter_plugin_ids())
 _story_export_default = 'yaml'
 
 

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -16,6 +16,7 @@ import tmt.base
 import tmt.steps
 import tmt.utils
 from tmt.options import option
+from tmt.plugins import PluginRegistry
 from tmt.steps import Action
 from tmt.utils import Command, GeneralError, Path, flatten
 
@@ -43,8 +44,8 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin):
 
     _data_class = DiscoverStepData
 
-    # List of all supported methods aggregated from all plugins of the same step.
-    _supported_methods: List[tmt.steps.Method] = []
+    # Methods ("how: ..." implementations) registered for the same step.
+    _supported_methods: PluginRegistry[tmt.steps.Method] = PluginRegistry()
 
     @classmethod
     def base_command(

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -14,6 +14,7 @@ import tmt.base
 import tmt.steps
 import tmt.utils
 from tmt.options import option
+from tmt.plugins import PluginRegistry
 from tmt.queue import TaskOutcome
 from tmt.result import Result, ResultGuestData, ResultOutcome
 from tmt.steps import Action, PhaseQueue, QueuedPhase, Step, StepData
@@ -121,8 +122,8 @@ class ExecutePlugin(tmt.steps.Plugin):
 
     _data_class = ExecuteStepData
 
-    # List of all supported methods aggregated from all plugins of the same step.
-    _supported_methods: List[tmt.steps.Method] = []
+    # Methods ("how: ..." implementations) registered for the same step.
+    _supported_methods: PluginRegistry[tmt.steps.Method] = PluginRegistry()
 
     # Internal executor is the default implementation
     how = 'tmt'

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -8,6 +8,7 @@ import fmf
 import tmt
 import tmt.steps
 from tmt.options import option
+from tmt.plugins import PluginRegistry
 from tmt.steps import (Action, Method, PhaseQueue, PullTask, QueuedPhase,
                        TaskOutcome, sync_with_guests)
 from tmt.steps.provision import Guest
@@ -26,8 +27,8 @@ class FinishPlugin(tmt.steps.Plugin):
 
     _data_class = FinishStepData
 
-    # List of all supported methods aggregated from all plugins of the same step.
-    _supported_methods: List[Method] = []
+    # Methods ("how: ..." implementations) registered for the same step.
+    _supported_methods: PluginRegistry[Method] = PluginRegistry()
 
     @classmethod
     def base_command(

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -14,6 +14,7 @@ import tmt.steps
 import tmt.steps.provision
 import tmt.utils
 from tmt.options import option
+from tmt.plugins import PluginRegistry
 from tmt.queue import TaskOutcome
 from tmt.steps import (Action, PhaseQueue, PullTask, PushTask, QueuedPhase,
                        sync_with_guests)
@@ -45,8 +46,8 @@ class PreparePlugin(tmt.steps.Plugin):
 
     _data_class = PrepareStepData
 
-    # List of all supported methods aggregated from all plugins of the same step.
-    _supported_methods: List[tmt.steps.Method] = []
+    # Methods ("how: ..." implementations) registered for the same step.
+    _supported_methods: PluginRegistry[tmt.steps.Method] = PluginRegistry()
 
     @classmethod
     def base_command(

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -23,6 +23,7 @@ import tmt.plugins
 import tmt.steps
 import tmt.utils
 from tmt.options import option
+from tmt.plugins import PluginRegistry
 from tmt.steps import Action
 from tmt.utils import BaseLoggerFnType, Command, Path, ShellScript, field
 
@@ -1335,8 +1336,8 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin):
     # Default implementation for provision is a virtual machine
     how = 'virtual'
 
-    # List of all supported methods aggregated from all plugins of the same step.
-    _supported_methods: List[tmt.steps.Method] = []
+    # Methods ("how: ..." implementations) registered for the same step.
+    _supported_methods: PluginRegistry[tmt.steps.Method] = PluginRegistry()
 
     # TODO: Generics would provide a better type, https://github.com/teemtee/tmt/issues/1437
     _guest: Optional[Guest] = None

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -1,11 +1,13 @@
 import dataclasses
-from typing import TYPE_CHECKING, Any, List, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Type, Union, cast
 
 import click
 
 import tmt
+import tmt.plugins
 import tmt.steps
 from tmt.options import option
+from tmt.plugins import PluginRegistry
 from tmt.steps import Action
 
 if TYPE_CHECKING:
@@ -25,8 +27,8 @@ class ReportPlugin(tmt.steps.GuestlessPlugin):
     # Default implementation for report is display
     how = 'display'
 
-    # List of all supported methods aggregated from all plugins of the same step.
-    _supported_methods: List[tmt.steps.Method] = []
+    # Methods ("how: ..." implementations) registered for the same step.
+    _supported_methods: PluginRegistry[tmt.steps.Method] = PluginRegistry()
 
     @classmethod
     def base_command(


### PR DESCRIPTION
The class is fairly trivial, but draws a clear distinction between an arbitrary dictionary and a "plugin registry" object. New types of plugins are heading our way, therefore making boundaries more visible, to clear up responsibilities.

Part of the effort behind https://github.com/teemtee/tmt/issues/1838 and https://github.com/teemtee/tmt/pull/216.