### PR TITLE
Improvements related to tests/full

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -203,6 +203,12 @@ or pip::
    fixtures, see https://docs.pytest.org/en/7.1.x/how-to/unittest.html for
    details.
 
+.. note::
+
+   Tests which try various provision methods should use ``PROVISION_METHODS``
+   environment variable to select which provision methods they can utilize
+   during their execution. This variable is likely to have default ``container``
+   or ``local`` and use ``adjust`` rule for ``how=full`` to add ``virtual`` method.
 
 Docs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -182,6 +182,11 @@ which tars sources to the expected location::
     cd tests/full
     make test
 
+Similar as above but run only tests which don't run for merge requests::
+
+    cd tests/full
+    make test-complement
+
 To run unit tests using pytest and generate coverage report::
 
     coverage run --source=tmt -m py.test tests

--- a/plans/install/main.fmf
+++ b/plans/install/main.fmf
@@ -6,3 +6,4 @@ enabled: false
 adjust:
   - enabled: true
     when: how == full or trigger == commit
+    tag+: [additional_coverage]

--- a/plans/provision/main.fmf
+++ b/plans/provision/main.fmf
@@ -8,3 +8,4 @@ enabled: false
 adjust+:
   - enabled: true
     when: how == full
+    tag+: [additional_coverage]

--- a/tests/core/escaping/main.fmf
+++ b/tests/core/escaping/main.fmf
@@ -13,3 +13,4 @@ adjust:
   - when: how == full
     environment:
         PROVISION_METHODS: container virtual local
+    tag+: [additional_coverage]

--- a/tests/core/escaping/main.fmf
+++ b/tests/core/escaping/main.fmf
@@ -8,8 +8,8 @@ framework: beakerlib
 tag-: [container, virtual]
 
 environment:
-    METHODS: local container
+    PROVISION_METHODS: local container
 adjust:
   - when: how == full
     environment:
-        METHODS: container virtual local
+        PROVISION_METHODS: container virtual local

--- a/tests/core/escaping/test.sh
+++ b/tests/core/escaping/test.sh
@@ -6,7 +6,7 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    for method in ${METHODS:-local}; do
+    for method in ${PROVISION_METHODS:-local}; do
         rlPhaseStartTest "Test ($method)"
             rlRun "tmt run -arvvv provision -h $method"
         rlPhaseEnd

--- a/tests/core/spaces/main.fmf
+++ b/tests/core/spaces/main.fmf
@@ -7,8 +7,8 @@ framework: beakerlib
 tag-: [container, virtual]
 
 environment:
-    METHODS: local container
+    PROVISION_METHODS: local container
 adjust:
   - when: how == full
     environment:
-        METHODS: container virtual local
+        PROVISION_METHODS: container virtual local

--- a/tests/core/spaces/main.fmf
+++ b/tests/core/spaces/main.fmf
@@ -12,3 +12,4 @@ adjust:
   - when: how == full
     environment:
         PROVISION_METHODS: container virtual local
+    tag+: [additional_coverage]

--- a/tests/core/spaces/test.sh
+++ b/tests/core/spaces/test.sh
@@ -6,7 +6,7 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    for method in ${METHODS:-local}; do
+    for method in ${PROVISION_METHODS:-local}; do
         rlPhaseStartTest "Test ($method)"
             rlRun "tmt run -arvvv provision -h $method"
         rlPhaseEnd

--- a/tests/discover/libraries/main.fmf
+++ b/tests/discover/libraries/main.fmf
@@ -17,3 +17,4 @@ adjust:
     enabled: True
     when: how == full
     because: this can be run only with a full virtualization
+    tag+: [additional_coverage]

--- a/tests/discover/main.fmf
+++ b/tests/discover/main.fmf
@@ -40,6 +40,7 @@
     adjust:
     - enabled: true
       when: how == full or trigger == commit
+      tag+: [additional_coverage]
 
 /dynamic-ref:
     /fmf:

--- a/tests/execute/duration/main.fmf
+++ b/tests/execute/duration/main.fmf
@@ -9,3 +9,4 @@ adjust:
         PROVISION_METHODS: "local container virtual"
     duration: 30m
     because: with full virtualization more methods can be tested
+    tag+: [additional_coverage]

