### PR TITLE
Require setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ install_requires = [
     'urllib3',
     'ruamel.yaml',
     'jinja2',
+    'setuptools',
     ]
 
 # typing_extensions is needed with Python 3.7 and older, types imported

--- a/tests/prepare/basic/data/main.fmf
+++ b/tests/prepare/basic/data/main.fmf
@@ -3,7 +3,7 @@ provision:
     image: fedora
 prepare:
     how: install
-    package: tmt
+    package: fmf
 execute:
     how: tmt
-    script: tmt --help
+    script: fmf --help

--- a/tests/prepare/basic/test.sh
+++ b/tests/prepare/basic/test.sh
@@ -8,12 +8,11 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun "tmt run -dddvvvr 2>&1 >/dev/null | tee output"
-        rlAssertGrep "Test Management Tool" "output"
+        rlRun -s "tmt run -dddvvvr"
+        rlAssertGrep "Flexible Metadata Format" "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun "rm -f output"
         rlRun "popd"
     rlPhaseEnd
 rlJournalEnd


### PR DESCRIPTION
Library is used by python3-tmt so we need to require it, it is not guaranteed to be present on the system.