### PR TITLE
Use `--version` to gather the package_manager fact

### DIFF
--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -290,7 +290,7 @@ class InstallDnf(InstallBase):
         command += Command(self.package_manager)
 
         if self.skip_missing:
-            command += Command('--skip-broken')
+            options += Command('--skip-broken')
 
         return (command, options)
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -286,8 +286,8 @@ class GuestFacts(tmt.utils.SerializableContainer):
             guest,
             [
                 (Command('stat', '/run/ostree-booted'), GuestPackageManager.RPM_OSTREE),
-                (Command('rpm', '-q', 'dnf'), GuestPackageManager.DNF),
-                (Command('rpm', '-q', 'yum'), GuestPackageManager.YUM),
+                (Command('dnf', '--version'), GuestPackageManager.DNF),
+                (Command('yum', '--version'), GuestPackageManager.YUM),
                 # And, one day, we'd follow up on this with...
                 # (Command('dpkg', '-l', 'apt'), 'apt')
                 ])


### PR DESCRIPTION
This way tmt is not affected by https://fedoraproject.org/wiki/Changes/ReplaceDnfWithDnf5

released 1.24.1 suffers from this bug so testing fedora-rawhide is not possible