### PR TITLE
Require `beaker` provision in `tmt-all`

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -159,6 +159,9 @@ Requires: tmt-report-html >= %{version}
 Requires: tmt-report-junit >= %{version}
 Requires: tmt-report-polarion >= %{version}
 Requires: tmt-report-reportportal >= %{version}
+%if 0%{?rhel} >= 9 || 0%{?fedora}
+Requires: tmt-provision-beaker >= %{version}
+%endif
 
 %description all
 All extra dependencies of the Test Management Tool. Install this


### PR DESCRIPTION
Add forgotten `Requires` for the new provision plugin.