### PR TITLE
Save click context in click context object

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -52,6 +52,9 @@ class ContextObject:
     manages across commands.
     """
 
+    # "Parent" Click context
+    cli_context: 'Context'
+
     logger: tmt.log.Logger
     common: tmt.utils.Common
     fmf_context: tmt.utils.FmfContextType
@@ -193,6 +196,7 @@ def main(
 
     # TODO: context object details need checks
     click_contex.obj = ContextObject(
+        cli_context=click_contex,
         logger=logger,
         common=tmt.utils.Common(logger=logger),
         fmf_context=tmt.utils.context_to_dict(context=context, logger=logger),


### PR DESCRIPTION
Click uses a `click.Context` instance to carry information needed for managing commands. Apps may attach "context object" to it, in our case, it's a `tmt.click.ContextObject`, and it's then reachable via `click.Context.obj` property. But when looking at `ContextObject`, there is not way to reach the parent `click.Context` - this patch fixes this.