### PR TITLE
Reimplement the `ReportPortal` plugin using API

### DIFF
--- a/spec/plans/report.fmf
+++ b/spec/plans/report.fmf
@@ -90,24 +90,38 @@ description:
     summary: Report test results to a ReportPortal instance
     story:
         As a tester I want to review results in a nicely arranged
-        web page with links to detailed test output.
+        web page, filter them via context attributes and get links
+        to detailed test output and other test information.
     description:
-        Prepare a JUnit report with test results, zip it and send
-        it to a ReportPortal instance.
+        Fill json with test results and other fmf data per each plan,
+        and send it to a Report Portal instance via its API.
     example:
       - |
         # Set environment variables with the server url and token
-        export TMT_REPORT_REPORTPORTAL_URL=...
-        export TMT_REPORT_REPORTPORTAL_TOKEN=...
+        export TMT_REPORT_REPORTPORTAL_URL=<url-to-RP-instance>
+        export TMT_REPORT_REPORTPORTAL_TOKEN=<token-from-RP-profile>
       - |
         # Enable ReportPortal report from the command line
-        tmt run --all report --how reportportal --project=baseosqe --launch-name=maven
+        tmt run --all report --how reportportal --project=baseosqe
+        tmt run --all report --how reportportal --project=baseosqe --exclude-variables="^(TMT|PACKIT|TESTING_FARM).*"
+        tmt run --all report --how reportportal --project=baseosqe --launch=test_plan
+        tmt run --all report --how reportportal --project=baseosqe --url=... --token=...
       - |
         # Use ReportPortal as the default report for given plan
         report:
             how: reportportal
             project: baseosqe
-            launch-name: maven
+
+        # Report context attributes for given plan
+        context:
+            ...
+      - |
+        # Report description, contact, id and environment variables for given test
+        summary: ...
+        contact: ...
+        id: ...
+        environment:
+            ...
     link:
         - implemented-by: /tmt/steps/report/reportportal.py
 

--- a/tests/report/reportportal/data/plan.fmf
+++ b/tests/report/reportportal/data/plan.fmf
@@ -1,3 +1,5 @@
+summary: Testing the integration of tmt and Report Portal via its API
+
 discover:
     how: fmf
 provision:
@@ -6,5 +8,18 @@ execute:
     how: tmt
 report:
     how: reportportal
-    project: tmt
-    launch-name: smoke
+    project: test_tmt
+
+context:
+    component: tmt
+    distro: rhel-8
+    arch: x86_64
+    trigger: build
+    compose: RHEL-8.9.0-20230323.20
+    subsystem: baseos_tools
+    purpose: None
+    tier: None
+    milestone: None
+
+environment:
+    ENV_VAR: example_value

--- a/tests/report/reportportal/data/test.fmf
+++ b/tests/report/reportportal/data/test.fmf
@@ -1,10 +1,13 @@
-/good:
-    summary: Passing test
-    test: echo "Everything's fine!"
-
 /bad:
     summary: Failing test
+    contact: tester@redhat.com
     test: echo "Something bad happened!"; false
+
+/good:
+    summary: Passing test
+    contact: tester_2@redhat.com
+    test: echo "Everything's fine!"
+    id: 63f26fb7-69c4-4781-a06e-098e2b58129f
 
 /weird:
     summary: An error encountered

