### PR TITLE
Add new link relation `test-script` definition

### DIFF
--- a/spec/core/link.fmf
+++ b/spec/core/link.fmf
@@ -75,6 +75,11 @@ description: |
         This object relates to the provided target.
         This is the **default** relation.
 
+    test-script
+        Web link to the location of the testing script, intended
+        for cases where the tests are stored in a different
+        directory or repository than the metadata files.
+
     An optional key ``note`` can be used to add an arbitrary
     comment describing the relation.
 

--- a/tests/core/link/data/tests/smoke/main.fmf
+++ b/tests/core/link/data/tests/smoke/main.fmf
@@ -3,4 +3,5 @@ test: tmt --version
 link:
   - verifies: /stories/covered
   - verifies: /stories/verified
+  - test-script: https://github.com/teemtee/tmt/tree/main/tests/core/link/test.sh
   - https://github.com/teemtee/tmt/pull/215

--- a/tests/core/link/test.sh
+++ b/tests/core/link/test.sh
@@ -14,6 +14,7 @@ rlJournalStart
         rlAssertGrep 'verifies /stories/covered' output
         rlAssertGrep 'verifies /stories/verified' output
         rlAssertGrep 'relates https://github.com' output
+        rlAssertGrep 'test-script https://github.com/teemtee/tmt/tree/main/tests/core/link/test.sh' output
     rlPhaseEnd
 
     rlPhaseStartTest "tmt plan show"

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -239,7 +239,7 @@ _RawLinkRelationName = Literal[
     'blocks', 'blocked-by',
     'duplicates', 'duplicated-by',
     'parent', 'child',
-    'relates',
+    'relates', 'test-script',
     # Special case: not a relation, but it can appear where relations appear in
     # link data structures.
     'note'
@@ -3182,7 +3182,7 @@ class Links(tmt.utils.SpecBasedContainer):
         'blocks', 'blocked-by',
         'duplicates', 'duplicated-by',
         'parent', 'child',
-        'relates',
+        'relates', 'test-script',
         ]
 
     _links: List[Link]
@@ -3240,7 +3240,8 @@ class Links(tmt.utils.SpecBasedContainer):
         """ Format a list of links with their relations """
         for link in self._links:
             # TODO: needs a format for fmf id target
-            echo(tmt.utils.format(link.relation.rstrip('-by'), f"{link.target}", key_color='cyan'))
+            echo(tmt.utils.format(
+                link.relation.rstrip('-by'), f"{link.target}", key_color='cyan', wrap=False))
 
     def has_link(self, needle: Optional[LinkNeedle] = None) -> bool:
         """

--- a/tmt/export/polarion.py
+++ b/tmt/export/polarion.py
@@ -214,11 +214,15 @@ def export_to_polarion(test: tmt.base.Test) -> None:
     assert test.fmf_id.url is not None  # narrow type
     if test.node.get('extra-task'):
         automation_script = test.node.get('extra-task')
-        automation_script += ' ' + test.fmf_id.url
+        automation_script += f'<br/>{test.fmf_id.url}'
     else:
         automation_script = test.fmf_id.url
     if not dry_mode:
         polarion_case.caseautomation = 'automated'
+        if test.link:
+            for link in test.link.get(relation='test-script'):
+                automation_script += f'<br/>{link.target}'
+                polarion_case.add_hyperlink(link.target, 'testscript')
         polarion_case.automation_script = automation_script
         polarion_case.add_hyperlink(test.web_link(), 'testscript')
     echo(style('script: ', fg='green') + automation_script)

--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -234,6 +234,9 @@ definitions:
       relates:
         $ref: "/schemas/common#/definitions/url_path_or_fmf_id"
 
+      test-script:
+        $ref: "/schemas/common#/definitions/url_path_or_fmf_id"
+
       note:
         type: string
 
@@ -264,6 +267,8 @@ definitions:
           - child
       - required:
           - relates
+      - required:
+          - test-script
 
   # helper for specifying an object with string properties
   object_with_string_properties:


### PR DESCRIPTION
Add specification, test and implementation for new link relation: test-script.
Used in Polarion export for fields Automation script and Hyperlink with role testscript.
In tmt show this is already visible as any other link.

fixes #1956 