### PR TITLE
Initial sketch of the integration with RP API [NEED HELP]

### DIFF
--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -1,30 +1,17 @@
 import dataclasses
-import io
 import os
-import types
-import zipfile
+from pathlib import Path
+from time import time
 from typing import Optional
+
+from reportportal_client import ReportPortalService
 
 import tmt.steps.report
 import tmt.utils
 
-from . import junit
 
-junit_xml: Optional[types.ModuleType] = None
-
-
-def import_junit_xml() -> None:
-    """
-    Import junit_xml module only when needed
-
-    Until we have a separate package for each plugin.
-    """
-    global junit_xml
-    try:
-        import junit_xml
-    except ImportError:
-        raise tmt.utils.ReportError(
-            "Missing 'junit-xml', fixable by 'pip install tmt[report-junit]'.")
+def timestamp():
+    return str(int(time() * 1000))
 
 
 @dataclasses.dataclass
@@ -46,105 +33,79 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
         help="The project name which is used to create the full URL.")
     launch_name: Optional[str] = tmt.utils.field(
         option="--launch-name",
-        metavar="NAME",
+        metavar="LAUNCH_NAME",
         default=None,
         help="The launch name (base name of run id used by default).")
 
 
 @tmt.steps.provides_method("reportportal")
 class ReportReportPortal(tmt.steps.report.ReportPlugin):
-    """
-    Report test results to a ReportPortal instance
-
-    Requires a TOKEN for authentication, a URL of the ReportPortal
-    instance and the PROJECT name. In addition to command line options
-    it's possible to use environment variables to set the url and token:
-
-        export TMT_REPORT_REPORTPORTAL_URL=...
-        export TMT_REPORT_REPORTPORTAL_TOKEN=...
-
-    The optional launch NAME is passed to ReportPortal. Assuming the URL
-    and TOKEN variables are provided by the environment, the config can
-    look like this:
-
-        report:
-            how: reportportal
-            project: baseosqe
-            launch-name: maven
-    """
+    """  Report test results to a ReportPortal instance  """
 
     _data_class = ReportReportPortalData
 
     def go(self) -> None:
-        """
-        Read executed tests, prepare junit, compress it to a zip zile and
-        send it to the ReportPortal instance.
-        """
-
+        """ Process results """
         super().go()
 
-        # Check the data, show interesting info to the user
-        # Required fields are: url, token and project
-        server = self.get("url")
-        if not server:
-            raise tmt.utils.ReportError("No ReportPortal server url provided.")
-        server = server.rstrip("/")
-
-        token = self.get("token")
-        if not token:
-            raise tmt.utils.ReportError("No ReportPortal token provided.")
-
+        endpoint = self.get("url")
         project = self.get("project")
-        if not project:
-            raise tmt.utils.ReportError("No ReportPortal project provided.")
-        self.info("project", project, color="green")
+        token = self.get("token")
+        launch_name = self.get("launch-name")
 
-        # Use provided launch name, default to run workdir name
-        assert self.step.plan.my_run is not None
-        assert self.step.plan.my_run.workdir is not None
-        launch_name = self.get("launch-name") or self.step.plan.my_run.workdir.name
-        self.info("launch", launch_name, color="green")
 
-        # Generate a xUnit report
-        import_junit_xml()
-        assert junit_xml is not None
-        suite = junit.make_junit_xml(self)
-        data = junit_xml.TestSuite.to_xml_string([suite])
+# # # # RP # # # #
+        service = ReportPortalService(endpoint=endpoint, project=project, token=token)
 
-        # Zip the report
-        bytestream = io.BytesIO()
-        with zipfile.ZipFile(bytestream, "w", compression=zipfile.ZIP_DEFLATED,
-                             compresslevel=1) as zipstream:
-            # XML file names are irrelevant to ReportPortal
-            with zipstream.open("tests.xml", "w") as entry:
-                entry.write(data.encode("utf-8"))
-        bytestream.seek(0)
+        # create launch and its items
+        launch_id = service.start_launch(name=launch_name,
+                                         start_time=timestamp(),
+                                         #  rerun=False,
+                                         #  rerunOf=None,
+                                         #  attributes={"attr1": "val1", "attr2": "val2"},
+                                         description="Testing RP API")
 
-        # Send the report to the ReportPortal instance
-        with tmt.utils.retry_session() as session:
-            url = f"{server}/api/v1/{project}/launch/import"
-            self.debug(f"Send the report to '{url}'.")
-            response = session.post(
-                url,
-                headers={
-                    "Authorization": "bearer " + token,
-                    "accept": "*/*",
-                    },
-                files={
-                    # The zip filename is used as the launch name in ReportPortal
-                    "file": (launch_name + ".zip", bytestream, "application/zip"),
-                    },
-                )
+        suite_id = service.start_test_item(name="Suite",
+                                           start_time=timestamp(),
+                                           item_type="SUITE",
+                                           #    attributes={"attr1": "val1", "attr2": "val2"},
+                                           description="Some Test Plan")
 
