### PR TITLE
Formalizing guest "facts" storage

### DIFF
--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -25,7 +25,7 @@ rlJournalStart
         rlPhaseStartTest "Selected step ($step)"
             rlRun "$tmt login -c true -s $step 2>&1 >/dev/null | tee output"
             rlAssertGrep "interactive" "output"
-            rlRun "grep '^    $step$' -A4 output | grep -i interactive"
+            rlRun "grep '^    $step$' -A5 output | grep -i interactive"
         rlPhaseEnd
     done
 

--- a/tests/provision/facts/main.fmf
+++ b/tests/provision/facts/main.fmf
@@ -1,0 +1,1 @@
+summary: Check that guest facts are discovered and reported correctly

--- a/tests/provision/facts/main.fmf
+++ b/tests/provision/facts/main.fmf
@@ -1,4 +1,4 @@
 summary: Check that guest facts are discovered and reported correctly
 
 environment:
-    PROVISION_METHODS: local
+    PROVISION_METHODS: local container

--- a/tests/provision/facts/main.fmf
+++ b/tests/provision/facts/main.fmf
@@ -1,1 +1,4 @@
 summary: Check that guest facts are discovered and reported correctly
+
+environment:
+    PROVISION_METHODS: local

--- a/tests/provision/facts/test.sh
+++ b/tests/provision/facts/test.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Check $provision_method plugin"
+        if [ -f /etc/os-release ]; then
+            distro="$(grep PRETTY_NAME /etc/os-release | cut -d'=' -f2 | tr -d '"')"
+        else
+            distro="$(cat /etc/redhat-release || cat /etc/fedora-release)"
+        fi
+
+        if [ grep "selinuxfs" /proc/filesystems ]; then
+            selinux="no"
+        else
+            selinux="yes"
+        fi
+
+        rlRun -s "tmt run -i $run --scratch     provision -h local plan -n /plans/features/core"
+
+        rlAssertGrep "arch: $(arch)" $rlRun_LOG
+        rlAssertGrep "distro: $distro" $rlRun_LOG
+
+        rlRun -s "tmt run -i $run --scratch -vv provision -h local plan -n /plans/features/core"
+
+        rlAssertGrep "arch: $(arch)" $rlRun_LOG
+        rlAssertGrep "distro: $distro" $rlRun_LOG
+        rlAssertGrep "kernel: $(uname -r)" $rlRun_LOG
+        rlAssertGrep "package manager: dnf\|yum" $rlRun_LOG
+        rlAssertGrep "selinux: $selinux" $rlRun_LOG
+
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "rm -r $run" 0 "Remove run directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/provision/facts/test.sh
+++ b/tests/provision/facts/test.sh
@@ -8,36 +8,40 @@ rlJournalStart
         rlRun "set -o pipefail"
     rlPhaseEnd
 
-    rlPhaseStartTest "Check $provision_method plugin"
-        if [ -f /etc/os-release ]; then
-            distro="$(grep PRETTY_NAME /etc/os-release | cut -d'=' -f2 | tr -d '"')"
-        else
-            distro="$(cat /etc/redhat-release || cat /etc/fedora-release)"
-        fi
+    for provision_method in ${PROVISION_METHODS:-local}; do
+        rlPhaseStartTest "Check $provision_method plugin"
+            if [ "$provision_method" = "local" ]; then
+                if [ -f /etc/os-release ]; then
+                    distro="$(grep PRETTY_NAME /etc/os-release | cut -d'=' -f2 | tr -d '"')"
+                else
+                    distro="$(cat /etc/redhat-release || cat /etc/fedora-release)"
+                fi
 
-        if [ grep "selinuxfs" /proc/filesystems ]; then
-            selinux="no"
-        else
-            selinux="yes"
-        fi
+                grep "selinuxfs" /proc/filesystems &> /dev/null
+                if [ $? -eq 1 ]; then
+                    selinux="no"
+                else
+                    selinux="yes"
+                fi
+            fi
 
-        rlRun -s "tmt run -i $run --scratch     provision -h local plan -n /plans/features/core"
+            rlRun -s "tmt run -i $run --scratch     provision -h "$provision_method" plan -n /plans/features/core"
 
