### PR TITLE
Refactor CLI error reporting to improve readability

### DIFF
--- a/bin/tmt
+++ b/bin/tmt
@@ -1,34 +1,28 @@
 #!/usr/bin/python
 
+import functools
+import sys
+
 import click
 
 import tmt.cli
 import tmt.utils
 
-
-def show_exception(exception: BaseException) -> None:
-    """ Show exception in red, handle exception chain """
-    click.echo(click.style(str(exception), fg='red'), err=True)
-
-    # Mention also the original exception if provided
-    if exception.__cause__:
-        click.echo("The exception was caused by the previous exception:", err=True)
-        show_exception(exception.__cause__)
+# A small helper for "print to sys.stderr".
+print_error = functools.partial(print, file=sys.stderr)
 
 
-try:
-    tmt.cli.main()
+def show_run_exception(exception: tmt.utils.RunError) -> None:
+    """ Display detailed output upon command execution errors """
 
-# Show detailed output upon command execution errors
-except tmt.utils.RunError as error:
     # Check verbosity level used during raising exception,
     # Supported way to correctly get verbosity is
     # tmt.util.Common.opt('verbose')
-    if isinstance(error.caller, tmt.utils.Common):
-        verbose = error.caller.opt('verbose')
+    if isinstance(exception.caller, tmt.utils.Common):
+        verbose = exception.caller.opt('verbose')
     else:
         verbose = 0
-    for name, output in (('stdout', error.stdout), ('stderr', error.stderr)):
+    for name, output in (('stdout', exception.stdout), ('stderr', exception.stderr)):
         if not output:
             continue
         lines = output.strip().split('\n')
@@ -38,13 +32,34 @@ except tmt.utils.RunError as error:
         else:
             line_summary = f"{min(len(lines), tmt.utils.OUTPUT_LINES)}/{len(lines)}"
             lines = lines[-tmt.utils.OUTPUT_LINES:]
-        print(
-            f"\n{name} ({line_summary} lines)"
+        print_error(
+            f"{name} ({line_summary} lines)"
             f"\n{tmt.utils.OUTPUT_WIDTH * '~'}\n" +
-            '\n'.join(lines))
-    print()
-    show_exception(error)
-    raise SystemExit(2)
+            '\n'.join(lines) +
+            f"\n{tmt.utils.OUTPUT_WIDTH * '~'}")
+        print_error()
+
+
+def show_exception(exception: BaseException) -> None:
+    """ Display the exception and its causes """
+
+    print_error()
+    print_error(click.style(str(exception), fg='red'))
+
+    if isinstance(exception, tmt.utils.RunError):
+        print_error()
+        show_run_exception(exception)
+
+    # Follow the chain
+    if exception.__cause__:
+        print_error()
+        print_error("The exception was caused by the previous exception:")
+
+        show_exception(exception.__cause__)
+
+
+try:
+    tmt.cli.main()
 
 # Basic error message for general errors
 except tmt.utils.GeneralError as error:

--- a/tests/prepare/require/test.sh
+++ b/tests/prepare/require/test.sh
@@ -17,18 +17,18 @@ rlJournalStart
         fi
 
         rlPhaseStartTest "Require an available package ($image)"
-            rlRun "$tmt plan --name available 2>&1 >/dev/null | tee output"
-            rlAssertGrep '1 preparation applied' output
+            rlRun -s "$tmt plan --name available"
+            rlAssertGrep '1 preparation applied' $rlRun_LOG
         rlPhaseEnd
 
         rlPhaseStartTest "Require a missing package ($image)"
-            rlRun "$tmt plan --name missing | tee output" 2
-            rlAssertGrep "$error" output
+            rlRun -s "$tmt plan --name missing" 2
+            rlAssertGrep "$error" $rlRun_LOG
         rlPhaseEnd
 
         rlPhaseStartTest "Require both available and missing ($image)"
-            rlRun "$tmt plan --name mixed | tee output" 2
-            rlAssertGrep "$error" output
+            rlRun -s "$tmt plan --name mixed" 2
+            rlAssertGrep "$error" $rlRun_LOG
         rlPhaseEnd
     done
 


### PR DESCRIPTION
Added a few empty lines to better separate exceptions in the chain, and while I was there, I refactored the code slightly to separate general exceptions from the special handling of `RunError` ones.