### PR TITLE
Fix tests run only in full testsuite

### DIFF
--- a/tests/execute/reboot/reuse.sh
+++ b/tests/execute/reboot/reuse.sh
@@ -36,7 +36,7 @@ rlJournalStart
             rlRun "rm $rlRun_LOG"
 
             # Check that the whole output log is kept
-            rlRun "log=$run/plan/execute/data/test/output.txt"
+            rlRun "log=$run/plan/execute/data/guest/default-0/test-1/output.txt"
             rlAssertGrep "After first reboot" $log
             rlAssertGrep "After second reboot" $log
             rlAssertGrep "After third reboot" $log

--- a/tests/execute/upgrade/full.sh
+++ b/tests/execute/upgrade/full.sh
@@ -17,8 +17,8 @@ rlJournalStart
         # 1 test before + 3 upgrade tasks + 1 test after
         rlAssertGrep "5 tests passed" $rlRun_LOG
         # Check that the IN_PLACE_UPGRADE variable was set
-        rlAssertGrep "IN_PLACE_UPGRADE=old" "$run/plan/path/execute/data/old/test/output.txt"
-        rlAssertGrep "IN_PLACE_UPGRADE=new" "$run/plan/path/execute/data/new/test/output.txt"
+        rlAssertGrep "IN_PLACE_UPGRADE=old" "$run/plan/path/execute/data/guest/default-0/old/test-1/output.txt"
+        rlAssertGrep "IN_PLACE_UPGRADE=new" "$run/plan/path/execute/data/guest/default-0/new/test-1/output.txt"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/login/ready.sh
+++ b/tests/login/ready.sh
@@ -18,7 +18,7 @@ rlJournalStart
                 rlRun -s "tmt run -a provision -h $method -i $image_url login -c exit" 0-255 \
                     "disallowed to login into guest which is virtual if image url is invalid"
                 rlAssertNotGrep "login: Starting interactive shell" "$rlRun_LOG"
-                rlAssertGrep "Could not map.*to compose" "$rlRun_LOG"
+                rlAssertGrep "Could not get image url" "$rlRun_LOG"
             rlPhaseEnd
 
             image_url="file:///rubbish"


### PR DESCRIPTION
These tests escaped the review as they require virtualization support to be run.

/tests/login/ready expected the old error message when testcloud/tmt could not convert `image` input into url with the qcow2

/tests/execute/reboot/reuse and /tests/execute/upgrade/full were expecting old location for 'output.txt' which changed as guest and test serial number are taken into account now as well