### PR TITLE
Rephrase results.yaml documentation and examples

### DIFF
--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -18,54 +18,9 @@ description: |
     :ref:`/spec/tests` attributes it also contains fmf ``name`` of
     the test.
 
-    For each ``plan`` the execute step must produce a
-    ``results.yaml`` file with the list of results for each test
-    in the following format::
-
-        /test/one:
-            result: OUTCOME
-            log:
-              - PATH
-
-        /test/two:
-            result: OUTCOME
-            log:
-              - PATH1
-              - PATH2
-            duration: DURATION
-
-    Where ``OUTCOME`` is the result of the test execution. It can
-    have the following values:
-
-        pass
-            Test execution successfully finished and passed.
-        info
-            Test finished but only produced an informational
-            message. Represents a soft pass, used for skipped
-            tests and for tests with the :ref:`/spec/tests/result`
-            attribute set to *ignore*. Automation must treat
-            this as a passed test.
-        warn
-            A problem appeared during test execution which does
-            not affect test results but might be worth checking
-            and fixing. For example test cleanup phase failed.
-            Automation must treat this as a failed test.
-        error
-            Undefined problem encountered during test execution.
-            Human inspection is needed to investigate whether it
-            was a test bug, infrastructure error or a real test
-            failure. Automation must treat it as a failed test.
-        fail
-            Test execution successfully finished and failed.
-
-    ``PATH`` or each ``PATH*`` are the test log output paths,
-    relative to the execute step working directory. ``log`` key
-    is a list of strings, even when there is just a single log, the first
-    log will be considered as the main one (e.g. presented to the
-    user for inspection).
-
-    The ``DURATION`` is an optional section stating how long did
-    the test run. Its value is in the ``hh:mm:ss`` format.
+    In each plan, the execute step must produce a ``results.yaml`` file
+    with results for executed tests. The format of the file is described
+    at :ref:`/spec/plans/results`.
 
 /upgrade:
     summary: Perform system upgrades during testing

--- a/spec/plans/results.fmf
+++ b/spec/plans/results.fmf
@@ -1,0 +1,133 @@
+summary: Define format of on-disk storage of results
+title: Results Format
+order: 90
+
+description: |
+    The following text defines a YAML file structure tmt uses for storing
+    results. tmt itself will use it when saving results of ``execute`` step,
+    and custom test results are required to follow it when creating their
+    ``results.yaml`` file.
+
+    Results are saved as a YAML file, containing a single list of mappings,
+    one mapping describing a single test result.
+
+    .. code-block::
+
+       # String, name of the test.
+       name: /test/one
+
+       # String, outcome of the test execution.
+       result: "pass"|"fail"|"info"|"warn"|"error"
+
+       # String, optional comment to report with the result.
+       note: "Things were great."
+
+       # List of strings, paths to file logs.
+       log:
+         - path/to/log1
+         - path/to/log1
+           ...
+
+       # Mapping, collection of various test IDs, if there are any to track.
+       ids:
+         some-id: foo
+         another-id: bar
+
+       # String, how long did the test run.
+       duration: hh:mm:ss
+
+       # Integer, serial number of the test in the sequence of all tests of a plan.
+       serialnumber: 1
+
+       # Mapping, describes the guest on which the test was executed.
+       guest:
+         name: client-1
+         role: clients
+
+    The ``result`` key can have the following values:
+
+    pass
+        Test execution successfully finished and passed.
+
+    info
+        Test finished but only produced an informational
+        message. Represents a soft pass, used for skipped
+        tests and for tests with the :ref:`/spec/tests/result`
+        attribute set to ``ignore``. Automation must treat
+        this as a passed test.
+
+    warn
+        A problem appeared during test execution which does
+        not affect test results but might be worth checking
+        and fixing. For example test cleanup phase failed.
+        Automation must treat this as a failed test.
+
+    error
+        Undefined problem encountered during test execution.
+        Human inspection is needed to investigate whether it
+        was a test bug, infrastructure error or a real test
+        failure. Automation must treat it as a failed test.
+
+    fail
+        Test execution successfully finished and failed.
+
+    The ``name`` and ``result`` keys are required. Custom result files
+    may omit all other keys, although tmt plugins will strive to provide
+    as many keys as possible.
+
+    The ``log`` key must list **relative** paths. Paths in the custom
+    results file are treated as relative to ``${TMT_TEST_DATA}`` path.
+    Paths in the final results file, saved by the execute step, will be
+    relative to the location of the results file itself.
+
+    The first ``log`` item is considered to be the "main" log, presented
+    to the user by default.
+
+    The ``serialnumber`` and ``guest`` keys, if present in the custom
+    results file, will be overwritten by tmt during their import after
+    test completes. This happens on purpose, to assure this vital
+    information is correct.
+
+    See also the complete `JSON schema`__.
+
+    __ https://github.com/teemtee/tmt/blob/main/tmt/schemas/results.yaml
+
+example:
+  - |
+    # Example content of results.yaml
+
+    - name: /test/passing
+      result: pass
+      serialnumber: 1
+      log:
+        - pass_log
+      duration: 00:11:22
+      note: good result
+      ids:
+        extra-nitrate: some-nitrate-id
+      guest:
+        name: default-0
+
+    - name: /test/failing
+      result: fail
+      serialnumber: 2
+      log:
+        - fail_log
+        - another_log
+      duration: 00:22:33
+      note: fail result
+      guest:
+        name: default-0
+
+  - |
+    # Example of a perfectly valid, yet stingy custom results file
+
+    - name: /test/passing
+      result: pass
+
+    - name: /test/failing
+      result: fail
+
+link:
+  - verified-by: /tests/execute/result
+  - implemented-by: /tmp/result.py

