### PR TITLE
Allow custom results.json

### DIFF
--- a/spec/tests/result.fmf
+++ b/spec/tests/result.fmf
@@ -20,13 +20,14 @@ description: |
         ignore the actual test result and always report provided
         value instead
     custom
-        test needs to create it's own ``results.yaml`` file in the
-        ``${TMT_TEST_DATA}`` directory. The format of the file is
-        documented at :ref:`/spec/plans/results`. When importing results
-        from the custom file, each test name, referenced in the file via
-        ``name`` key, would be prefixed by the original test name. A
-        special case, ``name: /``, sets the result for the original test
-        itself.
+        test needs to create it's own ``results.yaml`` or
+        ``results.json`` file in the ``${TMT_TEST_DATA}``
+        directory. The format of the file is documented at
+        :ref:`/spec/plans/results`. When importing results from
+        the custom file, each test name, referenced in the file
+        via ``name`` key, would be prefixed by the original test
+        name. A special case, ``name: /``, sets the result for the
+        original test itself.
 
 example:
   - |
@@ -54,6 +55,17 @@ example:
 
     - name: /test/no_keys
       result: pass
+  - |
+    # Example content of results.json
+    [
+    {
+    "name": "/test/passing",
+    "result": "pass",
+    "log": ["pass_log"],
+    "duration": "00:11:22",
+    "note": "good result"
+    }
+    ]
 
 link:
   - implemented-by: /tmt/base.py

--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -32,15 +32,34 @@ rlJournalStart
         rlAssertGrep "/test/custom-results/without-leading-slash 1 pass default-0" $rlRun_LOG
     rlPhaseEnd
 
+    testName="/test/custom-json-results"
+    rlPhaseStartTest "${testName}"
+        rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 1 "Test provides 'results.json' file by itself"
+        rlAssertGrep "00:12:23 pass /test/custom-json-results/test/passing" $rlRun_LOG
+        rlAssertGrep "00:23:34 fail /test/custom-json-results/test/failing" $rlRun_LOG
+        rlAssertGrep "00:34:56 pass /test/custom-json-results .* \[1/1\]" $rlRun_LOG
+        rlAssertGrep "total: 2 tests passed and 1 test failed" $rlRun_LOG
+
+        rlAssertExists "$(sed -n 's/ *pass_log: \(.\+\)/\1/p' $rlRun_LOG)"
+        rlAssertExists "$(sed -n 's/ *fail_log: \(.\+\)/\1/p' $rlRun_LOG)"
+        rlAssertExists "$(sed -n 's/ *another_log: \(.\+\)/\1/p' $rlRun_LOG)"
+    rlPhaseEnd
+
     testName="/test/missing-custom-results"
     rlPhaseStartTest "${testName}"
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test does not provide 'results.yaml' file"
-        rlAssertGrep "custom results file '/tmp/.*/plans/default/execute/data/guest/default-0/test/missing-custom-results-1/data/results.yaml' not found" $rlRun_LOG
+        rlAssertGrep "custom results file not found in '/tmp/.*/plans/default/execute/data/guest/default-0/test/missing-custom-results-1/data" $rlRun_LOG
     rlPhaseEnd
 
     testName="/test/empty-custom-results-file"
     rlPhaseStartTest "${testName}"
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 3 "Test provides empty 'results.yaml' file"
+        rlAssertGrep "total: no results found" $rlRun_LOG
+    rlPhaseEnd
+
+    testName="/test/empty-custom-results-json"
+    rlPhaseStartTest "${testName}"
+        rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 3 "Test provides empty 'results.json' file"
         rlAssertGrep "total: no results found" $rlRun_LOG
     rlPhaseEnd
 
@@ -50,10 +69,22 @@ rlJournalStart
         rlAssertGrep "Expected list in yaml data, got 'dict'." $rlRun_LOG
     rlPhaseEnd
 
