### PR TITLE
pytest warning fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,3 +113,8 @@ ignore = [
 
 [tool.ruff.per-file-ignores]
 "tmt/steps/report/polarion.py" = ["DTZ005"]
+
+[tool.pytest.ini_options]
+markers = [
+    "web: tests which need to access the web"
+]

--- a/tests/unit/pytest.ini
+++ b/tests/unit/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-    web: tests which need to access the web

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -165,7 +165,7 @@ def test_last_run_race(tmpdir, monkeypatch):
 def test_workdir_env_var(tmpdir, monkeypatch, root_logger):
     """ Test TMT_WORKDIR_ROOT environment variable """
     # Cannot use monkeypatch.context() as it is not present for CentOS Stream 8
-    monkeypatch.setenv('TMT_WORKDIR_ROOT', tmpdir)
+    monkeypatch.setenv('TMT_WORKDIR_ROOT', str(tmpdir))
     common = Common(logger=root_logger)
     common._workdir_init()
     monkeypatch.delenv('TMT_WORKDIR_ROOT')

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -115,7 +115,13 @@ def _explore_entry_point(entry_point: str, logger: Logger) -> None:
     logger = logger.descend()
 
     try:
-        for found in entry_points()[entry_point]:
+        eps = entry_points()
+        if hasattr(eps, "select"):
+            entry_point_group = eps.select(group=entry_point)
+        else:
+            entry_point_group = eps[entry_point]
+
+        for found in entry_point_group:
             logger.debug(f"Loading plugin '{found.name}' ({found.value}).")
             found.load()
 


### PR DESCRIPTION
1) Opportunistically use "selectable" entry_points.
    The “selectable” entry points were introduced in importlib_metadata 3.6 and Python 3.10.
    While this could be solved by adding entry_points>=3.6 for python<3.10 as a dependency, `python3-importib-metadata` el8 package currently only have version 0.23.
    See: https://github.com/python/importlib_metadata/issues/298
    Fixes:
```
tmt/plugins/__init__.py:116
  /opt/tmt/lib64/python3.11/site-packages/tmt/plugins/__init__.py:116: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
    for found in entry_points()[entry_point]:
```

2) The markings pytest.ini does not seem to be working properly.
    Taking this as an opportunity to move it to pyproject.toml and deleting pytest.ini
    Fixes:
```
tests/unit/test_beakerlib.py:56
  /root/tmt/tests/unit/test_beakerlib.py:56: PytestUnknownMarkWarning: Unknown pytest.mark.web - is this a typo? 
```

3) tmpdir was missing explicit convertion to str here:
```
tests/unit/test_utils.py::test_workdir_env_var
  /root/tmt/tests/unit/test_utils.py:179: PytestWarning: Value of environment variable TMT_WORKDIR_ROOT type should be str, but got local('/tmp/pytest-of-root/pytest-2/test_workdir_env_var0') (type: LocalPath); converted to str implicitly
```