--- a/spec/tests/result.fmf
+++ b/spec/tests/result.fmf
@@ -21,13 +21,12 @@ description: |
         value instead
     custom
         test needs to create it's own ``results.yaml`` file in the
-        ``${TMT_TEST_DATA}`` directory. The ``results.yaml`` contains list of
-        dictionaries. Each dictionary must contain at least a ``name`` key,
-        whose value would be appended to the original test name (a special
-        value ``name: "/"`` sets result for the test itself) and a ``result``
-        key. Optional keys are ``log`` (a list of paths to log
-        files, each path must be relative to path in ``$TMT_TEST_DATA``
-        environment variable), ``duration`` (in HH:MM:SS format) and ``note``.
+        ``${TMT_TEST_DATA}`` directory. The format of the file is
+        documented at :ref:`/spec/plans/results`. When importing results
+        from the custom file, each test name, referenced in the file via
+        ``name`` key, would be prefixed by the original test name. A
+        special case, ``name: /``, sets the result for the original test
+        itself.
 
 example:
   - |
@@ -36,7 +35,7 @@ example:
   - |
     # Custom results - results.yaml needs to be provided to the ${TMT_TEST_DATA} directory
     result: custom
-  - |
+
     # Example content of results.yaml
     - name: /test/passing
       result: pass
@@ -44,6 +43,7 @@ example:
         - pass_log
       duration: 00:11:22
       note: good result
+
     - name: /test/failing
       result: fail
       log:
@@ -51,6 +51,7 @@ example:
         - another_log
       duration: 00:22:33
       note: fail result
+
     - name: /test/no_keys
       result: pass
 

--- a/tmt/schemas/results.yaml
+++ b/tmt/schemas/results.yaml
@@ -33,6 +33,9 @@ items:
       type: string
       pattern: "^/.*"
 
+    serialnumber:
+      type: integer
+
     result:
       $ref: "/schemas/common#/definitions/result_outcome"
 


### PR DESCRIPTION
The documentation existed, but it was repeated in multiple places, several fields were not described, and recent changes were missing completely. So trying to improve all that, with a detailed format description, pointer to a schema and more words to accompany them.