### PR TITLE
Test data path must use safe guest/test names

### DIFF
--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -218,8 +218,8 @@ class ExecutePlugin(tmt.steps.Plugin):
         directory = self.step.workdir \
             / TEST_DATA \
             / 'guest' \
-            / guest.name \
-            / f'{test.name.lstrip("/") or "default"}-{test.serialnumber}'
+            / guest.safe_name \
+            / f'{test.safe_name.lstrip("/") or "default"}-{test.serialnumber}'
         if create and not directory.is_dir():
             directory.joinpath(TEST_DATA).mkdir(parents=True)
         if not filename:


### PR DESCRIPTION
Guest and test names are part of test data path, but instead of raw names, tmt must use the sanitized, "safe" variants. Only these are treated and suitable to be path components.