### PR TITLE
Do not export fmf id's ref when it's the default branch

### DIFF
--- a/tests/plan/show/test.sh
+++ b/tests/plan/show/test.sh
@@ -67,17 +67,21 @@ rlJournalStart
 
         rlRun "git clone https://github.com/teemtee/tmt $local_repo"
         rlRun "pushd $local_repo"
-        # The ref should not be shown when under the default branch
+        # fmf id fields should be shown when under the default branch
         rlRun -s "tmt plan show $plan -vvv"
         dump_fmf_id_block $rlRun_LOG > $show_tmp
         rlRun "cat $show_tmp"
-        rlAssertNotGrep "ref:" $show_tmp
-        # The ref should be shown when under a different branch
+        rlAssertGrep "url:" $show_tmp
+        rlAssertGrep "ref:" $show_tmp
+        rlAssertGrep "name:" $show_tmp
+        # fmf id fields should be shown when under a different branch, too
         rlRun -s "git checkout -b another-branch"
         rlRun -s "tmt plan show $plan -vvv"
         dump_fmf_id_block $rlRun_LOG > $show_tmp
         rlRun "cat $show_tmp"
+        rlAssertGrep "url:" $show_tmp
         rlAssertGrep "ref: another-branch" $show_tmp
+        rlAssertGrep "name:" $show_tmp
         # Create a new worktree
         rlRun "git branch $ref"
         rlRun "git worktree add $worktree $ref"
@@ -87,7 +91,9 @@ rlJournalStart
         rlRun -s "tmt plan show $plan -vvv"
         dump_fmf_id_block $rlRun_LOG > $show_tmp
         rlRun "cat $show_tmp"
+        rlAssertGrep "url:" $show_tmp
         rlAssertGrep "ref:.*$ref" $show_tmp
+        rlAssertGrep "name:" $show_tmp
         rlRun "popd"
     rlPhaseEnd
 

--- a/tmt/export/__init__.py
+++ b/tmt/export/__init__.py
@@ -254,7 +254,19 @@ class TrivialExporter(ExportPlugin):
                                 fmf_ids: List['tmt.base.FmfId'],
                                 keys: Optional[List[str]] = None,
                                 **kwargs: Any) -> str:
-        return cls._export([fmf_id._export(keys=keys) for fmf_id in fmf_ids])
+        # Special case: fmf id export shall not display `ref` if it is equal
+        # to the default branch.
+        exported_fmf_ids: List[tmt.base._RawFmfId] = []
+
+        for fmf_id in fmf_ids:
+            exported = fmf_id._export(keys=keys)
+
+            if fmf_id.default_branch and fmf_id.ref == fmf_id.default_branch:
+                exported.pop('ref')
+
+            exported_fmf_ids.append(cast(tmt.base._RawFmfId, exported))
+
+        return cls._export(cast(List[_RawExportedInstance], exported_fmf_ids))
 
     @classmethod
     def export_test_collection(cls,

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -300,11 +300,22 @@ class Discover(tmt.steps.Step):
         # TODO: This part should go into the 'fmf.py' module
         if self.opt('fmf_id'):
             if self.tests(enabled=True):
-                fmf_id_list = [
-                    tmt.utils.dict_to_yaml(
-                        test.fmf_id.to_minimal_spec(),
-                        start=True) for test in self.tests(enabled=True) if test.fmf_id.url]
-                click.echo(''.join(fmf_id_list), nl=False)
+                export_fmf_ids: List[str] = []
+
+                for test in self.tests(enabled=True):
+                    fmf_id = test.fmf_id
+
+                    if not fmf_id.url:
+                        continue
+
+                    exported = test.fmf_id.to_minimal_spec()
+
+                    if fmf_id.default_branch and fmf_id.ref == fmf_id.default_branch:
+                        exported.pop('ref')
+
+                    export_fmf_ids.append(tmt.utils.dict_to_yaml(exported, start=True))
+
+                click.echo(''.join(export_fmf_ids), nl=False)
             return
 
         # Give a summary, update status and save


### PR DESCRIPTION
This has been sort of a thing already, some tools depend on `ref` not being exported when it's "default branch", but after recent export and git-related changes, `ref` started to pop out in exports.

Patches saves the "context" - git root, fmf root, default branch - for each fmf id tmt creates. `ref` is now always set, and the decission whether or not to display it is left to code that exposes the ids: export, `show()` methods, etc. `tmt.utils.fmf_id()` is too low-level to see the bigger picture and understand the context.