--- a/tests/report/reportportal/test.sh
+++ b/tests/report/reportportal/test.sh
@@ -1,17 +1,142 @@
 #!/bin/bash
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
+TOKEN=$TMT_REPORT_REPORTPORTAL_TOKEN
+URL=$TMT_REPORT_REPORTPORTAL_URL
+PROJECT="$(grep 'project' 'data/plan.fmf' | awk -F ': ' '{print $2}')"
+
+# testing all the attributes/parameters under a label
+# $1=rl_message, $2=response, $3=jq_element, $4=fmf_file, $5=fmf_label
+check_attr_label() {
+    [[ $1 ]] && local rl_message=$1
+    [[ $2 ]] && local response=$2
+    [[ $3 ]] && local jq_element=$3
+    [[ $4 ]] && local fmf_file=$4
+    [[ $5 ]] && local fmf_label=$5
+    echo "$response" | jq -r ".$jq_element" > tmp_attributes.json && rlPass "$rl_message" || rlFail "$rl_message"
+    awk -v label=$fmf_label '$0~label,/^$/ {if($0 && $0!=label){print $0}}' $fmf_file | while IFS= read -r line
+        do
+            key="$(echo "$line" | grep -o '[^ :]*' | head -1)"
+            value="$(echo "$line" | grep -o '[^ :]*' | tail -1)"
+            rlAssertGrep "$key" tmp_attributes.json -A1 > tmp_attributes_selection
+            rlAssertGrep "$value" tmp_attributes_selection
+        done
+    rm tmp_attributes*
+}
+
+# testing one of the attributes/parameters under a specific key
+# $1=rl_message, $2=response, $3=jq_element, $4=fmf_file, $5=fmf_key, $6=test_index, $7=inv_grep_key, $8=inv_grep_value
+check_attr_key() {
+    [[ $1 ]] && local rl_message=$1
+    [[ $2 ]] && local response=$2
+    [[ $3 ]] && local jq_element=$3
+    [[ $4 ]] && local fmf_file=$4
+    [[ $5 ]] && local fmf_key=$5
+    [[ $6 ]] && local test_index=$6
+    [[ $7 ]] && local inv_grep_key="Not"   || local inv_grep_key=""
+    [[ $8 ]] && local inv_grep_value="Not" || local inv_grep_value=""
+    echo "$response" | jq -r ".$jq_element" > tmp_attributes.json && rlPass "$rl_message" || rlFail "$rl_message"
+    rlAssert${inv_grep_key}Grep "$fmf_key" tmp_attributes.json -A1 > tmp_attributes_selection
+    if [[ -f $file && ! $inv_grep_value ]]; then
+        value="$(grep $fmf_key $fmf_file | sed -n "$test_index p" | tr -s ' ' | grep -o '[^ :]*' | tail -1)"
+        rlAssert${inv_grep_value}Grep "$value" tmp_attributes_selection
+    fi
+    rm tmp_attributes*
+}
+
+
 rlJournalStart
     rlPhaseStartSetup
         rlRun "pushd data"
         rlRun "run=$(mktemp -d)" 0 "Create run workdir"
+        rlRun "set -o pipefail"
     rlPhaseEnd
 
     rlPhaseStartTest
         rlRun -s "tmt run --id $run --verbose" 2
