### PR TITLE
Correct `result:custom` docs, `log` is a list

### DIFF
--- a/spec/tests/result.fmf
+++ b/spec/tests/result.fmf
@@ -37,12 +37,14 @@ example:
     # Example content of results.yaml
     - name: /test/passing
       result: pass
-      log: pass_log
+      log:
+      - pass_log
       duration: 00:11:22
       note: good result
     - name: /test/failing
       result: fail
-      log: fail_log
+      log:
+      - fail_log
       duration: 00:22:33
       note: fail result
     - name: /test/no_keys


### PR DESCRIPTION
Just a small documentation fix.