### PR TITLE
Move testcloud url guessing logic out of tmt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ extras_require = {
         'mypy',
         'yq'
         ],
-    'provision': ['testcloud>=0.8.2'],
+    'provision': ['testcloud>=0.9.2'],
     'convert': [
         'nitrate',
         'markdown',

--- a/tmt.spec
+++ b/tmt.spec
@@ -44,7 +44,7 @@ BuildRequires: python%{python3_pkgversion}-pytest
 BuildRequires: python%{python3_pkgversion}-click
 BuildRequires: python%{python3_pkgversion}-fmf >= 1.2.0
 BuildRequires: python%{python3_pkgversion}-requests
-BuildRequires: python%{python3_pkgversion}-testcloud >= 0.8.2
+BuildRequires: python%{python3_pkgversion}-testcloud >= 0.9.2
 BuildRequires: python%{python3_pkgversion}-markdown
 BuildRequires: python%{python3_pkgversion}-junit_xml
 BuildRequires: python%{python3_pkgversion}-ruamel-yaml
@@ -78,7 +78,7 @@ Dependencies required to run tests in a container environment.
 Summary: Virtual machine provisioner for the Test Management Tool
 Obsoletes: tmt-testcloud < 0.17
 Requires: tmt == %{version}-%{release}
-Requires: python%{python3_pkgversion}-testcloud >= 0.8.2
+Requires: python%{python3_pkgversion}-testcloud >= 0.9.2
 Requires: libvirt-daemon-config-network
 Requires: openssh-clients
 Requires: (ansible or ansible-core)


### PR DESCRIPTION
testcloud counterpart: https://pagure.io/testcloud/pull-request/144 . 

Adds support for Alma Linux, Rocky Linux, and Oracle Linux. 

testcloud-side, things should be more robust. The one todo I have is for alma url guessing improvement as they have no base mirror/no transparent redirect to the fastest/closest.

@lbrabec took a look at libosinfo and found it insufficient for this use-case (he'll chime in next week with his findings).

Feel free to comment here even about testcloud side of changes.