### PR TITLE
Use `testcloud` domain API v2

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -28,8 +28,11 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - fedora-all
-      - epel-9
+        fedora-all: {}
+        epel-9: {}
+        fedora-39:
+            additional_repos:
+              - https://download.copr.fedorainfracloud.org/results/frantisekz/testcloud-wip/fedora-39-x86_64/
     enable_net: False
 
   # Test pull requests

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ extras_require = {
         'yq==3.1.1'  # frozen to be able to install on el8
         ],
     'provision': [
-        'testcloud>=0.9.2',
+        'testcloud>=0.9.10',
         'mrack>=1.12.1',
         ],
     'convert': [

--- a/tmt.spec
+++ b/tmt.spec
@@ -38,7 +38,7 @@ BuildRequires: python%{python3_pkgversion}-pytest
 BuildRequires: python%{python3_pkgversion}-click
 BuildRequires: python%{python3_pkgversion}-fmf >= 1.2.0
 BuildRequires: python%{python3_pkgversion}-requests
-BuildRequires: python%{python3_pkgversion}-testcloud >= 0.9.2
+BuildRequires: python%{python3_pkgversion}-testcloud >= 0.9.10
 BuildRequires: python%{python3_pkgversion}-markdown
 BuildRequires: python%{python3_pkgversion}-junit_xml
 BuildRequires: python%{python3_pkgversion}-ruamel-yaml


### PR DESCRIPTION
Refactors domain configuration interface between tmt and testcloud, to allow greater flexibility and superior api stability when making changes and additions in the future.

Apart from that, doesn't expose support for (will come as a separate PR):
- tpm emulation
- uefi
- cpu core count setting (more advanced topologies to follow https://tmt.readthedocs.io/en/stable/spec/hardware.html#cpu TBD)

testcloud counterparts: 
- https://pagure.io/testcloud/c/6f0942cb3ba31ff0927ee8b151218e8dc8b34d7d?branch=master
- https://pagure.io/testcloud/pull-request/155
- https://pagure.io/testcloud/c/7ee6dc839a46c72db6d23bcd2e057c2de6fe5ea8?branch=master
- ...

(compatible testcloud built at): https://copr.fedorainfracloud.org/coprs/frantisekz/testcloud-wip/