### PR TITLE
Include guest name in execute phase data paths

### DIFF
--- a/tests/discover/order.sh
+++ b/tests/discover/order.sh
@@ -49,9 +49,9 @@ rlJournalStart
 /tests/no-order-2
 EOF
     cat > $tmp/EXPECTED-EXECUTION <<EOF
-/tests/no-order-0-1
-/tests/no-order-1-2
-/tests/no-order-2-3
+/guest/default-0/tests/no-order-0-1
+/guest/default-0/tests/no-order-1-2
+/guest/default-0/tests/no-order-2-3
 EOF
     run_test
 
@@ -63,9 +63,9 @@ EOF
 /tests/no-order-2
 EOF
     cat > $tmp/EXPECTED-EXECUTION <<EOF
-/tests/no-order-0-1
-/tests/no-order-1-2
-/tests/no-order-2-3
+/guest/default-0/tests/no-order-0-1
+/guest/default-0/tests/no-order-1-2
+/guest/default-0/tests/no-order-2-3
 EOF
     run_test
 
@@ -77,9 +77,9 @@ EOF
 /tests/no-order-1
 EOF
     cat > $tmp/EXPECTED-EXECUTION <<EOF
-/tests/no-order-2-1
-/tests/no-order-0-2
-/tests/no-order-1-3
+/guest/default-0/tests/no-order-2-1
+/guest/default-0/tests/no-order-0-2
+/guest/default-0/tests/no-order-1-3
 EOF
     run_test
 
@@ -92,10 +92,10 @@ EOF
 /tests/no-order-1
 EOF
     cat > $tmp/EXPECTED-EXECUTION <<EOF
-/tests/no-order-2-1
-/tests/order-80-2
-/tests/no-order-0-3
-/tests/no-order-1-4
+/guest/default-0/tests/no-order-2-1
+/guest/default-0/tests/order-80-2
+/guest/default-0/tests/no-order-0-3
+/guest/default-0/tests/no-order-1-4
 EOF
     run_test
 
@@ -109,11 +109,11 @@ EOF
 /tests/order-80
 EOF
     cat > $tmp/EXPECTED-EXECUTION <<EOF
-/tests/order-10-1
-/tests/no-order-0-2
-/tests/no-order-1-3
-/tests/no-order-2-4
-/tests/order-80-5
+/guest/default-0/tests/order-10-1
+/guest/default-0/tests/no-order-0-2
+/guest/default-0/tests/no-order-1-3
+/guest/default-0/tests/no-order-2-4
+/guest/default-0/tests/order-80-5
 EOF
     run_test
 
@@ -133,17 +133,17 @@ EOF
 /third/order-default
 EOF
     cat > $tmp/EXPECTED-EXECUTION <<EOF
-/enumerate-and-order/tests/no-order-2-1
-/enumerate-and-order/tests/order-80-2
-/enumerate-and-order/tests/no-order-0-3
-/enumerate-and-order/tests/no-order-1-4
-/by-order-attribute/tests/order-10-5
-/by-order-attribute/tests/no-order-0-6
-/by-order-attribute/tests/no-order-1-7
-/by-order-attribute/tests/no-order-2-8
-/by-order-attribute/tests/order-80-9
-/third/order-20-10
-/third/order-default-11
+/guest/default-0/enumerate-and-order/tests/no-order-2-1
+/guest/default-0/enumerate-and-order/tests/order-80-2
+/guest/default-0/enumerate-and-order/tests/no-order-0-3
+/guest/default-0/enumerate-and-order/tests/no-order-1-4
+/guest/default-0/by-order-attribute/tests/order-10-5
+/guest/default-0/by-order-attribute/tests/no-order-0-6
+/guest/default-0/by-order-attribute/tests/no-order-1-7
+/guest/default-0/by-order-attribute/tests/no-order-2-8
+/guest/default-0/by-order-attribute/tests/order-80-9
+/guest/default-0/third/order-20-10
+/guest/default-0/third/order-default-11
 EOF
     run_test
 
@@ -163,17 +163,17 @@ EOF
 /order-80/tests/no-order-1
 EOF
     cat > $tmp/EXPECTED-EXECUTION <<EOF
-/order-10/tests/order-10-1
-/order-10/tests/no-order-0-2
-/order-10/tests/no-order-1-3
-/order-10/tests/no-order-2-4
-/order-10/tests/order-80-5
-/order-default/order-20-6
-/order-default/order-default-7
-/order-80/tests/no-order-2-8
-/order-80/tests/order-80-9
-/order-80/tests/no-order-0-10
-/order-80/tests/no-order-1-11
+/guest/default-0/order-10/tests/order-10-1
+/guest/default-0/order-10/tests/no-order-0-2
+/guest/default-0/order-10/tests/no-order-1-3
+/guest/default-0/order-10/tests/no-order-2-4
+/guest/default-0/order-10/tests/order-80-5
+/guest/default-0/order-default/order-20-6
+/guest/default-0/order-default/order-default-7
+/guest/default-0/order-80/tests/no-order-2-8
+/guest/default-0/order-80/tests/order-80-9
+/guest/default-0/order-80/tests/no-order-0-10
+/guest/default-0/order-80/tests/no-order-1-11
 EOF
     run_test
 

