### PR TITLE
Add Artemis's user defined watchdog delay

### DIFF
--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -7,8 +7,9 @@ description: |
     testing, for example
     :ref:`/spec/plans/provision/virtual`,
     :ref:`/spec/plans/provision/container`,
-    :ref:`/spec/plans/provision/connect` or
-    :ref:`/spec/plans/provision/local`.
+    :ref:`/spec/plans/provision/connect`,
+    :ref:`/spec/plans/provision/local` or
+    :ref:`/spec/plans/provision/artemis`.
     See individual plugin documentation for details about
     supported options.
 

--- a/spec/plans/provision/artemis.fmf
+++ b/spec/plans/provision/artemis.fmf
@@ -1,0 +1,62 @@
+summary: Provision a guest via an Artemis service
+description: |
+    Reserve a machine using the Artemis service.
+    Users can specify many requirements, mostly regarding the
+    desired OS, RAM, disk size and more. Most of the HW specifications
+    defined in the :ref:`/spec/hardware` are supported. Including the
+    :ref:`/spec/plans/provision/kickstart`.
+
+    Artemis takes machines from AWS, OpenStack, Beaker or Azure.
+    By default, Artemis handles the selection of a cloud provider
+    to its best abilities and the required specification. However, it
+    is possible to specify the keyword ``pool`` and select the
+    desired cloud provider.
+
+    Artemis project:
+    https://gitlab.com/testing-farm/artemis
+
+    .. note::
+
+        When used together with TF infrastructure
+        some of the options from the first example below
+        will be filled for you by the TF service.
+
+example:
+  - |
+    provision:
+        how: artemis
+        # Specify the Artemis URL where the service is running.
+        # Here is an example of a local Artemis instance
+        api-url: "http://127.0.0.1:8001/v0.0.56"
+        api-version: "0.0.56"
+        image: Fedora-37
+        # ssh key used to connect to the machine
+        keyname: master-key
+
+  - |
+    provision:
+        how: artemis
+        # How long (seconds) to wait for guest provisioning to complete
+        provision-timeout: 300
+        # How often (seconds) check Artemis API for provisioning status
+        provision-tick: 40
+        # How long (seconds) to wait for API operations to complete
+        api-timeout: 15
+        # How many attempts to use when talking to API
+        api-retries: 5
+        # How long (seconds) before the guest "is-alive" watchdog is dispatched
+        watchdog-dispatch-delay: 200
+        # How often (seconds) check that the guest "is-alive"
+        watchdog-period-delay : 500
+  - |
+    provision:
+        how: artemis
+        arch: x86_64
+        pool: beaker
+        hardware:
+            # Pick a guest with at least 8 GB RAM
+            memory: ">= 8 GB"
+
+link:
+  - implemented-by: /tmt/steps/provision/artemis.py
+  - implemented-by: /tmt/schemas/provision/artemis.yaml

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -259,3 +259,27 @@ def test_ks_schema_examples(ks: str, request) -> None:
         'Kickstart requirements',
         request.node.callspec.id
         )
+
+
+def test_watchdog_specification() -> None:
+    tree = tmt.Tree(logger=LOGGER)
+
+    # Our user defined watchdog timeout values for artemis are supposed to be referenced
+    # from provision plugin schemas. Instead of cutting it out, we can use a provision
+    # plugin schema & prepare the fmf node correctly, to pretend it comes from `provision` step.
+    # The only required field is usually `how`.
+    node = fmf.Tree(
+        {
+            'how': 'artemis',
+            'watchdog-period-delay': 10,
+            'watchdog-dispatch-delay': 42,
+            }
+        )
+
+    validate_node(
+        tree,
+        node,
+        os.path.join('provision', 'artemis.yaml'),
+        'Watchdog specification',
+        'both-wd-options'
+        )

--- a/tmt/schemas/provision/artemis.yaml
+++ b/tmt/schemas/provision/artemis.yaml
@@ -79,5 +79,13 @@ properties:
   user:
     type: string
 
+  watchdog-dispatch-delay:
+    type: integer
+    minimum: 1
+
+  watchdog-period-delay:
+    type: integer
+    minimum: 1
+
 required:
   - how


### PR DESCRIPTION
Story: As a user of Artemis service I want to have control over the Artemis's watchdogs timers. 
Some tests may run longer in a state without being accessible by ssh (Leapp tests).

This PR also adds Artemis to the provisioning documentation. 

The proposed addition collaborate with Artemis RFE: https://gitlab.com/testing-farm/artemis/-/merge_requests/1085

The Jira ticket: https://issues.redhat.com/browse/TFT-1949