-        rlAssertGrep "project: tmt" $rlRun_LOG
-        rlAssertGrep "launch: smoke" $rlRun_LOG
-        rlAssertGrep "report: Successfully uploaded." $rlRun_LOG
+        cat  $rlRun_LOG
+        rlAssertGrep "launch: /plan" $rlRun_LOG
+        rlAssertGrep "test: /test/bad" $rlRun_LOG
+        rlAssertGrep "test: /test/good" $rlRun_LOG
+        rlAssertGrep "test: /test/weird" $rlRun_LOG
+        rlAssertGrep "url: http.*redhat.com.ui/\#${PROJECT}/launches/all/[0-9]{4}" $rlRun_LOG -Eq
+    rlPhaseEnd
+
+    rlPhaseStartTest "Interface Test"
+        launch_uuid=$(rlRun "grep -A1 'launch:' $rlRun_LOG | tail -n1 | awk '{print \$NF}' ")
+        rlAssertNotEquals "Assert the launch uuid is not empty" "$launch_uuid" ""
+        test1_uuid=$(rlRun "grep -m1 -A1 'test:' $rlRun_LOG | tail -n1 | awk '{print \$NF}' ")
+        rlAssertNotEquals "Assert the test1 uuid is not empty" "$test1_uuid" ""
+        test2_uuid=$(rlRun "grep -m2 -A1 'test:' $rlRun_LOG | tail -n1 | awk '{print \$NF}' ")
+        rlAssertNotEquals "Assert the test2 uuid is not empty" "$test2_uuid" ""
+        test3_uuid=$(rlRun "grep -m3 -A1 'test:' $rlRun_LOG | tail -n1 | awk '{print \$NF}' ")
+        rlAssertNotEquals "Assert the test3 uuid is not empty" "$test3_uuid" ""
+        launch_id=$(rlRun "grep 'url:' $rlRun_LOG | awk '{print \$NF}' | xargs basename")
+        rlAssertNotEquals "Assert the launch id is not empty" "$launch_id" ""
+
+        # LAUNCH - via API launch-controller /v1/{projectName}/launch/uuid/{launchId}
+        rlLog "Testing a launch via API"
+        response=$(curl -X GET "${URL}/api/v1/${PROJECT}/launch/uuid/${launch_uuid}" -H  "accept: */*" -H  "Authorization: bearer ${TOKEN}")
+        rlAssertEquals "Assert the id of launch is correct (id from url)" "$(echo $response | jq -r '.id')" "$launch_id"
+        rlAssertEquals "Assert the name of launch is correct" "$(echo $response | jq -r '.name')" "/plan"
+        rlAssertEquals "Assert the status of launch is correct" "$(echo $response | jq -r '.status')" "FAILED"
+        rlAssertEquals "Assert the description of launch is correct" "$(echo $response | jq -r '.description')" "$(grep 'summary' 'plan.fmf' | awk -F ': ' '{print $2}')"
+        check_attr_label "Test attributes of the launch" "$response" "attributes" "plan.fmf" "context:"
+
+        # TEST ITEMS - via API test-item-controller /v1/{projectName}/item/uuid/{itemId}
+        rlLog "Testing test item for test1 via API"
+        response=$(curl -X GET "${URL}/api/v1/${PROJECT}/item/uuid/${test1_uuid}" -H  "accept: */*" -H  "Authorization: bearer ${TOKEN}")
+        test1_id=$(echo $response | jq -r '.id')
+        rlAssertNotEquals "Assert the test id is not empty" "$test1_id" ""
+        rlAssertEquals "Assert the name is correct" "$(echo $response | jq -r '.name')" "/test/bad"
+        rlAssertEquals "Assert the status is correct" "$(echo $response | jq -r '.status')" "FAILED"
+        rlAssertEquals "Assert the description is correct" "$(echo $response | jq -r '.description')" "$(grep 'summary' 'test.fmf' | sed -n "1 p" | awk -F ': ' '{print $2}')"
+        check_attr_label "Test attributes" "$response" "attributes" "plan.fmf" "context:"
+        check_attr_key "Test attributes - contains contact" "$response" "attributes" "test.fmf" "contact" 1
+        check_attr_label "Test parameters" "$response" "parameters" "test.fmf" "environment:"
+        check_attr_key "Test parameters - contains no tmt variables" "$response" "parameters" "" "TMT_TREE" 1 "AssertNotGrep"
+
+        rlLog "Testing test item for test2 via API"
+        response=$(curl -X GET "${URL}/api/v1/${PROJECT}/item/uuid/${test2_uuid}" -H  "accept: */*" -H  "Authorization: bearer ${TOKEN}")
+        test2_id=$(echo $response | jq -r '.id')
+        rlAssertNotEquals "Assert the test id is not empty" "$test2_id" ""
+        rlAssertEquals "Assert the name is correct" "$(echo $response | jq -r '.name')" "/test/good"
+        rlAssertEquals "Assert the status is correct" "$(echo $response | jq -r '.status')" "PASSED"
+        rlAssertEquals "Assert the description is correct" "$(echo $response | jq -r '.description')" "$(grep 'summary' 'test.fmf' | sed -n "2 p" | awk -F ': ' '{print $2}')"
+        rlAssertEquals "Assert the testCaseId is correct" "$(echo $response | jq -r '.testCaseId')" "$(grep 'id' 'test.fmf' | awk -F ': ' '{print $2}')"
+        check_attr_key "Test atributes - contains contact" "$response" "attributes" "test.fmf" "contact" 2
+        check_attr_key "Test attributes - does not contain a previous contact" "$response" "attributes" "test.fmf" "contact" 1 "" "AssertNotGrep"
+        check_attr_label "Test parameters" "$response" "parameters" "test.fmf" "environment:"
+
+        rlLog "Testing test item for test3 via API"
+        response=$(curl -X GET "${URL}/api/v1/${PROJECT}/item/uuid/${test3_uuid}" -H  "accept: */*" -H  "Authorization: bearer ${TOKEN}")
+        test3_id=$(echo $response | jq -r '.id')
+        rlAssertNotEquals "Assert the test id is not empty" "$test3_id" ""
+        rlAssertEquals "Assert the name is correct" "$(echo $response | jq -r '.name')" "/test/weird"
+        rlAssertEquals "Assert the status is correct" "$(echo $response | jq -r '.status')" "FAILED"
+        rlAssertEquals "Assert the description is correct" "$(echo $response | jq -r '.description')" "$(grep 'summary' 'test.fmf' | sed -n "3 p" | awk -F ': ' '{print $2}')"
+        check_attr_key "Test attributes - contains no contact" "$response" "attributes" "test.fmf" "contact" 3 "AssertNotGrep" ""
+
+        # LOGS - via API log-controller /v1/{projectName}/log/nested/{parentId}
+        rlLog "Testing logs for test1 via API"
+        response=$(curl -X GET "${URL}/api/v1/${PROJECT}/log/nested/${test1_id}" -H  "accept: */*" -H  "Authorization: bearer ${TOKEN}")
+        rlAssertEquals "Assert the level of the log is correct" "$(echo $response | jq -r '.content[0].level')" "INFO"
+        output="$(grep 'test:' 'test.fmf' | sed -n "1 p" | awk -F \" '{print $2}')"
+        rlAssertEquals "Assert the message of the log is correct" "$(echo $response | jq -r '.content[0].message')" "$output"
+        rlAssertEquals "Assert the level of the log is correct" "$(echo $response | jq -r '.content[1].level')" "ERROR"
+        rlAssertEquals "Assert the message of the log is correct" "$(echo $response | jq -r '.content[1].message')" "$output"
+
+        rlLog "Testing logs for test2 via API"
+        response=$(curl -X GET "${URL}/api/v1/${PROJECT}/log/nested/${test2_id}" -H  "accept: */*" -H  "Authorization: bearer ${TOKEN}")
+        rlAssertEquals "Assert the level of the log is correct" "$(echo $response | jq -r '.content[0].level')" "INFO"
+        output="$(grep 'test:' 'test.fmf' | sed -n "2 p" | awk -F \" '{print $2}')"
+        rlAssertEquals "Assert the message of the log is correct" "$(echo $response | jq -r '.content[0].message')" "$output"
+
+        rlLog "Testing logs for test3 via API"
+        response=$(curl -X GET "${URL}/api/v1/${PROJECT}/log/nested/${test3_id}" -H  "accept: */*" -H  "Authorization: bearer ${TOKEN}")
+        rlAssertEquals "Assert the level of the log is correct" "$(echo $response | jq -r '.content[0].level')" "INFO"
+        rlAssertEquals "Assert the level of the log is correct" "$(echo $response | jq -r '.content[1].level')" "ERROR"
+
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/schemas/report/reportportal.yaml
+++ b/tmt/schemas/report/reportportal.yaml
@@ -28,7 +28,10 @@ properties:
   project:
     type: string
 
