### PR TITLE
Fix a too strict check for the detected library

### DIFF
--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -57,7 +57,7 @@ rlJournalStart
         rlAssertGrep "summary: 3 tests selected" $rlRun_LOG
         rlAssertGrep "/strip_git_suffix/test2" $rlRun_LOG
         rlAssertGrep \
-            "Detected library '{'url': 'https://github.com/teemtee/fmf.git'}'." \
+            "Detected library.*https://github.com/teemtee/fmf.git" \
             "$rlRun_LOG"
         rlAssertNotGrep 'Library.*conflicts with already fetched library' \
             "$rlRun_LOG"


### PR DESCRIPTION
The full test suite failed because a bit different debug output is now provided for the detected library. Let's not be so strict about each character of the debug output.