### PR TITLE
Replace `/` in safe name, and fix prepare step to use safe names

### DIFF
--- a/tests/core/escaping/data/plans/escaping.fmf
+++ b/tests/core/escaping/data/plans/escaping.fmf
@@ -9,6 +9,11 @@ discover:
   - name: Advanced plan's name escaping \n @? 'test' \"|"
     how: fmf
 
+prepare:
+  - name: A dummy prepare step with spaces/slashes
+    how: shell
+    script: /bin/true
+
 provision:
   how: container
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1019,3 +1019,14 @@ def test_filter_paths(source_dir):
 
     paths = filter_paths(source_dir, ['bz[235]', '/tests/bz5'])
     assert len(paths) == 3
+
+
+@pytest.mark.parametrize(
+    ('name', 'allow_slash', 'sanitized'),
+    [
+        ('foo bar/baz', True, 'foo-bar/baz'),
+        ('foo bar/baz', False, 'foo-bar-baz')
+        ]
+    )
+def test_sanitize_name(name: str, allow_slash: bool, sanitized: str) -> None:
+    assert tmt.utils.sanitize_name(name, allow_slash=allow_slash) == sanitized

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -731,6 +731,21 @@ class BasePlugin(Phase):
         self.data = data
         self.step = step
 
+    # TODO: cached_property candidate
+    @property
+    def safe_name(self) -> str:
+        """
+        A safe variant of the name which does not contain special characters.
+
+        Override parent implementation as we do not allow phase names to contain
+        slash characters, ``/``.
+        """
+
+        if self._safe_name is None:
+            self._safe_name = tmt.utils.sanitize_name(self.name, allow_slash=False)
+
+        return self._safe_name
+
     @classmethod
     def base_command(
             cls,

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -77,7 +77,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin):
 
             # Since we do not have the test data dir at hand, we must make the topology
             # filename unique on our own, and include the phase name and guest name.
-            filename_base = f'{tmt.steps.TEST_TOPOLOGY_FILENAME_BASE}-{self.name}-{guest.name}'
+            filename_base = f'{tmt.steps.TEST_TOPOLOGY_FILENAME_BASE}-{self.safe_name}-{guest.safe_name}'  # noqa: E501
 
             environment.update(
                 topology.push(

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -679,6 +679,26 @@ class Command:
         return CommandOutput(stdout_logger.get_output(), stderr_logger.get_output())
 
 
+_SANITIZE_NAME_PATTERN: Pattern[str] = re.compile(r'[^\w/-]+')
+_SANITIZE_NAME_PATTERN_NO_SLASH: Pattern[str] = re.compile(r'[^\w-]+')
+
+
+def sanitize_name(name: str, allow_slash: bool = True) -> str:
+    """
+    Create a safe variant of a name that does not contain special characters.
+
+    Spaces and other special characters are removed to prevent problems with
+    tools which do not expect them (e.g. in directory names).
+
+    :param name: a name to sanitize.
+    :param allow_slash: if set, even a slash character, ``/``, would be replaced.
+    """
+
+    pattern = _SANITIZE_NAME_PATTERN if allow_slash else _SANITIZE_NAME_PATTERN_NO_SLASH
+
+    return pattern.sub('-', name).strip('-')
+
+
 class _CommonBase:
     """
     A base class for **all** classes contributing to "common" tree of classes.
@@ -851,7 +871,7 @@ class Common(_CommonBase):
         """
 
         if self._safe_name is None:
-            self._safe_name = re.sub(r"[^\w/-]+", "-", self.name).strip("-")
+            self._safe_name = sanitize_name(self.name)
 
         return self._safe_name
 


### PR DESCRIPTION
It has been reported that `prepare` phase with a slash, `/`, it its name fails to proceed. This was caused by slash not being removed from the name, and by `prepare/shell` using `name` instead of `safe_name`.