### PR TITLE
Add cache_property for things that are generated but not often

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -38,7 +38,7 @@ import tmt.options
 import tmt.utils
 from tmt.options import option, show_step_method_hints
 from tmt.queue import GuestlessTask, Queue, Task, TaskOutcome
-from tmt.utils import EnvironmentType, Path, field, flatten
+from tmt.utils import EnvironmentType, Path, cached_property, field, flatten
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -738,8 +738,7 @@ class BasePlugin(Phase):
         self.data = data
         self.step = step
 
-    # TODO: cached_property candidate
-    @property
+    @cached_property
     def safe_name(self) -> str:
         """
         A safe variant of the name which does not contain special characters.
@@ -748,10 +747,7 @@ class BasePlugin(Phase):
         slash characters, ``/``.
         """
 
-        if self._safe_name is None:
-            self._safe_name = tmt.utils.sanitize_name(self.name, allow_slash=False)
-
-        return self._safe_name
+        return tmt.utils.sanitize_name(self.name, allow_slash=False)
 
     @classmethod
     def base_command(

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -37,7 +37,7 @@ import tmt.utils
 from tmt.options import option
 from tmt.plugins import PluginRegistry
 from tmt.steps import Action
-from tmt.utils import Command, Path, ShellScript, field
+from tmt.utils import Command, Path, ShellScript, cached_property, field
 
 if TYPE_CHECKING:
     import tmt.base
@@ -457,7 +457,7 @@ class Guest(tmt.utils.Common):
         run_id = parent.plan.my_run.workdir.name
         return self._random_name(prefix=f"tmt-{run_id[-3:]}-")
 
-    @property
+    @cached_property
     def multihost_name(self) -> str:
         """ Return guest's multihost name, i.e. name and its role """
 

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -11,7 +11,7 @@ import tmt.options
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
-from tmt.utils import ProvisionError, field, retry_session, updatable_message
+from tmt.utils import ProvisionError, cached_property, field, retry_session, updatable_message
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -380,14 +380,9 @@ class GuestArtemis(tmt.GuestSsh):
     watchdog_dispatch_delay: Optional[int]
     watchdog_period_delay: Optional[int]
 
-    _api: Optional[ArtemisAPI] = None
-
-    @property
+    @cached_property
     def api(self) -> ArtemisAPI:
-        if self._api is None:
-            self._api = ArtemisAPI(self)
-
-        return self._api
+        return ArtemisAPI(self)
 
     @property
     def is_ready(self) -> bool:


### PR DESCRIPTION
There is an existing support in recent Python versions, but the quality of annotations varies because of RPM packaging different versions of typing extensions. Patch adds a very basic `cached_property` with correct annotations to be good enough for our use cases.

Also some properties have turned to this new decorator, to demonstrate the use, but it's definitely the complete transition.