### PR TITLE
Proper support for the `duration` format

### DIFF
--- a/spec/tests/duration.fmf
+++ b/spec/tests/duration.fmf
@@ -24,6 +24,18 @@ example:
     # One day
     duration: 1d
 
+  - |
+    # Combination & repetition of time suffixes (total 4h 2m 3s)
+    duration: 1h 3h 2m 3
+
+  - |
+    # Use context adjust to extend duration for given arch
+    duration: 5m
+    adjust:
+        duration+: 15m
+        when: arch == aarch64
+
+
 link:
   - implemented-by: /tmt/base
   - verified-by: /tests/discover/duration

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -225,8 +225,18 @@ def test_duration_to_seconds():
     assert duration_to_seconds('5m') == 300
     assert duration_to_seconds('5h') == 18000
     assert duration_to_seconds('5d') == 432000
+    assert duration_to_seconds('5d') == 432000
+    # `man sleep` says: Given two or more arguments, pause for the amount of time
+    # specified by the sum of their values.
+    assert duration_to_seconds('1s 2s') == 3
+    assert duration_to_seconds('1h 2 3m') == 3600 + 2 + 180
+    # Divergence from 'sleep' as that expects space separated arguments
+    assert duration_to_seconds('1s2s') == 3
+    assert duration_to_seconds('1 m2   m') == 180
     with pytest.raises(tmt.utils.SpecificationError):
         duration_to_seconds('bad')
+    with pytest.raises(tmt.utils.SpecificationError):
+        duration_to_seconds('1sm')
 
 
 class test_structured_field(unittest.TestCase):

--- a/tmt/schemas/test.yaml
+++ b/tmt/schemas/test.yaml
@@ -33,7 +33,7 @@ properties:
   # https://tmt.readthedocs.io/en/stable/spec/tests.html#duration
   duration:
     type: string
-    pattern: "^[0-9]+[smhd]$"
+    pattern: "^([0-9]+ *?[smhd]? *)+$"
 
   # https://tmt.readthedocs.io/en/stable/spec/core.html#enabled
   enabled:

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2191,14 +2191,12 @@ def duration_to_seconds(duration: str) -> int:
         'h': 60 * 60,
         'd': 60 * 60 * 24,
         }
-    try:
-        match = re.match(r'^(\d+)([smhd]?)$', str(duration))
-        if match is None:
-            raise SpecificationError(f"Invalid duration '{duration}'.")
-        number, suffix = match.groups()
-        return int(number) * units.get(suffix, 1)
-    except (ValueError, AttributeError):
+    if re.match(r'^(\d+ *?[smhd]? *)+$', str(duration)) is None:
         raise SpecificationError(f"Invalid duration '{duration}'.")
+    total_time = 0
+    for number, suffix in re.findall(r'(\d+) *([smhd]?)', str(duration)):
+        total_time += int(number) * units.get(suffix, 1)
+    return total_time
 
 
 @overload


### PR DESCRIPTION
We claim to support same format as `sleep` commands so let's actually do it.

* [x] implement the feature
* [x] extend the test coverage
* [x] update specification
* [x] modify json schema