-        # Handle the response
-        try:
-            message = tmt.utils.yaml_to_dict(response.text).get("message")
-        except (tmt.utils.GeneralError, KeyError):
-            message = response.text
-        if not response.ok:
-            raise tmt.utils.ReportError(
-                f"Received non-ok status code from ReportPortal, response text is: {message}")
-        else:
-            self.debug(f"Response code from the server: {response.status_code}")
-            self.debug(f"Message from the server: {message}")
-            self.info("report", "Successfully uploaded.", "yellow")
+        test_id = service.start_test_item(name="Test Case",
+                                          start_time=timestamp(),
+                                          item_type="TEST",
+                                          #   parent_item_id=suite_id,
+                                          #   test_case_id="xx123",
+                                          #   code_ref="12345xxx",
+                                          parameters={"key1": "val1", "key2": "val2"},
+                                          #   attributes={"attr1": "val1", "attr2": "val2"},
+                                          description="Some Test Case")
+        # print("URL:         " + service.get_launch_ui_url())
+        # print("LAUNCH UIID: " + str(service.get_launch_ui_id()))
+        print("LAUNCH ID:   " + launch_id)
+        print("SUITE ID:    " + suite_id)
+        print("TEST ID:     " + test_id)
+
+        # report the logs
+        service.log(
+            time=timestamp(),
+            message="Hello World!",
+            level="INFO")        # item_id=test_id
+        log = "/var/tmp/tmt/run-341/plans/default/execute/data/test/output.txt"
+        service.log(
+            time=timestamp(),
+            message=Path(log).read_text(),
+            level="INFO")  # item_id=test_id
+        # service.log(item_id=test_id,time=timestamp(),message="Adding log attachment",
+        #             level="INFO",attachment={"name": "output.txt",
+        #                                      "data": Path(log).read_text(),
+        #                                      "mime": "text/plain"})  # usecase?
+
+        # finnish reporting
+        service.finish_test_item(end_time=timestamp(), status="PASSED")     # item_id=test_id
+        service.finish_test_item(end_time=timestamp(), status="PASSED")     # item_id=suite_id
+        service.finish_launch(end_time=timestamp())
+        service.terminate()
+# # # # # # # # #
+
+        return

--- a/tmt/steps/report/reportportal_template.py
+++ b/tmt/steps/report/reportportal_template.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from time import time
+
+from reportportal_client import ReportPortalService
+
+
+def timestamp():
+    return str(int(time() * 1000))
+
+
+endpoint = "https://reportportal-rhel.apps.ocp-c1.prod.psi.redhat.com"
+project = "<project name>"
+token = "<UUID Access Token>"   # RP > User Profile > Access Token
+service = ReportPortalService(endpoint=endpoint, project=project, token=token)
+launch_name = "Test Launch"
+
+# create launch and its items
+launch_id = service.start_launch(name=launch_name,
+                                 start_time=timestamp(),
+                                 rerun=False,       # eg.: True
+                                 rerunOf=None,  # "3070a17f-1... <launch_id> ...477e972"
+                                 attributes={"attr1": "val1", "attr2": "val2"},
+                                 description="Testing RP API")
+
+suite_id = service.start_test_item(name="Suite",
+                                   start_time=timestamp(),
+                                   item_type="SUITE",
+                                   attributes={"attr1": "val1", "attr2": "val2"},
+                                   description="Some Test Plan")
+
+test_id = service.start_test_item(name="Test Case",
+                                  start_time=timestamp(),
+                                  item_type="TEST",
+                                  parent_item_id=suite_id,
+                                  test_case_id="xx123",     # use case?
+                                  code_ref="12345xxx",      # use case?
+                                  parameters={"key1": "val1", "key2": "val2"},  # use case?
+                                  attributes={"attr1": "val1", "attr2": "val2"},
+                                  description="Some Test Case")
+print("URL:         " + service.get_launch_ui_url())
+print("LAUNCH UIID: " + str(service.get_launch_ui_id()))
+print("LAUNCH ID:   " + launch_id)
+print("SUITE ID:    " + suite_id)
+print("TEST ID:     " + test_id)
+
+# report the logs
+service.log(item_id=test_id, time=timestamp(), message="Hello World!", level="INFO")
+log = "/var/tmp/tmt/run-341/plans/default/execute/data/test/output.txt"
+service.log(item_id=test_id, time=timestamp(), message=Path(log).read_text(), level="INFO")
+service.log(item_id=test_id, time=timestamp(), message="Adding log attachment", level="INFO",
+            attachment={"name": "output.txt",
+                        "data": Path(log).read_text(),
+                        "mime": "text/plain"})          # usecase?
+
+# finnish reporting
+service.finish_test_item(item_id=test_id, end_time=timestamp(), status="PASSED")
+service.finish_test_item(item_id=suite_id, end_time=timestamp(), status="PASSED")
+service.finish_launch(end_time=timestamp())
+service.terminate()


### PR DESCRIPTION
* Added reportportal_template.py to demonstrate the result in RP, yet without tmt
* Rewrote reportportal.py with contents of the reportportal_template.py to integrate it with tmt, but behavior differs Errors that occured: 
- virtualenv requires `export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt` 
- reportedly unexpected keyword arguments within reportportal_client (all commented lines) 
- launch is reported in RP but is not finnished successfully because of errors (missing the commented arguments) 
- problem to satisfy mypy (no module 'reportportal_client', untyped function 'timestamp')