--- a/tests/execute/reboot/main.fmf
+++ b/tests/execute/reboot/main.fmf
@@ -27,6 +27,7 @@ duration: 20m
         enabled: true
         when: how == full
         because: this can be run only with full virtualization
+        tag+: [additional_coverage]
 
 
 /reuse_provision:
@@ -38,3 +39,4 @@ duration: 20m
         enabled: true
         when: how == full
         because: this can be run only with full virtualization
+        tag+: [additional_coverage]

--- a/tests/execute/rsync/main.fmf
+++ b/tests/execute/rsync/main.fmf
@@ -6,3 +6,4 @@ adjust:
   duration: 10m
   when: how == full
   because: this can be run only with a full virtualization
+  tag+: [additional_coverage]

--- a/tests/execute/tty/main.fmf
+++ b/tests/execute/tty/main.fmf
@@ -6,3 +6,4 @@ adjust:
   - when: how == full
     environment:
         PROVISION_METHODS: local container virtual
+    tag+: [additional_coverage]

--- a/tests/execute/tty/main.fmf
+++ b/tests/execute/tty/main.fmf
@@ -1,8 +1,8 @@
 summary: Verify TTY handling in test environment
 
 environment:
-    METHODS: local container
+    PROVISION_METHODS: local container
 adjust:
   - when: how == full
     environment:
-        METHODS: local container virtual
+        PROVISION_METHODS: local container virtual

--- a/tests/execute/tty/test.sh
+++ b/tests/execute/tty/test.sh
@@ -6,7 +6,7 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    for method in ${METHODS:-local}; do
+    for method in ${PROVISION_METHODS:-local}; do
         rlPhaseStartTest "With $method provision method"
             rlRun -s "tmt run -avvvvddd provision -h $method"
 

--- a/tests/execute/upgrade/main.fmf
+++ b/tests/execute/upgrade/main.fmf
@@ -10,6 +10,7 @@ duration: 10m
     adjust:
     - enabled: true
       when: how == full
+      tag+: [additional_coverage]
     tier: 3
 
 /simple:

--- a/tests/finish/ansible/main.fmf
+++ b/tests/finish/ansible/main.fmf
@@ -8,13 +8,13 @@ description:
 
 # By default we run under a container only
 environment:
-    METHODS: container
+    PROVISION_METHODS: container
 adjust:
   - when: trigger == commit
     environment:
-        METHODS: container local
+        PROVISION_METHODS: container local
     because: the pipeline does not support nested virtualization
   - when: how == full
     environment:
-        METHODS: container virtual local
+        PROVISION_METHODS: container virtual local
     because: local/virtual provision needs root/full virtualization

--- a/tests/finish/ansible/main.fmf
+++ b/tests/finish/ansible/main.fmf
@@ -18,3 +18,4 @@ adjust:
     environment:
         PROVISION_METHODS: container virtual local
     because: local/virtual provision needs root/full virtualization
+    tag+: [additional_coverage]

--- a/tests/finish/ansible/test.sh
+++ b/tests/finish/ansible/test.sh
@@ -7,7 +7,7 @@ rlJournalStart
         rlRun "run=\$(mktemp -d)" 0 "Create run directory"
     rlPhaseEnd
 
-    for method in ${METHODS:-container}; do
+    for method in ${PROVISION_METHODS:-container}; do
         rlPhaseStartTest "Test ($method)"
             # Prepare common options, run given method
             tmt="tmt run -i $run --scratch"

--- a/tests/full/Makefile
+++ b/tests/full/Makefile
@@ -4,6 +4,8 @@
 # to the VM
 test: bundle
 	tmt run -vvv -e COPY_IN=1
+test-complement: bundle
+	tmt run -vvv -e COPY_IN=1 -e SCOPE=complement
 bundle: clean
 	tar czf ./repo_copy.tgz --exclude repo_copy.tgz -C $(shell git rev-parse --show-toplevel) .
 clean:

--- a/tests/full/test.fmf
+++ b/tests/full/test.fmf
@@ -1,15 +1,22 @@
 summary: Run the full tmt test suite in an external system
 description: |
     To check local changes without pushing to git:
-    make test
+      make test
+
+    To run only tests which will not run in merge request:
+      make test-complement
 
     Run under a local virtual machine:
