### PR TITLE
Crashed prepare and execute steps propagate all causes

### DIFF
--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -662,7 +662,10 @@ class Execute(tmt.steps.Step):
 
         if failed_phases:
             # TODO: needs a better message...
-            raise tmt.utils.GeneralError('execute step failed')
+            raise tmt.utils.GeneralError(
+                'execute step failed',
+                causes=[outcome.exc for outcome in failed_phases if outcome.exc is not None]
+                )
 
         # To separate "execute" from the follow-up logging visually
         self.info('')

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -293,7 +293,10 @@ class Prepare(tmt.steps.Step):
 
         if failed_phases:
             # TODO: needs a better message...
-            raise tmt.utils.GeneralError('prepare step failed') from failed_phases[0].exc
+            raise tmt.utils.GeneralError(
+                'prepare step failed',
+                causes=[outcome.exc for outcome in failed_phases if outcome.exc is not None]
+                )
 
         self.info('')
 


### PR DESCRIPTION
An exception was raised with `from $the_first_crashed_phase` which was fairly suboptimal. Fixing that.