### PR TITLE
Improve names and docs around CLI context in Common classes

### DIFF
--- a/tests/integration/test_nitrate.py
+++ b/tests/integration/test_nitrate.py
@@ -327,7 +327,7 @@ extra-task: /tmt/integration
         tree_f36_intel = tmt.Tree(
             logger=tmt.log.Logger.create(),
             path='.',
-            context={
+            fmf_context={
                 'distro': ['fedora-36'],
                 'arch': ['x86_64']})
 
@@ -341,7 +341,7 @@ extra-task: /tmt/integration
         tree_f35_intel = tmt.Tree(
             logger=tmt.log.Logger.create(),
             path='.',
-            context={
+            fmf_context={
                 'distro': ['fedora-35'],
                 'arch': ['x86_64']})
 

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -183,7 +183,7 @@ def main(
     click_contex.color = apply_colors_output
 
     # Save click context and fmf context for future use
-    tmt.utils.Common._save_context(click_contex)
+    tmt.utils.Common._save_cli_context(click_contex)
 
     # Initialize metadata tree (from given path or current directory)
     tree = tmt.Tree(logger=logger, path=Path(root))
@@ -263,7 +263,7 @@ def run(context: Context, id_: Optional[str], **kwargs: Any) -> None:
     run = tmt.Run(
         id_=Path(id_) if id_ is not None else None,
         tree=context.obj.tree,
-        context=context,
+        cli_context=context,
         logger=logger
         )
     context.obj.run = run
@@ -306,7 +306,7 @@ def run_plans(context: Context, **kwargs: Any) -> None:
     Regular expression can be used to filter plans by name.
     Use '.' to select plans under the current working directory.
     """
-    tmt.base.Plan._save_context(context)
+    tmt.base.Plan._save_cli_context(context)
 
 
 @run.command(name='tests')
@@ -332,7 +332,7 @@ def run_tests(context: Context, **kwargs: Any) -> None:
     Regular expression can be used to filter tests by name.
     Use '.' to select tests under the current working directory.
     """
-    tmt.base.Test._save_context(context)
+    tmt.base.Test._save_cli_context(context)
 
 
 # FIXME: click 8.0 renamed resultcallback to result_callback. The former
@@ -388,7 +388,7 @@ def tests_ls(context: Context, **kwargs: Any) -> None:
     Regular expression can be used to filter tests by name.
     Use '.' to select tests under the current working directory.
     """
-    tmt.Test._save_context(context)
+    tmt.Test._save_cli_context(context)
     for test in context.obj.tree.tests():
         test.ls()
 
@@ -404,7 +404,7 @@ def tests_show(context: Context, **kwargs: Any) -> None:
     Regular expression can be used to filter tests by name.
     Use '.' to select tests under the current working directory.
     """
-    tmt.Test._save_context(context)
+    tmt.Test._save_cli_context(context)
     for test in context.obj.tree.tests():
         test.show()
         echo()
@@ -425,7 +425,7 @@ def tests_lint(context: Context, **kwargs: Any) -> None:
     """
     # FIXME: Workaround https://github.com/pallets/click/pull/1840 for click 7
     context.params.update(**kwargs)
-    tmt.Test._save_context(context)
+    tmt.Test._save_cli_context(context)
     exit_code = 0
     for test in context.obj.tree.tests():
         if not test.lint():
@@ -459,7 +459,7 @@ def tests_create(
     current working directory.
     """
     assert context.obj.tree.root is not None  # narrow type
-    tmt.Test._save_context(context)
+    tmt.Test._save_cli_context(context)
     tmt.Test.create(name, template, context.obj.tree.root, force)
 
 
@@ -545,7 +545,7 @@ def tests_import(
     nitrate ...... contact, component, tag, environment, relevancy, enabled
     polarion ..... summary, enabled, assignee, id, component, tag, description, link
     """
-    tmt.Test._save_context(context)
+    tmt.Test._save_cli_context(context)
 
     if manual:
         if not (case or plan):
@@ -657,7 +657,7 @@ def tests_export(
     Regular expression can be used to filter tests by name.
     Use '.' to select tests under the current working directory.
     """
-    tmt.Test._save_context(context)
+    tmt.Test._save_cli_context(context)
 
     if nitrate:
         context.obj.common.warn(
@@ -703,7 +703,7 @@ def tests_id(context: Context, **kwargs: Any) -> None:
     filter and the value is stored to disk. Existing identifiers
     are kept intact.
     """
-    tmt.Test._save_context(context)
+    tmt.Test._save_cli_context(context)
     for test in context.obj.tree.tests():
         tmt.identifier.id_command(test.node, "test", dry=kwargs["dry"])
 
@@ -724,7 +724,7 @@ def plans(context: Context, **kwargs: Any) -> None:
     Search for available plans.
     Explore detailed test step configuration.
     """
-    tmt.Plan._save_context(context)
+    tmt.Plan._save_cli_context(context)
 
     # Show overview of available plans
     if context.invoked_subcommand is None:
@@ -743,7 +743,7 @@ def plans_ls(context: Context, **kwargs: Any) -> None:
     Regular expression can be used to filter plans by name.
     Use '.' to select plans under the current working directory.
     """
-    tmt.Plan._save_context(context)
+    tmt.Plan._save_cli_context(context)
     for plan in context.obj.tree.plans():
         plan.ls()
 
@@ -760,7 +760,7 @@ def plans_show(context: Context, **kwargs: Any) -> None:
     Regular expression can be used to filter plans by name.
     Use '.' to select plans under the current working directory.
     """
-    tmt.Plan._save_context(context)
+    tmt.Plan._save_cli_context(context)
     for plan in context.obj.tree.plans():
         plan.show()
         echo()
@@ -780,7 +780,7 @@ def plans_lint(context: Context, **kwargs: Any) -> None:
     """
     # FIXME: Workaround https://github.com/pallets/click/pull/1840 for click 7
     context.params.update(**kwargs)
-    tmt.Plan._save_context(context)
+    tmt.Plan._save_cli_context(context)
     exit_code = 0
     for plan in context.obj.tree.plans():
         if not plan.lint():
@@ -827,7 +827,7 @@ def plans_create(
         **kwargs: Any) -> None:
     """ Create a new plan based on given template. """
     assert context.obj.tree.root is not None  # narrow type
-    tmt.Plan._save_context(context)
+    tmt.Plan._save_cli_context(context)
     tmt.Plan.create(name, template, context.obj.tree.root, force)
 
 
@@ -866,7 +866,7 @@ def plans_export(
     Regular expression can be used to filter plans by name.
     Use '.' to select plans under the current working directory.
     """
-    tmt.Plan._save_context(context)
+    tmt.Plan._save_cli_context(context)
 
     if format != _test_export_default:
         context.obj.common.warn("Option '--format' is deprecated, please use '--how' instead.")
@@ -893,7 +893,7 @@ def plans_id(context: Context, **kwargs: Any) -> None:
     filter and the value is stored to disk. Existing identifiers
     are kept intact.
     """
-    tmt.Plan._save_context(context)
+    tmt.Plan._save_cli_context(context)
     for plan in context.obj.tree.plans():
         tmt.identifier.id_command(plan.node, "plan", dry=kwargs["dry"])
 
@@ -913,7 +913,7 @@ def stories(context: Context, **kwargs: Any) -> None:
     Check available user stories.
     Explore coverage (test, implementation, documentation).
     """
-    tmt.Story._save_context(context)
+    tmt.Story._save_cli_context(context)
 
     # Show overview of available stories
     if context.invoked_subcommand is None:
@@ -942,7 +942,7 @@ def stories_ls(
     Regular expression can be used to filter stories by name.
     Use '.' to select stories under the current working directory.
     """
-    tmt.Story._save_context(context)
+    tmt.Story._save_cli_context(context)
     for story in context.obj.tree.stories():
         if story._match(implemented, verified, documented, covered,
                         unimplemented, unverified, undocumented, uncovered):
@@ -971,7 +971,7 @@ def stories_show(
     Regular expression can be used to filter stories by name.
     Use '.' to select stories under the current working directory.
     """
-    tmt.Story._save_context(context)
+    tmt.Story._save_cli_context(context)
     for story in context.obj.tree.stories():
         if story._match(implemented, verified, documented, covered,
                         unimplemented, unverified, undocumented, uncovered):
@@ -999,7 +999,7 @@ def stories_create(
         **kwargs: Any) -> None:
     """ Create a new story based on given template. """
     assert context.obj.tree.root is not None  # narrow type
-    tmt.Story._save_context(context)
+    tmt.Story._save_cli_context(context)
     tmt.Story.create(name, template, context.obj.tree.root, force)
 
 
@@ -1034,7 +1034,7 @@ def stories_coverage(
     Regular expression can be used to filter stories by name.
     Use '.' to select stories under the current working directory.
     """
-    tmt.Story._save_context(context)
+    tmt.Story._save_cli_context(context)
 
     def headfoot(text: str) -> None:
         """ Format simple header/footer """
@@ -1124,7 +1124,7 @@ def stories_export(
     Regular expression can be used to filter stories by name.
     Use '.' to select stories under the current working directory.
     """
-    tmt.Story._save_context(context)
+    tmt.Story._save_cli_context(context)
 
     if format != _test_export_default:
         context.obj.common.warn("Option '--format' is deprecated, please use '--how' instead.")
@@ -1157,7 +1157,7 @@ def stories_lint(context: Context, **kwargs: Any) -> None:
     """
     # FIXME: Workaround https://github.com/pallets/click/pull/1840 for click 7
     context.params.update(**kwargs)
-    tmt.Story._save_context(context)
+    tmt.Story._save_cli_context(context)
     exit_code = 0
     for story in context.obj.tree.stories():
         if not story.lint():
@@ -1190,7 +1190,7 @@ def stories_id(
     filter and the value is stored to disk. Existing identifiers
     are kept intact.
     """
-    tmt.Story._save_context(context)
+    tmt.Story._save_cli_context(context)
     for story in context.obj.tree.stories():
         if story._match(implemented, verified, documented, covered,
                         unimplemented, unverified, undocumented, uncovered):
@@ -1230,7 +1230,7 @@ def init(
     * 'full' template contains a 'full' story, an 'full' plan and a shell test.
     """
 
-    tmt.Tree._save_context(context)
+    tmt.Tree._save_cli_context(context)
     tmt.Tree.init(logger=context.obj.logger, path=Path(path), template=template, force=force)
 
 
@@ -1282,7 +1282,7 @@ def status(
             "used together.")
     if not Path(workdir_root).exists():
         raise tmt.utils.GeneralError(f"Path '{workdir_root}' doesn't exist.")
-    status_obj = tmt.Status(logger=context.obj.logger, context=context)
+    status_obj = tmt.Status(logger=context.obj.logger, cli_context=context)
     status_obj.show()
 
 
@@ -1317,7 +1317,7 @@ def clean(context: Context, **kwargs: Any) -> None:
     clean_obj = tmt.Clean(
         logger=context.obj.clean_logger,
         parent=context.obj.common,
-        context=context
+        cli_context=context
         )
     context.obj.clean = clean_obj
     exit_code = 0
@@ -1333,7 +1333,7 @@ def clean(context: Context, **kwargs: Any) -> None:
             .descend(logger_name='clean-images', extra_shift=0)
             .apply_verbosity_options(**kwargs),
             parent=clean_obj,
-            context=context
+            cli_context=context
             )
         if tmt.utils.WORKDIR_ROOT.exists():
             if not clean_obj.guests():
@@ -1417,7 +1417,7 @@ def clean_runs(
         .descend(logger_name='clean-runs', extra_shift=0)
         .apply_verbosity_options(**kwargs),
         parent=context.obj.clean,
-        context=context)
+        cli_context=context)
     context.obj.clean_partials["runs"].append(clean_obj.runs)
 
 
@@ -1458,7 +1458,7 @@ def clean_guests(
         .descend(logger_name='clean-guests', extra_shift=0)
         .apply_verbosity_options(**kwargs),
         parent=context.obj.clean,
-        context=context
+        cli_context=context
         )
     context.obj.clean_partials["guests"].append(clean_obj.guests)
 
@@ -1484,7 +1484,7 @@ def clean_images(context: Context, **kwargs: Any) -> None:
         .descend(logger_name='clean-images', extra_shift=0)
         .apply_verbosity_options(**kwargs),
         parent=context.obj.clean,
-        context=context
+        cli_context=context
         )
     context.obj.clean_partials["images"].append(clean_obj.images)
 

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -216,7 +216,7 @@ class Step(tmt.utils.Common):
             workdir: tmt.utils.WorkdirArgumentType = None,
             logger: tmt.log.Logger) -> None:
         """ Initialize and check the step data """
-        logger.apply_verbosity_options(**self.__class__._options)
+        logger.apply_verbosity_options(**self.__class__._cli_options)
 
         super().__init__(name=name, parent=plan, workdir=workdir, logger=logger)
 
@@ -295,10 +295,10 @@ class Step(tmt.utils.Common):
     @property
     def enabled(self) -> Optional[bool]:
         """ True if the step is enabled """
-        if self.plan.my_run is None or self.plan.my_run._context_object is None:
+        if self.plan.my_run is None or self.plan.my_run._cli_context_object is None:
             return None
 
-        return self.name in self.plan.my_run._context_object.steps
+        return self.name in self.plan.my_run._cli_context_object.steps
 
     @property
     def plugins_in_standalone_mode(self) -> int:
@@ -682,7 +682,7 @@ class BasePlugin(Phase):
             workdir: tmt.utils.WorkdirArgumentType = None,
             logger: tmt.log.Logger) -> None:
         """ Store plugin name, data and parent step """
-        logger.apply_verbosity_options(**self.__class__._options)
+        logger.apply_verbosity_options(**self.__class__._cli_options)
 
         # Store name, data and parent step
         super().__init__(
@@ -1154,7 +1154,7 @@ class Reboot(Action):
             help='Hard reboot of the machine. Unsaved data may be lost.')
         def reboot(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             """ Reboot the guest. """
-            Reboot._save_context(context)
+            Reboot._save_cli_context(context)
             Reboot._enabled = True
 
         return reboot
@@ -1242,7 +1242,7 @@ class Login(Action):
             the tests finished with given result (pass, info, fail,
             warn, error).
             """
-            Login._save_context(context)
+            Login._save_cli_context(context)
             Login._enabled = True
 
         return login

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -71,7 +71,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin):
                 context.parent.params['debug'] = 0
                 context.parent.params['verbose'] = 0
             context.obj.steps.add('discover')
-            Discover._save_context(context)
+            Discover._save_cli_context(context)
 
         return discover
 

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -519,7 +519,10 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         if self.opt('dry'):
             self._tests = []
             return
-        tree = tmt.Tree(logger=self._logger, path=tree_path, context=self.step.plan._fmf_context())
+        tree = tmt.Tree(
+            logger=self._logger,
+            path=tree_path,
+            fmf_context=self.step.plan._fmf_context)
         self._tests = tree.tests(
             filters=filters,
             names=names,

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -158,7 +158,7 @@ class ExecutePlugin(tmt.steps.Plugin):
             help='Use specified method for test execution.')
         def execute(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             context.obj.steps.add('execute')
-            Execute._save_context(context)
+            Execute._save_cli_context(context)
 
         return execute
 

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -222,17 +222,16 @@ class ExecuteUpgrade(ExecuteInternal):
         """ Silently run discover upgrade """
         # Make it quiet, we do not want any output from discover
         assert self._discover_upgrade is not None
-        assert self._discover_upgrade._context is not None
-        quiet = self._discover_upgrade._context.params['quiet']
+        quiet = self._discover_upgrade._cli_options['quiet']
         try:
-            self._discover_upgrade._context.params['quiet'] = True
+            self._discover_upgrade._cli_options['quiet'] = True
             # Discover normally uses also options from global Test class
             # (e.g. test -n foo). Ignore this when selecting upgrade tasks.
             tmt.base.Test.ignore_class_options = True
             self._discover_upgrade.wake()
             self._discover_upgrade.go()
         finally:
-            self._discover_upgrade._context.params['quiet'] = quiet
+            self._discover_upgrade._cli_options['quiet'] = quiet
             tmt.base.Test.ignore_class_options = False
 
     def _prepare_remote_discover_data(self, plan: tmt.base.Plan) -> tmt.steps._RawStepData:

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -46,7 +46,7 @@ class FinishPlugin(tmt.steps.Plugin):
             help='Use specified method for finishing tasks.')
         def finish(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             context.obj.steps.add('finish')
-            Finish._save_context(context)
+            Finish._save_cli_context(context)
 
         return finish
 
@@ -110,7 +110,7 @@ class Finish(tmt.steps.Step):
             # operations inside finish plugins on the guest use the
             # finish step config rather than provision step config.
             guest_copy = copy.copy(guest)
-            guest_copy._logger = guest._logger.clone().apply_verbosity_options(**self._options)
+            guest_copy._logger = guest._logger.clone().apply_verbosity_options(**self._cli_options)
             guest_copy.parent = self
             for phase in self.phases(classes=(Action, FinishPlugin)):
                 if isinstance(phase, Action):

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -61,7 +61,7 @@ class PreparePlugin(tmt.steps.Plugin):
             help='Use specified method for environment preparation.')
         def prepare(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             context.obj.steps.add('prepare')
-            Prepare._save_context(context)
+            Prepare._save_cli_context(context)
 
         return prepare
 
@@ -229,7 +229,7 @@ class Prepare(tmt.steps.Step):
             # prepare step config rather than provision step config.
             guest_copy = copy.copy(guest)
             guest_copy.inject_logger(
-                guest._logger.clone().apply_verbosity_options(**self._options))
+                guest._logger.clone().apply_verbosity_options(**self._cli_options))
             guest_copy.parent = self
             # Execute each prepare plugin
             for phase in self.phases(classes=(Action, PreparePlugin)):

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1108,7 +1108,7 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin):
             help='Use specified method for provisioning.')
         def provision(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             context.obj.steps.add('provision')
-            Provision._save_context(context)
+            Provision._save_cli_context(context)
 
         return provision
 

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -46,7 +46,7 @@ class ReportPlugin(tmt.steps.GuestlessPlugin):
             help='Use specified method for results reporting.')
         def report(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             context.obj.steps.add('report')
-            Report._save_context(context)
+            Report._save_cli_context(context)
 
         return report
 


### PR DESCRIPTION
A CLI context is saved, both as a class and instance members, and it's used as a source of CLI options and fmf context. Unfortunatelly, the word "context" is slightly overloaded, the patch tries to improve this plus adding a couple of comments and more verbose docstrings.

* `Common._context` and `Common._options` attributes gained `_cli` prefix. This makes it clear what kind of context it is, and puts them on par with already present `_fmf_context`.
* related methods have been renamed to match the added "cli" tag.
* also `context` parameter of `Common.__init__` is now called `cli_context`.
* since `_cli_context` and `_cli_options` are variables, not methods, methods serving the context or its parts are now properties. No more `self._context` but `self._fmf_context()`.