### PR TITLE
Prepend '/' to custom test result name if missing

### DIFF
--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -17,16 +17,19 @@ rlJournalStart
         rlAssertGrep "00:11:22 pass /test/custom-results/test/passing" $rlRun_LOG
         rlAssertGrep "00:22:33 fail /test/custom-results/test/failing" $rlRun_LOG
         rlAssertGrep "00:33:55 pass /test/custom-results (on default-0) \[1/1\]" $rlRun_LOG
-        rlAssertGrep "total: 2 tests passed and 1 test failed" $rlRun_LOG
+        rlAssertGrep "00:55:44 pass /test/custom-results/without-leading-slash.*name should start with '/'" $rlRun_LOG
+        rlAssertGrep "total: 3 tests passed and 1 test failed" $rlRun_LOG
 
         rlAssertExists "$(sed -n 's/ *pass_log: \(.\+\)/\1/p' $rlRun_LOG)"
         rlAssertExists "$(sed -n 's/ *fail_log: \(.\+\)/\1/p' $rlRun_LOG)"
         rlAssertExists "$(sed -n 's/ *another_log: \(.\+\)/\1/p' $rlRun_LOG)"
+        rlAssertExists "$(sed -n 's/ *slash_log: \(.\+\)/\1/p' $rlRun_LOG)"
 
         rlRun -s "yq -er '.[] | \"\\(.name) \\(.serialnumber) \\(.result) \\(.guest.name)\"' $run/plans/default/execute/results.yaml"
         rlAssertGrep "/test/custom-results/test/passing 1 pass default-0" $rlRun_LOG
         rlAssertGrep "/test/custom-results/test/failing 1 fail default-0" $rlRun_LOG
         rlAssertGrep "/test/custom-results 1 pass default-0" $rlRun_LOG
+        rlAssertGrep "/test/custom-results/without-leading-slash 1 pass default-0" $rlRun_LOG
     rlPhaseEnd
 
     testName="/test/missing-custom-results"

--- a/tests/execute/result/custom/results.yaml
+++ b/tests/execute/result/custom/results.yaml
@@ -38,3 +38,16 @@
   guest:
     name: client-2
     role: clients
+
+- name: without-leading-slash
+  result: pass
+  log:
+    - slash_log
+  ids:
+    some-id: foo4
+    another-id: bar4
+  duration: 00:55:44
+  serialnumber: 4
+  guest:
+    name: client-1
+    role: clients

--- a/tests/execute/result/custom/test.fmf
+++ b/tests/execute/result/custom/test.fmf
@@ -2,7 +2,7 @@ result: custom
 
 /custom-results:
     summary: Test provides custom results
-    test: cp results.yaml ${TMT_TEST_DATA}; touch ${TMT_TEST_DATA}/{pass,fail,another}_log
+    test: cp results.yaml ${TMT_TEST_DATA}; touch ${TMT_TEST_DATA}/{pass,fail,another,slash}_log
 /missing-custom-results:
     summary: Test provides custom results but results.yaml is not present
     test: 'true'

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -411,6 +411,12 @@ class ExecutePlugin(tmt.steps.Plugin):
             if partial_result.name == '/':
                 partial_result.name = test.name
             else:
+                if not partial_result.name.startswith('/'):
+                    if partial_result.note and isinstance(partial_result.note, str):
+                        partial_result.note += ", custom test result name should start with '/'"
+                    else:
+                        partial_result.note = "custom test result name should start with '/'"
+                    partial_result.name = '/' + partial_result.name
                 partial_result.name = test.name + partial_result.name
 
             # Fix log paths as user provides relative path to TMT_TEST_DATA


### PR DESCRIPTION
If missing, tmt adds a leading slash to the name of the custom test result and also adds a warning message to the result note.

Since I'm new to tmt, I'm not sure if I should also add a test for this change. If there is anything I should change or add, please let me know.

Fix: #1963