### PR TITLE
Freeze the `yq` version to fix `el8` installation

### DIFF
--- a/plans/features/main.fmf
+++ b/plans/features/main.fmf
@@ -12,7 +12,10 @@ prepare+:
       # install yq there. Otherwise, we'd change system packages, but we'd
       # have to run as root to do that, and who's running tmt test suite
       # as root?
-      - pip3 install --user yq || pip3 install yq
+      #
+      # We need to freeze yq to 3.1.1 so that it's installable on el8 as
+      # newer yq requires tomlkit>=0.11.7 which is python 3.7+ only.
+      - pip3 install --user yq==3.1.1 || pip3 install yq==3.1.1
       - yq --help
 
 adjust+:

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ extras_require = {
         'requre',
         'pre-commit',
         'mypy',
-        'yq'
+        'yq==3.1.1'  # frozen to be able to install on el8
         ],
     'provision': [
         'testcloud>=0.9.2',


### PR DESCRIPTION
Latest `tomlkit` requires `python-3.7` and newer.