### PR TITLE
Fix /tests/status/base when /var/tmp/tmt is empty

### DIFF
--- a/tests/status/base/test.sh
+++ b/tests/status/base/test.sh
@@ -77,10 +77,21 @@ rlJournalStart
         rlRun -s "tmt status -v"
         rlAssertGrep "$tmprun" $rlRun_LOG
         rlRun -s "tmt status --workdir-root=/var/tmp/tmt -v"
-        rlAssertGrep "/var/tmp/tmt" $rlRun_LOG
+        # If /var/tmp/tmt is empty - because user does not really use it - then
+        # the best we can do is to make sure the $tmprun does not appear in the
+        # output.
+        if [ ls /var/tmp/tmt &> /dev/null ]; then
+            rlAssertGrep "/var/tmp/tmt" $rlRun_LOG
+        else
+            rlAssertNotGrep "$tmprun" $rlRun_LOG
+        fi
         rlRun "unset TMT_WORKDIR_ROOT"
         rlRun -s "tmt status -v"
-        rlAssertGrep "/var/tmp/tmt" $rlRun_LOG
+        if [ ls /var/tmp/tmt &> /dev/null ]; then
+            rlAssertGrep "/var/tmp/tmt" $rlRun_LOG
+        else
+            rlAssertNotGrep "$tmprun" $rlRun_LOG
+        fi
         rlRun -s "tmt status --workdir-root=$tmprun -v"
         rlAssertGrep "$tmprun" $rlRun_LOG
     rlPhaseEnd


### PR DESCRIPTION
Some users may avoid this directory completely, yet the test assumes there would be at least one run there.