### PR TITLE
Allow `pre-commit` to run in subpath

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 -   id: tmt-lint
     name: tmt lint
     entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt lint --failed-only --source $@" PAD
-    files: '.*\.fmf$'
+    files: '(?:.*\.fmf|.*/\.fmf/version)$'
     verbose: false
     pass_filenames: true
     language: python
@@ -10,7 +10,7 @@
 -   id: tmt-tests-lint
     name: tmt tests lint
     entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt tests lint --failed-only --source $@" PAD
-    files: '.*\.fmf$'
+    files: '(?:.*\.fmf|.*/\.fmf/version)$'
     verbose: false
     pass_filenames: true
     language: python
@@ -19,7 +19,7 @@
 -   id: tmt-plans-lint
     name: tmt plans lint
     entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt plans lint --failed-only --source $@" PAD
-    files: '.*\.fmf$'
+    files: '(?:.*\.fmf|.*/\.fmf/version)$'
     verbose: false
     pass_filenames: true
     language: python
@@ -28,7 +28,7 @@
 -   id: tmt-stories-lint
     name: tmt stories lint
     entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt stories lint --failed-only --source $@" PAD
-    files: '.*\.fmf$'
+    files: '(?:.*\.fmf|.*/\.fmf/version)$'
     verbose: false
     pass_filenames: true
     language: python

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,8 @@
 -   id: tmt-lint
     name: tmt lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt lint --failed-only --source $@" PAD
+    # Use a simple wrapper instead of simply `tmt lint` in order to reorder
+    # some arguments that need to be passed to `tmt`
+    entry: python -m tmt._pre_commit --pre-check lint --failed-only --source
     files: '(?:.*\.fmf|.*/\.fmf/version)$'
     verbose: false
     pass_filenames: true
@@ -9,7 +11,7 @@
 
 -   id: tmt-tests-lint
     name: tmt tests lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt tests lint --failed-only --source $@" PAD
+    entry: python -m tmt._pre_commit --pre-check tests lint --failed-only --source
     files: '(?:.*\.fmf|.*/\.fmf/version)$'
     verbose: false
     pass_filenames: true
@@ -18,7 +20,7 @@
 
 -   id: tmt-plans-lint
     name: tmt plans lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt plans lint --failed-only --source $@" PAD
+    entry: python -m tmt._pre_commit --pre-check plans lint --failed-only --source
     files: '(?:.*\.fmf|.*/\.fmf/version)$'
     verbose: false
     pass_filenames: true
@@ -27,7 +29,7 @@
 
 -   id: tmt-stories-lint
     name: tmt stories lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt stories lint --failed-only --source $@" PAD
+    entry: python -m tmt._pre_commit --pre-check stories lint --failed-only --source
     files: '(?:.*\.fmf|.*/\.fmf/version)$'
     verbose: false
     pass_filenames: true

--- a/tmt/_pre_commit/__main__.py
+++ b/tmt/_pre_commit/__main__.py
@@ -1,0 +1,67 @@
+import re
+import sys
+
+from tmt.__main__ import run_cli
+
+
+def _run_precommit() -> None:  # pyright: ignore[reportUnusedFunction] (used by project.scripts)
+    """
+    A simple wrapper that re-orders cli arguments before :py:func:`run_cli`.
+
+    This utility is needed in order to move arguments like ``--root`` before
+    the ``lint`` keyword when run by ``pre-commit``.
+
+    Only a limited number of arguments are reordered.
+    """
+
+    # Only re-ordering a few known/necessary cli arguments of `main` command
+    # Could be improved if the click commands can be introspected like with
+    # `attrs.fields`
+    # https://github.com/pallets/click/issues/2709
+
+    argv = sys.argv
+    # Get the last argument that starts with `-`. Other inputs after that are
+    # assumed to be filenames (which can be thousands of them)
+    for last_arg in reversed(range(len(argv))):
+        if argv[last_arg].startswith("-"):
+            break
+    else:
+        # If there were no args passed, then just `run_cli`
+        run_cli()
+        return
+
+    # At this point we need to check and re-order the arguments if needed
+    for pattern, nargs in [
+            (r"(--root$|-r)", 1),
+            (r"(--root=.*)", 0),
+            (r"(--verbose$|-v+)", 0),
+            (r"(--debug$|-d+)", 0),
+            (r"(--pre-check$)", 0),
+            ]:
+        if any(match := re.match(pattern, arg) for arg in argv[1:last_arg + 1]):
+            assert match
+            # Actual argument matched
+            actual_arg = match.group(1)
+            indx = argv.index(actual_arg)
+            # Example of reorder args:
+            # ["tmt", "tests", "lint", "--fix", "--root", "/some/path", "some_file"]
+            # - argv[0]: name of the program is always first
+            #   ["tmt"]
+            # - argv[indx:indx+1+nargs]: args to move (pass to `tmt.cli.main`)
+            #   ["--root", "/some/path"]
+            # - argv[1:indx]: all other keywords (`lint` keyword is in here)
+            #   ["tests", "lint", "--fix"]
+            # - argv[indx+1+nargs:]: All remaining keywords
+            #   ["some_file"]
+            # After reorder:
+            # ["tmt", "--root", "/some/path", "tests", "lint", "--fix", "some_file"]
+            argv = (
+                argv[0:1] + argv[indx: indx + 1 + nargs] + argv[1:indx] + argv[indx + 1 + nargs:]
+                )
+    # Finally move the reordered args to sys.argv and run the cli
+    sys.argv = argv
+    run_cli()
+
+
+if __name__ == "__main__":
+    _run_precommit()

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -79,6 +79,7 @@ def option(
         metavar: Optional[str] = None,
         prompt: Optional[str] = None,
         envvar: Optional[str] = None,
+        hidden: bool = False,
         # Following parameters are our additions.
         choices: Optional[Sequence[str]] = None,
         deprecated: Optional[Deprecated] = None) -> ClickOptionDecoratorType:


### PR DESCRIPTION
Took some mucking around, but I've finally got something half-decent approach. It almost works other than #2006. Here is an example for testing:
```yaml
  - repo: https://github.com/LecrisUT/tmt.git
    rev: pre-commit
    hooks:
      - id: tmt-lint
        args:
          - "--root"
          - "path/to/fmf"
```

Fixes: #2004 