### PR TITLE
Fix fmf_root when using dist-git

### DIFF
--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -187,7 +187,11 @@ description: |
 
         There is a support for discovering tests from extracted
         (rpm) sources. Needs to run on top of the supported
-        DistGit (Fedora, CentOS).
+        DistGit (Fedora, CentOS). By default tmt will search for
+        the first ``.fmf/version`` and use that as the fmf root,
+        ignoring all other files in the extracted sources. This
+        behavior can be changed: see "Advanced ``dist-git``
+        options" bellow.
 
         Patches are not yet supported, only tarball extraction
         happens.

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -187,9 +187,10 @@ description: |
 
         There is a support for discovering tests from extracted
         (rpm) sources. Needs to run on top of the supported
-        DistGit (Fedora, CentOS), ``path`` denotes path to the metadata
-        tree root within extracted sources. At this moment no
-        patches are applied, only tarball extraction happens.
+        DistGit (Fedora, CentOS).
+
+        Patches are not yet supported, only tarball extraction
+        happens.
 
         dist-git-source
             Set to ``true`` to enable extracting sources.
@@ -213,6 +214,9 @@ description: |
         dist-git-remove-fmf-root
             set to ``true`` to remove fmf root from
             extracted sources
+        path
+            denotes path to the metadata tree root within extracted
+            sources
 
         .. _fmf identifier: https://fmf.readthedocs.io/en/latest/concept.html#identifiers
         .. _Flexible Metadata Format: https://fmf.readthedocs.io/

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -215,9 +215,6 @@ description: |
         dist-git-extract
             directory (glob supported) to copy from extracted sources.
             Set to ``/`` to extract all sources
