### PR TITLE
Add type annotations to tmt.steps.STEPS/ACTIONS

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -35,8 +35,8 @@ DEFAULT_PLUGIN_METHOD_ORDER: int = 50
 
 
 # Supported steps and actions
-STEPS = ['discover', 'provision', 'prepare', 'execute', 'report', 'finish']
-ACTIONS = ['login', 'reboot']
+STEPS: List[str] = ['discover', 'provision', 'prepare', 'execute', 'report', 'finish']
+ACTIONS: List[str] = ['login', 'reboot']
 
 # Step phase order
 PHASE_START = 10


### PR DESCRIPTION
It shouldn't be needed, but I already met mypy complaining about having a hard time to infer types of these two lists. Adding annotations to help mypy and reduce an unrelated noise when `base.py` is modified.