### PR TITLE
Replace named tuples with data classes

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -547,19 +547,19 @@ class TestStructuredField(unittest.TestCase):
 
 
 def test_run_interactive_not_joined(tmpdir, root_logger):
-    stdout, stderr = ShellScript("echo abc; echo def >2").to_shell_command().run(
+    output = ShellScript("echo abc; echo def >2").to_shell_command().run(
         shell=True,
         interactive=True,
         cwd=Path(str(tmpdir)),
         env={},
         log=None,
         logger=root_logger)
-    assert stdout is None
-    assert stderr is None
+    assert output.stdout is None
+    assert output.stderr is None
 
 
 def test_run_interactive_joined(tmpdir, root_logger):
-    stdout, _ = ShellScript("echo abc; echo def >2").to_shell_command().run(
+    output = ShellScript("echo abc; echo def >2").to_shell_command().run(
         shell=True,
         interactive=True,
         cwd=Path(str(tmpdir)),
@@ -567,39 +567,39 @@ def test_run_interactive_joined(tmpdir, root_logger):
         join=True,
         log=None,
         logger=root_logger)
-    assert stdout is None
+    assert output.stdout is None
 
 
 def test_run_not_joined_stdout(root_logger):
-    stdout, stderr = Command("ls", "/").run(
+    output = Command("ls", "/").run(
         shell=False,
         cwd=Path.cwd(),
         env={},
         log=None,
         logger=root_logger)
-    assert "sbin" in stdout
+    assert "sbin" in output.stdout
 
 
 def test_run_not_joined_stderr(root_logger):
-    _, stderr = ShellScript("ls non_existing || true").to_shell_command().run(
+    output = ShellScript("ls non_existing || true").to_shell_command().run(
         shell=False,
         cwd=Path.cwd(),
         env={},
         log=None,
         logger=root_logger)
-    assert "ls: cannot access" in stderr
+    assert "ls: cannot access" in output.stderr
 
 
 def test_run_joined(root_logger):
-    stdout, _ = ShellScript("ls non_existing / || true").to_shell_command().run(
+    output = ShellScript("ls non_existing / || true").to_shell_command().run(
         shell=False,
         cwd=Path.cwd(),
         env={},
         log=None,
         join=True,
         logger=root_logger)
-    assert "ls: cannot access" in stdout
-    assert "sbin" in stdout
+    assert "ls: cannot access" in output.stdout
+    assert "sbin" in output.stdout
 
 
 def test_run_big(root_logger):
@@ -612,15 +612,15 @@ def test_run_big(root_logger):
         done
         """
 
-    stdout, _ = ShellScript(textwrap.dedent(script)).to_shell_command().run(
+    output = ShellScript(textwrap.dedent(script)).to_shell_command().run(
         shell=False,
         cwd=Path.cwd(),
         env={},
         log=None,
         join=True,
         logger=root_logger)
-    assert "n n" in stdout
-    assert len(stdout) == 200000
+    assert "n n" in output.stdout
+    assert len(output.stdout) == 200000
 
 
 def test_get_distgit_handler():

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -1,9 +1,10 @@
 """ Common options and the MethodCommand class """
 
 import contextlib
+import dataclasses
 import re
 import textwrap
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
 
 import click
 
@@ -27,7 +28,8 @@ if TYPE_CHECKING:
     import tmt.utils
 
 
-class Deprecated(NamedTuple):
+@dataclasses.dataclass(frozen=True)
+class Deprecated:
     """ Version information and hint for obsolete options """
     since: str
     hint: Optional[str] = None

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -91,13 +91,13 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin):
         Source tarball is discovered from the 'sources' file content.
         """
         if handler_name is None:
-            stdout, _ = self.run(
+            output = self.run(
                 Command("git", "config", "--get-regexp", '^remote\\..*.url'),
                 cwd=distgit_dir)
-            if stdout is None:
+            if output.stdout is None:
                 raise tmt.utils.GeneralError("Missing remote origin url.")
 
-            remotes = stdout.split('\n')
+            remotes = output.stdout.split('\n')
             handler = tmt.utils.get_distgit_handler(remotes=remotes)
         else:
             handler = tmt.utils.get_distgit_handler(usage_name=handler_name)

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -260,12 +260,12 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 "the `--dist-git-merge` option.")
 
         def get_git_root(dir: Path) -> Path:
-            stdout, _ = self.run(
+            output = self.run(
                 Command("git", "rev-parse", "--show-toplevel"),
                 cwd=dir,
                 ignore_dry=True)
-            assert stdout is not None
-            return Path(stdout.strip("\n"))
+            assert output.stdout is not None
+            return Path(output.stdout.strip("\n"))
 
         # Raise an exception if --fmf-id uses w/o url and git root
         # doesn't exist for discovered plan
@@ -384,10 +384,10 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         # Show current commit hash if inside a git repository
         if self.testdir.is_dir():
             try:
-                hash_, _ = self.run(Command("git", "rev-parse", "--short", "HEAD"),
-                                    cwd=self.testdir)
-                if hash_ is not None:
-                    self.verbose('hash', hash_.strip(), 'green')
+                output = self.run(Command("git", "rev-parse", "--short", "HEAD"),
+                                  cwd=self.testdir)
+                if output.stdout is not None:
+                    self.verbose('hash', output.stdout.strip(), 'green')
             except (tmt.utils.RunError, AttributeError):
                 pass
 
@@ -507,9 +507,9 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             output = self.run(
                 Command(
                     'git', 'log', '--format=', '--stat', '--name-only', f"{modified_ref}..HEAD"
-                    ), cwd=self.testdir)[0]
-            if output:
-                directories = [os.path.dirname(name) for name in output.split('\n')]
+                    ), cwd=self.testdir)
+            if output.stdout:
+                directories = [os.path.dirname(name) for name in output.stdout.split('\n')]
                 modified = {f"^/{re.escape(name)}" for name in directories if name}
                 self.debug(f"Limit to modified test dirs: {modified}", level=3)
                 names.extend(modified)

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -347,9 +347,9 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
                 run_result = self.run(
                     Command("git", "rev-parse", "--show-toplevel"),
                     cwd=self.step.plan.my_run.tree.root,
-                    ignore_dry=True)[0]
-                assert run_result is not None
-                git_root = Path(run_result.strip('\n'))
+                    ignore_dry=True)
+                assert run_result.stdout is not None
+                git_root = Path(run_result.stdout.strip('\n'))
             except tmt.utils.RunError:
                 assert self.step.plan.my_run is not None  # narrow type
                 assert self.step.plan.my_run.tree is not None  # narrow type

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -251,7 +251,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
         # Execute the test, save the output and return code
         starttime = datetime.datetime.now(datetime.timezone.utc)
         try:
-            stdout, _ = guest.execute(
+            output = guest.execute(
                 remote_command,
                 cwd=workdir,
                 env=environment,
@@ -262,6 +262,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
                 test_session=True,
                 friendly_command=str(test.test))
             test.returncode = 0
+            stdout = output.stdout
         except tmt.utils.RunError as error:
             stdout = error.stdout
             test.returncode = error.returncode

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -995,11 +995,11 @@ class GuestSsh(Guest):
         # FIXME: cast() - https://github.com/teemtee/tmt/issues/1372
         parent = cast(Provision, self.parent)
 
-        stdout, _ = self.run(
+        output = self.run(
             ansible_command,
             cwd=parent.plan.worktree,
             env=self._prepare_environment())
-        self._ansible_summary(stdout)
+        self._ansible_summary(output.stdout)
 
     @property
     def is_ready(self) -> bool:

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -29,7 +29,7 @@ class GuestLocal(tmt.Guest):
     def ansible(self, playbook: Path, extra_args: Optional[str] = None) -> None:
         """ Prepare localhost using ansible playbook """
         playbook = self._ansible_playbook_path(playbook)
-        stdout, _ = self.run(
+        output = self.run(
             Command(
                 'sudo', '-E',
                 'ansible-playbook',
@@ -39,7 +39,7 @@ class GuestLocal(tmt.Guest):
                 '-i', 'localhost,',
                 str(playbook)),
             env=self._prepare_environment())
-        self._ansible_summary(stdout)
+        self._ansible_summary(output.stdout)
 
     def execute(self,
                 command: Union[Command, ShellScript],

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -72,8 +72,7 @@ class GuestContainer(tmt.Guest):
             '--format', '{{json .State.Running}}',
             self.container
             ))
-        cmd_stdout, cmd_stderr = cmd_output
-        return str(cmd_stdout).strip() == 'true'
+        return str(cmd_output.stdout).strip() == 'true'
 
     def wake(self) -> None:
         """ Wake up the guest """
@@ -157,11 +156,11 @@ class GuestContainer(tmt.Guest):
             '-c', 'podman', '-i', f'{self.container},', str(playbook)
             ]
 
-        stdout, _ = self.run(
+        output = self.run(
             podman_command,
             cwd=self.parent.plan.worktree,
             env=self._prepare_environment())
-        self._ansible_summary(stdout)
+        self._ansible_summary(output.stdout)
 
     def podman(self, command: Command, **kwargs: Any) -> tmt.utils.CommandOutput:
         """ Run given command via podman """

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -35,7 +35,6 @@ from typing import (
     Generic,
     Iterable,
     List,
-    NamedTuple,
     Optional,
     Pattern,
     Sequence,
@@ -396,7 +395,8 @@ CommonDerivedType = TypeVar('CommonDerivedType', bound='Common')
 _CommandElement = str
 
 
-class CommandOutput(NamedTuple):
+@dataclasses.dataclass(frozen=True)
+class CommandOutput:
     stdout: Optional[str]
     stderr: Optional[str]
 


### PR DESCRIPTION
Data classes are superior in every aspect except one, data classes cannot be unpacked:

```python
stdout, _ = ShellScript(...).run()
```

But this is rarely used to for anything that could not be replaced with a data class:

```python
stdout,_ = ShellScript(...).run()
self.info('foo', stdout)
```

As `stdout` exists only to be passed to another call, without any computation, a data class without unpacking does not look like a downgrade:

```
output = ShellScript(...).run()
self.info('foo', output.stdout)
```

Data classes are often faster, can be made immutable, and are aligned with the rest of tmt code base where named tuples are exception, while data classes are very common.