### PR TITLE
Add `pyright` as a `pre-commit` check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,22 +18,70 @@ repos:
     rev: "v1.6.1"
     hooks:
       - id: mypy
-        # Do not install *types-click* - it's not recommended with Click 8 & newer,
-        # which is the version a developer encounters given the requirements are not
-        # frozen.
+        # TODO: find out how to amend mypy, pyright, pre-commit and package requirements.
+        # Apparently, there is no easy way to avoid some level of duplication of
+        # information when the package is *not* installed, which is the case of tmt
+        # & pre-commit in our setup.
+        #
+        # For now, we simply copy & paste from pyproject.toml :(
         additional_dependencies:
-          - click!=8.1.4  # TODO github.com/pallets/click/issues/2558
-          - types-Markdown
-          - types-requests
-          - types-setuptools
-          - types-jsonschema
-          - types-urllib3
-          - ruamel.yaml
-          - types-jinja2
-          - pint==0.20
-          - types-babel
+          - "click>=8.0.3,!=8.1.4"   # 8.1.3 / 8.1.6 TODO type annotations tmt.cli.Context -> click.core.Context click/issues/2558
+          - "fmf>=1.3.0"
+          - "jinja2>=2.11.3"         # 3.1.2 / 3.1.2
+          - "pint>=0.16.1,<0.20"     # 0.16.1 / 0.19.x  TODO: Pint 0.20 requires larger changes to tmt.hardware
+          - "requests>=2.25.1"       # 2.28.2 / 2.31.0
+          - "ruamel.yaml>=0.16.6"    # 0.17.32 / 0.17.32
+          - "urllib3>=1.26.5, <2.0"  # 1.26.16 / 2.0.4
+
+          - "typing-extensions>=4.4.0; python_version < '3.10'" # TypeAlias introduced in 3.10, Self in 3.11
+          - "pytest"
+          - "requre"
+          # Do not install *types-click* - it's not recommended with Click 8 & newer,
+          # which is the version a developer encounters given the requirements are not
+          # frozen.
+          - "types-Markdown"
+          - "types-requests"
+          - "types-setuptools"
+          - "types-jsonschema"
+          - "types-urllib3"
+          - "types-jinja2"
+          - "types-babel"
+
         pass_filenames: false
         args: [--config-file=pyproject.toml]
+
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.334
+    hooks:
+      - id: pyright
+        # TODO: find out how to amend mypy, pyright, pre-commit and package requirements.
+        # Apparently, there is no easy way to avoid some level of duplication of
+        # information when the package is *not* installed, which is the case of tmt
+        # & pre-commit in our setup.
+        #
+        # For now, we simply copy & paste from pyproject.toml :(
+        additional_dependencies:
+          - "click>=8.0.3,!=8.1.4"   # 8.1.3 / 8.1.6 TODO type annotations tmt.cli.Context -> click.core.Context click/issues/2558
+          - "fmf>=1.3.0"
+          - "jinja2>=2.11.3"         # 3.1.2 / 3.1.2
+          - "pint>=0.16.1,<0.20"     # 0.16.1 / 0.19.x  TODO: Pint 0.20 requires larger changes to tmt.hardware
+          - "requests>=2.25.1"       # 2.28.2 / 2.31.0
+          - "ruamel.yaml>=0.16.6"    # 0.17.32 / 0.17.32
+          - "urllib3>=1.26.5, <2.0"  # 1.26.16 / 2.0.4
+
+          - "typing-extensions>=4.4.0; python_version < '3.10'" # TypeAlias introduced in 3.10, Self in 3.11
+          - "pytest"
+          - "requre"
+          # Do not install *types-click* - it's not recommended with Click 8 & newer,
+          # which is the version a developer encounters given the requirements are not
+          # frozen.
+          - "types-Markdown"
+          - "types-requests"
+          - "types-setuptools"
+          - "types-jsonschema"
+          - "types-urllib3"
+          - "types-jinja2"
+          - "types-babel"
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: "0.27.0"
@@ -63,4 +111,4 @@ repos:
       additional_dependencies:
         # Make sure we use fmf compatible with tmt in the repo, not the 1.26.0 version.
         - "fmf>=1.3.0"
-        - pint==0.20
+        - "pint<0.20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [              # F39 / PyPI
     "click>=8.0.3,!=8.1.4",   # 8.1.3 / 8.1.6 TODO type annotations tmt.cli.Context -> click.core.Context click/issues/2558
     "fmf>=1.3.0",
     "jinja2>=2.11.3",         # 3.1.2 / 3.1.2
-    "pint>=0.16.1",           # 0.16.1 / 0.22
+    "pint>=0.16.1,<0.20",     # 0.16.1 / 0.19.x  TODO: Pint 0.20 requires larger changes to tmt.hardware
     "requests>=2.25.1",       # 2.28.2 / 2.31.0
     "ruamel.yaml>=0.16.6",    # 0.17.32 / 0.17.32
     "urllib3>=1.26.5, <2.0",  # 1.26.16 / 2.0.4
@@ -118,6 +118,9 @@ dependencies = [
     "requre",
     "yq==3.1.1",
     "pre-commit",
+    # Do not install *types-click* - it's not recommended with Click 8 & newer,
+    # which is the version a developer encounters given the requirements are not
+    # frozen.
     "types-Markdown",
     "types-requests",
     "types-setuptools",
@@ -202,6 +205,36 @@ module = [
     "mrack.*",
     ]
 ignore_missing_imports = true
+
+[tool.pyright]
+include = [
+    "tmt/**/*.py",
+]
+ignore = [
+    "docs/**",
+    "examples/**",
+    "tests/**",
+    "tmt/checks/*.py",
+    "tmt/export/*.py",
+    "tmt/frameworks/*.py",
+    "tmt/libraries/*.py",
+    "tmt/plugins/*.py",
+    "tmt/steps/**/*.py",
+    "tmt/*.py",
+]
+
+pythonVersion = "3.9"
+pythonPlatform = "Linux"
+
+# Be vewy, vewy stwict, we'we hunting wabbits^Wbugs.
+typeCheckingMode = "strict"
+
+# Kicking off with some common issues we put aside for now. We might re-enable
+# these checks later, or not, but for now they are not useful.
+reportMissingTypeStubs = false  # Stub file not found for "foo.bar"
+reportPrivateUsage = false
+reportUnknownMemberType = false
+reportUnnecessaryCast = false  # Unnecessary "cast" call; type is already...
 
 [tool.autopep8]
 max_line_length = 99


### PR DESCRIPTION
Another pair of eyes, pyright is a type check plus a bit more, and will inspect the code from slightyl different point of view. As a result, it will report issues mypy cannot spot, or cannot spot *yet* because the set of implemented checks is simply different.

The slow, gradual approach is the key here, like the one we know from mypy introduction, and slowly files and packages will get covered.