-        rlAssertGrep "arch: $(arch)" $rlRun_LOG
-        rlAssertGrep "distro: $distro" $rlRun_LOG
-        rlAssertNotGrep "kernel: $(uname -r)" $rlRun_LOG
-        rlAssertNotGrep "package manager: dnf\|yum" $rlRun_LOG
-        rlAssertNotGrep "selinux: $selinux" $rlRun_LOG
+            rlAssertGrep "arch: $(arch)" $rlRun_LOG
+            rlAssertGrep "distro: $distro" $rlRun_LOG
+            rlAssertNotGrep "kernel: $(uname -r)" $rlRun_LOG
+            rlAssertNotGrep "package manager: dnf\|yum" $rlRun_LOG
+            rlAssertNotGrep "selinux: $selinux" $rlRun_LOG
 
-        rlRun -s "tmt run -i $run --scratch -vv provision -h local plan -n /plans/features/core"
+            rlRun -s "tmt run -i $run --scratch -vv provision -h "$provision_method" plan -n /plans/features/core"
 
-        rlAssertGrep "arch: $(arch)" $rlRun_LOG
-        rlAssertGrep "distro: $distro" $rlRun_LOG
-        rlAssertGrep "kernel: $(uname -r)" $rlRun_LOG
-        rlAssertGrep "package manager: dnf\|yum" $rlRun_LOG
-        rlAssertGrep "selinux: $selinux" $rlRun_LOG
-
-    rlPhaseEnd
+            rlAssertGrep "arch: $(arch)" $rlRun_LOG
+            rlAssertGrep "distro: $distro" $rlRun_LOG
+            rlAssertGrep "kernel: $(uname -r)" $rlRun_LOG
+            rlAssertGrep "package manager: dnf\|yum" $rlRun_LOG
+            rlAssertGrep "selinux: $selinux" $rlRun_LOG
+        rlPhaseEnd
+    done
 
     rlPhaseStartCleanup
         rlRun "rm -r $run" 0 "Remove run directory"

--- a/tests/provision/facts/test.sh
+++ b/tests/provision/facts/test.sh
@@ -11,11 +11,19 @@ rlJournalStart
     for provision_method in ${PROVISION_METHODS:-local}; do
         rlPhaseStartTest "Check $provision_method plugin"
             if [ "$provision_method" = "local" ]; then
+                provision_options=""
+
+                arch="$(arch)"
+
                 if [ -f /etc/os-release ]; then
                     distro="$(grep PRETTY_NAME /etc/os-release | cut -d'=' -f2 | tr -d '"')"
                 else
                     distro="$(cat /etc/redhat-release || cat /etc/fedora-release)"
                 fi
+
+                kernel="$(uname -r)"
+
+                package_manager="dnf\|yum"
 
                 grep "selinuxfs" /proc/filesystems &> /dev/null
                 if [ $? -eq 1 ]; then
@@ -23,22 +31,40 @@ rlJournalStart
                 else
                     selinux="yes"
                 fi
+
+            elif [ "$provision_method" = "container" ]; then
+                provision_options="--image fedora:37"
+
+                arch="$(arch)"
+                distro="Fedora Linux 37 (Container Image)"
+                kernel="$(uname -r)"
+                package_manager="dnf"
+
+                grep "selinuxfs" /proc/filesystems &> /dev/null
+                if [ $? -eq 1 ]; then
+                    selinux="no"
+                else
+                    selinux="yes"
+                fi
+
+            else
+                rlDie "Provision method ${provision_method} is not supported by the test."
             fi
 
-            rlRun -s "tmt run -i $run --scratch     provision -h "$provision_method" plan -n /plans/features/core"
+            rlRun -s "tmt run -i $run --scratch     provision -h "$provision_method" $provision_options plan -n /plans/features/core"
 
-            rlAssertGrep "arch: $(arch)" $rlRun_LOG
+            rlAssertGrep "arch: $arch" $rlRun_LOG
             rlAssertGrep "distro: $distro" $rlRun_LOG
