### PR TITLE
Revert the `Source0` url to the original value

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -13,7 +13,7 @@ ExcludeArch: %{power64}
 %endif
 
 URL: https://github.com/teemtee/tmt
-Source0: https://github.com/teemtee/tmt/archive/refs/tags/%{version}.tar.gz
+Source0: https://github.com/teemtee/tmt/releases/download/%{version}/tmt-%{version}.tar.gz
 
 %define workdir_root /var/tmp/tmt
 

--- a/tmt.spec
+++ b/tmt.spec
@@ -1,5 +1,5 @@
 Name: tmt
-Version: 1.24.0
+Version: 1.24.1
 Release: 1%{?dist}
 
 Summary: Test Management Tool
@@ -250,6 +250,10 @@ install -pm 644 %{name}/steps/provision/mrack/mrack* %{buildroot}/etc/%{name}/
 
 
 %changelog
+* Fri Jun 09 2023 Petr Šplíchal <psplicha@redhat.com> - 1.24.1-1
+- Revert the `Source0` url to the original value
+- Use correct url for the release archive, fix docs
+
 * Wed Jun 07 2023 Petr Šplíchal <psplicha@redhat.com> - 1.24.0-1
 - Do not display guest facts when showing a plan
 - Add new guide/summary for multihost testing


### PR DESCRIPTION
As for now we need to manually upload the source tarball to the github release because the archive prepared by github does not contain the generated man page and version is not substituted.

This also fixes the broken `make rpm` target. We should simplify the tarball creation but that will be work for another patch.
