### PR TITLE
Move test framework code into distinct framework classes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ __pkgdir__: Dict[str, str] = {}
 __pkgs__ = [
     'tmt',
     'tmt/export',
+    'tmt/frameworks',
     'tmt/libraries',
     'tmt/plugins',
     'tmt/steps',

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -38,6 +38,7 @@ from fmf.utils import listed
 from ruamel.yaml.error import MarkedYAMLError
 
 import tmt.export
+import tmt.frameworks
 import tmt.identifier
 import tmt.lint
 import tmt.log
@@ -1183,6 +1184,15 @@ class Test(
         assert self.path
 
         return Path(self.node.root) / self.path.unrooted() / str(self.test)
+
+    @property
+    def test_framework(self) -> tmt.frameworks.TestFrameworkClass:
+        framework = tmt.frameworks._FRAMEWORK_PLUGIN_REGISTRY.get_plugin(self.framework)
+
+        if framework is None:
+            raise tmt.utils.SpecificationError(f"Unknown framework '{self.framework}'.")
+
+        return framework
 
     def show(self) -> None:
         """ Show test details """

--- a/tmt/frameworks/__init__.py
+++ b/tmt/frameworks/__init__.py
@@ -1,0 +1,126 @@
+from typing import TYPE_CHECKING, Callable, List, Type
+
+import tmt.log
+import tmt.plugins
+import tmt.result
+import tmt.utils
+
+if TYPE_CHECKING:
+    from tmt.base import Test
+    from tmt.steps.execute import ExecutePlugin
+    from tmt.steps.provision import Guest
+
+
+TestFrameworkClass = Type['TestFramework']
+
+
+_FRAMEWORK_PLUGIN_REGISTRY: tmt.plugins.PluginRegistry[TestFrameworkClass] = \
+    tmt.plugins.PluginRegistry()
+
+
+def provides_framework(framework: str) -> Callable[[TestFrameworkClass], TestFrameworkClass]:
+    """
+    A decorator for registering test frameworks.
+
+    Decorate a test framework plugin class to register a test framework.
+    """
+
+    def _provides_framework(framework_cls: TestFrameworkClass) -> TestFrameworkClass:
+        _FRAMEWORK_PLUGIN_REGISTRY.register_plugin(
+            plugin_id=framework,
+            plugin=framework_cls,
+            logger=tmt.log.Logger.get_bootstrap_logger())
+
+        return framework_cls
+
+    return _provides_framework
+
+
+class TestFramework:
+    """
+    A base class for test framework plugins.
+
+    All methods provide viable default behavior with the exception of
+    :py:meth:`extract_results` which must be implemented by the plugin.
+    """
+
+    @classmethod
+    def get_environment_variables(
+            cls,
+            parent: 'ExecutePlugin',
+            test: 'Test',
+            guest: 'Guest',
+            logger: tmt.log.Logger) -> tmt.utils.EnvironmentType:
+        """
+        Provide additional environment variables for the test.
+
+        :param parent: ``execute`` plugin managing the test.
+        :param test: a test that would be executed.
+        :param guest: a guest on which the test would run.
+        :param logger: to use for logging.
+        :returns: environment variables to expose for the test. Variables
+            would be added on top of any variables the plugin, test or plan
+            might have already collected.
+        """
+
+        return {}
+
+    @classmethod
+    def get_test_command(
+            cls,
+            parent: 'ExecutePlugin',
+            test: 'Test',
+            guest: 'Guest',
+            logger: tmt.log.Logger) -> tmt.utils.ShellScript:
+        """
+        Provide a test command.
+
+        :param parent: ``execute`` plugin managing the test.
+        :param test: a test that would be executed.
+        :param guest: a guest on which the test would run.
+        :param logger: to use for logging.
+        :returns: a command to use to run the test.
+        """
+
+        assert test.test is not None  # narrow type
+
+        return test.test
+
+    @classmethod
+    def get_pull_options(
+            cls,
+            parent: 'ExecutePlugin',
+            test: 'Test',
+            guest: 'Guest',
+            logger: tmt.log.Logger) -> List[str]:
+        """
+        Provide additional options for pulling test data directory.
+
+        :param parent: ``execute`` plugin managing the test.
+        :param test: a test that would be executed.
+        :param guest: a guest on which the test would run.
+        :param logger: to use for logging.
+        :returns: additional options for the ``rsync`` tmt would use to pull
+            the test data directory from the guest.
+        """
+
+        return []
+
+    @classmethod
+    def extract_results(
+            cls,
+            parent: 'ExecutePlugin',
+            test: 'Test',
+            guest: 'Guest',
+            logger: tmt.log.Logger) -> List[tmt.result.Result]:
+        """
+        Extract test results.
+
+        :param parent: ``execute`` plugin managing the test.
+        :param test: a test that would be executed.
+        :param guest: a guest on which the test would run.
+        :param logger: to use for logging.
+        :returns: list of results produced by the given test.
+        """
+
+        raise NotImplementedError

--- a/tmt/frameworks/beakerlib.py
+++ b/tmt/frameworks/beakerlib.py
@@ -1,0 +1,119 @@
+import re
+from typing import TYPE_CHECKING, List, Optional
+
+import tmt.base
+import tmt.log
+import tmt.result
+import tmt.steps.execute
+import tmt.utils
+from tmt.frameworks import TestFramework, provides_framework
+from tmt.result import ResultOutcome
+from tmt.utils import Path
+
+if TYPE_CHECKING:
+    from tmt.base import Test
+    from tmt.steps.execute import ExecutePlugin
+    from tmt.steps.provision import Guest
+
+
+@provides_framework('beakerlib')
+class Beakerlib(TestFramework):
+    @classmethod
+    def get_environment_variables(
+            cls,
+            parent: 'ExecutePlugin',
+            test: 'Test',
+            guest: 'Guest',
+            logger: tmt.log.Logger) -> tmt.utils.EnvironmentType:
+
+        return {
+            'BEAKERLIB_DIR': str(parent.data_path(test, guest, full=True)),
+            'BEAKERLIB_COMMAND_SUBMIT_LOG': f'bash {tmt.steps.execute.TMT_FILE_SUBMIT_SCRIPT.path}'
+            }
+
+    @classmethod
+    def get_pull_options(
+            cls,
+            parent: 'ExecutePlugin',
+            test: 'Test',
+            guest: 'Guest',
+            logger: tmt.log.Logger) -> List[str]:
+        return [
+            '--exclude',
+            str(parent.data_path(test, guest, "backup*", full=True))
+            ]
+
+    @classmethod
+    def extract_results(
+            cls,
+            parent: 'ExecutePlugin',
+            test: 'Test',
+            guest: 'Guest',
+            logger: tmt.log.Logger) -> List[tmt.result.Result]:
+        """ Check result of a beakerlib test """
+        # Initialize data, prepare log paths
+        note: Optional[str] = None
+        log: List[Path] = []
+        for filename in [tmt.steps.execute.TEST_OUTPUT_FILENAME, 'journal.txt']:
+            if parent.data_path(test, guest, filename, full=True).is_file():
+                log.append(parent.data_path(test, guest, filename))
+
+        # Check beakerlib log for the result
+        try:
+            beakerlib_results_file = parent.data_path(test, guest, 'TestResults', full=True)
+            results = parent.read(beakerlib_results_file, level=3)
+        except tmt.utils.FileError:
+            logger.debug(f"Unable to read '{beakerlib_results_file}'.", level=3)
+            note = 'beakerlib: TestResults FileError'
+
+            return [tmt.Result.from_test(
+                test=test,
+                result=ResultOutcome.ERROR,
+                note=note,
+                log=log,
+                guest=guest)]
+
+        search_result = re.search('TESTRESULT_RESULT_STRING=(.*)', results)
+        # States are: started, incomplete and complete
+        # FIXME In quotes until beakerlib/beakerlib/pull/92 is merged
+        search_state = re.search(r'TESTRESULT_STATE="?(\w+)"?', results)
+
+        if search_result is None or search_state is None:
+            # Same outcome but make it easier to debug
+            if search_result is None:
+                missing_piece = 'TESTRESULT_RESULT_STRING='
+                hint = ''
+            else:
+                missing_piece = 'TESTRESULT_STATE='
+                hint = ', possibly outdated beakerlib (requires 1.23+)'
+            logger.debug(
+                f"No '{missing_piece}' found in '{beakerlib_results_file}'{hint}.",
+                level=3)
+            note = 'beakerlib: Result/State missing'
+            return [tmt.Result.from_test(
+                test=test,
+                result=ResultOutcome.ERROR,
+                note=note,
+                log=log,
+                guest=guest)]
+
+        result = search_result.group(1)
+        state = search_state.group(1)
+
+        # Check if it was killed by timeout (set by tmt executor)
+        actual_result = ResultOutcome.ERROR
+        if test.returncode == tmt.utils.PROCESS_TIMEOUT:
+            note = 'timeout'
+            parent.timeout_hint(test, guest)
+        # Test results should be in complete state
+        elif state != 'complete':
+            note = f"beakerlib: State '{state}'"
+        # Finally we have a valid result
+        else:
+            actual_result = ResultOutcome.from_spec(result.lower())
+        return [tmt.Result.from_test(
+            test=test,
+            result=actual_result,
+            note=note,
+            log=log,
+            guest=guest)]

--- a/tmt/frameworks/shell.py
+++ b/tmt/frameworks/shell.py
@@ -1,0 +1,56 @@
+from typing import TYPE_CHECKING, List
+
+import tmt.base
+import tmt.log
+import tmt.result
+import tmt.steps.execute
+import tmt.utils
+from tmt.frameworks import TestFramework, provides_framework
+from tmt.result import ResultOutcome
+
+if TYPE_CHECKING:
+    from tmt.base import Test
+    from tmt.steps.execute import ExecutePlugin
+    from tmt.steps.provision import Guest
+
+
+@provides_framework('shell')
+class Shell(TestFramework):
+    @classmethod
+    def get_test_command(
+            cls,
+            parent: 'ExecutePlugin',
+            test: 'Test',
+            guest: 'Guest',
+            logger: tmt.log.Logger) -> tmt.utils.ShellScript:
+
+        # Use default options for shell tests
+        return tmt.utils.ShellScript(f"{tmt.utils.SHELL_OPTIONS}; {test.test}")
+
+    @classmethod
+    def extract_results(
+            cls,
+            parent: 'ExecutePlugin',
+            test: 'Test',
+            guest: 'Guest',
+            logger: tmt.log.Logger) -> List[tmt.result.Result]:
+        """ Check result of a shell test """
+        assert test.returncode is not None
+        note = None
+
+        try:
+            # Process the exit code and prepare the log path
+            result = {0: ResultOutcome.PASS, 1: ResultOutcome.FAIL}[test.returncode]
+        except KeyError:
+            result = ResultOutcome.ERROR
+            # Add note about the exceeded duration
+            if test.returncode == tmt.utils.PROCESS_TIMEOUT:
+                note = 'timeout'
+                parent.timeout_hint(test, guest)
+
+        return [tmt.Result.from_test(
+            test=test,
+            result=result,
+            log=[parent.data_path(test, guest, tmt.steps.execute.TEST_OUTPUT_FILENAME)],
+            note=note,
+            guest=guest)]

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -68,7 +68,8 @@ def _discover_packages() -> List[Tuple[str, Path]]:
         for step in STEPS
         ] + [
         ('tmt.plugins', Path('plugins')),
-        ('tmt.export', Path('export'))
+        ('tmt.export', Path('export')),
+        ('tmt.frameworks', Path('frameworks'))
         ]
 
 


### PR DESCRIPTION
The implementation of various framework-specific steps is now wrapped by their own plugin construct.