### PR TITLE
Tag cloud resources to `tmt` in Testing Farm

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -42,6 +42,13 @@ jobs:
   - fedora-latest-stable
   use_internal_tf: True
   fmf_url: "https://gitlab.cee.redhat.com/baseos-qe/tmt.git"
+  # Tag cloud resources for tmt
+  tf_extra_params:
+    environments:
+      - settings:
+          provisioning:
+            tags:
+              BusinessUnit: tmt
 
 - job: tests
   trigger: pull_request
@@ -51,6 +58,12 @@ jobs:
   use_internal_tf: True
   fmf_url: "https://gitlab.cee.redhat.com/baseos-qe/integration_scripts.git"
   tmt_plan: "/tmt/integration/plan"
+  tf_extra_params:
+    environments:
+      - settings:
+          provisioning:
+            tags:
+              BusinessUnit: tmt
 
 - job: copr_build
   trigger: commit


### PR DESCRIPTION
We want to get granular overview of the cloud resources usage on RH ranch.

To distinguish Packit users, we need to override the default tag set to the Testing Farm user name to the specific project.