### PR TITLE
Always try to run dhclient in cloud-init in virtual provision

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -84,8 +84,7 @@ runcmd:
   systemctl restart systemd-networkd; fi']
   - [sh, -c, 'if cat /etc/os-release |
   grep -q platform:el8; then systemctl restart sshd; fi']
-  - [sh, -c, 'if cat /etc/os-release |
-  grep -q ID=ubuntu; then dhclient; fi']
+  - [sh, -c, 'dhclient || :']
 """
 
 COREOS_DATA = """variant: fcos


### PR DESCRIPTION
Fixes https://github.com/teemtee/tmt/issues/1957
Fixes https://github.com/teemtee/tmt/issues/1716
Different fix for https://github.com/teemtee/tmt/pull/1938

I don't really understand *why* is this needed (on all Ubuntu and CentOS 7), but we can just run it everywhere with || : so it always returns 0 (even if the image doesn't have dhclient).