-        dist-git-remove-fmf-root
-            set to ``true`` to remove fmf root from
-            extracted sources
         path
             denotes path to the metadata tree root relative to
             the extracted source root (equivalent to ``BUILDROOT``

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -213,14 +213,16 @@ description: |
             set to ``true`` and ``fmf init`` will be called inside
             extracted sources (at dist-git-extract or top directory)
         dist-git-extract
-            directory (glob supported) to copy from
-            extracted sources (defaults to inner fmf-root)
+            directory (glob supported) to copy from extracted sources.
+            Set to ``/`` to extract all sources
         dist-git-remove-fmf-root
             set to ``true`` to remove fmf root from
             extracted sources
         path
-            denotes path to the metadata tree root within extracted
-            sources
+            denotes path to the metadata tree root relative to
+            the extracted source root (equivalent to ``BUILDROOT``
+            in rpm builds). Must set ``dist-git-extract`` to have
+            any effect
 
         .. _fmf identifier: https://fmf.readthedocs.io/en/latest/concept.html#identifiers
         .. _Flexible Metadata Format: https://fmf.readthedocs.io/

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -200,6 +200,21 @@ description: |
             ``Fedora`` and ``CentOS`` are supported as values,
             help will print all possible values.
 
+        Advanced ``dist-git`` options:
+
+        dist-git-merge
+            set to ``true`` if you want to copy in extracted
+            sources to the local repo
+        dist-git-init
+            set to ``true`` and ``fmf init`` will be called inside
+            extracted sources (at dist-git-extract or top directory)
+        dist-git-extract
+            directory (glob supported) to copy from
+            extracted sources (defaults to inner fmf-root)
+        dist-git-remove-fmf-root
+            set to ``true`` to remove fmf root from
+            extracted sources
+
         .. _fmf identifier: https://fmf.readthedocs.io/en/latest/concept.html#identifiers
         .. _Flexible Metadata Format: https://fmf.readthedocs.io/
     example: |

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -187,8 +187,7 @@ description: |
 
         There is a support for discovering tests from extracted
         (rpm) sources. Needs to run on top of the supported
-        DistGit (Fedora, CentOS), ``url`` can be used to point to
-        such repository, ``path`` denotes path to the metadata
+        DistGit (Fedora, CentOS), ``path`` denotes path to the metadata
         tree root within extracted sources. At this moment no
         patches are applied, only tarball extraction happens.
 

--- a/tests/discover/distgit.sh
+++ b/tests/discover/distgit.sh
@@ -292,7 +292,7 @@ done
 
         rlRun -s 'tmt run --id $WORKDIR --scratch plans --default \
             discover -v --how fmf --dist-git-source \
-            --dist-git-type TESTING --dist-git-merge --dist-git-remove-fmf-root'
+            --dist-git-type TESTING --dist-git-merge'
         rlAssertGrep "\s/top_test" $rlRun_LOG -E
         rlAssertGrep "\s/simple-1/tests/magic" $rlRun_LOG -E
         rlAssertGrep "summary: 2 tests selected" $rlRun_LOG -F

--- a/tmt/schemas/discover/fmf.yaml
+++ b/tmt/schemas/discover/fmf.yaml
@@ -47,7 +47,18 @@ properties:
     $ref: "/schemas/common#/definitions/one_or_more_strings"
 
   dist-git-extract:
-    type: string
+    anyOf:
+      - type: string
+      - type: array
+        items:
+          anyOf:
+            - type: string
+            - type: object
+              properties:
+                src:
+                  type: string
+                dest:
+                  type: string
 
   dist-git-init:
     type: boolean

--- a/tmt/schemas/discover/fmf.yaml
+++ b/tmt/schemas/discover/fmf.yaml
@@ -66,9 +66,6 @@ properties:
   dist-git-merge:
     type: boolean
 
-  dist-git-remove-fmf-root:
-    type: boolean
-
   dist-git-source:
     $ref: "/schemas/common#/definitions/dist-git-source"
 

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -418,6 +418,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             if not dist_git_init and not dist_git_extract:
                 try:
                     top_fmf_root = tmt.utils.find_fmf_root(sourcedir)[0]
+                    # Using the fmf_root as the working directory, additional path is redundant
+                    path = None
                 except tmt.utils.MetadataError:
                     dist_git_extract = sourcedir
                     if not dist_git_merge:

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -127,8 +127,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
       extracted sources (at dist-git-extract or top directory)
     * dist-git-extract - directory (glob supported) to copy from
       extracted sources (defaults to inner fmf-root)
-    * dist-git-remove-fmf-root - set to True to remove fmf root from
-      extracted sources
 
     Selecting tests containing specified link is possible using 'link'
     option accepting RELATION:TARGET format of values. Regular
@@ -212,11 +210,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                 help='Initialize fmf root inside extracted sources '
                      '(at dist-git-extract or top directory).'),
             option(
-                '--dist-git-remove-fmf-root', is_flag=True,
-                help='Remove fmf root from extracted source '
-                     '(top one or selected by copy-path, '
-                     'happens before dist-git-extract.'),
-            option(
                 '--dist-git-merge', is_flag=True,
                 help='Merge copied sources and plan fmf root.'),
             option(
@@ -251,7 +244,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
         dist_git_merge = self.get('dist-git-merge', False)
         dist_git_init = self.get('dist-git-init', False)
         dist_git_extract = self.get('dist-git-extract', None)
-        dist_git_remove_fmf_root = self.get('dist-git-remove-fmf-root', False)
 
         # Self checks
         if dist_git_source and not dist_git_merge and (ref or url):

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -407,8 +407,12 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
                     dist_git_extract = sourcedir
                 else:
                     try:
-                        dist_git_extract = glob.glob(os.path.join(
-                            sourcedir, dist_git_extract.lstrip('/')))[0]
+                        # Glob everything
+                        glob_path = glob.glob(os.path.join(sourcedir, dist_git_extract.lstrip('/')))
+                        # Use only the directories
+                        glob_dirs = [d for d  in glob_path if Path(d).is_dir()]
+                        # Use only the first valid directory
+                        dist_git_extract = glob_dirs[0]
                     except IndexError:
                         raise tmt.utils.DiscoverError(
                             f"Couldn't glob '{dist_git_extract}' "


### PR DESCRIPTION
I don't think this is a suitable "fix", but it highlights the logic issue
- `path` is only used when `dist-git-extract` is specified
- `dist-git-extract` must be a directory in the current implementation. It does not behave as documented, i.e. to specify the sources to copy over
  One would expect in this case the root to be the same as if passed `dist-git-extract`, but it is actually flattened out
- `path`  should support glob pattern because the extracted source is generally `package_name-0.1.2`

TODO:
- [ ] Document the spec file change of `dist-git-extract` in help, stories and cli