### PR TITLE
Run all available tests only upon a user request

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -36,9 +36,23 @@ jobs:
           # with the latest timestamp always wins.
           - bash -c "hatch version | sed -E 's/\\.[0-9]+\\.dev.*/.dev888/'"
 
-  # Test pull requests
+  # Test pull requests (core)
   - job: tests
+    identifier: core
     trigger: pull_request
+    targets:
+      - fedora-all
+      - epel-9
+    tf_extra_params:
+        test:
+            tmt:
+                name: /plans/features/(core|basic)
+
+  # Test pull requests (full)
+  - job: tests
+    identifier: full
+    trigger: pull_request
+    manual_trigger: true
     targets:
       - fedora-all
       - epel-9

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -300,6 +300,15 @@ it, for example:
 
     Fix #1234.
 
+By default only a core set of tests is executed against a newly
+created pull request and its updates to verify basic sanity of the
+change. In order to run the full test suite add the following
+comment to the pull request:
+
+.. code-block::
+
+   /packit test --identifier full
+
 
 Merging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
It does not make sense to run all enabled tests and plans for each and every pull request change. Let's rather execute a core set of tests for each update to ensure basic sanity of the change and run the full set of available tests upon a user request using the `/packit test --identifier full` comment.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation

Some relevant links:

* https://github.com/kornys/strimzi-kafka-operator/pull/4
* https://github.com/strimzi/strimzi-kafka-operator/pull/8565
* https://github.com/packit/packit-service/pull/2088
* packit/packit-service/issues/2259