-    tmt run -vvv -e BRANCH=<tested branch>
+      tmt run -vvv -e BRANCH=<tested branch>
+    Run just tests not run in a merge request:
+      tmt run -vvv -e BRANCH=<tested branch> -e SCOPE=complement
 
     Schedule a job using workflow-tomorrow:
-    tmt test export --fmf-id | wow fedora-35 x86_64 --fmf-id - --taskparam=BRANCH=<branch>
+      tmt test export --fmf-id | wow fedora-37 x86_64 --fmf-id - --taskparam=BRANCH=<branch>
+    Again just test not run in a merge request
+      tmt test export --fmf-id | wow fedora-37 x86_64 --fmf-id - --taskparam=SCOPE=complement --taskparam=BRANCH=<branch>
 
-    See head of the test.sh for future information
+    See head of the test.sh for further information
 
 test: ./test.sh
 framework: beakerlib

--- a/tests/login/main.fmf
+++ b/tests/login/main.fmf
@@ -22,8 +22,8 @@
     summary: Try to log into guest to verify property is_ready
     test: ./ready.sh
     environment:
-        METHODS: local container
+        PROVISION_METHODS: local container
     adjust:
       - when: how == full
         environment:
-            METHODS: local container virtual
+            PROVISION_METHODS: local container virtual

--- a/tests/login/main.fmf
+++ b/tests/login/main.fmf
@@ -27,3 +27,4 @@
       - when: how == full
         environment:
             PROVISION_METHODS: local container virtual
+        tag+: [additional_coverage]

--- a/tests/login/ready.sh
+++ b/tests/login/ready.sh
@@ -6,7 +6,7 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    for method in ${METHODS:-virtual}; do
+    for method in ${PROVISION_METHODS:-virtual}; do
         rlPhaseStartTest "Positive login test for ($method)"
             rlRun -s "tmt run -a provision -h $method login -c exit" 0-255
             rlAssertGrep "login: Starting interactive shell" "$rlRun_LOG"

--- a/tests/multihost/web/main.fmf
+++ b/tests/multihost/web/main.fmf
@@ -12,3 +12,4 @@ enabled: false
 adjust:
   - enabled: true
     when: how == full
+    tag+: [additional_coverage]

--- a/tests/prepare/ansible/main.fmf
+++ b/tests/prepare/ansible/main.fmf
@@ -7,13 +7,13 @@ description:
 
 # By default we run under a container only
 environment:
-    METHODS: container
+    PROVISION_METHODS: container
 adjust:
   - when: trigger == commit
     environment:
-        METHODS: container local
+        PROVISION_METHODS: container local
     because: the pipeline does not support nested virtualization
   - when: how == full
     environment:
-        METHODS: container virtual local
+        PROVISION_METHODS: container virtual local
     because: local/virtual provision needs root/full virtualization

--- a/tests/prepare/ansible/main.fmf
+++ b/tests/prepare/ansible/main.fmf
@@ -17,3 +17,4 @@ adjust:
     environment:
         PROVISION_METHODS: container virtual local
     because: local/virtual provision needs root/full virtualization
+    tag+: [additional_coverage]

--- a/tests/prepare/ansible/test.sh
+++ b/tests/prepare/ansible/test.sh
@@ -6,7 +6,7 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    for method in ${METHODS:-container}; do
+    for method in ${PROVISION_METHODS:-container}; do
         for plan in local remote; do
             rlPhaseStartTest "Test $plan playbook ($method)"
                 rlRun "tmt run -arv provision -h $method plan -n /$plan"

--- a/tests/prepare/install/main.fmf
+++ b/tests/prepare/install/main.fmf
@@ -15,3 +15,4 @@ adjust:
     environment:
         PROVISION_METHODS: container virtual local
     because: local/virtual provision needs root/full virtualization
+    tag+: [additional_coverage]

--- a/tests/prepare/install/main.fmf
+++ b/tests/prepare/install/main.fmf
@@ -5,13 +5,13 @@ description:
     Verify that installation from copr works for epel7. Exercises
     all provision methods in full mode, container only by default.
 environment:
-    METHODS: container
+    PROVISION_METHODS: container
 adjust:
   - when: trigger == commit
     environment:
