### PR TITLE
Enable ruff checks for mutable dataclass field defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,11 +96,13 @@ ignore = [
     "PIE790",  # Unnecessary `pass` statement
     "PLC1901",  # `{}` can be simplified to `{}` as an empty string is falsey
     "PLE1205",  # Too many arguments for `logging` format string
-    "RUF008",  # Do not use mutable default values for dataclass attributes
-    "RUF009",  # Do not perform function call `field` in dataclass defaults
     "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF013",  # PEP 484 prohibits implicit `Optional`
 ]
+
+[tool.ruff.flake8-bugbear]
+extend-immutable-calls = [ "tmt.utils.field" ]
+
 [tool.ruff.isort]
 known-first-party = ["tmt"]
 


### PR DESCRIPTION
Namely:

 * RUF008 Do not use mutable default values for dataclass attributes
 * RUF009 Do not perform function call `field` in dataclass defaults

We allow `tmt.utils.field()` to be used as a "default" field value, because it's our `dataclasses.field()` wrapper, but that's it.