### PR TITLE
Make relevancy/coverage linters to not re-read fmf files

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import _pytest.logging
 import _pytest.tmpdir
+import fmf
 import py.path
 import pytest
 
@@ -97,3 +98,15 @@ def source_dir(tmppath_factory: TempPathFactory) -> Path:
 def target_dir(tmppath_factory: TempPathFactory) -> Path:
     """ Return target directory path and clean up after tests """
     return tmppath_factory.mktemp('target')
+
+
+# Present two trees we have for identifier unit tests as fixtures, to make them
+# usable in other tests as well.
+@pytest.fixture(name='id_tree_defined')
+def fixture_id_tree_defined() -> fmf.Tree:
+    return fmf.Tree(Path(__file__).parent / 'id' / 'defined')
+
+
+@pytest.fixture(name='id_tree_empty')
+def fixture_id_tree_empty() -> fmf.Tree:
+    return fmf.Tree(Path(__file__).parent / 'id' / 'empty')

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -9,52 +9,12 @@ from click.testing import CliRunner
 import tmt
 import tmt.cli
 import tmt.log
-from tmt.identifier import ID_KEY, locate_key
+from tmt.identifier import ID_KEY
 from tmt.utils import Path
 
 runner = CliRunner()
 test_path = Path(__file__).parent / "id"
 root_logger = tmt.log.Logger.create()
-
-
-class IdLocationDefined(TestCase):
-    def setUp(self) -> None:
-        self.base_tree = fmf.Tree(test_path / "defined")
-
-    def test_defined(self):
-        node = self.base_tree.find("/yes")
-        assert locate_key(node, ID_KEY) == node
-
-    def test_defined_partially(self):
-        node = self.base_tree.find("/partial")
-        test = tmt.Test(logger=root_logger, node=node)
-        assert locate_key(node, ID_KEY) == test.node
-
-    def test_not_defined(self):
-        node = self.base_tree.find("/deep/structure/no")
-        assert locate_key(node, ID_KEY).name == "/deep"
-
-    def test_deeper(self):
-        node = self.base_tree.find("/deep/structure/yes")
-        assert node == locate_key(node, ID_KEY)
-
-    def test_deeper_not_defined(self):
-        node = self.base_tree.find("/deep/structure/no")
-        assert node != locate_key(node, ID_KEY)
-        assert locate_key(node, ID_KEY).name == "/deep"
-
-
-class IdLocationEmpty(TestCase):
-    def setUp(self) -> None:
-        self.base_tree = fmf.Tree(test_path / "empty")
-
-    def test_defined_root(self):
-        node = self.base_tree.find("/")
-        assert locate_key(node, ID_KEY) is None
-
-    def test_defined(self):
-        node = self.base_tree.find("/some/structure")
-        assert locate_key(node, ID_KEY) is None
 
 
 class IdEmpty(TestCase):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -9,6 +9,7 @@ import unittest.mock
 from datetime import timedelta
 from typing import Any, List, Tuple
 
+import fmf
 import pytest
 
 import tmt
@@ -1032,3 +1033,49 @@ def test_filter_paths(source_dir):
     )
 def test_sanitize_name(name: str, allow_slash: bool, sanitized: str) -> None:
     assert tmt.utils.sanitize_name(name, allow_slash=allow_slash) == sanitized
+
+
+def test_locate_key_origin(id_tree_defined: fmf.Tree) -> None:
+    node = id_tree_defined.find('/yes')
+
+    assert tmt.utils.locate_key_origin(node, 'id') is node
+
+
+def test_locate_key_origin_defined_partially(
+        root_logger: tmt.log.Logger,
+        id_tree_defined: fmf.Tree) -> None:
+    node = id_tree_defined.find('/partial')
+    test = tmt.Test(logger=root_logger, node=node)
+
+    assert tmt.utils.locate_key_origin(node, 'id') is test.node
+
+
+def test_locate_key_origin_not_defined(id_tree_defined: fmf.Tree) -> None:
+    node = id_tree_defined.find('/deep/structure/no')
+
+    assert tmt.utils.locate_key_origin(node, 'id').name == '/deep'
+
+
+def test_locate_key_origin_deeper(id_tree_defined: fmf.Tree) -> None:
+    node = id_tree_defined.find('/deep/structure/yes')
+
+    assert tmt.utils.locate_key_origin(node, 'id') is node
+
+
+def test_locate_key_origin_deeper_not_defined(id_tree_defined: fmf.Tree) -> None:
+    node = id_tree_defined.find('/deep/structure/no')
+
+    assert tmt.utils.locate_key_origin(node, 'id') is not node
+    assert tmt.utils.locate_key_origin(node, 'id').name == '/deep'
+
+
+def test_locate_key_origin_empty_defined_root(id_tree_empty: fmf.Tree) -> None:
+    node = id_tree_empty.find('/')
+
+    assert tmt.utils.locate_key_origin(node, 'id') is None
+
+
+def test_locate_key_origin_empty_defined(id_tree_empty: fmf.Tree) -> None:
+    node = id_tree_empty.find('/some/structure')
+
+    assert tmt.utils.locate_key_origin(node, 'id') is None

