### PR TITLE
Add option to set ssl certificate location report --how reportportal

### DIFF
--- a/tests/report/reportportal/test.sh
+++ b/tests/report/reportportal/test.sh
@@ -10,7 +10,7 @@ rlJournalStart
     rlPhaseStartTest
         rlRun -s "tmt run --id $run --verbose" 2
         rlAssertGrep "project: tmt" $rlRun_LOG
-        rlAssertGrep "launch: smoke" $rlRun_LOG
+        rlAssertGrep "launch-name: smoke" $rlRun_LOG
         rlAssertGrep "report: Successfully uploaded." $rlRun_LOG
     rlPhaseEnd
 

--- a/tmt/schemas/report/reportportal.yaml
+++ b/tmt/schemas/report/reportportal.yaml
@@ -31,6 +31,9 @@ properties:
   launch-name:
     type: string
 
+  ca-cert-file:
+    type: string
+
 required:
   - how
   - project

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -50,7 +50,7 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
         default=None,
         help="The launch name (base name of run id used by default).")
     ca_cert_file: Optional[str] = tmt.utils.field(
-        option="--ca_cert_file",
+        option="--ca-cert-file",
         metavar="CA_CERT",
         default=None,
         help="Set reportportal cert file")
@@ -127,8 +127,8 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
 
         # Send the report to the ReportPortal instance
         with tmt.utils.retry_session() as session:
-            if self.get("ca_cert_file"):
-                session.verify = self.get("ca_cert_file")
+            if self.get("ca-cert-file"):
+                session.verify = self.get("ca-cert-file")
             url = f"{server}/api/v1/{project}/launch/import"
             self.debug(f"Send the report to '{url}'.")
             response = session.post(

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -49,6 +49,11 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
         metavar="NAME",
         default=None,
         help="The launch name (base name of run id used by default).")
+    ca_cert_file: Optional[str] = tmt.utils.field(
+        option="--ca_cert_file",
+        metavar="CA_CERT",
+        default=None,
+        help="Set reportportal cert file")
 
 
 @tmt.steps.provides_method("reportportal")
@@ -122,6 +127,8 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
 
         # Send the report to the ReportPortal instance
         with tmt.utils.retry_session() as session:
+            if self.get("ca_cert_file"):
+                session.verify = self.get("ca_cert_file")
             url = f"{server}/api/v1/{project}/launch/import"
             self.debug(f"Send the report to '{url}'.")
             response = session.post(


### PR DESCRIPTION
tmt run report --how reportportal --ca_cert_file

In my runs ssl certificate to interact with ReportPortal was not found.
Adding the option to set cert file dynamically, to set request.session.verify in case of existence

--ca_cert_file <file path to .crt file>