-  launch-name:
+  launch:
+    type: string
+
+  exclude-variables:
     type: string
 
 required:

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -1,60 +1,49 @@
 import dataclasses
-import io
 import os
-import types
-import zipfile
+import re
 from typing import Optional
 
+import requests
+
 import tmt.steps.report
-import tmt.utils
-
-from . import junit
-
-junit_xml: Optional[types.ModuleType] = None
-
-
-def import_junit_xml() -> None:
-    """
-    Import junit_xml module only when needed
-
-    Until we have a separate package for each plugin.
-    """
-    global junit_xml
-    try:
-        import junit_xml
-    except ImportError:
-        raise tmt.utils.ReportError(
-            "Missing 'junit-xml', fixable by 'pip install tmt[report-junit]'.")
+from tmt.result import ResultOutcome
+from tmt.utils import field, yaml_to_dict
 
 
 @dataclasses.dataclass
 class ReportReportPortalData(tmt.steps.report.ReportStepData):
-    url: Optional[str] = tmt.utils.field(
+    url: Optional[str] = field(
         option="--url",
         metavar="URL",
         default=os.environ.get("TMT_REPORT_REPORTPORTAL_URL"),
         help="The URL of the ReportPortal instance where the data should be sent to.")
-    token: Optional[str] = tmt.utils.field(
+    token: Optional[str] = field(
         option="--token",
         metavar="TOKEN",
         default=os.environ.get("TMT_REPORT_REPORTPORTAL_TOKEN"),
-        help="The token to use for upload to the ReportPortal instance.")
-    project: Optional[str] = tmt.utils.field(
+        help="The token to use for upload to the ReportPortal instance (from the user profile).")
+    project: Optional[str] = field(
         option="--project",
-        metavar="PROJECT",
+        metavar="PROJECT_NAME",
         default=None,
-        help="The project name which is used to create the full URL.")
-    launch_name: Optional[str] = tmt.utils.field(
-        option="--launch-name",
-        metavar="NAME",
+        help="Name of the project into which the results should be uploaded.")
+    launch: Optional[str] = field(
+        option="--launch",
+        metavar="LAUNCH_NAME",
         default=None,
-        help="The launch name (base name of run id used by default).")
+        help="The launch name (name of plan per launch is used by default).")
+    exclude_variables: str = field(
+        option="--exclude-variables",
+        metavar="PATTERN",
+        default="^TMT_.*",
+        help="Regular expression for excluding environment variables "
+             "from reporting to ReportPortal ('^TMT_.*' used by default).")
 
 
 @tmt.steps.provides_method("reportportal")
 class ReportReportPortal(tmt.steps.report.ReportPlugin):
     """
-    Report test results to a ReportPortal instance
+    Report test results to a ReportPortal instance via API.
 
     Requires a TOKEN for authentication, a URL of the ReportPortal
     instance and the PROJECT name. In addition to command line options
@@ -63,90 +52,195 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
         export TMT_REPORT_REPORTPORTAL_URL=...
         export TMT_REPORT_REPORTPORTAL_TOKEN=...
 
-    The optional launch NAME is passed to ReportPortal. Assuming the URL
-    and TOKEN variables are provided by the environment, the config can
-    look like this:
+    The optional LAUNCH name doesn't have to be provided if it is the
+    same as the plan name (by default). Assuming the URL and TOKEN
+    variables are provided by the environment, the plan config can look
+    like this:
 
         report:
             how: reportportal
             project: baseosqe
-            launch-name: maven
+
+        context:
+            ...
+
+        environment:
+            ...
+
+    The context and environment sections must be filled in order to
+    report context as attributes and environment variables as parameters
+    in the Item Details. Environment variables can be filtered out by
+    pattern to prevent overloading and to preserve the history
+    aggregation for ReportPortal item if tmt id is not provided. Other
+    reported fmf data are summary, id, web link and contact per test.
     """
 
     _data_class = ReportReportPortalData
 
+    DEFAULT_API_VERSION = "v1"
+
+    TMT_TO_RP_RESULT_STATUS = {
+        ResultOutcome.PASS: "PASSED",
+        ResultOutcome.FAIL: "FAILED",
+        ResultOutcome.ERROR: "FAILED",
+        ResultOutcome.WARN: "FAILED",
+        ResultOutcome.INFO: "SKIPPED"
+        }
+
+    def handle_response(self, response: requests.Response) -> None:
+        """
+        Check the server response and raise an exception if needed.
+        """
+
+        if not response.ok:
+            raise tmt.utils.ReportError(
+                f"Received non-ok status code from ReportPortal: {response.text}")
+
+        self.debug("Response code from the server", str(response.status_code))
+        self.debug("Message from the server", str(response.text))
+
     def go(self) -> None:
         """
-        Read executed tests, prepare junit, compress it to a zip zile and
-        send it to the ReportPortal instance.
+        Report test results to the server
+
+        Create a ReportPortal launch and its test items,
+        fill it with all parts needed and report the logs.
         """
 
         super().go()
 
-        # Check the data, show interesting info to the user
-        # Required fields are: url, token and project
         server = self.get("url")
         if not server:
             raise tmt.utils.ReportError("No ReportPortal server url provided.")
         server = server.rstrip("/")
 
+        project = self.get("project")
+        if not project:
+            raise tmt.utils.ReportError("No ReportPortal project provided.")
+
         token = self.get("token")
         if not token:
             raise tmt.utils.ReportError("No ReportPortal token provided.")
 
-        project = self.get("project")
-        if not project:
-            raise tmt.utils.ReportError("No ReportPortal project provided.")
-        self.info("project", project, color="green")
+        assert self.step.plan.name is not None
+        launch_name = self.get("launch") or self.step.plan.name
 
-        # Use provided launch name, default to run workdir name
-        assert self.step.plan.my_run is not None
-        assert self.step.plan.my_run.workdir is not None
-        launch_name = self.get("launch-name") or self.step.plan.my_run.workdir.name
-        self.info("launch", launch_name, color="green")
+        url = f"{server}/api/{self.DEFAULT_API_VERSION}/{project}"
+        headers = {
+            "Authorization": "bearer " + token,
+            "accept": "*/*",
+            "Content-Type": "application/json"}
 
-        # Generate a xUnit report
-        import_junit_xml()
-        assert junit_xml is not None
-        suite = junit.make_junit_xml(self)
-        data = junit_xml.TestSuite.to_xml_string([suite])
+        envar_pattern = self.get("exclude-variables") or "$^"
+        attributes = [
+            {'key': key, 'value': value[0]}
+            for key, value in self.step.plan._fmf_context.items()]
+        launch_time = self.step.plan.execute.results()[0].starttime
 
-        # Zip the report
-        bytestream = io.BytesIO()
-        # SIM117: Use a single `with` statement with multiple contexts instead of nested `with`
-        # statements. Here, `zipstream` is being used in the second nested context.
-        with zipfile.ZipFile(bytestream, "w", compression=zipfile.ZIP_DEFLATED,  # noqa: SIM117
-                             compresslevel=1) as zipstream:
-            # XML file names are irrelevant to ReportPortal
-            with zipstream.open("tests.xml", "w") as entry:
-                entry.write(data.encode("utf-8"))
-        bytestream.seek(0)
-
-        # Send the report to the ReportPortal instance
+        # Communication with RP instance
         with tmt.utils.retry_session() as session:
-            url = f"{server}/api/v1/{project}/launch/import"
-            self.debug(f"Send the report to '{url}'.")
+
+            # Create a launch
+            self.info("launch", launch_name, color="cyan")
             response = session.post(
-                url,
-                headers={
-                    "Authorization": "bearer " + token,
-                    "accept": "*/*",
-                    },
-                files={
-                    # The zip filename is used as the launch name in ReportPortal
-                    "file": (launch_name + ".zip", bytestream, "application/zip"),
-                    },
-                )
+                url=f"{url}/launch",
+                headers=headers,
+                json={
+                    "name": launch_name,
+                    "description": self.step.plan.summary,
+                    "attributes": attributes,
+                    "startTime": launch_time})
+            self.handle_response(response)
+            launch_uuid = yaml_to_dict(response.text).get("id")
+            assert launch_uuid is not None
+            self.verbose("uuid", launch_uuid, "yellow", shift=1)
 
