### PR TITLE
Cache resolved linters

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -377,10 +377,13 @@ def _lint_class(
 
     exit_code = 0
 
+    linters = klass.resolve_enabled_linters(
+        enable_checks=enable_checks or None,
+        disable_checks=disable_checks or None)
+
     for lintable in klass.from_tree(context.obj.tree):
         valid, rulings = lintable.lint(
-            enable_checks=enable_checks or None,
-            disable_checks=disable_checks or None,
+            linters=linters,
             enforce_checks=enforce_checks or None)
 
         # If the object pass the checks, and we're asked to show only the failed

--- a/tmt/lint.py
+++ b/tmt/lint.py
@@ -259,7 +259,8 @@ class Lintable(Generic[LintableT]):
             self,
             enable_checks: Optional[List[str]] = None,
             disable_checks: Optional[List[str]] = None,
-            enforce_checks: Optional[List[str]] = None) -> Tuple[bool, List[LinterRuling]]:
+            enforce_checks: Optional[List[str]] = None,
+            linters: Optional[List[Linter]] = None) -> Tuple[bool, List[LinterRuling]]:
         """
         Check the instance against a battery of linters and report results.
 
@@ -270,6 +271,8 @@ class Lintable(Generic[LintableT]):
         :param enforce_checks: if set, listed checks would be marked as failed
             if their outcome is not ``pass``, i.e. even a warning would become
             a fail.
+        :param linters: if set, only these linters would be applied. Providing
+            ``linters`` makes ``enable_checks`` and ``disable_checks`` ignored.
         :returns: a tuple of two items: a boolean reporting whether the instance
             passed the test, and a list of :py:class:`LinterRuling` items, each
             describing one linter outcome. Note that linters may produce none or
@@ -278,7 +281,7 @@ class Lintable(Generic[LintableT]):
 
         enforce_checks = enforce_checks or []
 
-        linters = self.resolve_enabled_linters(
+        linters = linters or self.resolve_enabled_linters(
             enable_checks=enable_checks,
             disable_checks=disable_checks)
 


### PR DESCRIPTION
Improves the speed of linting of multiple items: `Lintable.lint()` can find out what linters to run, by combining lists of enabled and disabled checks. The final list is not saved, but it also does not depend on the actual object to be checked. Therefore the patch adds a bit of caching: list of linters is created and re-used for checking object of the same class (test/plan/story).

Simple change, but fairly measurable: linting all tests, plans and stories takes around 4.5 seconds on my workstation, compared to 5.5 seconds before the patch.