### PR TITLE
Make web-link test play nicely with custom SSH host config

### DIFF
--- a/tests/core/web-link/test.py
+++ b/tests/core/web-link/test.py
@@ -1,9 +1,25 @@
 import re
 
 import tmt
+import tmt.utils
 
-tree = tmt.Tree(logger=tmt.Logger.create(), path='data')
-prefix = r'https://github.com/.*/tmt/tree/.*/tests/core/web-link/data/'
+logger = tmt.Logger.create()
+tree = tmt.Tree(logger=logger, path='data')
+
+# Try to find out what git thinks about the origin of the repository.
+# This should deal with custom SSH `Host` config one might have for
+# Github.
+try:
+    output = tmt.utils.Command('git', 'config', '--get', 'remote.origin.url').run(
+        cwd=None,
+        logger=logger)
+
+    base_url = output.stdout.strip().replace('.git', '')
+
+except tmt.utils.RunError:
+    base_url = r'https://github.com/.*/tmt'
+
+prefix = rf'{base_url}/tree/.*/tests/core/web-link/data/'
 
 
 def test_stories():


### PR DESCRIPTION
A custom SSH `Host` entry, when used in git remote URL, would be honored by web-link generator, but the test would report it as a failure:

```
Host github
  HostName github.com
  User git
  IdentityFile ~/.ssh/id_rsa_git
```

```
$ git config --get remote.origin.url
github:teemtee/tmt.git
```

Yet test expects all fmf IDs in this repo to begin with the actual Github URL.