### PR TITLE
Update release instructions with simplified steps

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -346,41 +346,38 @@ Follow the steps below to create a new major or minor release:
 * Use ``git log --oneline --no-decorate x.y-1..`` to generate the changelog
 * Update ``README`` with new contributors since the last release
 * Add a ``Release tmt-x.y.0`` commit with the specfile update
-* Create a pull request with the commit, ensure tests pass
+* Create a pull request with the commit, ensure tests pass, merge it
 
 Release a new package to Fedora and EPEL repositories:
 
 * Move the ``fedora`` branch to point to the new release
-* Create a source rpm using the ``make srpm`` command
-* Enable Fedora kerberos ``kinit nick@FEDORAPROJECT.ORG``
-* Change to the fedora rpms git or ``fedpkg clone tmt``
-* Check out the rawhide branch ``git checkout rawhide``
-* Import the srpm using ``fedpkg import /path/to/the/srpm``
-* Restore any files removed by fedpkg if necessary
-* Ensure the proposed changes are ok and commit them
-* Create a pull request against rawhide from your fork
-* After tests pass, merge the pull request to rawhide
-* Build the package for rawhide ``fedpkg build --nowait``
-* Build package for all `active releases`__
-  ``git checkout f33 && git merge rawhide && git push && fedpkg build --nowait``
-* Create a bodhi update for each release
-  ``git checkout f33 && fedpkg update --type enhancement --notes 'Update title'``
+* Tag the commit with ``x.y.0``, push tags ``git push --tags``
+* Create a source tarball using the ``make tarball`` command
+* Draft a new `github release`__ based on the tag above
+* Upload tarball to the release attachments and publish it
+* Check Fedora `pull requests`__, make sure tests pass and merge
 
 Finally, if everything went well:
 
-* Tag the commit with ``x.y.0``, push tags ``git push --tags``
-* **Manually** merge the original release pull request on github (to avoid rebase)
-  ``git checkout main && git merge --ff-only <release_branch> && git push origin main``
-* Create a new `github release`__ based on the tag above
+* Close the corresponding release milestone
+* Once the `copr build`__ is completed, move the ``quay`` branch
+  to point to the release commit as well to build fresh container
+  images.
+
+Handle manually what did not went well:
+
 * If the automation triggered by publishing the new github release
   was not successful, publish the fresh code to the `pypi`__
   repository manually using ``make wheel && make upload``
-* Once the `copr build`__ is completed, move the ``quay`` branch to
-  point to the release commit as well to build fresh container
-  images.
-* Close the corresponding release milestone
+* If there was a problem with creating Fedora pull requests, you
+  can trigger them manually using ``/packit propose-downstream``
+  in any open issue.
+* If running `packit propose-downstream`__ from your laptop make
+  sure that the ``post-upstream-clone`` action is disabled in
+  ``.packit.yaml`` to prevent bumping the devel version.
 
-__ https://bodhi.fedoraproject.org/releases/
 __ https://github.com/teemtee/tmt/releases/
-__ https://pypi.org/project/tmt/
+__ https://src.fedoraproject.org/rpms/tmt/pull-requests
 __ https://copr.fedorainfracloud.org/coprs/psss/tmt/builds/
+__ https://pypi.org/project/tmt/
+__ https://packit.dev/docs/cli/propose-downstream/


### PR DESCRIPTION
Now when the packit `propose-downstream` feature was enabled, many of the manual steps for creating Fedora builds and bodhi updates are not needed. Let's update the `Contribute` section accordingly.