+    testName="/test/wrong-json-results-file"
+    rlPhaseStartTest "${testName}"
+        rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test provides 'results.json' in valid JSON but wrong results format"
+        rlAssertGrep "Expected list in json data, got 'dict'." $rlRun_LOG
+    rlPhaseEnd
+
     testName="/test/invalid-yaml-results-file"
     rlPhaseStartTest "${testName}"
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test provides 'results.yaml' not in YAML format"
         rlAssertGrep "Invalid yaml syntax:" $rlRun_LOG
+    rlPhaseEnd
+
+    testName="/test/invalid-json-results-file"
+    rlPhaseStartTest "${testName}"
+        rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test provides 'results.json' not in JSON format"
+        rlAssertGrep "Invalid json syntax:" $rlRun_LOG
     rlPhaseEnd
 
     testName="/test/wrong-yaml-content"

--- a/tests/execute/result/custom/results.json
+++ b/tests/execute/result/custom/results.json
@@ -1,0 +1,55 @@
+[
+  {
+    "name": "/test/passing",
+    "result": "pass",
+    "note": "good result",
+    "log": [
+      "pass_log"
+    ],
+    "ids": {
+      "some-id": "foo1",
+      "another-id": "bar1"
+    },
+    "duration": "00:12:23",
+    "serialnumber": 1,
+    "guest": {
+      "name": "client-1",
+      "role": "clients"
+    }
+  },
+  {
+    "name": "/test/failing",
+    "result": "fail",
+    "log": [
+      "fail_log"
+    ],
+    "ids": {
+      "some-id": "foo2",
+      "another-id": "bar2"
+    },
+    "duration": "00:23:34",
+    "note": "fail result",
+    "serialnumber": 2,
+    "guest": {
+      "name": "client-1",
+      "role": "clients"
+    }
+  },
+  {
+    "name": "/",
+    "result": "pass",
+    "log": [
+      "another_log"
+    ],
+    "ids": {
+      "some-id": "foo3",
+      "another-id": "bar3"
+    },
+    "duration": "00:34:56",
+    "serialnumber": 3,
+    "guest": {
+      "name": "client-2",
+      "role": "clients"
+    }
+  }
+]

--- a/tests/execute/result/custom/test.fmf
+++ b/tests/execute/result/custom/test.fmf
@@ -1,20 +1,35 @@
 result: custom
 
 /custom-results:
-    summary: Test provides custom results
+    summary: Test provides custom results.yaml
     test: cp results.yaml ${TMT_TEST_DATA}; touch ${TMT_TEST_DATA}/{pass,fail,another,slash}_log
+/custom-json-results:
+    summary: Test provides custom results.json
+    test: cp results.json ${TMT_TEST_DATA}; touch ${TMT_TEST_DATA}/{pass,fail,another}_log
 /missing-custom-results:
-    summary: Test provides custom results but results.yaml is not present
+    summary: Test provides custom results but results.yaml or results.json are not present
     test: 'true'
 /empty-custom-results-file:
     summary: results.yaml is empty
     test: touch ${TMT_TEST_DATA}/results.yaml
+/empty-custom-results-json:
+    summary: results.json is empty
+    test: touch ${TMT_TEST_DATA}/results.json && touch ${TMT_TEST_DATA}/results.yaml
 /wrong-yaml-results-file:
     summary: results.yaml is valid YAML but wrong format
     test: echo "{}" > ${TMT_TEST_DATA}/results.yaml
+/wrong-json-results-file:
+    summary: results.json is valid json but wrong format
+    test: echo "{}" > ${TMT_TEST_DATA}/results.json
 /invalid-yaml-results-file:
     summary: results.yaml is invalid YAML
