### PR TITLE
Add the `show()` method for guest data packages

### DIFF
--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -26,7 +26,9 @@ rlJournalStart
             rlRun "$tmt login -c true -s $step 2>&1 >/dev/null | tee output"
             rlAssertGrep "interactive" "output"
 
-            if [ "$step" = "prepare" ]; then
+            if [ "$step" = "provision" ]; then
+                rlRun "grep '^    $step$' -A6 output | grep -i interactive"
+            elif [ "$step" = "prepare" ]; then
                 rlRun "grep '^    $step$' -A8 output | grep -i interactive"
             elif [ "$step" = "execute" ]; then
                 rlRun "grep '^    $step$' -A9 output | grep -i interactive"

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -349,6 +349,49 @@ class GuestData(tmt.utils.SerializableContainer):
         unserialize=lambda serialized: GuestFacts.from_serialized(serialized)
         )
 
+    def show(
+            self,
+            *,
+            keys: Optional[List[str]] = None,
+            verbose: int = 0,
+            logger: tmt.log.Logger) -> None:
+        """
+        Display guest data in a nice way.
+
+        :param keys: if set, only these keys would be shown.
+        :param verbose: desired verbosity. Some fields may be omitted in low
+            verbosity modes.
+        :param logger: logger to use for logging.
+        """
+
+        # If all keys are set to their defaults, do not bother showing them - unless
+        # forced to do so by the power of `-v`.
+        if self.is_bare and not verbose:
+            return
+
+        keys = keys or list(self.keys())
+
+        for key in keys:
+            # TODO: teach GuestFacts to cooperate with show() methods, honor
+            # the verbosity at the same time.
+            if key == 'facts':
+                return
+
+            value = getattr(self, key)
+
+            if value is None:
+                return
+
+            # TODO: it seems tmt.utils.format() needs a key, and logger.info()
+            # does not accept already formatted string.
+            if isinstance(value, (list, tuple)):
+                printable_value = fmf.utils.listed(value)
+
+            else:
+                printable_value = str(value)
+
+            logger.info(tmt.utils.key_to_option(key), printable_value, color='green')
+
 
 class Guest(tmt.utils.Common):
     """

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -4,7 +4,6 @@ import sys
 from typing import Any, Dict, List, Optional, cast
 
 import click
-import fmf.utils
 import requests
 
 import tmt
@@ -601,13 +600,11 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
             api_retries=self.get('api-retries'),
             api_retry_backoff_factor=self.get('api-retry-backoff-factor'),
             watchdog_dispatch_delay=self.get('watchdog-dispatch-delay'),
-            watchdog_period_delay=self.get('watchdog-period-delay')
+            watchdog_period_delay=self.get('watchdog-period-delay'),
+            ssh_option=self.get('ssh-option')
             )
 
-        # FIXME: cast() - typeless "dispatcher" method
-        data.ssh_option = cast(List[str], self.get('ssh-option'))
-        if data.ssh_option:
-            self.info('ssh options', fmf.utils.listed(data.ssh_option), 'green')
+        data.show(verbose=self.get('verbose'), logger=self._logger)
 
         self._guest = GuestArtemis(
             logger=self._logger,

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -138,6 +138,9 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
             guest='localhost',
             role=self.get('role')
             )
+
+        data.show(verbose=self.get('verbose'), logger=self._logger)
+
         self._guest = GuestLocal(logger=self._logger, data=data, name=self.name, parent=self.step)
 
     def guest(self) -> Optional[GuestLocal]:

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -575,6 +575,8 @@ class ProvisionBeaker(tmt.steps.provision.ProvisionPlugin):
             provision_tick=self.get('provision-tick'),
             )
 
+        data.show(verbose=self.get('verbose'), logger=self._logger)
+
         self._guest = GuestBeaker(
             data=data,
             name=self.name,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -299,10 +299,6 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
         """ Provision the container """
         super().go()
 
-        # Show which image we are using
-        pull = ' (force pull)' if self.get('force_pull') else ''
-        self.info('image', f"{self.get('image')}{pull}", 'green')
-
         # Prepare data for the guest instance
         data_from_options = {
             key: self.get(key)
@@ -312,6 +308,8 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
             }
 
         data = PodmanGuestData(**data_from_options)
+
+        data.show(verbose=self.get('verbose'), logger=self._logger)
 
         # Create a new GuestTestcloud instance and start it
         self._guest = GuestContainer(


### PR DESCRIPTION
To unify printing of guest data before provisioning, a `GuestData.show()` method is now available. Handles the default behavior, and it's easy to override when plugin wants to do something different.

Related to #2117.