### PR TITLE
Print only failed objects when linting in hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,35 +1,35 @@
 -   id: tmt-lint
     name: tmt lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt lint --source $@" PAD
+    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt lint --failed-only --source $@" PAD
     files: '.*\.fmf$'
-    verbose: true
+    verbose: false
     pass_filenames: true
     language: python
     language_version: python3
 
 -   id: tmt-tests-lint
     name: tmt tests lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt tests lint --source $@" PAD
+    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt tests lint --failed-only --source $@" PAD
     files: '.*\.fmf$'
-    verbose: true
+    verbose: false
     pass_filenames: true
     language: python
     language_version: python3
 
 -   id: tmt-plans-lint
     name: tmt plans lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt plans lint --source $@" PAD
+    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt plans lint --failed-only --source $@" PAD
     files: '.*\.fmf$'
-    verbose: true
+    verbose: false
     pass_filenames: true
     language: python
     language_version: python3
 
 -   id: tmt-stories-lint
     name: tmt stories lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt stories lint --source $@" PAD
+    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt stories lint --failed-only --source $@" PAD
     files: '.*\.fmf$'
-    verbose: true
+    verbose: false
     pass_filenames: true
     language: python
     language_version: python3

--- a/tests/precommit/test.sh
+++ b/tests/precommit/test.sh
@@ -86,11 +86,12 @@ EOF
         rlRun -s "git commit -m 'add_good'"
         rlAssertGrep "$expected_command.*Passed" $rlRun_LOG
 
-        # Modify main.fmf so both /good and /wrong are checked
+        # Modify main.fmf so /wrong is checked
+        # /good is checked as well but since it passes it is not reported
         rlRun "echo summary: foo >> main.fmf"
         rlRun -s "git commit -a -m 'modify_main'" "1"
         rlAssertGrep "$expected_command.*Failed" $rlRun_LOG
-        rlAssertGrep '/good' $rlRun_LOG
+        rlAssertNotGrep '/good' $rlRun_LOG
         rlAssertGrep '/wrong' $rlRun_LOG
 
         rlRun "popd"


### PR DESCRIPTION
Success == silence, let's not be verbose and print only what we have to. 

Fix: #1819