-    test: echo ":" > ${TMT_TEST_DATA}/results.yaml
+    test: echo "," > ${TMT_TEST_DATA}/results.yaml
+/invalid-json-results-file:
+    summary: results.json is invalid JSON
+    test: echo "," > ${TMT_TEST_DATA}/results.json
 /wrong-yaml-content:
     summary: results.yaml with wrong key in results YAML
     test: cp wrong_results.yaml ${TMT_TEST_DATA}/results.yaml
+/wrong-json-content:
+    summary: results.json with wrong key in results JSON
+    test: cp wrong_results.json ${TMT_TEST_DATA}/results.json

--- a/tests/execute/result/custom/wrong_results.json
+++ b/tests/execute/result/custom/wrong_results.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "/test/wrong-value",
+    "result": "errrrrr"
+  }
+]

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -388,20 +388,26 @@ class ExecutePlugin(tmt.steps.Plugin):
         """
         self.debug("Processing custom 'results.yaml' file created by the test itself.")
 
-        custom_results_path = self.data_path(test, guest, full=True) \
-            / tmt.steps.execute.TEST_DATA \
-            / 'results.yaml'
+        test_data_path = self.data_path(test, guest, full=True) \
+            / tmt.steps.execute.TEST_DATA
 
-        if not custom_results_path.exists():
-            # Missing results.yaml means error result, but tmt contines with other tests
+        custom_results_path_yaml = test_data_path / 'results.yaml'
+        custom_results_path_json = test_data_path / 'results.json'
+
+        if custom_results_path_yaml.exists():
+            with open(custom_results_path_yaml) as results_file:
+                results = tmt.utils.yaml_to_list(results_file)
+
+        elif custom_results_path_json.exists():
+            with open(custom_results_path_json) as results_file:
+                results = tmt.utils.json_to_list(results_file)
+
+        else:
             return [tmt.Result.from_test(
                 test=test,
-                note=f"custom results file '{custom_results_path}' not found",
+                note=f"custom results file not found in '{test_data_path}'",
                 result=ResultOutcome.ERROR,
                 guest=guest)]
-
-        with open(custom_results_path) as custom_results_file:
-            results = tmt.utils.yaml_to_list(custom_results_file)
 
         custom_results = []
         for partial_result_data in results:

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -7,6 +7,7 @@ import dataclasses
 import datetime
 import functools
 import io
+import json
 import os
 import pathlib
 import pprint
@@ -1751,6 +1752,21 @@ def yaml_to_list(data: Any,
     if not isinstance(loaded_data, list):
         raise GeneralError(
             f"Expected list in yaml data, "
+            f"got '{type(loaded_data).__name__}'.")
+    return loaded_data
+
+
+def json_to_list(data: Any) -> List[Any]:
+    """ Convert json into list """
+
+    try:
+        loaded_data = json.load(data)
+    except json.decoder.JSONDecodeError as error:
+        raise GeneralError(f"Invalid json syntax: {error}")
+
+    if not isinstance(loaded_data, list):
+        raise GeneralError(
+            f"Expected list in json data, "
             f"got '{type(loaded_data).__name__}'.")
     return loaded_data
 


### PR DESCRIPTION
Currently, users can let their tests [create their own results.yaml](https://tmt.readthedocs.io/en/stable/spec/tests.html#result). Looking at the code, I don't see anything that would fundamentally require it to be yaml-only, though I haven't familiarized myself with the inner-workings of tmt yet, so feel free to close this PR if it's stupid :smiling_face_with_tear:   

Rationale:  
When running tests written in Python, generating yaml files without creating custom yaml parser means importing external package, which means adding extra dependency. This is especially problematic for packages like pyYAML, ruamel, etc, as they are not pure-python and pre-built wheels are not available for all architectures (e.g. ppc64le, s390x).

with json, users can just use (built-in) json.dump(). Example:
```
import json

result = []

if some_setup_step():
    result.append({'name': '/some_setup', 'result': 'pass''})

#...test...

with open(f"{TMT_TEST_DATA}/results.json", "w") as f:
    json.dump(result, f)
```