### PR TITLE
Sync changelog when creating downstream release

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,6 +2,7 @@ specfile_path: tmt.spec
 files_to_sync:
   - tmt.spec
   - .packit.yaml
+sync_changelog: true
 
 upstream_project_name: tmt
 downstream_package_name: tmt


### PR DESCRIPTION
By default, packit generates changelog items based on the commits since the last release tag and includes author names as well. Let's keep the whole spec file synced, including the changelog.