### PR TITLE
Add test for step data update with CLI options

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -938,19 +938,12 @@ class BasePlugin(Phase):
         :param keys: if specified, only the listed keys would be affected.
         """
 
-        keys = keys or list(self.data.keys())
-
-        for keyname in keys:
-            value = self.opt(tmt.utils.key_to_option(keyname))
-
-            # TODO: this test is incorrect. It should not test for false-ish values,
-            # but rather check whether the value returned by `self.opt()` is or is
-            # not option default. And that's apparently not trivial with current CLI
-            # handling.
-            if value is None or value == [] or value == () or value is False:
-                continue
-
-            tmt.utils.dataclass_normalize_field(self.data, keyname, value, self._logger)
+        tmt.utils.dataclass_normalize_options(
+            container=self.data,
+            option_getter=self.opt,
+            keys=keys,
+            logger=self._logger
+            )
 
     def wake(self) -> None:
         """

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -940,7 +940,7 @@ class BasePlugin(Phase):
 
         tmt.utils.dataclass_normalize_options(
             container=self.data,
-            option_getter=self.opt,
+            option_getter=self._click_opt,
             keys=keys,
             logger=self._logger
             )

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -4034,13 +4034,14 @@ def dataclass_normalize_options(
         are considered.
     :param preserve_modified: if set, only options whose value is not equal
         to field's default value would be saved in the container.
+    :param logger: used for logging.
     """
 
     keys = keys or list(container.keys())
 
     for keyname in keys:
         # Checks below try to prevent default options of CLI options from
-        # overwriting values already consumed from fmf nodes.This is no
+        # overwriting values already consumed from fmf nodes. This is no
         # simple task, since options have defaults, they are always present
         # in the set of options provided by Click, therefore we have no way
         # how to check whether the option was specified or not. Instead, we


### PR DESCRIPTION
This functionality has been inside `BasePlugin`, and today a bug was reported with its handling of flag-like options. Therefore, this patch:

* extracts the code into a standalone function, complementing the rest of normalization code,
* fixes the bug,
* fixes a few more issues discovered, mostly readability,
* adds a pile of comment WRT various related issues, and
* adds a unit test.