### PR TITLE
Create option metavar from listed choices

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -235,19 +235,19 @@ def main(
 @option(
     '-a', '--all', help='Run all steps, customize some.', is_flag=True)
 @option(
-    '-u', '--until', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
+    '-u', '--until', type=click.Choice(tmt.steps.STEPS),
     help='Enable given step and all preceding steps.')
 @option(
-    '-s', '--since', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
+    '-s', '--since', type=click.Choice(tmt.steps.STEPS),
     help='Enable given step and all following steps.')
 @option(
-    '-A', '--after', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
+    '-A', '--after', type=click.Choice(tmt.steps.STEPS),
     help='Enable all steps after the given one.')
 @option(
-    '-B', '--before', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
+    '-B', '--before', type=click.Choice(tmt.steps.STEPS),
     help='Enable all steps before the given one.')
 @option(
-    '-S', '--skip', type=click.Choice(tmt.steps.STEPS), metavar='STEP',
+    '-S', '--skip', type=click.Choice(tmt.steps.STEPS),
     help='Skip given step(s) during test run execution.', multiple=True)
 @option(
     '-e', '--environment', metavar='KEY=VALUE|@FILE', multiple=True,
@@ -704,11 +704,11 @@ _test_export_default = 'yaml'
 @click.pass_context
 @filter_options_long
 @option(
-    '-h', '--how', metavar='METHOD', default=_test_export_default, show_default=True,
+    '-h', '--how', default=_test_export_default, show_default=True,
     help='Output format.',
     type=click.Choice(choices=_test_export_formats))
 @option(
-    '--format', metavar='FORMAT', default=_test_export_default, show_default=True,
+    '--format', default=_test_export_default, show_default=True,
     help='Output format. Deprecated, use --how instead.',
     type=click.Choice(choices=_test_export_formats))
 @option(
@@ -971,11 +971,11 @@ _plan_export_default = 'yaml'
 @click.pass_context
 @filter_options_long
 @option(
-    '-h', '--how', metavar='METHOD', default=_plan_export_default, show_default=True,
+    '-h', '--how', default=_plan_export_default, show_default=True,
     help='Output format.',
     type=click.Choice(choices=_plan_export_formats))
 @option(
-    '--format', metavar='FORMAT', default=_plan_export_default, show_default=True,
+    '--format', default=_plan_export_default, show_default=True,
     help='Output format. Deprecated, use --how instead.',
     type=click.Choice(choices=_plan_export_formats))
 @option(
@@ -1221,11 +1221,11 @@ _story_export_default = 'yaml'
 @filter_options_long
 @story_flags_filter_options
 @option(
-    '-h', '--how', metavar='METHOD', default=_story_export_default, show_default=True,
+    '-h', '--how', default=_story_export_default, show_default=True,
     help='Output format.',
     type=click.Choice(choices=_story_export_formats))
 @option(
-    '--format', metavar='FORMAT', default=_story_export_default, show_default=True,
+    '--format', default=_story_export_default, show_default=True,
     help='Output format. Deprecated, use --how instead.',
     type=click.Choice(choices=_story_export_formats))
 @option(
@@ -1351,9 +1351,9 @@ def stories_id(
 @click.pass_context
 @click.argument('path', default='.')
 @option(
-    '-t', '--template', default='empty', metavar='TEMPLATE',
+    '-t', '--template', default='empty',
     type=click.Choice(['empty', *tmt.templates.INIT_TEMPLATES]),
-    help=f"Template ({listed(tmt.templates.INIT_TEMPLATES, join='or')}).")
+    help="Use this template to populate the tree.")
 @verbosity_options
 @force_dry_options
 def init(

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -99,6 +99,10 @@ def option(
         else:
             help = deprecated.rendered
 
+    # Add a metavar listing choices unless an explicit metavar has been provided
+    if isinstance(type, click.Choice) and metavar is None:
+        metavar = '|'.join(type.choices)
+
     # Instead of repeating all keyword parameters, use locals(), they are all there
     # already, and it's a dictionary - just don't forget to remove names that are
     # not accepted by click and the positional parameter.
@@ -122,9 +126,8 @@ VERBOSITY_OPTIONS: List[ClickOptionDecoratorType] = [
         help='Be quiet. Exit code is just enough for me.'),
     option(
         '--log-topic',
-        metavar=f'[{"|".join(topic.value for topic in tmt.log.Topic)}]',
+        type=click.Choice([topic.value for topic in tmt.log.Topic]),
         multiple=True,
-        type=str,
         help='If specified, --debug and --verbose would emit logs also for these topics.')
     ]
 
@@ -278,7 +281,6 @@ LINT_OPTIONS: List[ClickOptionDecoratorType] = [
         help='Display only tests/plans/stories that fail a check.'),
     option(
         '--outcome-only',
-        metavar='|'.join(_lint_outcomes),
         multiple=True,
         type=click.Choice(_lint_outcomes),
         help='Display only checks with the given outcome.')


### PR DESCRIPTION
For options of type `click.Choice`, we can easily create a default metavar, listing all possible choices. It is still possible to provide a custom metavar if needed, but the default seems to be fine for most of the existing options.