--- a/tmt/identifier.py
+++ b/tmt/identifier.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 import fmf
 
-from tmt.utils import log
+from tmt.utils import is_key_origin, log
 
 # Name of the key holding the unique identifier
 ID_KEY = "id"
@@ -17,27 +17,6 @@ class IdLeafError(IdError):
     """ Identifier not stored in a leaf """
 
 
-def locate_key(node: fmf.Tree, key: str) -> Optional[fmf.Tree]:
-    """ Return fmf node where the 'key' is defined, None if not found """
-
-    # Find the closest parent with different key content
-    while node.parent:
-        if node.get(key) != node.parent.get(key):
-            break
-        node = node.parent
-
-    # Return node only if the key is defined
-    if node.get(key) is None:
-        return None
-    return node
-
-
-def key_defined_in_leaf(node: fmf.Tree, key: str) -> bool:
-    """ Is the key defined inside this node """
-    location = locate_key(node, key=key)
-    return location is not None and node.name == location.name
-
-
 def get_id(node: fmf.Tree, leaf_only: bool = True) -> Optional[str]:
     """
     Get identifier if defined, optionally ensure leaf node
@@ -49,7 +28,7 @@ def get_id(node: fmf.Tree, leaf_only: bool = True) -> Optional[str]:
     """
     if node.get(ID_KEY) is None:
         return None
-    if leaf_only and not key_defined_in_leaf(node, ID_KEY):
+    if leaf_only and not is_key_origin(node, ID_KEY):
         raise IdLeafError(
             f"Key '{ID_KEY}' not defined in leaf '{node.name}'.")
     # FIXME: cast() - typeless "dispatcher" method
@@ -60,7 +39,7 @@ def add_uuid_if_not_defined(node: fmf.Tree, dry: bool) -> Optional[str]:
     """ Add UUID into node and return it unless already defined """
 
     # Already defined
-    if key_defined_in_leaf(node, key=ID_KEY):
+    if is_key_origin(node, ID_KEY):
         log.debug(
             f"Id '{node.data[ID_KEY]}' already defined for '{node.name}'.")
         return None

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -5050,3 +5050,41 @@ def is_selinux_supported() -> bool:
     """
     with open('/proc/filesystems') as file:
         return any('selinuxfs' in line for line in file)
+
+
+def locate_key_origin(node: fmf.Tree, key: str) -> Optional[fmf.Tree]:
+    """
+    Find an fmf node where the given key is defined.
+
+    :param node: node to begin with.
+    :param key: key to look for.
+    :returns: first node in which the key is defined, ``None`` if ``node`` nor
+        any of its parents define it.
+    """
+
+    # Find the closest parent with different key content
+    while node.parent:
+        if node.get(key) != node.parent.get(key):
+            break
+        node = node.parent
+
+    # Return node only if the key is defined
+    if node.get(key) is None:
+        return None
+
+    return node
+
+
+def is_key_origin(node: fmf.Tree, key: str) -> bool:
+    """
+    Find out whether the given key is defined in the given node.
+
+    :param node: node to check.
+    :param key: key to check.
+    :returns: ``True`` if the key is defined in ``node``, not by one of its
+        parents, ``False`` otherwise.
+    """
+
+    origin = locate_key_origin(node, key)
+
+    return origin is not None and node.name == origin.name


### PR DESCRIPTION
Two test linters checking for legacy constructs were re-reading the original fmf sources, to focus on leaf node only. Patch changes the linters:

* both now focus on loaded fmf data, i.e. `self.node` is inspected.
* this may report keys defined by parents in the node fmf tree, but that is expected - the key is defined, somewhere, and it's inherited by the test metadata, user should be aware. The current implementation might miss this case, although it should be said, relevancycoverage inheritance is probably pretty rare.
* optional `relevancy` key fix is applied only when relevancy is defined in the leaf node, i.e. in the test's direct metadata. It relevancy's inherited, the fix would be impractical as it would fix the wrong node.

To get the right tools for this, two functions from `tmt.identifier` were moved into `tmt.utils` and generalized a bit.

With this change, two extra reads of fmf files for each test visited by `tmt lint` are gone, dropping `tmt test lint` of tmt repo from 3.7 down to 2.6 seconds (on my laptop, YMMV).