-        METHODS: container local
+        PROVISION_METHODS: container local
     because: the pipeline does not support nested virtualization
   - when: how == full
     environment:
-        METHODS: container virtual local
+        PROVISION_METHODS: container virtual local
     because: local/virtual provision needs root/full virtualization

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -7,7 +7,7 @@ rlJournalStart
     rlPhaseEnd
 
     # Run basic tests against all enabled provision methods
-    for method in ${METHODS:-container}; do
+    for method in ${PROVISION_METHODS:-container}; do
         provision="provision --how $method"
 
         rlPhaseStartTest "Install an existing package ($method)"

--- a/tests/prepare/recommend/main.fmf
+++ b/tests/prepare/recommend/main.fmf
@@ -14,3 +14,4 @@ adjust:
     environment:
         PROVISION_METHODS: container virtual local
     because: local/virtual provision needs root/full virtualization
+    tag+: [additional_coverage]

--- a/tests/prepare/recommend/main.fmf
+++ b/tests/prepare/recommend/main.fmf
@@ -4,13 +4,13 @@ description:
     the existing one is installed and the other one is ignored. No
     error should be reported.
 environment:
-    METHODS: container
+    PROVISION_METHODS: container
 adjust:
   - when: trigger == commit
     environment:
-        METHODS: container local
+        PROVISION_METHODS: container local
     because: the pipeline does not support nested virtualization
   - when: how == full
     environment:
-        METHODS: container virtual local
+        PROVISION_METHODS: container virtual local
     because: local/virtual provision needs root/full virtualization

--- a/tests/prepare/recommend/test.sh
+++ b/tests/prepare/recommend/test.sh
@@ -6,7 +6,7 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    for method in ${METHODS:-container}; do
+    for method in ${PROVISION_METHODS:-container}; do
         tmt="tmt run --all --remove provision --how $method"
         basic="plan --name 'mixed|weird'"
         debuginfo="plan --name debuginfo"

--- a/tests/provision/reboot/main.fmf
+++ b/tests/provision/reboot/main.fmf
@@ -2,4 +2,4 @@ summary: Check that the reboot command works
 adjust:
   - when: how == full
     environment:
-        METHODS: container virtual
+        PROVISION_METHODS: container virtual

--- a/tests/provision/reboot/main.fmf
+++ b/tests/provision/reboot/main.fmf
@@ -3,3 +3,4 @@ adjust:
   - when: how == full
     environment:
         PROVISION_METHODS: container virtual
+    tag+: [additional_coverage]

--- a/tests/provision/reboot/test.sh
+++ b/tests/provision/reboot/test.sh
@@ -2,7 +2,7 @@
 # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
-METHODS=${METHODS:-container}
+PROVISION_METHODS=${PROVISION_METHODS:-container}
 
 rlJournalStart
     rlPhaseStartSetup
@@ -14,7 +14,7 @@ rlJournalStart
         rlRun "tmt plan create -t mini plan"
     rlPhaseEnd
 
-    if [[ "$METHODS" =~ container ]]; then
+    if [[ "$PROVISION_METHODS" =~ container ]]; then
         rlPhaseStartTest "Container"
             rlRun "tmt run -i $run provision -h container"
 
@@ -26,7 +26,7 @@ rlJournalStart
         rlPhaseEnd
     fi
 
-    if [[ "$METHODS" =~ virtual ]]; then
+    if [[ "$PROVISION_METHODS" =~ virtual ]]; then
         rlPhaseStartTest "Virtual"
             rlRun "tmt run --scratch -i $run provision -h virtual"
 

--- a/tests/provision/ssh-options/main.fmf
+++ b/tests/provision/ssh-options/main.fmf
@@ -3,3 +3,4 @@ enabled: false
 adjust:
   - when: how == full
     enabled: true
+    tag+: [additional_coverage]

--- a/tests/provision/ssh-options/test.sh
+++ b/tests/provision/ssh-options/test.sh
@@ -2,7 +2,7 @@
 # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
-METHODS=${METHODS:-virtual}
+PROVISION_METHODS=${PROVISION_METHODS:-virtual}
 
 rlJournalStart
     rlPhaseStartSetup
