### PR TITLE
Allow report result for itself in results:custom

### DIFF
--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -16,7 +16,7 @@ rlJournalStart
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 1 "Test provides 'results.yaml' file by itself"
         rlAssertGrep "00:11:22 pass /test/custom-results/test/passing" $rlRun_LOG
         rlAssertGrep "00:22:33 fail /test/custom-results/test/failing" $rlRun_LOG
-        rlAssertGrep "         pass /test/custom-results/test/no_keys \[1/1\]" $rlRun_LOG
+        rlAssertGrep "         pass /test/custom-results \[1/1\]" $rlRun_LOG
         rlAssertGrep "total: 2 tests passed and 1 test failed" $rlRun_LOG
     rlPhaseEnd
 

--- a/tests/execute/result/custom/results.yaml
+++ b/tests/execute/result/custom/results.yaml
@@ -10,5 +10,5 @@
     - fail_log
   duration: 00:22:33
   note: fail result
-- name: /test/no_keys
+- name: /
   result: pass

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -393,7 +393,11 @@ class ExecutePlugin(tmt.steps.Plugin):
         custom_results = []
         for partial_result_data in results:
             partial_result = tmt.Result.from_serialized(partial_result_data)
-            partial_result.name = test.name + partial_result.name
+            # Name '/' means the test itself
+            if partial_result.name == '/':
+                partial_result.name = test.name
+            else:
+                partial_result.name = test.name + partial_result.name
             custom_results.append(partial_result)
 
         return custom_results


### PR DESCRIPTION
Name '/' means the test itself

Fix: #1855