### PR TITLE
Fix `get_bootstrap_logger` name and docstring typo

### DIFF
--- a/plans/install/docs.fmf
+++ b/plans/install/docs.fmf
@@ -13,4 +13,4 @@ execute:
         cd docs
         python3 -m sphinx -T -E -b html -d _build/doctrees \
             . _build/html 2>&1 | tee output
-        grep WARNING output && exit 1 || exit 0
+        egrep 'ERROR|WARNING' output && exit 1 || exit 0

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -223,4 +223,4 @@ def test_labels(caplog: _pytest.logging.LogCaptureFixture, root_logger: Logger) 
 
 
 def test_bootstrap_logger(caplog: _pytest.logging.LogCaptureFixture) -> None:
-    _exercise_logger(caplog, Logger.get_boostrap_logger())
+    _exercise_logger(caplog, Logger.get_bootstrap_logger())

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -613,18 +613,19 @@ class Logger:
     _bootstrap_logger: Optional['Logger'] = None
 
     @classmethod
-    def get_boostrap_logger(cls) -> 'Logger':
+    def get_bootstrap_logger(cls) -> 'Logger':
         """
         Create a logger designed for tmt startup time.
 
         .. warning::
 
-        This logger has a **very** limited use case span, i.e. before tmt can
-        digest its command-line options and create a proper logger. This happens
-        inside :py:funs:`tmt.cli.main` function, but there are some actions taken
-        by tmt code before this function is called by Click, actions that need
-        to emit logging messages. Using it anywhere outside of this brief time
-        in tmt's runtime should be ruled out.
+            This logger has a **very** limited use case span, i.e.
+            before tmt can digest its command-line options and create a
+            proper logger. This happens inside :py:func:`tmt.cli.main`
+            function, but there are some actions taken by tmt code
+            before this function is called by Click, actions that need
+            to emit logging messages. Using it anywhere outside of this
+            brief time in tmt's runtime should be ruled out.
         """
 
         if cls._bootstrap_logger is None:


### PR DESCRIPTION
Two errors were raised when building documentation using `make docs`:

    Content block expected for the "warning" directive; none found.
    Unknown interpreted text role "py:funs".

Fix them, fix typo in the method name and extend `/plans/install/docs` to catch similar problems in the future.