### PR TITLE
Rename multi-word keys to use dashes

### DIFF
--- a/spec/plans/results.fmf
+++ b/spec/plans/results.fmf
@@ -44,16 +44,16 @@ description: |
          another-id: bar
 
        # String, when the test started, in an ISO 8601 format.
-       starttime: "yyyy-mm-ddThh:mm:ss.mmmmm+ZZ:ZZ"
+       start-time: "yyyy-mm-ddThh:mm:ss.mmmmm+ZZ:ZZ"
 
        # String, when the test finished, in an ISO 8601 format.
-       endtime: "yyyy-mm-ddThh:mm:ss.mmmmm+ZZ:ZZ"
+       end-time: "yyyy-mm-ddThh:mm:ss.mmmmm+ZZ:ZZ"
 
        # String, how long did the test run.
        duration: hh:mm:ss
 
        # Integer, serial number of the test in the sequence of all tests of a plan.
-       serialnumber: 1
+       serial-number: 1
 
        # Mapping, describes the guest on which the test was executed.
        guest:
@@ -104,12 +104,12 @@ description: |
     The first ``log`` item is considered to be the "main" log, presented
     to the user by default.
 
-    The ``serialnumber``, ``guest`` and ``fmf_id`` keys, if present in the
+    The ``serial-number``, ``guest`` and ``fmf-id`` keys, if present in the
     custom results file, will be overwritten by tmt during their import after
     test completes. This happens on purpose, to assure this vital
     information is correct.
 
-    Similarly, the ``duration``, ``starttime`` and ``endtime`` keys, if
+    Similarly, the ``duration``, ``start-time`` and ``end-time`` keys, if
     present in the special custom result, representing the original test
     itself - ``name: /`` -, will be overwritten by tmt with actual
     observed values. This also happens on purpose: while tmt cannot
@@ -128,11 +128,11 @@ example:
     # Example content of results.yaml
     - name: /test/passing
       result: pass
-      serialnumber: 1
+      serial-number: 1
       log:
         - pass_log
-      starttime: "2023-03-10T09:44:14.439120+00:00"
-      endtime: "2023-03-10T09:44:24.242227+00:00"
+      start-time: "2023-03-10T09:44:14.439120+00:00"
+      end-time: "2023-03-10T09:44:24.242227+00:00"
       duration: 00:00:09
       note: good result
       ids:
@@ -142,12 +142,12 @@ example:
 
     - name: /test/failing
       result: fail
-      serialnumber: 2
+      serial-number: 2
       log:
         - fail_log
         - another_log
-      starttime: "2023-03-10T09:44:14.439120+00:00"
-      endtime: "2023-03-10T09:44:24.242227+00:00"
+      start-time: "2023-03-10T09:44:14.439120+00:00"
+      end-time: "2023-03-10T09:44:24.242227+00:00"
       duration: 00:00:09
       note: fail result
       guest:

--- a/tests/discover/serial-number.sh
+++ b/tests/discover/serial-number.sh
@@ -10,7 +10,7 @@ rlJournalStart
     rlPhaseStartTest "Single discover phase"
         rlRun 'pushd serial-number'
         rlRun "tmt -vv run --scratch --id $workdir discover plan --name '/single-discover'"
-        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serialnumber)\"' $workdir/plans/single-discover/discover/tests.yaml"
+        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serial-number)\"' $workdir/plans/single-discover/discover/tests.yaml"
         rlAssertGrep "/tests/bar 1" $rlRun_LOG
         rlAssertGrep "/tests/foo 2" $rlRun_LOG
         rlRun 'popd'
@@ -19,7 +19,7 @@ rlJournalStart
     rlPhaseStartTest "Multiple discover phases"
         rlRun 'pushd serial-number'
         rlRun "tmt -vv run --scratch --id $workdir discover plan --name '/multiple-discover'"
