### PR TITLE
Cache that library url is not accessible

### DIFF
--- a/tests/discover/libraries/data/plan.fmf
+++ b/tests/discover/libraries/data/plan.fmf
@@ -1,3 +1,6 @@
+/:
+    inherit: false
+
 discover:
     how: fmf
 provision:
@@ -68,3 +71,7 @@ execute:
             summary: "Missing reference"
             discover+:
                 test: missing/reference
+/querying:
+    summary: "Many tests requiring same rpm-only library"
+    discover+:
+        test: querying

--- a/tests/discover/libraries/data/querying.fmf
+++ b/tests/discover/libraries/data/querying.fmf
@@ -1,0 +1,10 @@
+test: echo
+require:
+- "library(FOOBAR/foobar)"
+
+/1:
+/2:
+/3:
+/4:
+/5:
+/6:


### PR DESCRIPTION
TMT hits this for tests which still use rpm beakerlib libraries and used to clone same (but not existent) repo again and again.

Now we make a note that such repo doesn't exist on github/beakerlib and process discover much faster