### PR TITLE
Fix duplicate export for Polarion hyperlinks

### DIFF
--- a/tmt/export/polarion.py
+++ b/tmt/export/polarion.py
@@ -147,6 +147,18 @@ def create_polarion_case(summary: str, project_id: str, path: Path) -> PolarionT
     return testcase
 
 
+def add_hyperlink(polarion_case: PolarionTestCase, link: str, role: str = 'testscript') -> None:
+    """ Add new hyperlink to a Polarion case and check/remove duplicates """
+    existing_hyperlinks = [link.uri for link in polarion_case.hyperlinks if link.role == role]
+    if link not in existing_hyperlinks:
+        polarion_case.add_hyperlink(link, role)
+    else:
+        for hyperlink in set(existing_hyperlinks):
+            for _ in range(existing_hyperlinks.count(hyperlink) - 1):
+                # Remove all but one occurence of the same hyperlink
+                polarion_case.remove_hyperlink(hyperlink)
+
+
 def export_to_polarion(test: tmt.base.Test) -> None:
     """ Export fmf metadata to a Polarion test case """
     import tmt.export.nitrate
@@ -221,10 +233,13 @@ def export_to_polarion(test: tmt.base.Test) -> None:
         polarion_case.caseautomation = 'automated'
         if test.link:
             for link in test.link.get(relation='test-script'):
-                automation_script += f'<br/>{link.target}'
-                polarion_case.add_hyperlink(link.target, 'testscript')
+                if isinstance(link.target, str):
+                    automation_script += f'<br/>{link.target}'
+                    add_hyperlink(polarion_case, link.target)
         polarion_case.automation_script = automation_script
-        polarion_case.add_hyperlink(test.web_link(), 'testscript')
+        web_link = test.web_link()
+        if web_link:
+            add_hyperlink(polarion_case, web_link)
     echo(style('script: ', fg='green') + automation_script)
 
     # Components


### PR DESCRIPTION
Hyperlinks exported to Polarion are not checked for duplicates, this does it and removes all duplicate entries.