### PR TITLE
Request newer os image and python version for docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,9 @@
 # Config for building https://tmt.readthedocs.io/
 version: 2
+build:
+    os: ubuntu-22.04
+    tools:
+        python: "3"
 python:
     install:
       - method: pip


### PR DESCRIPTION
Documentation building stopped working on the readthedocs.io site because of the following error:

    ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+,
    currently the 'ssl' module is compiled with OpenSSL 1.0.2n

It seems that the default os image and Python version is too old. Let's request something more up-to-date.