### PR TITLE
Do not display guest facts when showing a plan

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -947,6 +947,12 @@ class BasePlugin(Phase):
             if key == 'summary':
                 return
 
+            # TODO: this field belongs to provision, but does it even make sense
+            # to *show* this field? When a plan is shown, there is no guest to
+            # speak about, nothing is provisioned...
+            if key == 'facts':
+                return
+
             value = self.get(key)
 
             # No need to show the default order


### PR DESCRIPTION
There is no guest to show anyway. This is a simple patch, the proper solution would land when fields become owners of their visibility.