### PR TITLE
Handle el6 as a legacy os too in virtual provision

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -434,7 +434,7 @@ class GuestTestcloud(tmt.GuestSsh):
             import guestfs  # noqa: F401
         except ImportError:
             match_legacy = re.search(
-                r'(rhel|centos).*-7', self.image_url.lower())
+                r'(rhel|centos)\D+(6\.|7\.).*', self.image_url.lower())
             if match_legacy:
                 self._instance.pci_net = "e1000"
             else:


### PR DESCRIPTION
This isn't everything that's necessary to make it work just yet, I'll also release a minor testcloud in a bit to go along.

Can somebody double check if didn't miss anything in the re? The motivation for the other change apart from adding 6 there is to prevent it from matching eg. rhel-guest-image-8.5-6XX.x86_64.qcow2 as legacy net OS.