-            rlAssertNotGrep "kernel: $(uname -r)" $rlRun_LOG
-            rlAssertNotGrep "package manager: dnf\|yum" $rlRun_LOG
+            rlAssertNotGrep "kernel: $kernel" $rlRun_LOG
+            rlAssertNotGrep "package manager: $package_manager" $rlRun_LOG
             rlAssertNotGrep "selinux: $selinux" $rlRun_LOG
 
-            rlRun -s "tmt run -i $run --scratch -vv provision -h "$provision_method" plan -n /plans/features/core"
+            rlRun -s "tmt run -i $run --scratch -vv provision -h "$provision_method" $provision_options plan -n /plans/features/core"
 
-            rlAssertGrep "arch: $(arch)" $rlRun_LOG
+            rlAssertGrep "arch: $arch" $rlRun_LOG
             rlAssertGrep "distro: $distro" $rlRun_LOG
-            rlAssertGrep "kernel: $(uname -r)" $rlRun_LOG
-            rlAssertGrep "package manager: dnf\|yum" $rlRun_LOG
+            rlAssertGrep "kernel: $kernel" $rlRun_LOG
+            rlAssertGrep "package manager: $package_manager" $rlRun_LOG
             rlAssertGrep "selinux: $selinux" $rlRun_LOG
         rlPhaseEnd
     done

--- a/tests/provision/facts/test.sh
+++ b/tests/provision/facts/test.sh
@@ -25,6 +25,9 @@ rlJournalStart
 
         rlAssertGrep "arch: $(arch)" $rlRun_LOG
         rlAssertGrep "distro: $distro" $rlRun_LOG
+        rlAssertNotGrep "kernel: $(uname -r)" $rlRun_LOG
+        rlAssertNotGrep "package manager: dnf\|yum" $rlRun_LOG
+        rlAssertNotGrep "selinux: $selinux" $rlRun_LOG
 
         rlRun -s "tmt run -i $run --scratch -vv provision -h local plan -n /plans/features/core"
 

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -14,7 +14,7 @@ import tmt.options
 import tmt.steps
 import tmt.steps.prepare
 import tmt.utils
-from tmt.steps.provision import Guest
+from tmt.steps.provision import Guest, GuestPackageManager
 from tmt.utils import Command, Path, ShellScript, field
 
 if sys.version_info >= (3, 8):
@@ -605,13 +605,13 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin):
         # Pick the right implementation
         # TODO: it'd be nice to use a "plugin registry" and make the implementations
         # discovered as any other plugins.
-        if guest.facts.package_manager == 'rpm-ostree':
+        if guest.facts.package_manager == GuestPackageManager.RPM_OSTREE:
             installer: InstallBase = InstallRpmOstree(logger=logger, parent=self, guest=guest)
 
-        elif guest.facts.package_manager == 'dnf':
+        elif guest.facts.package_manager == GuestPackageManager.DNF:
             installer = InstallDnf(logger=logger, parent=self, guest=guest)
 
-        elif guest.facts.package_manager == 'yum':
+        elif guest.facts.package_manager == GuestPackageManager.YUM:
             installer = InstallYum(logger=logger, parent=self, guest=guest)
 
         else:

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -2,7 +2,6 @@ import collections
 import dataclasses
 import datetime
 import enum
-import functools
 import os
 import random
 import re
@@ -11,8 +10,8 @@ import string
 import subprocess
 import tempfile
 from shlex import quote
-from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple,
-                    Type, TypeVar, Union, cast, overload)
+from typing import (TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type,
+                    TypeVar, Union, cast, overload)
 
 import click
 import fmf
@@ -67,25 +66,6 @@ class GuestPackageManager(enum.Enum):
 
 
 T = TypeVar('T')
-_FactQuery = Callable[['GuestFacts', 'Guest'], Optional[T]]
-_SafeFactQuery = Callable[['GuestFacts', 'Guest'], T]
-
-
-def raise_on_none(family: str) -> Callable[[_FactQuery[T]], _SafeFactQuery[T]]:
-    def outer(fn: _FactQuery[T]) -> _SafeFactQuery[T]:
-        @functools.wraps(fn)
-        def inner(self: 'GuestFacts', guest: 'Guest') -> T:
-            fact = fn(self, guest)
-
-            if fact is not None:
-                return fact
-
-            raise tmt.utils.GeneralError(
-                f'Failed to identify {family} of guest "{guest}".')
-
-        return inner
-
-    return outer
 
 
 @dataclasses.dataclass
