### PR TITLE
Explore all available plugins only once

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1579,20 +1579,19 @@ Coding
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you want to perform more advanced processing of the metadata
-which is not supported by the command line use Python.  Just
-import the ``tmt`` module and create a logger for debugging::
+which is not supported by the command line use Python. To get
+quickly started just import the ``tmt`` module and grow a new
+``tmt.Tree`` object::
 
     import tmt
-    from tmt.utils import Path
 
-    tree = tmt.Tree.grow(path=Path("/path/to/the/tree"))
+    tree = tmt.Tree.grow()
 
     for test in tree.tests():
         print(test.name)
 
-You might also want to explore all available plugins if you need
-to work with metadata export::
+Use the ``tmt.utils.Path`` class when specifying paths::
 
-    tmt.plugins.explore()
-    for plan in tree.plans():
-        print(plan.export(format="yaml"))
+    from tmt.utils import Path
+
+    tree = tmt.Tree.grow(path=Path("/path/to/the/tree"))

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -24,6 +24,8 @@ ENTRY_POINT_NAME = 'tmt.plugin'
 # Directories with module in environment variable
 ENVIRONMENT_NAME = 'TMT_PLUGINS'
 
+# Make a note when plugins have been already explored
+ALREADY_EXPLORED = False
 
 _TMT_ROOT = Path(tmt.__file__).resolve().parent
 
@@ -146,12 +148,25 @@ def _explore_entry_points(logger: Logger) -> None:
     _explore_entry_point(ENTRY_POINT_NAME, logger.descend())
 
 
-def explore(logger: Logger) -> None:
-    """ Explore all available plugin locations """
+def explore(logger: Logger, again: bool = False) -> None:
+    """
+    Explore all available plugin locations
+
+    By default plugins are explored only once to save time. Repeated
+    call does not have any effect. Use ``again=True`` to force plugin
+    exploration even if it has been already completed before.
+    """
+
+    # Nothing to do if already explored
+    global ALREADY_EXPLORED
+    if ALREADY_EXPLORED and not again:
+        return
 
     _explore_packages(logger)
     _explore_directories(logger)
     _explore_entry_points(logger)
+
+    ALREADY_EXPLORED = True
 
 
 def import_(*, module: str, path: Optional[Path] = None, logger: Logger) -> None:


### PR DESCRIPTION
By default, skip plugin exploration if already done. Allow repeatedly exploring plugins when explicitly requested. Update the code example as `Tree.grow()` now takes care of exploring plugins.
