### PR TITLE
Set a new dict instance to the Plan class

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1337,6 +1337,11 @@ class Plan(
         tmt.lint.Lintable['Plan']):
     """ Plan object (L2 Metadata) """
 
+    # The class variable _cli_options need to be reassigned with a new empty
+    # dictionary instance. Otherwise, it would use the shared dictionary
+    # from Common class and causes error in certain cases.
+    _cli_options = {}
+
     # `environment` and `environment-file` are NOT promoted to instance variables.
     context: FmfContextType = {}
     gate: List[str] = []

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2009,7 +2009,7 @@ class Plan(
             self.debug(f"Import remote plan '{plan_id.name}' from '{plan_id.url}'.", level=3)
 
             # Clone the whole git repository if executing tests (run is attached)
-            if self.my_run and not self.my_run.opt('dry') and not self.opt('dry'):
+            if self.my_run and not self.my_run.opt('dry'):
                 assert self.parent is not None  # narrow type
                 assert self.parent.workdir is not None  # narrow type
                 destination = self.parent.workdir / "import" / self.name.lstrip("/")

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -693,6 +693,8 @@ class Common(_CommonBase):
     # perfectly fine to define multiple report plugins in plan's fmf data,
     # doing so via CLI - `report -h display report -h html` - is not supported.
     _cli_context: Optional['tmt.cli.Context'] = None
+    # FIXME: The class inheritance sets the same instance of _cli_options
+    # dictionary to all child class and causes error in certain cases.
     _cli_options: Dict[str, Any] = {}
 
     # When set to true, _opt will be ignored (default will be returned)


### PR DESCRIPTION
The Common class dictionary in _options is shared
across all child instance and causes errors in
some use cases. Therefore, the Plan class needs
a distinct dict instance.

Closes https://github.com/teemtee/tmt/issues/1977