### PR TITLE
Rename Guest.full_name to Guest.multihost_name

### DIFF
--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -2,13 +2,13 @@ from tmt.log import Logger
 from tmt.steps.provision import Guest, GuestData
 
 
-def test_full_name(root_logger: Logger) -> None:
+def test_multihost_name(root_logger: Logger) -> None:
     assert Guest(
         logger=root_logger,
         name='foo',
-        data=GuestData(guest='bar')).full_name == 'foo'
+        data=GuestData(guest='bar')).multihost_name == 'foo'
 
     assert Guest(
         logger=root_logger,
         name='foo',
-        data=GuestData(guest='bar', role='client')).full_name == 'foo (client)'
+        data=GuestData(guest='bar', role='client')).multihost_name == 'foo (client)'

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -129,8 +129,8 @@ class Guest(tmt.utils.Common):
         return self._random_name(prefix="tmt-{0}-".format(run_id[-3:]))
 
     @property
-    def full_name(self) -> str:
-        """ Return guest's full name, i.e. name and its role """
+    def multihost_name(self) -> str:
+        """ Return guest's multihost name, i.e. name and its role """
 
         if self.role is None:
             return self.name
@@ -200,7 +200,7 @@ class Guest(tmt.utils.Common):
         if self.opt('dry'):
             return
 
-        self.info('full name', self.full_name, 'green')
+        self.info('multihost name', self.multihost_name, 'green')
 
         # A small helper to make the repeated run & extract combo easier on eyes.
         def _fetch_detail(command: Command, pattern: str) -> str:


### PR DESCRIPTION
New name fits the use case better.