### PR TITLE
Change help text of the `tmt --root` option

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -143,7 +143,7 @@ remote_plan_options = create_options_decorator(tmt.options.REMOTE_PLAN_OPTIONS)
 @click.pass_context
 @click.option(
     '-r', '--root', metavar='PATH', show_default=True, default='.',
-    help="Path to the tree root, '.' by default.")
+    help="Path to the metadata tree root, '.' used by default.")
 @click.option(
     '-c', '--context', metavar='DATA', multiple=True,
     help='Set the fmf context. Use KEY=VAL or KEY=VAL1,VAL2... format '


### PR DESCRIPTION
Change help text of '-r' option. 
The original text was a bit confusing according to issue https://github.com/teemtee/tmt/issues/371
If you have another suggestion, let me know.