@@ -10,7 +10,7 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    for provision_method in $METHODS; do
+    for provision_method in $PROVISION_METHODS; do
         rlPhaseStartTest "Test with provision $provision_method"
             rlRun "tmt run --scratch -vvi $run -a provision -h $provision_method --ssh-option ServerAliveCountMax=123456789"
             rlAssertGrep "Run command: ssh .*-oServerAliveCountMax=123456789" "$run/log.txt"

--- a/tests/provision/user/test.sh
+++ b/tests/provision/user/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
-METHODS=${METHODS:-container}
+PROVISION_METHODS=${PROVISION_METHODS:-container}
 
 rlJournalStart
     rlPhaseStartSetup
@@ -15,7 +15,7 @@ rlJournalStart
         rlRun "tmt plan create test --template mini $STEPS"
     rlPhaseEnd
 
-    if [[ "$METHODS" =~ container ]]; then
+    if [[ "$PROVISION_METHODS" =~ container ]]; then
         rlPhaseStartTest "Container, default user root"
             rlRun -s "tmt run -i $run -a provision -h container report -vvv"
             rlAssertGrep "uid=0(root) gid=0(root) groups=0(root)" $rlRun_LOG

--- a/tests/provision/virtual.testcloud/main.fmf
+++ b/tests/provision/virtual.testcloud/main.fmf
@@ -5,4 +5,4 @@ adjust:
     because: needs to be able to spawn VM
 require:
 - tmt-provision-virtual
-tag: [virtual]
+tag: [virtual, additional_coverage]

--- a/tests/provision/virtual.testcloud/test.sh
+++ b/tests/provision/virtual.testcloud/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
-METHODS=${METHODS:-virtual.testcloud}
+PROVISION_METHODS=${PROVISION_METHODS:-virtual.testcloud}
 
 SRC_PLAN="$(pwd)/data/plan.fmf"
 

--- a/tests/pull/results/main.fmf
+++ b/tests/pull/results/main.fmf
@@ -5,8 +5,8 @@ description:
     directory content is synced back.
 
 environment:
-    METHODS: container local
+    PROVISION_METHODS: container local
 adjust:
   - when: how == full
     environment:
-        METHODS: container virtual local
+        PROVISION_METHODS: container virtual local

--- a/tests/pull/results/main.fmf
+++ b/tests/pull/results/main.fmf
@@ -10,3 +10,4 @@ adjust:
   - when: how == full
     environment:
         PROVISION_METHODS: container virtual local
+    tag+: [additional_coverage]

--- a/tests/pull/results/test.sh
+++ b/tests/pull/results/test.sh
@@ -7,7 +7,7 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    for method in ${METHODS:-local}; do
+    for method in ${PROVISION_METHODS:-local}; do
         rlPhaseStartTest "Test $method"
             # Run the plan, check for expected results
             rlRun -s "tmt run -av --scratch --id $run provision -h $method" 1

--- a/tests/pull/simple/main.fmf
+++ b/tests/pull/simple/main.fmf
@@ -12,3 +12,4 @@ adjust:
   - when: how == full
     environment:
         PROVISION_METHODS: container virtual local
+    tag+: [additional_coverage]

--- a/tests/pull/simple/main.fmf
+++ b/tests/pull/simple/main.fmf
@@ -7,8 +7,8 @@ link:
   - verifies: https://github.com/teemtee/tmt/issues/1011
 
 environment:
-    METHODS: container local
+    PROVISION_METHODS: container local
 adjust:
   - when: how == full
     environment:
-        METHODS: container virtual local
+        PROVISION_METHODS: container virtual local

--- a/tests/pull/simple/test.sh
+++ b/tests/pull/simple/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
         rlRun "pushd $tmp"
     rlPhaseEnd
 
-    for method in ${METHODS:-local}; do
+    for method in ${PROVISION_METHODS:-local}; do
         rlPhaseStartTest "Test one step ($method)"
             rlRun "tmt run -i $run --scratch provision -h $method finish"
         rlPhaseEnd

--- a/tests/run/shell/main.fmf
+++ b/tests/run/shell/main.fmf
@@ -11,4 +11,5 @@ enabled: false
 adjust:
   - enabled: true
     when: how == full
+    tag+: [additional_coverage]
 tier: null

