### PR TITLE
Install `beakerlib` before running `ShellCheck`

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Clone beakerlib repository
+        run: git clone --depth=1 https://github.com/beakerlib/beakerlib.git
+
+      - name: Build and install beakerlib
+        run: cd beakerlib && sudo make && sudo make install && cd -
+
       - id: ShellCheck
         name: Differential ShellCheck
         uses: redhat-plumbers-in-action/differential-shellcheck@v4


### PR DESCRIPTION
It should prevent ShellCheck from reporting defects like: `Not following: /usr/share/beakerlib/beakerlib.sh: openBinaryFile: does not exist (No such file or directory)`

- https://github.com/teemtee/tmt/pull/1965#discussion_r1156857054

/cc @psss 