### PR TITLE
Extract "run a command" functionality into a stand-alone helper

### DIFF
--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -260,7 +260,10 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 "the `--dist-git-merge` option.")
 
         def get_git_root(dir: Path) -> Path:
-            stdout, _ = self.run(Command("git", "rev-parse", "--show-toplevel"), cwd=dir, dry=True)
+            stdout, _ = self.run(
+                Command("git", "rev-parse", "--show-toplevel"),
+                cwd=dir,
+                ignore_dry=True)
             assert stdout is not None
             return Path(stdout.strip("\n"))
 

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -347,7 +347,7 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
                 run_result = self.run(
                     Command("git", "rev-parse", "--show-toplevel"),
                     cwd=self.step.plan.my_run.tree.root,
-                    dry=True)[0]
+                    ignore_dry=True)[0]
                 assert run_result is not None
                 git_root = Path(run_result.strip('\n'))
             except tmt.utils.RunError:


### PR DESCRIPTION
There are other places where running a command is a necessary tool, but as they lay outside of `Common` class tree, they cannot use `Common.run()`. To avoid duplication, and present "one obvious way to do 'it'", patch extracts the functionality into a stand-alone function, and teaches `Common` class to use it.