### PR TITLE
Display guest full name in "html" plugin report

### DIFF
--- a/tests/report/html/data/main.fmf
+++ b/tests/report/html/data/main.fmf
@@ -24,3 +24,22 @@
         summary: Run command 'false' but report pass
         test: 'false'
         result: xfail
+
+# Special plan to introduce more than one guest, for verification of --display-guest.
+# Disabled by default, but enabled in the corresponding test by a magic of context.
+/multihost-plan:
+    enabled: false
+
+    discover:
+        how: fmf
+    provision:
+        - name: guest-1
+          how: container
+        - name: guest-2
+          how: container
+    execute:
+        how: tmt
+
+    adjust:
+      - when: report_multihost == yes
+        enabled: true

--- a/tests/report/html/test.sh
+++ b/tests/report/html/test.sh
@@ -67,6 +67,28 @@ rlJournalStart
         fi
     done
 
+    rlPhaseStartTest "Check guest display modes"
+        # Two cases for multihost, one with a single guest, other with multiple, to test the default "auto"...
+        rlRun -s "tmt run -av --scratch --id $tmp test -n pass report -h html"
+        rlAssertNotGrep "<th>Guest</th>" "$tmp/plan/report/default-0/index.html"
+        rlAssertNotGrep "<td class=\"guest\">default-0</td>" "$tmp/plan/report/default-0/index.html"
+
+        rlRun -s "tmt -c report_multihost=yes run -av --scratch --id $tmp plan -n multihost-plan test -n pass report -h html"
+        rlAssertGrep "<th>Guest</th>" "$tmp/multihost-plan/report/default-0/index.html"
+        rlAssertGrep "<td class=\"guest\">guest-1</td>" "$tmp/multihost-plan/report/default-0/index.html"
+        rlAssertGrep "<td class=\"guest\">guest-2</td>" "$tmp/multihost-plan/report/default-0/index.html"
+
+        # ...then "always", ...
+        rlRun -s "tmt run -av --scratch --id $tmp test -n pass report -h html --display-guest always"
+        rlAssertGrep "<th>Guest</th>" "$tmp/plan/report/default-0/index.html"
+        rlAssertGrep "<td class=\"guest\">default-0</td>" "$tmp/plan/report/default-0/index.html"
+
+        # ... and "never".
+        rlRun -s "tmt run -av --scratch --id $tmp test -n pass report -h html --display-guest never"
+        rlAssertNotGrep "<th>Guest</th>" "$tmp/plan/report/default-0/index.html"
+        rlAssertNotGrep "<td class=\"guest\">default-0</td>" "$tmp/plan/report/default-0/index.html"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -rf $tmp"

--- a/tmt/schemas/report/html.yaml
+++ b/tmt/schemas/report/html.yaml
@@ -25,5 +25,8 @@ properties:
   absolute-paths:
     type: boolean
 
+  display-guest:
+    type: boolean
+
 required:
   - how

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -31,6 +31,15 @@ class ReportHtmlData(tmt.steps.report.ReportStepData):
         help='Make paths absolute rather than relative to working directory.'
         )
 
+    display_guest: str = field(
+        default='auto',
+        option='--display-guest',
+        metavar='auto|always|never',
+        choices=['auto', 'always', 'never'],
+        help="When to display full guest name in report:"
+             " when more than a single guest was involved (default), always, or never."
+        )
+
 
 @tmt.steps.provides_method('html')
 class ReportHtml(tmt.steps.report.ReportPlugin):
@@ -70,6 +79,20 @@ class ReportHtml(tmt.steps.report.ReportPlugin):
         with open(HTML_TEMPLATE_PATH) as file:
             template = environment.from_string(file.read())
 
+        if self.get('display-guest') == 'always':
+            display_guest = True
+
+        elif self.get('display-guest') == 'never':
+            display_guest = False
+
+        else:
+            seen_guests = {
+                result.guest.name
+                for result in self.step.plan.execute.results() if result.guest.name is not None
+                }
+
+            display_guest = len(seen_guests) > 1
+
         # Write the report
         filename = Path('index.html')
         self.write(
@@ -77,7 +100,8 @@ class ReportHtml(tmt.steps.report.ReportPlugin):
             data=template.render(
                 results=self.step.plan.execute.results(),
                 base_dir=self.step.plan.execute.workdir,
-                plan=self.step.plan))
+                plan=self.step.plan,
+                display_guest=display_guest))
 
         # Nothing more to do in dry mode
         if self.opt('dry'):

--- a/tmt/steps/report/html/template.html.j2
+++ b/tmt/steps/report/html/template.html.j2
@@ -88,6 +88,19 @@
         }
     </style>
 </head>
+
+{% macro emit_guest(guest) %}
+{% if display_guest %}
+  {% if guest %}
+    {% if guest.role %}
+      {{ guest.name }} ({{ guest.role }})
+    {% else %}
+      {{ guest.name }}
+    {% endif %}
+  {% endif %}
+{% endif %}
+{% endmacro %}
+
 <body>
 <div>
 <h1>{{ plan.name }}</h1>
@@ -98,6 +111,9 @@
         <tr>
             <th>Result</th>
             <th>Test</th>
+{% if display_guest %}
+            <th>Guest</th>
+{% endif %}
             <th>Logs</th>
         </tr>
     </thead>
@@ -105,6 +121,9 @@
     <tr class="result {{ loop.cycle('odd', 'even') }}">
         <td class="result {{ result.result.value|e }}">{{ result.result.value|e }}</td>
         <td class="name">{{ result.name|e }}</td>
+{% if display_guest %}
+        <td class="guest">{{ emit_guest(result.guest) | trim | e }}</td>
+{% endif %}
         <td class="log">
         {% for log in result.log %}
             <a href="{{ base_dir | linkable_path | urlencode }}/{{ log | urlencode }}">{{ log | basename }}</a>


### PR DESCRIPTION
To visualy connect results with the guest - with multi-host in queue, a single test may appear multiple times, this should be a nice visual aid.