-        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serialnumber)\"' $workdir/plans/multiple-discover/discover/tests.yaml"
+        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serial-number)\"' $workdir/plans/multiple-discover/discover/tests.yaml"
         rlAssertGrep "/default-0/tests/bar 1" $rlRun_LOG
         rlAssertGrep "/default-0/tests/foo 2" $rlRun_LOG
         rlAssertGrep "/default-1/tests/bar 3" $rlRun_LOG
@@ -33,17 +33,17 @@ rlJournalStart
         rlRun 'pushd serial-number'
         rlRun "tmt -vv run --scratch --id $workdir discover plan --name '/multiple-plans'"
 
-        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serialnumber)\"' $workdir/plans/multiple-plans/plan1/discover/tests.yaml"
+        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serial-number)\"' $workdir/plans/multiple-plans/plan1/discover/tests.yaml"
         rlAssertGrep "/default-0/tests/bar 1" $rlRun_LOG
         rlAssertGrep "/default-0/tests/foo 2" $rlRun_LOG
         rlAssertGrep "/default-1/tests/bar 3" $rlRun_LOG
         rlAssertGrep "/default-1/tests/foo 4" $rlRun_LOG
 
-        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serialnumber)\"' $workdir/plans/multiple-plans/plan2/discover/tests.yaml"
+        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serial-number)\"' $workdir/plans/multiple-plans/plan2/discover/tests.yaml"
         rlAssertGrep "/tests/bar 1" $rlRun_LOG
         rlAssertGrep "/tests/foo 2" $rlRun_LOG
 
-        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serialnumber)\"' $workdir/plans/multiple-plans/plan3/discover/tests.yaml"
+        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serial-number)\"' $workdir/plans/multiple-plans/plan3/discover/tests.yaml"
         rlAssertGrep "/default-0/tests/bar 1" $rlRun_LOG
         rlAssertGrep "/default-0/tests/foo 2" $rlRun_LOG
         rlAssertGrep "/default-1/tests/bar 3" $rlRun_LOG
@@ -54,7 +54,7 @@ rlJournalStart
     rlPhaseStartTest "Single '/' test"
         rlRun 'pushd serial-number-root-test'
         rlRun "tmt -vv run --scratch --id $workdir discover -h fmf"
-        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serialnumber)\"' $workdir/plans/default/discover/tests.yaml"
+        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serial-number)\"' $workdir/plans/default/discover/tests.yaml"
         rlAssertGrep "/ 1" $rlRun_LOG
         rlRun 'popd'
     rlPhaseEnd

--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -26,7 +26,7 @@ rlJournalStart
         rlAssertExists "$(sed -n 's/ *another_log: \(.\+\)/\1/p' $rlRun_LOG)"
         rlAssertExists "$(sed -n 's/ *slash_log: \(.\+\)/\1/p' $rlRun_LOG)"
 
-        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serialnumber) \\(.result) \\(.guest.name)\"' $run/plans/default/execute/results.yaml"
+        rlRun -s "yq -er '.[] | \"\\(.name) \\(.serial-number) \\(.result) \\(.guest.name)\"' $run/plans/default/execute/results.yaml"
         rlAssertGrep "/test/custom-results/test/passing 1 pass default-0" $rlRun_LOG
         rlAssertGrep "/test/custom-results/test/failing 1 fail default-0" $rlRun_LOG
         rlAssertGrep "/test/custom-results 1 pass default-0" $rlRun_LOG

--- a/tests/execute/result/custom/results.json
+++ b/tests/execute/result/custom/results.json
@@ -11,7 +11,7 @@
       "another-id": "bar1"
     },
     "duration": "00:12:23",
-    "serialnumber": 1,
+    "serial-number": 1,
     "guest": {
       "name": "client-1",
       "role": "clients"
@@ -29,7 +29,7 @@
     },
     "duration": "00:23:34",
     "note": "fail result",
-    "serialnumber": 2,
+    "serial-number": 2,
     "guest": {
       "name": "client-1",
       "role": "clients"
@@ -46,7 +46,7 @@
       "another-id": "bar3"
     },
     "duration": "00:34:56",
