### PR TITLE
A custom wrapper for options instead of click.option()

### DIFF
--- a/examples/plugins/provision.py
+++ b/examples/plugins/provision.py
@@ -1,7 +1,7 @@
-import click
 
 import tmt
 import tmt.steps
+from tmt.options import option
 
 # See the online documentation for more details about writing plugins
 # https://tmt.readthedocs.io/en/stable/plugins.html
@@ -29,10 +29,10 @@ class ProvisionExample(tmt.steps.provision.ProvisionPlugin):
     def options(cls, how=None):
         """ Prepare command line options for example """
         return [
-            click.option(
+            option(
                 '-w', '--what', metavar='WHAT',
                 help="Example how to pass value."),
-            click.option(
+            option(
                 '-s', '--switch', is_flag=True,
                 help="Example how to enable something.")
             ] + super().options(how)

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -26,7 +26,7 @@ import tmt.plugins
 import tmt.steps
 import tmt.templates
 import tmt.utils
-from tmt.options import create_options_decorator
+from tmt.options import create_options_decorator, option
 from tmt.utils import Path
 
 if TYPE_CHECKING:
@@ -144,23 +144,23 @@ lint_options = create_options_decorator(tmt.options.LINT_OPTIONS)
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 @click.group(invoke_without_command=True, cls=CustomGroup)
 @click.pass_context
-@click.option(
+@option(
     '-r', '--root', metavar='PATH', show_default=True, default='.',
     help="Path to the metadata tree root, '.' used by default.")
-@click.option(
+@option(
     '-c', '--context', metavar='DATA', multiple=True,
     help='Set the fmf context. Use KEY=VAL or KEY=VAL1,VAL2... format '
          'to define individual dimensions or the @FILE notation to load data '
          'from provided yaml file. Can be specified multiple times. ')
 @verbosity_options
-@click.option(
+@option(
     '--version', is_flag=True,
     help='Show tmt version and commit hash.')
-@click.option(
+@option(
     '--no-color', is_flag=True, default=False,
     help='Forces tmt to not use any colors in the output or logging.'
     )
-@click.option(
+@option(
     '--force-color', is_flag=True, default=False,
     help='Forces tmt to use colors in the output and logging.'
     )
@@ -213,45 +213,45 @@ def main(
 
 @main.group(chain=True, invoke_without_command=True, cls=CustomGroup)
 @click.pass_context
-@click.option(
+@option(
     '-i', '--id', 'id_', help='Run id (name or directory path).', metavar="ID")
-@click.option(
+@option(
     '-l', '--last', help='Execute the last run once again.', is_flag=True)
-@click.option(
+@option(
     '-r', '--rm', '--remove', 'remove', is_flag=True,
     help='Remove the workdir when test run is finished.')
-@click.option(
+@option(
     '-k', '--keep', is_flag=True,
     help='Keep all files in the run workdir after testing is done '
          '(skip pruning during the finish step).')
-@click.option(
+@option(
     '--scratch', is_flag=True,
     help='Remove the run workdir before executing to start from scratch.')
-@click.option(
+@option(
     '--follow', is_flag=True,
     help='Output the logfile as it grows.')
-@click.option(
+@option(
     '-a', '--all', help='Run all steps, customize some.', is_flag=True)
-@click.option(
+@option(
     '-u', '--until', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
     help='Enable given step and all preceding steps.')
-@click.option(
+@option(
     '-s', '--since', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
     help='Enable given step and all following steps.')
-@click.option(
+@option(
     '-A', '--after', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
     help='Enable all steps after the given one.')
-@click.option(
+@option(
     '-B', '--before', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
     help='Enable all steps before the given one.')
-@click.option(
+@option(
     '-S', '--skip', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
     help='Skip given step(s) during test run execution.', multiple=True)
-@click.option(
+@option(
     '-e', '--environment', metavar='KEY=VALUE|@FILE', multiple=True,
     help='Set environment variable. Can be specified multiple times. The '
          '"@" prefix marks a file to load (yaml or dotenv formats supported).')
-@click.option(
+@option(
     '--environment-file', metavar='FILE|URL', multiple=True,
     help='Set environment variables from file or url (yaml or dotenv formats '
          'are supported). Can be specified multiple times.')
@@ -285,20 +285,20 @@ run.add_command(tmt.steps.Reboot.command())
 
 @run.command(name='plans')
 @click.pass_context
-@click.option(
+@option(
     '-n', '--name', 'names', metavar='[REGEXP|.]', multiple=True,
     help="Regular expression to match plan name or '.' for current directory.")
-@click.option(
+@option(
     '-f', '--filter', 'filters', metavar='FILTER', multiple=True,
     help="Apply advanced filter (see 'pydoc fmf.filter').")
-@click.option(
+@option(
     '-c', '--condition', 'conditions', metavar="EXPR", multiple=True,
     help="Use arbitrary Python expression for filtering.")
-@click.option(
+@option(
     '--link', 'links', metavar="RELATION:TARGET", multiple=True,
     help="Filter by linked objects (regular expressions are "
          "supported for both relation and target).")
-@click.option(
+@option(
     '--default', is_flag=True,
     help="Use default plans even if others are available.")
 @verbosity_options
@@ -314,16 +314,16 @@ def run_plans(context: Context, **kwargs: Any) -> None:
 
 @run.command(name='tests')
 @click.pass_context
-@click.option(
+@option(
     '-n', '--name', 'names', metavar='[REGEXP|.]', multiple=True,
     help="Regular expression to match test name or '.' for current directory.")
-@click.option(
+@option(
     '-f', '--filter', 'filters', metavar='FILTER', multiple=True,
     help="Apply advanced filter (see 'pydoc fmf.filter').")
-@click.option(
+@option(
     '-c', '--condition', 'conditions', metavar="EXPR", multiple=True,
     help="Use arbitrary Python expression for filtering.")
-@click.option(
+@option(
     '--link', 'links', metavar="RELATION:TARGET", multiple=True,
     help="Filter by linked objects (regular expressions are "
          "supported for both relation and target).")
@@ -540,7 +540,7 @@ _test_templates = listed(tmt.templates.TEST, join='or')
 @tests.command(name='create')
 @click.pass_context
 @click.argument('name')
-@click.option(
+@option(
     '-t', '--template', metavar='TEMPLATE',
     help='Test template ({}).'.format(_test_templates),
     prompt='Template ({})'.format(_test_templates))
@@ -566,50 +566,50 @@ def tests_create(
 @tests.command(name='import')
 @click.pass_context
 @click.argument('paths', nargs=-1, metavar='[PATH]...')
-@click.option(
-    '--nitrate / --no-nitrate', default=True, show_default=True,
+@option(
+    '--nitrate / --no-nitrate', default=True, show_default=True, is_flag=True,
     help='Import test metadata from Nitrate.')
-@click.option(
-    '--polarion / --no-polarion', default=False, show_default=True,
+@option(
+    '--polarion / --no-polarion', default=False, show_default=True, is_flag=True,
     help='Import test metadata from Polarion.')
-@click.option(
-    '--purpose / --no-purpose', default=True, show_default=True,
+@option(
+    '--purpose / --no-purpose', default=True, show_default=True, is_flag=True,
     help='Migrate description from PURPOSE file.')
-@click.option(
-    '--makefile / --no-makefile', default=True, show_default=True,
+@option(
+    '--makefile / --no-makefile', default=True, show_default=True, is_flag=True,
     help='Convert Beaker Makefile metadata.')
-@click.option(
-    '--restraint / --no-restraint', default=False, show_default=True,
+@option(
+    '--restraint / --no-restraint', default=False, show_default=True, is_flag=True,
     help='Convert restraint metadata file.')
-@click.option(
-    '--general / --no-general', default=True,
+@option(
+    '--general / --no-general', default=True, is_flag=True,
     help='Detect components from linked nitrate general plans '
          '(overrides Makefile/restraint component).')
-@click.option(
+@option(
     '--polarion-case-id', multiple=True,
     help='Polarion Test case ID(s) to import data from. Can be provided multiple times. '
          'Can provide also test case name like: TEST-123:test_name')
-@click.option(
-    '--link-polarion / --no-link-polarion', default=False, show_default=True,
+@option(
+    '--link-polarion / --no-link-polarion', default=False, show_default=True, is_flag=True,
     help='Add Polarion link to fmf testcase metadata.')
-@click.option(
+@option(
     '--type', 'types', metavar='TYPE', default=['multihost'], multiple=True,
     show_default=True,
     help="Convert selected types from Makefile into tags. "
          "Use 'all' to convert all detected types.")
-@click.option(
+@option(
     '--disabled', default=False, is_flag=True,
     help='Import disabled test cases from Nitrate as well.')
-@click.option(
+@option(
     '--manual', default=False, is_flag=True,
     help='Import manual test cases from Nitrate.')
-@click.option(
+@option(
     '--plan', metavar='PLAN', type=int,
     help='Identifier of test plan from which to import manual test cases.')
-@click.option(
+@option(
     '--case', metavar='CASE', type=int,
     help='Identifier of manual test case to be imported.')
-@click.option(
+@option(
     '--with-script', default=False, is_flag=True,
     help='Import manual cases with non-empty script field in Nitrate.')
 @verbosity_options
@@ -699,61 +699,61 @@ _test_export_default = 'yaml'
 @tests.command(name='export')
 @click.pass_context
 @filter_options_long
-@click.option(
+@option(
     '-h', '--how', metavar='METHOD', default=_test_export_default, show_default=True,
     help='Output format.',
     type=click.Choice(choices=_test_export_formats))
-@click.option(
+@option(
     '--format', metavar='FORMAT', default=_test_export_default, show_default=True,
     help='Output format. Deprecated, use --how instead.',
     type=click.Choice(choices=_test_export_formats))
-@click.option(
+@option(
     '--nitrate', is_flag=True,
     help="Export test metadata to Nitrate, deprecated by '--how nitrate'.")
-@click.option(
+@option(
     '--project-id', help='Use specific Polarion project ID.')
-@click.option(
-    '--link-polarion / --no-link-polarion', default=False,
+@option(
+    '--link-polarion / --no-link-polarion', default=False, is_flag=True,
     help='Add Polarion link to fmf testcase metadata')
-@click.option(
+@option(
     '--bugzilla', is_flag=True,
     help="Link Nitrate case to Bugzilla specified in the 'link' attribute "
          "with the relation 'verifies'.")
-@click.option(
+@option(
     '--ignore-git-validation', is_flag=True,
     help="Ignore unpublished git changes and export to Nitrate. "
     "The case might not be able to be scheduled!")
-@click.option(
-    '--append-summary / --no-append-summary', default=False,
+@option(
+    '--append-summary / --no-append-summary', default=False, is_flag=True,
     help="Include test summary in the Nitrate/Polarion test case summary as well. "
     "By default, only the repository name and test name are used."
     )
-@click.option(
+@option(
     '--create', is_flag=True,
     help="Create test cases in nitrate if they don't exist.")
-@click.option(
-    '--general / --no-general', default=False,
+@option(
+    '--general / --no-general', default=False, is_flag=True,
     help="Link Nitrate case to component's General plan. Disabled by default. "
          "Note that this will unlink any previously connected general plans.")
-@click.option(
-    '--link-runs / --no-link-runs', default=False,
+@option(
+    '--link-runs / --no-link-runs', default=False, is_flag=True,
     help="Link Nitrate case to all open runs of descendant plans of "
          "General plan. Disabled by default. Implies --general option.")
-@click.option(
+@option(
     '--fmf-id', is_flag=True,
     help='Show fmf identifiers instead of test metadata.')
-@click.option(
-    '--duplicate / --no-duplicate', default=False, show_default=True,
+@option(
+    '--duplicate / --no-duplicate', default=False, show_default=True, is_flag=True,
     help='Allow or prevent creating duplicates in Nitrate by searching for '
          'existing test cases with the same fmf identifier.')
-@click.option(
+@option(
     '-n', '--dry', is_flag=True,
     help="Run in dry mode. No changes, please.")
-@click.option(
+@option(
     '-d', '--debug', is_flag=True,
     help='Provide as much debugging details as possible.')
 # TODO: move to `template` export plugin options
-@click.option(
+@option(
     '--template', metavar='PATH',
     help="Path to a template to use for rendering the export. Used with '--how=template' only."
     )
@@ -923,26 +923,26 @@ _plan_templates = listed(tmt.templates.PLAN, join='or')
 @plans.command(name='create')
 @click.pass_context
 @click.argument('name')
-@click.option(
+@option(
     '-t', '--template', metavar='TEMPLATE',
     help='Plan template ({}).'.format(_plan_templates),
     prompt='Template ({})'.format(_plan_templates))
-@click.option(
+@option(
     '--discover', metavar='YAML', multiple=True,
     help='Discover phase content in yaml format.')
-@click.option(
+@option(
     '--provision', metavar='YAML', multiple=True,
     help='Provision phase content in yaml format.')
-@click.option(
+@option(
     '--prepare', metavar='YAML', multiple=True,
     help='Prepare phase content in yaml format.')
-@click.option(
+@option(
     '--execute', metavar='YAML', multiple=True,
     help='Execute phase content in yaml format.')
-@click.option(
+@option(
     '--report', metavar='YAML', multiple=True,
     help='Report phase content in yaml format.')
-@click.option(
+@option(
     '--finish', metavar='YAML', multiple=True,
     help='Finish phase content in yaml format.')
 @verbosity_options
@@ -966,19 +966,19 @@ _plan_export_default = 'yaml'
 @plans.command(name='export')
 @click.pass_context
 @filter_options_long
-@click.option(
+@option(
     '-h', '--how', metavar='METHOD', default=_plan_export_default, show_default=True,
     help='Output format.',
     type=click.Choice(choices=_plan_export_formats))
-@click.option(
+@option(
     '--format', metavar='FORMAT', default=_plan_export_default, show_default=True,
     help='Output format. Deprecated, use --how instead.',
     type=click.Choice(choices=_plan_export_formats))
-@click.option(
+@option(
     '-d', '--debug', is_flag=True,
     help='Provide as much debugging details as possible.')
 # TODO: move to `template` export plugin options
-@click.option(
+@option(
     '--template', metavar='PATH',
     help="Path to a template to use for rendering the export. Used with '--how=template' only."
     )
@@ -1113,7 +1113,7 @@ _story_templates = listed(tmt.templates.STORY, join='or')
 @stories.command(name='create')
 @click.pass_context
 @click.argument('name')
-@click.option(
+@option(
     '-t', '--template', metavar='TEMPLATE',
     prompt='Template ({})'.format(_story_templates),
     help='Story template ({}).'.format(_story_templates))
@@ -1132,11 +1132,11 @@ def stories_create(
 
 
 @stories.command(name='coverage')
-@click.option(
+@option(
     '--docs', is_flag=True, help='Show docs coverage.')
-@click.option(
+@option(
     '--test', is_flag=True, help='Show test coverage.')
-@click.option(
+@option(
     '--code', is_flag=True, help='Show code coverage.')
 @click.pass_context
 @filter_options_long
@@ -1216,19 +1216,19 @@ _story_export_default = 'yaml'
 @click.pass_context
 @filter_options_long
 @story_flags_filter_options
-@click.option(
+@option(
     '-h', '--how', metavar='METHOD', default=_story_export_default, show_default=True,
     help='Output format.',
     type=click.Choice(choices=_story_export_formats))
-@click.option(
+@option(
     '--format', metavar='FORMAT', default=_story_export_default, show_default=True,
     help='Output format. Deprecated, use --how instead.',
     type=click.Choice(choices=_story_export_formats))
-@click.option(
+@option(
     '-d', '--debug', is_flag=True,
     help='Provide as much debugging details as possible.')
 # TODO: move to `template` export plugin options
-@click.option(
+@option(
     '--template', metavar='PATH',
     help="Path to a template to use for rendering the export. Used with '--how=template' only."
     )
@@ -1346,7 +1346,7 @@ def stories_id(
 @main.command()
 @click.pass_context
 @click.argument('path', default='.')
-@click.option(
+@option(
     '-t', '--template', default='empty', metavar='TEMPLATE',
     type=click.Choice(['empty'] + tmt.templates.INIT_TEMPLATES),
     help='Template ({}).'.format(
@@ -1383,18 +1383,18 @@ def init(
 @main.command()
 @click.pass_context
 @workdir_root_options
-@click.option(
+@option(
     '-i', '--id', metavar="ID",
     help='Run id (name or directory path) to show status of.')
-@click.option(
+@option(
     '--abandoned', is_flag=True, default=False,
     help='List runs which have provision step completed but finish step '
          'not yet done.')
-@click.option(
+@option(
     '--active', is_flag=True, default=False,
     help='List runs where at least one of the enabled steps has not '
          'been finished.')
-@click.option(
+@option(
     '--finished', is_flag=True, default=False,
     help='List all runs which have all enabled steps completed.')
 @verbosity_options
@@ -1521,12 +1521,12 @@ def perform_clean(
 @clean.command(name='runs')
 @click.pass_context
 @workdir_root_options
-@click.option(
+@option(
     '-l', '--last', is_flag=True, help='Clean the workdir of the last run.')
-@click.option(
+@option(
     '-i', '--id', 'id_', metavar="ID",
     help='Run id (name or directory path) to clean workdir of.')
-@click.option(
+@option(
     '-k', '--keep', type=int,
     help='The number of latest workdirs to keep, clean the rest.')
 @verbosity_options
@@ -1566,12 +1566,12 @@ def clean_runs(
 @clean.command(name='guests')
 @click.pass_context
 @workdir_root_options
-@click.option(
+@option(
     '-l', '--last', is_flag=True, help='Stop the guest of the last run.')
-@click.option(
+@option(
     '-i', '--id', 'id_', metavar="ID",
     help='Run id (name or directory path) to stop the guest of.')
-@click.option(
+@option(
     '-h', '--how', metavar='METHOD',
     help='Stop guests of the specified provision method.')
 @verbosity_options
@@ -1733,7 +1733,7 @@ def setup_completion(shell: str, install: bool) -> None:
 
 @completion.command(name='bash')
 @click.pass_context
-@click.option(
+@option(
     '--install', '-i', 'install', is_flag=True,
     help="Persistently store the script to tmt's configuration directory "
          "and set it up by modifying '~/.bashrc'.")
@@ -1746,7 +1746,7 @@ def completion_bash(context: Context, install: bool, **kwargs: Any) -> None:
 
 @completion.command(name='zsh')
 @click.pass_context
-@click.option(
+@option(
     '--install', '-i', 'install', is_flag=True,
     help="Persistently store the script to tmt's configuration directory "
          "and set it up by modifying '~/.zshrc'.")
@@ -1759,7 +1759,7 @@ def completion_zsh(context: Context, install: bool, **kwargs: Any) -> None:
 
 @completion.command(name='fish')
 @click.pass_context
-@click.option(
+@option(
     '--install', '-i', 'install', is_flag=True,
     help="Persistently store the script to "
          "'~/.config/fish/completions/tmt.fish'.")

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 import tmt.base
 import tmt.steps
 import tmt.utils
+from tmt.options import option
 from tmt.steps import Action
 from tmt.utils import Command, GeneralError, Path, flatten
 
@@ -59,7 +60,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin):
         # Create the command
         @click.command(cls=method_class, help=usage)
         @click.pass_context
-        @click.option(
+        @option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method to discover tests.')
         def discover(context: 'tmt.cli.Context', **kwargs: Any) -> None:

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -6,7 +6,6 @@ import shutil
 import subprocess
 from typing import Any, List, Optional, cast
 
-import click
 import fmf
 
 import tmt
@@ -17,6 +16,7 @@ import tmt.options
 import tmt.steps
 import tmt.steps.discover
 import tmt.utils
+from tmt.options import option
 from tmt.utils import Command, Path
 
 
@@ -74,16 +74,16 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
             self.ref = self.revision
 
 
-REF_OPTION = click.option(
+REF_OPTION = option(
     '-r', '--ref', metavar='REVISION',
     help='Branch, tag or commit specifying the git revision.')
-TEST_OPTION = click.option(
+TEST_OPTION = option(
     '-t', '--test', metavar='NAMES', multiple=True,
     help='Select tests by name.')
-FILTER_OPTION = click.option(
+FILTER_OPTION = option(
     '-F', '--filter', metavar='FILTERS', multiple=True,
     help='Include only tests matching the filter.')
-EXCLUDE_OPTION = click.option(
+EXCLUDE_OPTION = option(
     '-x', '--exclude', metavar='[REGEXP]', multiple=True,
     help="Exclude a regular expression from search result.")
 
@@ -175,51 +175,51 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for given method """
         return [
-            click.option(
+            option(
                 '-u', '--url', metavar='REPOSITORY',
                 help='URL of the git repository with fmf metadata.'),
             REF_OPTION,
-            click.option(
+            option(
                 '--modified-url', metavar='REPOSITORY',
                 help='URL of the reference git repository with fmf metadata.'),
-            click.option(
+            option(
                 '--modified-ref', metavar='REVISION',
                 help='Branch, tag or commit specifying the reference git '
                 'revision (if not provided, the default branch is used).'),
-            click.option(
+            option(
                 '-m', '--modified-only', is_flag=True,
                 help='If set, select only tests modified '
                 'since reference revision.'),
-            click.option(
+            option(
                 '-p', '--path', metavar='ROOT',
                 help='Path to the metadata tree root.'),
             TEST_OPTION,
-            click.option(
+            option(
                 '--link', metavar="RELATION:TARGET", multiple=True,
                 help="Filter by linked objects (regular expressions are "
                      "supported for both relation and target)."),
             FILTER_OPTION,
             EXCLUDE_OPTION,
-            click.option(
+            option(
                 '--fmf-id', default=False, is_flag=True,
                 help='Show fmf identifiers for tests discovered in plan.'),
-            click.option(
+            option(
                 '--sync-repo', default=False, is_flag=True,
                 help='Force the sync of the whole git repo. By default, the '
                      'repo is copied only if the used options require it.'),
-            click.option(
+            option(
                 '--dist-git-init', is_flag=True,
                 help='Initialize fmf root inside extracted sources '
                      '(at dist-git-extract or top directory).'),
-            click.option(
+            option(
                 '--dist-git-remove-fmf-root', is_flag=True,
                 help='Remove fmf root from extracted source '
                      '(top one or selected by copy-path, '
                      'happens before dist-git-extract.'),
-            click.option(
+            option(
                 '--dist-git-merge', is_flag=True,
                 help='Merge copied sources and plan fmf root.'),
-            click.option(
+            option(
                 '--dist-git-extract',
                 help='What to copy from extracted sources, globbing is '
                      'supported. Defaults to the top fmf root if it is '

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -13,6 +13,7 @@ import tmt
 import tmt.base
 import tmt.steps
 import tmt.utils
+from tmt.options import option
 from tmt.queue import TaskOutcome
 from tmt.result import Result, ResultGuestData, ResultOutcome
 from tmt.steps import Action, PhaseQueue, QueuedPhase, Step, StepData
@@ -159,7 +160,7 @@ class ExecutePlugin(tmt.steps.Plugin):
         # Create the command
         @click.command(cls=method_class, help=usage)
         @click.pass_context
-        @click.option(
+        @option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method for test execution.')
         def execute(context: 'tmt.cli.Context', **kwargs: Any) -> None:
@@ -172,7 +173,7 @@ class ExecutePlugin(tmt.steps.Plugin):
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         # Add option to exit after the first test failure
         return [
-            click.option(
+            option(
                 '-x', '--exit-first', is_flag=True,
                 help='Stop execution after the first test failure.'),
             ] + super().options(how)

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -15,6 +15,7 @@ import tmt.steps
 import tmt.steps.execute
 import tmt.utils
 from tmt.base import Test
+from tmt.options import option
 from tmt.result import Result, ResultOutcome
 from tmt.steps.execute import (SCRIPTS, TEST_OUTPUT_FILENAME,
                                TMT_FILE_SUBMIT_SCRIPT, TMT_REBOOT_SCRIPT)
@@ -79,15 +80,15 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for given method """
         return [
-            click.option(
+            option(
                 '-s', '--script', metavar='SCRIPT', multiple=True,
                 help='Shell script to be executed as a test.'),
             # Interactive mode
-            click.option(
+            option(
                 '-i', '--interactive', is_flag=True,
                 help='Run in interactive mode, do not capture output.'),
             # Disable interactive progress bar
-            click.option(
+            option(
                 '--no-progress-bar', is_flag=True,
                 help='Disable interactive progress bar showing the current test.')
             ] + super().options(how)

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -1,7 +1,6 @@
 import dataclasses
 from typing import Any, List, Optional, Union, cast
 
-import click
 import fmf.utils
 
 import tmt.base
@@ -12,6 +11,7 @@ import tmt.steps.discover.fmf
 import tmt.steps.execute
 import tmt.steps.provision
 import tmt.utils
+from tmt.options import option
 from tmt.steps.discover import DiscoverPlugin
 from tmt.steps.discover.fmf import DiscoverFmf, DiscoverFmfStepData
 from tmt.steps.execute import ExecutePlugin
@@ -122,10 +122,10 @@ class ExecuteUpgrade(ExecuteInternal):
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for given method """
         return [
-            click.option(
+            option(
                 '--url', '-u', metavar='REPOSITORY',
                 help='URL of the git repository with upgrade tasks.'),
-            click.option(
+            option(
                 '--upgrade-path', '-p', metavar='PLAN_NAME',
                 help='Upgrade path corresponding to a plan name in the repository '
                 'with upgrade tasks.'),

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -7,6 +7,7 @@ import fmf
 
 import tmt
 import tmt.steps
+from tmt.options import option
 from tmt.steps import (Action, Method, PhaseQueue, PullTask, QueuedPhase,
                        TaskOutcome, sync_with_guests)
 from tmt.steps.provision import Guest
@@ -42,7 +43,7 @@ class FinishPlugin(tmt.steps.Plugin):
         # Create the command
         @click.command(cls=method_class, help=usage)
         @click.pass_context
-        @click.option(
+        @option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method for finishing tasks.')
         def finish(context: 'tmt.cli.Context', **kwargs: Any) -> None:

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -13,6 +13,7 @@ import tmt.log
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
+from tmt.options import option
 from tmt.queue import TaskOutcome
 from tmt.steps import (Action, PhaseQueue, PullTask, PushTask, QueuedPhase,
                        sync_with_guests)
@@ -61,7 +62,7 @@ class PreparePlugin(tmt.steps.Plugin):
         # Create the command
         @click.command(cls=method_class, help=usage)
         @click.pass_context
-        @click.option(
+        @option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method for environment preparation.')
         def prepare(context: 'tmt.cli.Context', **kwargs: Any) -> None:

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -22,6 +22,7 @@ import tmt.log
 import tmt.plugins
 import tmt.steps
 import tmt.utils
+from tmt.options import option
 from tmt.steps import Action
 from tmt.utils import BaseLoggerFnType, Command, Path, ShellScript, field
 
@@ -908,10 +909,10 @@ class GuestSsh(Guest):
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options related to SSH-capable guests """
         return super().options(how=how) + [
-            click.option('--ssh-option', metavar="OPTION", multiple=True, default=[],
-                         help="Specify additional SSH option. "
-                              "Value is passed to SSH's -o option, see ssh_config(5) for "
-                              "supported options. Can be specified multiple times.")]
+            option('--ssh-option', metavar="OPTION", multiple=True, default=[],
+                   help="Specify additional SSH option. "
+                   "Value is passed to SSH's -o option, see ssh_config(5) for "
+                   "supported options. Can be specified multiple times.")]
 
     def ansible(self, playbook: Path, extra_args: Optional[str] = None) -> None:
         """ Prepare guest using ansible playbook """
@@ -1354,7 +1355,7 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin):
         # Create the command
         @click.command(cls=method_class, help=usage)
         @click.pass_context
-        @click.option(
+        @option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method for provisioning.')
         def provision(context: 'tmt.cli.Context', **kwargs: Any) -> None:

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -12,6 +12,7 @@ import tmt.options
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
+from tmt.options import option
 from tmt.utils import ProvisionError, retry_session, updatable_message
 
 if sys.version_info >= (3, 8):
@@ -488,75 +489,75 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for Artemis """
         return [
-            click.option(
+            option(
                 '--api-url', metavar='URL',
                 help="Artemis API URL.",
                 envvar='ARTEMIS_API_URL'
                 ),
-            click.option(
+            option(
                 '--api-version', metavar='x.y.z',
                 help="Artemis API version to use.",
                 type=click.Choice(SUPPORTED_API_VERSIONS),
                 envvar='ARTEMIS_API_VERSION'
                 ),
-            click.option(
+            option(
                 '--arch', metavar='ARCH',
                 help='Architecture to provision.'
                 ),
-            click.option(
+            option(
                 '--image', metavar='COMPOSE',
                 help='Image (or "compose" in Artemis terminology) '
                      'to provision.'
                 ),
-            click.option(
+            option(
                 '--pool', metavar='NAME',
                 help='Pool to enforce.'
                 ),
-            click.option(
+            option(
                 '--priority-group', metavar='NAME',
                 help='Provisioning priority group.'
                 ),
-            click.option(
+            option(
                 '--keyname', metavar='NAME',
                 help='SSH key name.'
                 ),
-            click.option(
+            option(
                 '--user-data', metavar='KEY=VALUE',
                 help='Optional data to attach to guest.',
                 multiple=True,
                 default=[]
                 ),
-            click.option(
+            option(
                 '--provision-timeout', metavar='SECONDS',
                 help=f'How long to wait for provisioning to complete, '
                      f'{DEFAULT_PROVISION_TIMEOUT} seconds by default.'
                 ),
-            click.option(
+            option(
                 '--provision-tick', metavar='SECONDS',
                 help=f'How often check Artemis API for provisioning status, '
                      f'{DEFAULT_PROVISION_TICK} seconds by default.',
                 ),
-            click.option(
+            option(
                 '--api-timeout', metavar='SECONDS',
                 help=f'How long to wait for API operations to complete, '
                      f'{DEFAULT_API_TIMEOUT} seconds by default.',
                 ),
-            click.option(
+            option(
                 '--api-retries', metavar='COUNT',
                 help=f'How many attempts to use when talking to API, '
                      f'{DEFAULT_API_RETRIES} by default.',
                 ),
-            click.option(
+            option(
                 '--api-retry-backoff-factor', metavar='COUNT',
                 help=f'A factor for exponential API retry backoff, '
                      f'{DEFAULT_RETRY_BACKOFF_FACTOR} by default.',
                 ),
-            click.option(
+            option(
                 '--watchdog-dispatch-delay', metavar='SECONDS',
                 help='How long (seconds) before the guest "is-alive" watchdog is dispatched. '
                      'The dispatch timer starts once the guest is successfully provisioned.'
                 ),
-            click.option(
+            option(
                 '--watchdog-period-delay', metavar='SECONDS',
                 help='How often (seconds) check that the guest "is-alive".'
                 ),

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -1,13 +1,13 @@
 import dataclasses
 from typing import List, Optional, cast
 
-import click
 import fmf.utils
 
 import tmt
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
+from tmt.options import option
 
 DEFAULT_USER = "root"
 
@@ -61,19 +61,19 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for connect """
         return [
-            click.option(
+            option(
                 '-g', '--guest', metavar='GUEST',
                 help='Select remote host to connect to (hostname or ip).'),
-            click.option(
+            option(
                 '-P', '--port', metavar='PORT',
                 help='Use specific port to connect to.'),
-            click.option(
+            option(
                 '-k', '--key', metavar='PRIVATE_KEY',
                 help='Private key for login into the guest system.'),
-            click.option(
+            option(
                 '-u', '--user', metavar='USER',
                 help='Username to use for all guest operations.'),
-            click.option(
+            option(
                 '-p', '--password', metavar='PASSWORD',
                 help='Password for login into the guest system.'),
             ] + super().options(how)

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -5,13 +5,12 @@ import os
 import sys
 from typing import Any, Dict, List, Optional, Tuple, cast
 
-import click
-
 import tmt
 import tmt.options
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
+from tmt.options import option
 from tmt.utils import ProvisionError, updatable_message
 
 if sys.version_info >= (3, 8):
@@ -527,21 +526,21 @@ class ProvisionBeaker(tmt.steps.provision.ProvisionPlugin):
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for Beaker """
         return [
-            click.option(
+            option(
                 '--arch', metavar='ARCH',
                 help='Architecture to provision.'
                 ),
-            click.option(
+            option(
                 '--image', metavar='COMPOSE',
                 help='Image (distro or "compose" in Beaker terminology) '
                      'to provision.'
                 ),
-            click.option(
+            option(
                 '--provision-timeout', metavar='SECONDS',
                 help=f'How long to wait for provisioning to complete, '
                      f'{DEFAULT_PROVISION_TIMEOUT} seconds by default.'
                 ),
-            click.option(
+            option(
                 '--provision-tick', metavar='SECONDS',
                 help=f'How often check Beaker for provisioning status, '
                      f'{DEFAULT_PROVISION_TICK} seconds by default.',

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -3,13 +3,12 @@ import os
 from shlex import quote
 from typing import Any, List, Optional, Union
 
-import click
-
 import tmt
 import tmt.base
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
+from tmt.options import option
 from tmt.utils import BaseLoggerFnType, Command, Path, ShellScript
 
 # Timeout in seconds of waiting for a connection
@@ -274,16 +273,16 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for connect """
         return [
-            click.option(
+            option(
                 '-i', '--image', metavar='IMAGE',
                 help='Select image to use. Short name or complete url.'),
-            click.option(
+            option(
                 '-c', '--container', metavar='NAME',
                 help='Name or id of an existing container to be used.'),
-            click.option(
+            option(
                 '-p', '--pull', 'force_pull', is_flag=True,
                 help='Force pulling a fresh container image.'),
-            click.option(
+            option(
                 '-u', '--user', metavar='USER',
                 help='User to use for all container operations.')
             ] + super().options(how)

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -18,6 +18,7 @@ import tmt
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
+from tmt.options import option
 from tmt.utils import (WORKDIR_ROOT, Command, Path, ProvisionError,
                        ShellScript, retry_session)
 
@@ -580,31 +581,31 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
     def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for testcloud """
         return [
-            click.option(
+            option(
                 '-i', '--image', metavar='IMAGE',
                 help='Select image to be used. Provide a short name, '
                      'full path to a local file or a complete url.'),
-            click.option(
+            option(
                 '-m', '--memory', metavar='MEMORY', type=int,
                 help='Set available memory in MB, 2048 MB by default.'),
-            click.option(
+            option(
                 '-D', '--disk', metavar='MEMORY', type=int,
                 help='Specify disk size in GB, 10 GB by default.'),
-            click.option(
+            option(
                 '-u', '--user', metavar='USER',
                 help='Username to use for all guest operations.'),
-            click.option(
+            option(
                 '-c', '--connection',
                 type=click.Choice(['session', 'system']),
                 help="What session type to use, 'session' by default."),
-            click.option(
+            option(
                 '-a', '--arch',
                 type=click.Choice(['x86_64', 'aarch64', 's390x', 'ppc64le']),
                 help="What architecture to virtualize, host arch by default."),
-            click.option(
+            option(
                 '-k', '--key', metavar='PRIVATE_KEY', multiple=True,
                 help='Existing private key for login into the guest system.'),
-            click.option(
+            option(
                 '--list-local-images', is_flag=True,
                 help="List locally available images."),
             ] + super().options(how)

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -5,6 +5,7 @@ import click
 
 import tmt
 import tmt.steps
+from tmt.options import option
 from tmt.steps import Action
 
 if TYPE_CHECKING:
@@ -41,7 +42,7 @@ class ReportPlugin(tmt.steps.GuestlessPlugin):
         # Create the command
         @click.command(cls=method_class, help=usage)
         @click.pass_context
-        @click.option(
+        @option(
             '-h', '--how', metavar='METHOD',
             help='Use specified method for results reporting.')
         def report(context: 'tmt.cli.Context', **kwargs: Any) -> None:


### PR DESCRIPTION
Q: Ok, but... But... But why?!?

It might look as a pointless exercise or "not invented here" syndrome, but hear me out :)

The patch adds a very trivial wrapper, `tmt.options.option`, which accepts a bunch of parameters, and calls `click.option()` with them. Effctively a `click.option` replacement. The added value?

* type annotations. The original `click.option` is annotated, but in the very basic form, similar to `*args: Any, **kwargs: Any`. This prevents no accidental mistakes like `is_flag=(1, 2)`.
* *stricter* type annotations. `click.option` has some functionality tmt is not using, to accomodate said functionality, some parameters are allowed the range of types wider than what can appear in tmt code. Out wrapper gives us a chance to be stricter.
* `deprecated` support. A container describing a deprecated field, or an option, but it's part of `tmt.utils.field` API - that's good - but `click.option` does not accept it, and that's sad. Plenty of options defined in `tmt.cli` are deprecated, wouldn't it be nice if we could use the same approach to tracking deprecation we established for plugin fields? Our `option()` accepts `Deprecated` container, adds it to help, just like the `field()` does. Actually, since our `field()` calls our `option()`, `field()` no longer has to care about rendering of `deprecated` flag, and `option()` does that for both fields and options.

Not so pointless anymore, is it? :) In the future, we can teach our `option()` few more tricks, like default `metavar` for `Choice` options, or some custom defaults that would have to be repeated in every `click.option()` call.