@@ -499,9 +479,9 @@ class Guest(tmt.utils.Common):
         if self.opt('dry'):
             return
 
-        self.info('arch', self.facts.arch, 'green')
-        self.info('distro', self.facts.distro, 'green')
-        self.verbose('kernel', self.facts.kernel_release, 'green')
+        self.info('arch', self.facts.arch or 'unknown', 'green')
+        self.info('distro', self.facts.distro or 'unknown', 'green')
+        self.verbose('kernel', self.facts.kernel_release or 'unknown', 'green')
         self.verbose(
             'package manager',
             self.facts.package_manager.value if self.facts.package_manager else 'unknown',

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -104,7 +104,12 @@ class GuestFacts(tmt.utils.SerializableContainer):
     arch: Optional[str] = None
     distro: Optional[str] = None
     kernel_release: Optional[str] = None
-    package_manager: Optional[GuestPackageManager] = None
+    package_manager: Optional[GuestPackageManager] = field(
+        # cast: since the default is None, mypy cannot infere the full type,
+        # and reports `package_manager` parameter to be `object`.
+        default=cast(Optional[GuestPackageManager], None),
+        serialize=lambda package_manager: package_manager.value if package_manager else None,
+        unserialize=lambda raw_value: GuestPackageManager(raw_value) if raw_value else None)
 
     os_release_content: Dict[str, str] = field(default_factory=dict)
     lsb_release_content: Dict[str, str] = field(default_factory=dict)

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -206,13 +206,13 @@ class GuestFacts(tmt.utils.SerializableContainer):
             output = self._execute(guest, command)
 
             if not output or not output.stdout:
-                guest.debug('query', f'Command "{str(command)}" produced no usable output')
+                guest.debug('query', f"Command '{str(command)}' produced no usable output.")
                 continue
 
             match = re.search(pattern, output.stdout)
 
             if not match:
-                guest.debug('query', f'Command "{str(command)}" produced no usable output')
+                guest.debug('query', f"Command '{str(command)}' produced no usable output.")
                 continue
 
             return match.group(1)


### PR DESCRIPTION
I've been looking into tmt usage on Ubuntu/Debian, and while playing with changes that might be needed to make things work - mostly rpm-centric bits need tweaks - I slowly realized I'm adding bits that rely on awareness of distro or distro family. This slowly resulted into a refactoring of extra information tmt tracks about guests, besides the IP address/hostname & keys defined by specification.

So, here are "facts", attached to each `Guest` instance, saved into `guests.yaml`, documented, with primitives for easier adding new fields. There is a slight increase in the overhead, with one extra `Guest.execute()` call, but the previous worst cases should improve because of a bit of caching. And I plan to improve the caching in the future, but getting annotations right for cache, dataclass, property and Python 3.6 is not as easy as I'd like.

```yaml
default-0:
    role:
    guest: tmt-313-rNVYCvFt
    facts:
        in_sync: true
        distro: CentOS Stream 9
        kernel_release: 5.10.102.1-microsoft-standard-WSL2
        package_manager: dnf
        os_release_content:
            NAME: CentOS Stream
            VERSION: '9'
            ID: centos
            ID_LIKE: rhel fedora
            VERSION_ID: '9'
            PLATFORM_ID: platform:el9
            PRETTY_NAME: CentOS Stream 9
            ANSI_COLOR: 0;31
            LOGO: fedora-logo-icon
            CPE_NAME: cpe:/o:centos:centos:9
            HOME_URL: https://centos.org/
            BUG_REPORT_URL: https://bugzilla.redhat.com/
            REDHAT_SUPPORT_PRODUCT: Red Hat Enterprise Linux 9
            REDHAT_SUPPORT_PRODUCT_VERSION: CentOS Stream
        lsb_release_content: {}
        __class__:
            module: tmt.steps.provision
            name: GuestFacts
    image: centos:stream9
    user: root
    force_pull: false
    container: tmt-313-rNVYCvFt
    __class__:
        module: tmt.steps.provision.podman
        name: PodmanGuestData
```