### PR TITLE
Drop enum from HW hypervisor and boot method constraints

### DIFF
--- a/tmt/schemas/provision/hardware.yaml
+++ b/tmt/schemas/provision/hardware.yaml
@@ -21,9 +21,6 @@ definitions:
     properties:
       method:
         type: string
-        enum:
-          - bios
-          - uefi
 
     additionalProperties: false
 
@@ -197,10 +194,6 @@ definitions:
 
       hypervisor:
         type: string
-        enum:
-          - nitro
-          - kvm
-          - xen
 
     additionalProperties: false
 


### PR DESCRIPTION
The enum is too strict and does not allow use of operators. We can later immitate enum with regular expressions, e.g. `(=|>=...)?(bios|uefi)`.