-    "serialnumber": 3,
+    "serial-number": 3,
     "guest": {
       "name": "client-2",
       "role": "clients"

--- a/tests/execute/result/custom/results.yaml
+++ b/tests/execute/result/custom/results.yaml
@@ -7,7 +7,7 @@
     some-id: foo1
     another-id: bar1
   duration: 00:11:22
-  serialnumber: 1
+  serial-number: 1
   guest:
     name: client-1
     role: clients
@@ -21,7 +21,7 @@
     another-id: bar2
   duration: 00:22:33
   note: fail result
-  serialnumber: 2
+  serial-number: 2
   guest:
     name: client-1
     role: clients
@@ -34,7 +34,7 @@
     some-id: foo3
     another-id: bar3
   duration: 00:33:55
-  serialnumber: 3
+  serial-number: 3
   guest:
     name: client-2
     role: clients
@@ -47,7 +47,7 @@
     some-id: foo4
     another-id: bar4
   duration: 00:55:44
-  serialnumber: 4
+  serial-number: 4
   guest:
     name: client-1
     role: clients

--- a/tests/unit/test_report_junit.py
+++ b/tests/unit/test_report_junit.py
@@ -126,7 +126,7 @@ def assert_xml(actual_filepath, expected):
 class TestStateMapping:
     def test_pass(self, report_fix):
         report, results, out_file_path = report_fix
-        results.append(Result(result=ResultOutcome.PASS, name="/pass", serialnumber=1))
+        results.append(Result(result=ResultOutcome.PASS, name="/pass", serial_number=1))
 
         report.go()
 
@@ -140,7 +140,7 @@ class TestStateMapping:
 
     def test_info(self, report_fix):
         report, results, out_file_path = report_fix
-        results.append(Result(result=ResultOutcome.INFO, name="/info", serialnumber=1))
+        results.append(Result(result=ResultOutcome.INFO, name="/info", serial_number=1))
         report.go()
 
         assert_xml(out_file_path, """<?xml version="1.0" ?>
@@ -155,7 +155,7 @@ class TestStateMapping:
 
     def test_warn(self, report_fix):
         report, results, out_file_path = report_fix
-        results.append(Result(result=ResultOutcome.WARN, name="/warn", serialnumber=1))
+        results.append(Result(result=ResultOutcome.WARN, name="/warn", serial_number=1))
         report.go()
 
         assert_xml(out_file_path, """<?xml version="1.0" ?>
@@ -170,7 +170,7 @@ class TestStateMapping:
 
     def test_error(self, report_fix):
         report, results, out_file_path = report_fix
-        results.append(Result(result=ResultOutcome.ERROR, name="/error", serialnumber=1))
+        results.append(Result(result=ResultOutcome.ERROR, name="/error", serial_number=1))
         report.go()
 
         assert_xml(out_file_path, """<?xml version="1.0" ?>
@@ -185,7 +185,7 @@ class TestStateMapping:
 
     def test_fail(self, report_fix):
         report, results, out_file_path = report_fix
-        results.append(Result(result=ResultOutcome.FAIL, name="/fail", serialnumber=1))
+        results.append(Result(result=ResultOutcome.FAIL, name="/fail", serial_number=1))
         report.go()
 
         assert_xml(out_file_path, """<?xml version="1.0" ?>

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -82,7 +82,7 @@ class Result(tmt.utils.SerializableContainer):
     """ Describes what tmt knows about a single test result """
 
     name: str
-    serialnumber: int = 0
+    serial_number: int = 0
     fmf_id: Optional['tmt.base.FmfId'] = field(
         default=cast(Optional['tmt.base.FmfId'], None),
         serialize=lambda fmf_id: fmf_id.to_minimal_spec() if fmf_id is not None else {},
@@ -105,8 +105,8 @@ class Result(tmt.utils.SerializableContainer):
         unserialize=lambda serialized: ResultGuestData.from_serialized(serialized)
         )
 
-    starttime: Optional[str] = None
-    endtime: Optional[str] = None
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
     duration: Optional[str] = None
 
     @classmethod
@@ -158,12 +158,12 @@ class Result(tmt.utils.SerializableContainer):
 
         _result = Result(
             name=test.name,
-            serialnumber=test.serialnumber,
+            serial_number=test.serial_number,
             fmf_id=test.fmf_id,
             result=result,
             note=note,
-            starttime=test.starttime,
-            endtime=test.endtime,
+            start_time=test.start_time,
+            end_time=test.end_time,
             duration=test.real_duration,
             ids=ids,
             log=log or [],

--- a/tmt/schemas/results.yaml
+++ b/tmt/schemas/results.yaml
@@ -33,7 +33,7 @@ items:
       type: string
       pattern: "^/.*"
 
-    serialnumber:
+    serial-number:
       type: integer
 
     result:
@@ -42,10 +42,10 @@ items:
     note:
       type: string
 
-    starttime:
+    start-time:
       $ref: "/schemas/common#/definitions/timestamp"
 
-    endtime:
+    end-time:
       $ref: "/schemas/common#/definitions/timestamp"
 
     duration:

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -183,7 +183,7 @@ class Discover(tmt.steps.Step):
                 if test.enabled is not True:
                     continue
 
-                exported_test = test._export()
+                exported_test = test.to_serialized()
                 exported_test['discover_phase'] = phase_name
 
                 raw_test_data.append(exported_test)
@@ -308,7 +308,7 @@ class Discover(tmt.steps.Step):
                 raise GeneralError(f'Unexpected phase in discover step: {phase}')
 
         for test in self.tests():
-            test.serialnumber = self.plan.draw_test_serial_number(test)
+            test.serial_number = self.plan.draw_test_serial_number(test)
 
         # Show fmf identifiers for tests discovered in plan
         # TODO: This part should go into the 'fmf.py' module

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -218,7 +218,7 @@ class ExecutePlugin(tmt.steps.Plugin):
             / TEST_DATA \
             / 'guest' \
             / guest.safe_name \
-            / f'{test.safe_name.lstrip("/") or "default"}-{test.serialnumber}'
+            / f'{test.safe_name.lstrip("/") or "default"}-{test.serial_number}'
         if create and not directory.is_dir():
             directory.joinpath(TEST_DATA).mkdir(parents=True)
         if not filename:
@@ -373,7 +373,7 @@ class ExecutePlugin(tmt.steps.Plugin):
             # data directories, they are all confined into its parent test's
             # directory. And the serial number correspondence in results.yaml
             # can be useful, for grouping results that belong to the same tests.
-            partial_result.serialnumber = test.serialnumber
+            partial_result.serial_number = test.serial_number
 
             # Enforce the correct guest info
             partial_result.guest = ResultGuestData(name=guest.name, role=guest.role)
@@ -381,8 +381,8 @@ class ExecutePlugin(tmt.steps.Plugin):
             # For the result representing the test itself, set the duration
             # and timestamps to what tmt measured.
             if partial_result.name == test.name:
-                partial_result.starttime = test.starttime
-                partial_result.endtime = test.endtime
+                partial_result.start_time = test.start_time
+                partial_result.end_time = test.end_time
                 partial_result.duration = test.real_duration
 
             custom_results.append(partial_result)

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -141,7 +141,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
 
         environment["TMT_TEST_NAME"] = test.name
         environment["TMT_TEST_DATA"] = str(data_directory / tmt.steps.execute.TEST_DATA)
-        environment['TMT_TEST_SERIAL_NUMBER'] = str(test.serialnumber)
+        environment['TMT_TEST_SERIAL_NUMBER'] = str(test.serial_number)
         environment["TMT_TEST_METADATA"] = str(
             data_directory / tmt.steps.execute.TEST_METADATA_FILENAME)
         environment["TMT_REBOOT_REQUEST"] = str(
@@ -247,7 +247,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
                 topic=topic)
 
         # Execute the test, save the output and return code
-        starttime = datetime.datetime.now(datetime.timezone.utc)
+        start_time = datetime.datetime.now(datetime.timezone.utc)
         try:
             output = guest.execute(
                 remote_command,
@@ -266,14 +266,14 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             test.returncode = error.returncode
             if test.returncode == tmt.utils.PROCESS_TIMEOUT:
                 logger.debug(f"Test duration '{test.duration}' exceeded.")
-        endtime = datetime.datetime.now(datetime.timezone.utc)
+        end_time = datetime.datetime.now(datetime.timezone.utc)
         self.write(
             self.data_path(test, guest, TEST_OUTPUT_FILENAME, full=True),
             stdout or '', mode='a', level=3)
 
-        test.starttime = self.format_timestamp(starttime)
-        test.endtime = self.format_timestamp(endtime)
-        test.real_duration = self.format_duration(endtime - starttime)
+        test.start_time = self.format_timestamp(start_time)
+        test.end_time = self.format_timestamp(end_time)
+        test.real_duration = self.format_duration(end_time - start_time)
 
     def _will_reboot(self, test: Test, guest: Guest) -> bool:
         """ True if reboot is requested """

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -552,8 +552,12 @@ class Guest(tmt.utils.Common):
         return facts
 
     @facts.setter
-    def facts(self, facts: Dict[str, Any]) -> None:
-        self.__dict__['facts'] = GuestFacts.from_serialized(facts)
+    def facts(self, facts: Union[GuestFacts, Dict[str, Any]]) -> None:
+        if isinstance(facts, GuestFacts):
+            self.__dict__['facts'] = facts
+
+        else:
+            self.__dict__['facts'] = GuestFacts.from_serialized(facts)
 
     def details(self) -> None:
         """ Show guest details such as distro and kernel """

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -135,7 +135,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
         attributes = [
             {'key': key, 'value': value[0]}
             for key, value in self.step.plan._fmf_context.items()]
-        launch_time = self.step.plan.execute.results()[0].starttime
+        launch_time = self.step.plan.execute.results()[0].start_time
 
         # Communication with RP instance
         with tmt.utils.retry_session() as session:
@@ -158,7 +158,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
             # For each test
             for result in self.step.plan.execute.results():
                 test = [test for test in self.step.plan.discover.tests()
-                        if test.serialnumber == result.serialnumber][0]
+                        if test.serial_number == result.serial_number][0]
                 # TODO: for happz, connect Test to Result if possible
 
                 item_attributes = attributes.copy()
@@ -183,7 +183,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
                         "launchUuid": launch_uuid,
                         "type": "step",
                         "testCaseId": test.id or None,
-                        "startTime": result.starttime})
+                        "startTime": result.start_time})
                 self.handle_response(response)
                 item_uuid = yaml_to_dict(response.text).get("id")
                 assert item_uuid is not None
@@ -208,7 +208,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
                             "itemUuid": item_uuid,
                             "launchUuid": launch_uuid,
                             "level": level,
-                            "time": result.endtime})
+                            "time": result.end_time})
                     self.handle_response(response)
 
                     # Write out failures
@@ -222,7 +222,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
                                 "itemUuid": item_uuid,
                                 "launchUuid": launch_uuid,
                                 "level": "ERROR",
-                                "time": result.endtime})
+                                "time": result.end_time})
                         self.handle_response(response)
 
                 # Finish the test item
@@ -231,10 +231,10 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
                     headers=headers,
                     json={
                         "launchUuid": launch_uuid,
-                        "endTime": result.endtime,
+                        "endTime": result.end_time,
                         "status": status})
                 self.handle_response(response)
-                launch_time = result.endtime
+                launch_time = result.end_time
 
             # Finish the launch
             response = session.put(


### PR DESCRIPTION
`serialnumber` becomes `serial-number`, `starttime` and `endtime` change
to `start-time` and `end-time`. There will be some changes in files tmt
save for its own use, but these three fields should be the only change
visible to the user.

Fixes #2054.