### PR TITLE
Allow running next plan in queue when one fails to complete

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -112,7 +112,9 @@ def test_step_execute():
 
     # Test execute empty with discover output missing
     assert result.exit_code != 0
-    assert isinstance(result.exception, tmt.utils.ExecuteError)
+    assert isinstance(result.exception, tmt.utils.GeneralError)
+    assert len(result.exception.causes) == 1
+    assert isinstance(result.exception.causes[0], tmt.utils.ExecuteError)
     assert step in result.output
     assert 'provision' not in result.output
     shutil.rmtree(tmp)

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -3023,8 +3023,24 @@ class Run(tmt.utils.Common):
         self.save()
 
         # Iterate over plans
+        crashed_plans: List[Tuple[Plan, Exception]] = []
+
         for plan in self.plans:
-            plan.go()
+            try:
+                plan.go()
+
+            except Exception as exc:
+                if self.opt('on-plan-error') == 'quit':
+                    raise tmt.utils.GeneralError(
+                        'plan failed',
+                        causes=[exc])
+
+                crashed_plans.append((plan, exc))
+
+        if crashed_plans:
+            raise tmt.utils.GeneralError(
+                'plan failed',
+                causes=[exc for _, exc in crashed_plans])
 
         # Update the last run id at the very end
         # (override possible runs created during execution)

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -257,6 +257,13 @@ def main(
     '--environment-file', metavar='FILE|URL', multiple=True,
     help='Set environment variables from file or url (yaml or dotenv formats '
          'are supported). Can be specified multiple times.')
+@click.option(
+    '--on-plan-error',
+    type=click.Choice(['quit', 'continue']),
+    default='quit',
+    help='What to do when plan fails to finish. Quit by default, or continue'
+         'with the next plan.'
+    )
 @verbosity_options
 @force_dry_options
 def run(context: Context, id_: Optional[str], **kwargs: Any) -> None:


### PR DESCRIPTION
The default behavior is to let the exception bubble up and quit. The patch adds an option to change the behavior, the exception is logged and the next plan in line is processed.