### PR TITLE
Remove `group` from the `multihost` specification

### DIFF
--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -203,18 +203,3 @@ example: |
             role: client
           - name: tester-two
             role: client
-
-        # Synchronize guests using groups
-        provision:
-          - group: across-arches
-            guests:
-              - name: client-one
-                arch: s390x
-              - name: server-one
-                arch: ppc64le
-          - group: across-distros
-            guests:
-              - name: client-two
-                distro: centos-stream-8
-              - name: server-two
-                distro: centos-stream-9


### PR DESCRIPTION
The original concept of groups has been deprecated during the last hacking day discussions in favor of considering a single `tmt run` as a group of guests (recipe set in the Beaker terminology) which should be handled together.