### PR TITLE
Convert gitlab private namespace into dist-git url

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -90,6 +90,15 @@ def test_public_git_url():
             }, {
             'original': 'ssh://git@pagure.io/fedora-ci/metadata.git',
             'expected': 'https://pagure.io/fedora-ci/metadata.git',
+            }, {
+            'original': 'git@gitlab.com:redhat/rhel/NAMESPACE/COMPONENT.git',
+            'expected': 'git://pkgs.devel.redhat.com/NAMESPACE/COMPONENT.git',
+            }, {
+            'original': 'https://gitlab.com/redhat/rhel/NAMESPACE/COMPONENT',
+            'expected': 'git://pkgs.devel.redhat.com/NAMESPACE/COMPONENT',
+            }, {
+            'original': 'https://gitlab.com/redhat/centos-stream/NAMESPACE/COMPONENT.git',
+            'expected': 'https://gitlab.com/redhat/centos-stream/NAMESPACE/COMPONENT.git',
             },
         ]
     for example in examples:

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2525,6 +2525,15 @@ def public_git_url(url: str) -> str:
     authentication. For now just cover the most common services.
     """
 
+    # Gitlab on private namepace is synced to pkgs.devel.redhat.com
+    # old: https://gitlab.com/redhat/rhel/tests/bash
+    # old: git@gitlab.com:redhat/rhel/tests/bash
+    # new: git://pkgs.devel.redhat.com/tests/bash
+    matched = re.match(r'(?:git@|https://)gitlab.com[:/]redhat/rhel(/.+)', url)
+    if matched:
+        project = matched.group(1)
+        return f'git://pkgs.devel.redhat.com{project}'
+
     # GitHub, GitLab
     # old: git@github.com:teemtee/tmt.git
     # new: https://github.com/teemtee/tmt.git


### PR DESCRIPTION
Workaround for #1818 so exported tests can be fetched without authentication. This will work while the sync is being done.