--- a/tests/execute/filesubmit/test.sh
+++ b/tests/execute/filesubmit/test.sh
@@ -9,7 +9,7 @@ rlJournalStart
     rlPhaseEnd
 
     # would be set by TMT_TEST_DATA
-    tmt_test_data="plans/default/execute/data/default-1/data"
+    tmt_test_data="plans/default/execute/data/guest/default-0/default-1/data"
 
     rlPhaseStartTest
         rlRun "tmt run -vfi $tmp -a provision -h container"

--- a/tests/execute/metadata/test.sh
+++ b/tests/execute/metadata/test.sh
@@ -10,7 +10,7 @@ rlJournalStart
 
     rlPhaseStartTest
         rlRun "tmt run -vi $tmp"
-        metadata="$tmp/plan/execute/data/test-1/metadata.yaml"
+        metadata="$tmp/plan/execute/data/guest/default-0/test-1/metadata.yaml"
         rlRun "cat $metadata" 0 "Check metadata.yaml content"
         rlAssertGrep "name: /test" $metadata
         rlAssertGrep "summary: Simple test" $metadata

--- a/tests/execute/reboot/basic.sh
+++ b/tests/execute/reboot/basic.sh
@@ -22,7 +22,7 @@ rlJournalStart
             # Check that the whole output log is kept
             # The test output is not stored in log in interactive mode
             if [ -z "$interactive" ]; then
-                rlRun "log=$run/plan/execute/data/test-1/output.txt"
+                rlRun "log=$run/plan/execute/data/guest/default-0/test-1/output.txt"
                 rlAssertGrep "After first reboot" $log
                 rlAssertGrep "After second reboot" $log
                 rlAssertGrep "After third reboot" $log

--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -26,7 +26,7 @@ rlJournalStart
     testName="/test/missing-custom-results"
     rlPhaseStartTest "${testName}"
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test does not provide 'results.yaml' file"
-        rlAssertGrep "custom results file '/tmp/.*/plans/default/execute/data/test/missing-custom-results-1/data/results.yaml' not found" $rlRun_LOG
+        rlAssertGrep "custom results file '/tmp/.*/plans/default/execute/data/guest/default-0/test/missing-custom-results-1/data/results.yaml' not found" $rlRun_LOG
     rlPhaseEnd
 
     testName="/test/empty-custom-results-file"

--- a/tests/execute/upgrade/ignore-test.sh
+++ b/tests/execute/upgrade/ignore-test.sh
@@ -20,10 +20,10 @@ rlJournalStart
         rlAssertGrep "3 tests passed" $rlRun_LOG
         # Check that the IN_PLACE_UPGRADE variable was set
         data="$run/plan/no-path/execute/data"
-        rlAssertGrep "IN_PLACE_UPGRADE=old" "$data/old/test-1/output.txt"
-        rlAssertGrep "IN_PLACE_UPGRADE=new" "$data/new/test-1/output.txt"
+        rlAssertGrep "IN_PLACE_UPGRADE=old" "$data/guest/default-0/old/test-1/output.txt"
+        rlAssertGrep "IN_PLACE_UPGRADE=new" "$data/guest/default-0/new/test-1/output.txt"
         # No upgrade path -> no environment variable
-        rlAssertNotGrep "VERSION_ID=$PREVIOUS_VERSION" "$data/upgrade/tasks/prepare-0/output.txt"
+        rlAssertNotGrep "VERSION_ID=$PREVIOUS_VERSION" "$data/guest/default-0/upgrade/tasks/prepare-0/output.txt"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/execute/upgrade/override.sh
+++ b/tests/execute/upgrade/override.sh
@@ -23,10 +23,10 @@ rlJournalStart
             rlAssertGrep "3 tests passed" $rlRun_LOG
             # Check that the IN_PLACE_UPGRADE variable was set
             data="$run/plan/path/execute/data"
-            rlAssertGrep "IN_PLACE_UPGRADE=old" "$data/old/test-1/output.txt"
-            rlAssertGrep "IN_PLACE_UPGRADE=new" "$data/new/test-1/output.txt"
+            rlAssertGrep "IN_PLACE_UPGRADE=old" "$data/guest/default-0/old/test-1/output.txt"
+            rlAssertGrep "IN_PLACE_UPGRADE=new" "$data/guest/default-0/new/test-1/output.txt"
             # Environment of plan was passed
-            rlAssertGrep "VERSION_ID=$PREVIOUS_VERSION" "$data/upgrade/tasks/prepare-0/output.txt"
+            rlAssertGrep "VERSION_ID=$PREVIOUS_VERSION" "$data/guest/default-0/upgrade/tasks/prepare-0/output.txt"
         rlPhaseEnd
     done
 

--- a/tests/execute/upgrade/simple.sh
+++ b/tests/execute/upgrade/simple.sh
@@ -20,10 +20,10 @@ rlJournalStart
         rlAssertGrep "3 tests passed" $rlRun_LOG
         # Check that the IN_PLACE_UPGRADE variable was set
         data="$run/plan/no-path/execute/data"