-        # Handle the response
-        try:
-            message = tmt.utils.yaml_to_dict(response.text).get("message")
-        except (tmt.utils.GeneralError, KeyError):
-            message = response.text
-        if not response.ok:
-            raise tmt.utils.ReportError(
-                f"Received non-ok status code from ReportPortal, response text is: {message}")
+            # For each test
+            for result in self.step.plan.execute.results():
+                test = [test for test in self.step.plan.discover.tests()
+                        if test.serialnumber == result.serialnumber][0]
+                # TODO: for happz, connect Test to Result if possible
 
-        self.debug(f"Response code from the server: {response.status_code}")
-        self.debug(f"Message from the server: {message}")
-        self.info("report", "Successfully uploaded.", "yellow")
+                item_attributes = attributes.copy()
+                if test.contact:
+                    item_attributes.append({"key": "contact", "value": test.contact[0]})
+                env_vars = [
+                    {'key': key, 'value': value}
+                    for key, value in test.environment.items()
+                    if not re.search(envar_pattern, key)]
+
+                # Create a test item
+                self.info("test", result.name, color="cyan")
+                response = session.post(
+                    url=f"{url}/item",
+                    headers=headers,
+                    json={
+                        "name": result.name,
+                        "description": test.summary,
+                        "attributes": item_attributes,
+                        "parameters": env_vars,
+                        "codeRef": test.web_link() or None,
+                        "launchUuid": launch_uuid,
+                        "type": "step",
+                        "testCaseId": test.id or None,
+                        "startTime": result.starttime})
+                self.handle_response(response)
+                item_uuid = yaml_to_dict(response.text).get("id")
+                assert item_uuid is not None
+                self.verbose("uuid", item_uuid, "yellow", shift=1)
+
+                # For each log
+                for index, log_path in enumerate(result.log):
+                    try:
+                        log = self.step.plan.execute.read(log_path)
+                    except tmt.utils.FileError:
+                        continue
+
+                    level = "INFO" if log_path == result.log[0] else "TRACE"
+                    status = self.TMT_TO_RP_RESULT_STATUS[result.result]
+
+                    # Upload log
+                    response = session.post(
+                        url=f"{url}/log/entry",
+                        headers=headers,
+                        json={
+                            "message": log,
+                            "itemUuid": item_uuid,
+                            "launchUuid": launch_uuid,
+                            "level": level,
+                            "time": result.endtime})
+                    self.handle_response(response)
+
+                    # Write out failures
+                    if index == 0 and status == "FAILED":
+                        message = result.failures(log)
+                        response = session.post(
+                            url=f"{url}/log/entry",
+                            headers=headers,
+                            json={
+                                "message": message,
+                                "itemUuid": item_uuid,
+                                "launchUuid": launch_uuid,
+                                "level": "ERROR",
+                                "time": result.endtime})
+                        self.handle_response(response)
+
+                # Finish the test item
+                response = session.put(
+                    url=f"{url}/item/{item_uuid}",
+                    headers=headers,
+                    json={
+                        "launchUuid": launch_uuid,
+                        "endTime": result.endtime,
+                        "status": status})
+                self.handle_response(response)
+                launch_time = result.endtime
+
+            # Finish the launch
+            response = session.put(
+                url=f"{url}/launch/{launch_uuid}/finish",
+                headers=headers,
+                json={"endTime": launch_time})
+            self.handle_response(response)
+            link = yaml_to_dict(response.text).get("link")
+            self.info("url", link, "magenta")


### PR DESCRIPTION
Implemented an integration of tmt and ReportPortal with basic features via REST API.
(Based on implementation via reportportal-client on [tmt reportportal branch](https://github.com/teemtee/tmt/blob/reportportal/tmt/steps/report/reportportal.py))
Creates launch per plan with items per each test, and uploads main log, its failures and rest of the logs arranged in the RP log levels accordingly (ERROR, INFO, TRACE).

Launch is identified either by name of the plan, or it gets the name from '--launch' argument.
Additional information for launch are attributes from fmf_context(component, distro, arch, trigger, compose, subsystem, purpose, tier, milestone, etc.), and description from the plan summary.
Each test has same attributes + contact per test, and there are also environment variables, test id and test web_link (if present) in RP item details. Environment variables exclude all formated "TMT_*" if they are not specified in arguments (they tend to to break history aggregation) unless '--tmt-vars' argument is specified
Print name and uuid per each RP item and final URL of the launch.
Project name is a mandatory argument, and both URL and token (from RP user profile) can be exported also as environment variables.