### PR TITLE
Fix ruamel.yaml type waivers that mypy sometimes ignores

### DIFF
--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1734,8 +1734,14 @@ def dict_to_yaml(
     yaml.encoding = 'utf-8'
     # ignore[assignment]: ruamel bug workaround, see stackoverflow.com/questions/58083562,
     # sourceforge.net/p/ruamel-yaml/tickets/322/
-    yaml.width = width  # type: ignore[assignment]
-    yaml.explicit_start = start  # type: ignore[assignment]
+    #
+    # Yeah, but sometimes the ignore is not needed, at least mypy in a Github
+    # check tells us it's unused... When disabled, the local pre-commit fails.
+    # It seems we cannot win until ruamel.yaml gets its things fixed, therefore,
+    # giving up, and using `cast()` to enforce matching types to silence mypy,
+    # being fully aware the enforce types are wrong.
+    yaml.width = cast(None, width)  # # type: ignore[assignment]
+    yaml.explicit_start = cast(None, start)  # # type: ignore[assignment]
 
     # For simpler dumping of well-known classes
     def _represent_path(representer: Representer, data: Path) -> Any:


### PR DESCRIPTION
`ruamel.yaml` available to use does not set annotations of attributes fully, which leaves mypy with autodetection. Infered types are the in conflict with what we wish to assign to `YAML.width` and `YAML.explicit_start`, even though our values are perfectly valid. The first remedy, `type: ignore[assignment]` *used to* work - from time to time, probably because of `ruamel.yaml` updates, mypy realizes we were right and `ignore` is not needed, but this leads to failures when running `pre-commit` locally, and it's far from being deterministic.

Therefore, giving up. Instead of `ignore`, use `cast()`, and change type of our values - for mypy, that is - to match the attributes, being fully aware they are incorrect. This should silence mypy until ruamel.yaml gets fixed.