-        rlAssertGrep "IN_PLACE_UPGRADE=old" "$data/old/test-1/output.txt"
-        rlAssertGrep "IN_PLACE_UPGRADE=new" "$data/new/test-1/output.txt"
+        rlAssertGrep "IN_PLACE_UPGRADE=old" "$data/guest/default-0/old/test-1/output.txt"
+        rlAssertGrep "IN_PLACE_UPGRADE=new" "$data/guest/default-0/new/test-1/output.txt"
         # No upgrade path -> no environment variable
-        rlAssertNotGrep "VERSION_ID=$PREVIOUS_VERSION" "$data/upgrade/tasks/prepare-0/output.txt"
+        rlAssertNotGrep "VERSION_ID=$PREVIOUS_VERSION" "$data/guest/default-0/upgrade/tasks/prepare-0/output.txt"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/finish/prune/test.sh
+++ b/tests/finish/prune/test.sh
@@ -14,7 +14,7 @@ rlJournalStart
         rlAssertNotExists $tmp1/plan/discover/default-0
         rlAssertNotExists $tmp1/plan/discover/default-1
         rlAssertExists $tmp1/plan/data/out-plan.txt
-        rlAssertExists $tmp1/plan/execute/data/default-2/write/test-data-3/data/out-test.txt
+        rlAssertExists $tmp1/plan/execute/data/guest/default-0/default-2/write/test-data-3/data/out-test.txt
         for step in discover execute finish prepare provision report; do
             rlAssertExists $tmp1/plan/$step/step.yaml
         done
@@ -37,7 +37,7 @@ rlJournalStart
         rlAssertExists $tmp2/plan/discover/default-0
         rlAssertExists $tmp2/plan/discover/default-1
         rlAssertExists $tmp2/plan/data/out-plan.txt
-        rlAssertExists $tmp2/plan/execute/data/default-2/write/test-data-3/data/out-test.txt
+        rlAssertExists $tmp2/plan/execute/data/guest/default-0/default-2/write/test-data-3/data/out-test.txt
         for step in discover execute finish prepare provision report; do
             rlAssertExists $tmp2/plan/$step/step.yaml
         done

--- a/tests/pull/results/test.sh
+++ b/tests/pull/results/test.sh
@@ -15,10 +15,10 @@ rlJournalStart
 
             # Check output and extra logs in the test data directory
             data="$run/plan/execute/data"
-            rlAssertGrep "ok" "$data/test/good-3/output.txt"
-            rlAssertGrep "ko" "$data/test/bad-1/output.txt"
-            rlAssertGrep "extra good" "$data/test/good-3/data/extra.log"
-            rlAssertGrep "extra bad" "$data/test/bad-1/data/extra.log"
+            rlAssertGrep "ok" "$data/guest/default-0/test/good-3/output.txt"
+            rlAssertGrep "ko" "$data/guest/default-0/test/bad-1/output.txt"
+            rlAssertGrep "extra good" "$data/guest/default-0/test/good-3/data/extra.log"
+            rlAssertGrep "extra bad" "$data/guest/default-0/test/bad-1/data/extra.log"
 
             # Check logs in the plan data directory
             rlAssertGrep "common good" "$run/plan/data/log.txt"
@@ -31,14 +31,14 @@ rlJournalStart
             # Check beakerlib's backup directory pull
             if [[ "$method" =~ local|container ]]; then
                 # No pull happened so it shoud be present
-                rlAssertExists "$data/test/beakerlib-2/backup"
-                rlAssertExists "$data/test/beakerlib-2/backup-NS1"
-                rlAssertNotEquals "any backup dir is present" "$(eval 'echo $data/test/beakerlib-2/backup*')" "$data/test/beakerlib-2/backup*"
+                rlAssertExists "$data/guest/default-0/test/beakerlib-2/backup"
+                rlAssertExists "$data/guest/default-0/test/beakerlib-2/backup-NS1"
+                rlAssertNotEquals "any backup dir is present" "$(eval 'echo $data/guest/default-0/test/beakerlib-2/backup*')" "$data/guest/default-0/test/beakerlib-2/backup*"
             else
                 # Should be ignored
-                rlAssertNotExists "$data/test/beakerlib-2/backup"
-                rlAssertNotExists "$data/test/beakerlib-2/backup-NS1"
-                rlAssertEquals "no backup dir is present" "$(eval 'echo $data/test/beakerlib-2/backup*')" "$data/test/beakerlib-2/backup*"
+                rlAssertNotExists "$data/guest/default-0/test/beakerlib-2/backup"
+                rlAssertNotExists "$data/guest/default-0/test/beakerlib-2/backup-NS1"
+                rlAssertEquals "no backup dir is present" "$(eval 'echo $data/guest/default-0/test/beakerlib-2/backup*')" "$data/guest/default-0/test/beakerlib-2/backup*"
             fi
         rlPhaseEnd
     done


### PR DESCRIPTION
This should create a separate directory for each phase/guest combination, avoiding collisions in multihost scenarios when the same phase is executed on multiple guests at the same time.

Part of the effort in https://github.com/teemtee/tmt/pull/1790.