### PR TITLE
Make `Step` class own export of step data

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2036,10 +2036,12 @@ class Plan(
             if value:
                 data[key] = value
 
-        for step in tmt.steps.STEPS:
-            value = self.node.data.get(step)
+        for step_name in tmt.steps.STEPS:
+            step = cast(tmt.steps.Step, getattr(self, step_name))
+
+            value = step._export()
             if value:
-                data[step] = value
+                data[step.step_name] = value
 
         return data
 

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -32,6 +32,7 @@ else:
 import click
 from click import echo
 
+import tmt.export
 import tmt.log
 import tmt.options
 import tmt.utils
@@ -200,7 +201,7 @@ class WhereableStepData:
         )
 
 
-class Step(tmt.utils.Common):
+class Step(tmt.utils.Common, tmt.export.Exportable['Step']):
     """ Common parent of all test steps """
 
     # Default implementation for all steps is "shell", but some
@@ -303,6 +304,15 @@ class Step(tmt.utils.Common):
             data.append(plugin.data)
 
         return data
+
+    def _export(self, *, keys: Optional[List[str]] = None) -> tmt.export._RawExportedInstance:
+        # TODO: one day, this should recurse down into each materialized plugin,
+        # to give them chance to affect the export of their data.
+        return cast(tmt.export._RawExportedInstance, self._raw_data)
+
+    @property
+    def step_name(self) -> str:
+        return self.__class__.__name__.lower()
 
     @property
     def data(self) -> List[StepData]:


### PR DESCRIPTION
Current implementation of plan export exports step data on plan level. Instead, the patch makes `Step` class responsible for this operation.

This should open the door to exporting normalized step data - the raw data from fmf nodes are not normalized, unlike test, plan and story fields. This cannot be done from outside, i.e. `Plan` class cannot "peek" into steps and decide how to export various step data, that's up to steps and plugins.

The patch moves the responsibility, it does not implement the actual step/plugin export yet, as that would be much more complicated patch.