### PR TITLE
Upload the source tarball to pypi during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,13 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           ref: ${{ github.event.inputs.ref }}
-      - name: Create dist
-        run: make wheel
+      - name: Install dependencies
+        run: sudo apt-get install -y python3-docutils
+      - name: Create dist and tarball
+        run: |
+          make tarball
+          make wheel
+          mv tmp/SOURCES/*.tar.gz dist
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/tmt.spec
+++ b/tmt.spec
@@ -13,7 +13,7 @@ ExcludeArch: %{power64}
 %endif
 
 URL: https://github.com/teemtee/tmt
-Source0: https://github.com/teemtee/tmt/archive/refs/tags/%{version}.tar.gz
+Source0: %pypi_source
 
 %define workdir_root /var/tmp/tmt
 


### PR DESCRIPTION
This should fix local `make rpm` and include the built man page in the tarball as well so that building in Fedora works as expected.