### PR TITLE
Add test for template-based export plugin

### DIFF
--- a/tests/story/export/story-template.j2
+++ b/tests/story/export/story-template.j2
@@ -1,0 +1,1 @@
+This is a test template, it should have access to the story: "{{ STORY.name }}" means "{{ STORY.story }}".

--- a/tests/story/export/test.sh
+++ b/tests/story/export/test.sh
@@ -53,6 +53,11 @@ rlJournalStart
         rlAssertGrep "Status: implemented" $rlRun_LOG
     rlPhaseEnd
 
+    rlPhaseStartTest "Export with a custom template"
+        rlRun -s "tmt story export mini --how=template --template=../story-template.j2"
+        rlAssertGrep "This is a test template, it should have access to the story: \"/mini\" means \"As a user I want this and that\"." "$rlRun_LOG"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
     rlPhaseEnd


### PR DESCRIPTION
The plugin is already tested because `--how=rst` is using its code, but to make sure the standalone plugin works as expected, a trivial `story export` test is added.

Fixes #1825.
