### PR TITLE
Add missing fields to custom results test

### DIFF
--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -16,11 +16,17 @@ rlJournalStart
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 1 "Test provides 'results.yaml' file by itself"
         rlAssertGrep "00:11:22 pass /test/custom-results/test/passing" $rlRun_LOG
         rlAssertGrep "00:22:33 fail /test/custom-results/test/failing" $rlRun_LOG
-        rlAssertGrep "         pass /test/custom-results \[1/1\]" $rlRun_LOG
+        rlAssertGrep "00:33:55 pass /test/custom-results \[1/1\]" $rlRun_LOG
         rlAssertGrep "total: 2 tests passed and 1 test failed" $rlRun_LOG
 
         rlAssertExists "$(sed -n 's/ *pass_log: \(.\+\)/\1/p' $rlRun_LOG)"
         rlAssertExists "$(sed -n 's/ *fail_log: \(.\+\)/\1/p' $rlRun_LOG)"
+        rlAssertExists "$(sed -n 's/ *another_log: \(.\+\)/\1/p' $rlRun_LOG)"
+
+        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serialnumber) \\(.result) \\(.guest.name)\"' $run/plans/default/execute/results.yaml"
+        rlAssertGrep "/test/custom-results/test/passing 1 pass default-0" $rlRun_LOG
+        rlAssertGrep "/test/custom-results/test/failing 1 fail default-0" $rlRun_LOG
+        rlAssertGrep "/test/custom-results 1 pass default-0" $rlRun_LOG
     rlPhaseEnd
 
     testName="/test/missing-custom-results"

--- a/tests/execute/result/custom/results.yaml
+++ b/tests/execute/result/custom/results.yaml
@@ -1,14 +1,40 @@
 - name: /test/passing
   result: pass
+  note: good result
   log:
     - pass_log
+  ids:
+    some-id: foo1
+    another-id: bar1
   duration: 00:11:22
-  note: good result
+  serialnumber: 1
+  guest:
+    name: client-1
+    role: clients
+
 - name: /test/failing
   result: fail
   log:
     - fail_log
+  ids:
+    some-id: foo2
+    another-id: bar2
   duration: 00:22:33
   note: fail result
+  serialnumber: 2
+  guest:
+    name: client-1
+    role: clients
+
 - name: /
   result: pass
+  log:
+    - another_log
+  ids:
+    some-id: foo3
+    another-id: bar3
+  duration: 00:33:55
+  serialnumber: 3
+  guest:
+    name: client-2
+    role: clients

--- a/tests/execute/result/custom/test.fmf
+++ b/tests/execute/result/custom/test.fmf
@@ -2,7 +2,7 @@ result: custom
 
 /custom-results:
     summary: Test provides custom results
-    test: cp results.yaml ${TMT_TEST_DATA}; touch ${TMT_TEST_DATA}/{pass,fail}_log
+    test: cp results.yaml ${TMT_TEST_DATA}; touch ${TMT_TEST_DATA}/{pass,fail,another}_log
 /missing-custom-results:
     summary: Test provides custom results but results.yaml is not present
     test: 'true'

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -12,7 +12,7 @@ import tmt
 import tmt.base
 import tmt.steps
 import tmt.utils
-from tmt.result import Result, ResultOutcome
+from tmt.result import Result, ResultGuestData, ResultOutcome
 from tmt.steps import Action, Step, StepData
 from tmt.steps.provision import Guest
 from tmt.utils import GeneralError, Path
@@ -435,6 +435,9 @@ class ExecutePlugin(tmt.steps.Plugin):
             # directory. And the serial number correspondence in results.yaml
             # can be useful, for grouping results that belong to the same tests.
             partial_result.serialnumber = test.serialnumber
+
+            # Enforce the correct guest info
+            partial_result.guest = ResultGuestData(name=guest.name, role=guest.role)
 
             custom_results.append(partial_result)
 


### PR DESCRIPTION
And while doing so, a bug was discovered, `guest` field was not updated during custom results loading.