### PR TITLE
Add test start/end timestamps into results

### DIFF
--- a/spec/plans/results.fmf
+++ b/spec/plans/results.fmf
@@ -37,6 +37,12 @@ description: |
          some-id: foo
          another-id: bar
 
+       # String, when the test started, in an ISO 8601 format.
+       starttime: "yyyy-mm-ddThh:mm:ss.mmmmm+ZZ:ZZ"
+
+       # String, when the test finished, in an ISO 8601 format.
+       endtime: "yyyy-mm-ddThh:mm:ss.mmmmm+ZZ:ZZ"
+
        # String, how long did the test run.
        duration: hh:mm:ss
 
@@ -97,6 +103,13 @@ description: |
     test completes. This happens on purpose, to assure this vital
     information is correct.
 
+    Similarly, the ``duration``, ``starttime`` and ``endtime`` keys, if
+    present in the special custom result, representing the original test
+    itself - ``name: /`` -, will be overwritten by tmt with actual
+    observed values. This also happens on purpose: while tmt cannot
+    tell how long it took to produce various custom results, it is still
+    able to report the duration of the whole test.
+
     See also the complete `JSON schema`__.
 
     For custom results files in JSON format, the same rules and schema
@@ -112,7 +125,9 @@ example:
       serialnumber: 1
       log:
         - pass_log
-      duration: 00:11:22
+      starttime: "2023-03-10T09:44:14.439120+00:00"
+      endtime: "2023-03-10T09:44:24.242227+00:00"
+      duration: 00:00:09
       note: good result
       ids:
         extra-nitrate: some-nitrate-id
@@ -125,7 +140,9 @@ example:
       log:
         - fail_log
         - another_log
-      duration: 00:22:33
+      starttime: "2023-03-10T09:44:14.439120+00:00"
+      endtime: "2023-03-10T09:44:24.242227+00:00"
+      duration: 00:00:09
       note: fail result
       guest:
         name: default-0

--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -16,7 +16,8 @@ rlJournalStart
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 1 "Test provides 'results.yaml' file by itself"
         rlAssertGrep "00:11:22 pass /test/custom-results/test/passing" $rlRun_LOG
         rlAssertGrep "00:22:33 fail /test/custom-results/test/failing" $rlRun_LOG
-        rlAssertGrep "00:33:55 pass /test/custom-results (on default-0) \[1/1\]" $rlRun_LOG
+        # The duration of the main result is replaced with the duration measured by tmt for the whole test.
+        rlAssertGrep "00:00:00 pass /test/custom-results (on default-0) \[1/1\]" $rlRun_LOG
         rlAssertGrep "00:55:44 pass /test/custom-results/without-leading-slash.*name should start with '/'" $rlRun_LOG
         rlAssertGrep "total: 3 tests passed and 1 test failed" $rlRun_LOG
 
@@ -37,7 +38,8 @@ rlJournalStart
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 1 "Test provides 'results.json' file by itself"
         rlAssertGrep "00:12:23 pass /test/custom-json-results/test/passing" $rlRun_LOG
         rlAssertGrep "00:23:34 fail /test/custom-json-results/test/failing" $rlRun_LOG
-        rlAssertGrep "00:34:56 pass /test/custom-json-results .* \[1/1\]" $rlRun_LOG
+        # The duration of the main result is replaced with the duration measured by tmt for the whole test.
+        rlAssertGrep "00:00:00 pass /test/custom-json-results .* \[1/1\]" $rlRun_LOG
         rlAssertGrep "total: 2 tests passed and 1 test failed" $rlRun_LOG
 
         rlAssertExists "$(sed -n 's/ *pass_log: \(.\+\)/\1/p' $rlRun_LOG)"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -8,6 +8,7 @@ import threading
 import time
 import unittest
 import unittest.mock
+from datetime import timedelta
 from typing import Any, List, Tuple
 
 import py
@@ -985,3 +986,18 @@ def test_uniq(values: List[Any], expected: List[Any]) -> None:
     )
 def test_flatten(lists: List[List[Any]], unique: bool, expected: List[Any]) -> None:
     assert tmt.utils.flatten(lists, unique=unique) == expected
+
+
+@pytest.mark.parametrize(
+    ('duration', 'expected'),
+    (
+        (timedelta(seconds=8), '00:00:08'),
+        (timedelta(minutes=6, seconds=8), '00:06:08'),
+        (timedelta(hours=4, minutes=6, seconds=8), '04:06:08'),
+        (timedelta(days=15, hours=4, minutes=6, seconds=8), '364:06:08'),
+        )
+    )
+def test_format_duration(duration, expected):
+    from tmt.steps.execute import ExecutePlugin
+
+    assert ExecutePlugin.format_duration(duration) == expected

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -739,6 +739,8 @@ class Test(Core, tmt.export.Exportable['Test']):
     serialnumber: int = 0
 
     returncode: Optional[int] = None
+    starttime: Optional[str] = None
+    endtime: Optional[str] = None
     real_duration: Optional[str] = None
     _reboot_count: int = 0
 

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -81,7 +81,6 @@ class Result(tmt.utils.SerializableContainer):
         unserialize=ResultOutcome.from_spec
         )
     note: Optional[str] = None
-    duration: Optional[str] = None
     ids: Dict[str, Optional[str]] = field(default_factory=dict)
     log: List[Path] = field(
         default_factory=list,
@@ -93,6 +92,10 @@ class Result(tmt.utils.SerializableContainer):
         unserialize=lambda serialized: ResultGuestData.from_serialized(serialized)
         )
 
+    starttime: Optional[str] = None
+    endtime: Optional[str] = None
+    duration: Optional[str] = None
+
     @classmethod
     def from_test(
             cls,
@@ -100,7 +103,6 @@ class Result(tmt.utils.SerializableContainer):
             test: 'tmt.base.Test',
             result: ResultOutcome,
             note: Optional[str] = None,
-            duration: Optional[str] = None,
             ids: Optional[Dict[str, Optional[str]]] = None,
             log: Optional[List[Path]] = None,
             guest: Optional['tmt.steps.provision.Guest'] = None) -> 'Result':
@@ -146,7 +148,9 @@ class Result(tmt.utils.SerializableContainer):
             serialnumber=test.serialnumber,
             result=result,
             note=note,
-            duration=duration,
+            starttime=test.starttime,
+            endtime=test.endtime,
+            duration=test.real_duration,
             ids=ids,
             log=log or [],
             guest=guest_data)

--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -362,3 +362,8 @@ definitions:
       - error
       - fail
       - custom
+
+  timestamp:
+    type: string
+    # yamllint disable-line rule:line-length
+    pattern: "^\\d{2,}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+\\+\\d{2}:\\d{2}$"

--- a/tmt/schemas/results.yaml
+++ b/tmt/schemas/results.yaml
@@ -42,6 +42,12 @@ items:
     note:
       type: string
 
+    starttime:
+      $ref: "/schemas/common#/definitions/timestamp"
+
+    endtime:
+      $ref: "/schemas/common#/definitions/timestamp"
+
     duration:
       type: string
       pattern: "^[0-9]{2,}:[0-5][0-9]:[0-5][0-9]$"


### PR DESCRIPTION
There's already a duration, some users also find use for the actual
start/end timestamps.