### PR TITLE
Fix enforcement of workdir root in full workdir root test

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -174,7 +174,7 @@ def test_workdir_env_var(tmpdir, monkeypatch, root_logger):
 
 def test_workdir_root_full(tmpdir, monkeypatch, root_logger):
     """ Raise if all ids lower than WORKDIR_MAX are exceeded """
-    monkeypatch.setattr(tmt.utils, 'WORKDIR_ROOT', Path(str(tmpdir)))
+    monkeypatch.setenv('TMT_WORKDIR_ROOT', str(tmpdir))
     monkeypatch.setattr(tmt.utils, 'WORKDIR_MAX', 1)
     possible_workdir = Path(str(tmpdir)) / 'run-001'
     # First call success


### PR DESCRIPTION
Externally set `TMT_WORKDIR_ROOT` would overrule test's attempt to monkeypatch `tmt.utils.WORKDIR_ROOT`. I am using a custom tmt workdir root location, and I do not wish to unset it for this single test :)