### PR TITLE
Replace self.opt() when looking for debug/verbose/quiet setting

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1201,9 +1201,9 @@ class Test(
                 continue
             if value not in [None, [], {}]:
                 echo(tmt.utils.format(key, value))
-        if self.opt('verbose'):
+        if self.verbosity_level:
             self._show_additional_keys()
-        if self.opt('verbose', 0) >= 2:
+        if self.verbosity_level >= 2:
             # Print non-empty unofficial attributes
             for key in sorted(self.node.get().keys()):
                 # Already asked to be printed
@@ -1819,11 +1819,11 @@ class Plan(
             echo(tmt.utils.format('tier', self.tier, key_color='cyan'))
         if self.link is not None:
             self.link.show()
-        if self.opt('verbose'):
+        if self.verbosity_level:
             self._show_additional_keys()
 
         # Show fmf id of the remote plan in verbose mode
-        if (self._original_plan or self._remote_plan_fmf_id) and self.opt('verbose'):
+        if (self._original_plan or self._remote_plan_fmf_id) and self.verbosity_level:
             # Pick fmf id from the original plan by default, use the
             # current plan in shallow mode when no plans are fetched.
             if self._original_plan is not None:
@@ -2302,7 +2302,7 @@ class Story(
             if value is not None and value != []:
                 wrap: tmt.utils.FormatWrap = False if key == 'example' else 'auto'
                 echo(tmt.utils.format(key, value, wrap=wrap))
-        if self.opt('verbose'):
+        if self.verbosity_level:
             self._show_additional_keys()
 
     def coverage(self, code: bool, test: bool, docs: bool) -> Tuple[bool, bool, bool]:
@@ -3221,9 +3221,9 @@ class Status(tmt.utils.Common):
         if not loaded:
             self.warn(f"Failed to load run '{run.workdir}': {error}")
             return
-        if self.opt('verbose') == 0:
+        if self.verbosity_level == 0:
             self.print_run_status(run)
-        elif self.opt('verbose') == 1:
+        elif self.verbosity_level == 1:
             self.print_plans_status(run)
         else:
             self.print_verbose_status(run)
@@ -3231,7 +3231,7 @@ class Status(tmt.utils.Common):
     def print_header(self) -> None:
         """ Print the header of the status table based on verbosity """
         header = ''
-        if self.opt('verbose') >= 2:
+        if self.verbosity_level >= 2:
             for step in tmt.steps.STEPS:
                 header += (step[0:4] + ' ')
             header += ' '

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -1434,7 +1434,10 @@ def status(
             "used together.")
     if not Path(workdir_root).exists():
         raise tmt.utils.GeneralError(f"Path '{workdir_root}' doesn't exist.")
-    status_obj = tmt.Status(logger=context.obj.logger, cli_context=context)
+
+    status_obj = tmt.Status(
+        logger=context.obj.logger.clone().apply_verbosity_options(**kwargs),
+        cli_context=context)
     status_obj.show()
 
 

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -966,7 +966,7 @@ class BasePlugin(Phase):
         import tmt.base
 
         # Show empty config with default method only in verbose mode
-        if self.data.is_bare and not self.opt('verbose'):
+        if self.data.is_bare and not self.verbosity_level:
             return
         # Step name (and optional summary)
         echo(tmt.utils.format(

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -95,7 +95,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
         """
         # Verbose mode outputs other information, using \r to
         # create a status bar wouldn't work.
-        if self.opt('verbose'):
+        if self.verbosity_level:
             return
 
         # No progress if terminal not attached or explicitly disabled
@@ -104,7 +104,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
 
         # For debug mode show just an info message (unless finishing)
         message = f"{test_name} [{progress}]" if not finish else ""
-        if self.opt('debug'):
+        if self.debug_level:
             if not finish:
                 self.info(message, shift=1)
             return
@@ -409,7 +409,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             results = self.check(test, guest)  # Produce list of results
             assert test.real_duration is not None  # narrow type
             duration = click.style(test.real_duration, fg='cyan')
-            shift = 1 if self.opt('verbose') < 2 else 2
+            shift = 1 if self.verbosity_level < 2 else 2
 
             # Handle reboot, abort, exit-first
             if self._will_reboot(test, guest):

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -160,7 +160,7 @@ class InstallBase(tmt.utils.Common):
         """ Show package info and return package names """
 
         # Show a brief summary by default
-        if not self.opt('verbose'):
+        if not self.verbosity_level:
             summary = fmf.utils.listed(packages, max=3)
             self.info(title, summary, 'green')
         # Provide a full list of packages in verbose mode

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -576,9 +576,9 @@ class Guest(tmt.utils.Common):
 
     def _ansible_verbosity(self) -> List[str]:
         """ Prepare verbose level based on the --debug option count """
-        if self.opt('debug') < 3:
+        if self.debug_level < 3:
             return []
-        return ['-' + (self.opt('debug') - 2) * 'v']
+        return ['-' + (self.debug_level - 2) * 'v']
 
     @staticmethod
     def _ansible_extra_args(extra_args: Optional[str]) -> List[str]:

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -413,7 +413,7 @@ class GuestTestcloud(tmt.GuestSsh):
 
         # Make sure download progress is disabled unless in debug mode,
         # so it does not spoil our logging
-        self.config.DOWNLOAD_PROGRESS = self.opt('debug') > 2
+        self.config.DOWNLOAD_PROGRESS = self.debug_level > 2
         self.config.DOWNLOAD_PROGRESS_VERBOSE = False
 
         # Configure to tmt's storage directories

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -55,7 +55,7 @@ class ReportDisplay(tmt.steps.report.ReportPlugin):
         """ Discover available tests """
         super().go()
         # Show individual test results only in verbose mode
-        if not self.opt('verbose'):
+        if not self.verbosity_level:
             return
 
         if self.get('display-guest') == 'always':
@@ -73,4 +73,4 @@ class ReportDisplay(tmt.steps.report.ReportPlugin):
             display_guest = len(seen_guests) > 1
 
         for result in self.step.plan.execute.results():
-            self.details(result, self.opt('verbose'), display_guest)
+            self.details(result, self.verbosity_level, display_guest)


### PR DESCRIPTION
`self.opt()` is used to acquire values of options, but it's hard to annotate and ensure returned values are used correctly. The patch is part of the series replaces type-unaware dispatcher methods with more formal ways. The move of responsibility for logging from `Common` to `Logger` together with dataclasses, step data and other makes `opt()` much less needed, and it can be slowly replaced for the well-known and shared options.