--- a/tests/run/worktree/main.fmf
+++ b/tests/run/worktree/main.fmf
@@ -11,13 +11,13 @@ description:
 require+: [tmt-provision-container]
 
 environment:
-    METHODS: 'container'
+    PROVISION_METHODS: 'container'
 adjust:
   - environment:
-        METHODS: 'container local'
+        PROVISION_METHODS: 'container local'
     when: trigger == commit
   - environment:
-        METHODS: 'container local virtual'
+        PROVISION_METHODS: 'container local virtual'
     result: xfail # issue 964
     duration: 10m
     when: how == full

--- a/tests/run/worktree/main.fmf
+++ b/tests/run/worktree/main.fmf
@@ -21,3 +21,4 @@ adjust:
     result: xfail # issue 964
     duration: 10m
     when: how == full
+    tag+: [additional_coverage]

--- a/tests/run/worktree/test.sh
+++ b/tests/run/worktree/test.sh
@@ -2,7 +2,7 @@
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 rlJournalStart
-    for method in ${METHODS:-container}; do
+    for method in ${PROVISION_METHODS:-container}; do
         rlPhaseStartTest "Simple ($method)"
             rlRun "pushd data/simple"
             rlRun "tmt run -ar provision -h $method report -vvv"

--- a/tests/security/ansible/main.fmf
+++ b/tests/security/ansible/main.fmf
@@ -12,3 +12,4 @@ adjust:
     environment:
         PROVISION_METHODS: container virtual local
     because: local/virtual provision needs root/full virtualization
+    tag+: [additional_coverage]

--- a/tests/security/ansible/main.fmf
+++ b/tests/security/ansible/main.fmf
@@ -2,13 +2,13 @@ summary: Check whether an injected shell code is executed
 
 # By default, we run under a container only
 environment:
-    METHODS: container
+    PROVISION_METHODS: container
 adjust:
   - when: trigger == commit
     environment:
-        METHODS: container local
+        PROVISION_METHODS: container local
     because: the pipeline does not support nested virtualization
   - when: how == full
     environment:
-        METHODS: container virtual local
+        PROVISION_METHODS: container virtual local
     because: local/virtual provision needs root/full virtualization

--- a/tests/security/ansible/test.sh
+++ b/tests/security/ansible/test.sh
@@ -9,7 +9,7 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    for method in ${METHODS:-container}; do
+    for method in ${PROVISION_METHODS:-container}; do
         rlPhaseStartTest "Test ($method)"
             rlRun -s "tmt run --id $run -avvvddd provision -h $method" 1-3
             rlAssertNotGrep "revealed" $rlRun_LOG

--- a/tests/test/debug/main.fmf
+++ b/tests/test/debug/main.fmf
@@ -9,3 +9,4 @@ adjust:
     environment:
         PROVISION_METHODS: local container virtual
     when: how == full
+    tag+: [additional_coverage]

--- a/tests/test/debug/main.fmf
+++ b/tests/test/debug/main.fmf
@@ -4,8 +4,8 @@ description:
     then debug test code using repeated discover & execute.
 
 environment:
-    METHODS: local container
+    PROVISION_METHODS: local container
 adjust:
     environment:
-        METHODS: local container virtual
+        PROVISION_METHODS: local container virtual
     when: how == full

--- a/tests/test/debug/test.sh
+++ b/tests/test/debug/test.sh
@@ -11,7 +11,7 @@ rlJournalStart
         rlRun "tmt test create --template shell /test"
     rlPhaseEnd
 
-    for method in ${METHODS:-local}; do
+    for method in ${PROVISION_METHODS:-local}; do
         rlPhaseStartTest "Test $method"
             # Run until execute
             tmt="tmt run --id $run --verbose"


### PR DESCRIPTION
To make it easier to dive into failures otherwise the output is too huge.

In the journal will appear e.g

                    :: [ 10:11:38 ] :: [   LOG    ] :: Results of tests ran in this plan:
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/adjust 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/debug 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/docs 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/dry 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/enabled 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/env 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/environment-file 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/error 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/escaping 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/fmf-id 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/force 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/link 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/ls 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/order 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/path 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/smoke 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/spaces 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/core/web-link 
                    :: [ 10:11:38 ] :: [   PASS   ] :: /tests/unit 

