### PR TITLE
Use correct url for the release archive, fix docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -446,7 +446,8 @@ TMT_REBOOT_COUNT
 TMT_TOPOLOGY_BASH, TMT_TOPOLOGY_YAML
     Paths of files describing existing guests, their roles and the
     guest on which the test is running. Format of these files
-    is described at :ref:`/spec/plans/guest-topology`.
+    is described in the ``Guest Topology Format`` section of the
+    plan specification.
 
 
 Plugin Variables

--- a/tests/core/docs/test.sh
+++ b/tests/core/docs/test.sh
@@ -55,6 +55,7 @@ rlJournalStart
         rlRun -s "man tmt" 0 "Check man page"
         rlAssertGrep "usage is straightforward" "$rlRun_LOG"
         rlAssertNotGrep "WARNING" "$rlRun_LOG"
+        rlAssertNotGrep "ERROR" "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartTest "examples"

--- a/tmt.spec
+++ b/tmt.spec
@@ -13,7 +13,7 @@ ExcludeArch: %{power64}
 %endif
 
 URL: https://github.com/teemtee/tmt
-Source0: https://github.com/teemtee/tmt/releases/download/%{version}/tmt-%{version}.tar.gz
+Source0: https://github.com/teemtee/tmt/archive/refs/tags/%{version}.tar.gz
 
 %define workdir_root /var/tmp/tmt
 


### PR DESCRIPTION
Fix the `Source0` url in the spec file so that it points to a correct location from where `packit` can download the archive when proposing downstream pull requests.

The `:ref:` text role cannot be used in the README as it would not be correctly rendered in the man page and the long description on the pypi server. Let's just describe the section location instead. Documentation test updated to prevent such errors in the future.