### PR TITLE
Fix search function in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ sys.path.insert(0, os.path.abspath('../'))
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx_rtd_theme',
     ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Search function on tmt.readthedocs is currently not working even when switching to latest.  
This fixes it for me locally.

See: https://github.com/readthedocs/sphinx_rtd_theme/issues/1434