### PR TITLE
Export `TMT_TEST_NAME` and `TMT_TEST_METADATA`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -370,11 +370,19 @@ TMT_PLAN_DATA
 The following environment variables are provided to the test
 during the execution:
 
+TMT_TEST_NAME
+    The test name, as a resolved FMF object name starting with ``/``
+    from the root of the hierarchy.
+
 TMT_TEST_DATA
     Path to the directory where test can store logs and other
     artifacts generated during its execution. These will be pulled
     back from the guest and available for inspection after the
     test execution is finished.
+
+TMT_TEST_METADATA
+    Path to a YAML-formatted file with test metadata collected
+    during the ``discover`` step.
 
 TMT_SOURCE_DIR
     Path to directory with downloaded and extracted sources if

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -32,6 +32,9 @@ DEFAULT_FRAMEWORK = 'shell'
 # The main test output filename
 TEST_OUTPUT_FILENAME = 'output.txt'
 
+# Metadata file with details about the current test
+TEST_METADATA_FILENAME = 'metadata.yaml'
+
 # Scripts source directory
 SCRIPTS_SRC_DIR = Path(pkg_resources.resource_filename(
     'tmt', 'steps/execute/scripts'))
@@ -216,13 +219,13 @@ class ExecutePlugin(tmt.steps.Plugin):
         Prepare discovered tests for testing
 
         Check which tests have been discovered, for each test prepare
-        the aggregated metadata in a 'metadata.yaml' file under the test
-        data directory and finally return a list of discovered tests.
+        the aggregated metadata in a file under the test data directory
+        and finally return a list of discovered tests.
         """
         tests: List[tmt.Test] = self.discover.tests()
         for test in tests:
             metadata_filename = self.data_path(
-                test, filename='metadata.yaml', full=True, create=True)
+                test, filename=TEST_METADATA_FILENAME, full=True, create=True)
             self.write(
                 metadata_filename, tmt.utils.dict_to_yaml(test._metadata))
         return tests

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -146,6 +146,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
         assert self.parent is not None
         assert isinstance(self.parent, tmt.steps.execute.Execute)
 
+        environment["TMT_TEST_NAME"] = test.name
         environment["TMT_TEST_DATA"] = str(data_directory / tmt.steps.execute.TEST_DATA)
         environment["TMT_REBOOT_REQUEST"] = str(
             data_directory / tmt.steps.execute.TEST_DATA / TMT_REBOOT_SCRIPT.created_file)

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -148,6 +148,8 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
 
         environment["TMT_TEST_NAME"] = test.name
         environment["TMT_TEST_DATA"] = str(data_directory / tmt.steps.execute.TEST_DATA)
+        environment["TMT_TEST_METADATA"] = str(
+            data_directory / tmt.steps.execute.TEST_METADATA_FILENAME)
         environment["TMT_REBOOT_REQUEST"] = str(
             data_directory / tmt.steps.execute.TEST_DATA / TMT_REBOOT_SCRIPT.created_file)
         # Set all supported reboot variables


### PR DESCRIPTION
The test name is mostly self-explanatory - a test likely should have easy access to its name. My use case is calling external logic (waiving scripts), which consult an external database, indexed by test name.

While discussing this with other tmt maintainers, `metadata.yaml` was also mentioned, and that it probably should be part of some accessible-to-test interface. Hence the export as another variable.
(I moved the `metadata.yaml` name to a class variable, to avoid hardcoding on two places.)

Example from a test running `env`:
```
...
TMT_TEST_NAME=/parent/dir/oscap-scan
...
TMT_TEST_METADATA=/var/tmp/tmt/run-078/plans/example/execute/data/parent/dir/oscap-scan/metadata.yaml
...
```