### PR TITLE
Consistent yaml formatting in .fmf files

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,19 +11,18 @@ upstream_project_url: https://github.com/teemtee/tmt
 issue_repository: https://github.com/teemtee/tmt
 
 actions:
-    post-upstream-clone:
-      - make bump2dev
-    create-archive:
-      - make tarball
-    get-current-version:
-      - make version
+  post-upstream-clone:
+    - make bump2dev
+  create-archive:
+    - make tarball
+  get-current-version:
+    - make version
 
 srpm_build_deps:
   - make
   - python3-docutils
 
 jobs:
-
   # Build pull requests
   - job: copr_build
     trigger: pull_request
@@ -31,7 +30,7 @@ jobs:
       - fedora-all
       - epel-8
       - epel-9
-    enable_net: False
+    enable_net: false
 
   # Test pull requests
   - job: tests
@@ -44,34 +43,34 @@ jobs:
   # Test internal plugins
   - job: tests
     trigger: pull_request
-    identifier: "internal-plugins"
+    identifier: 'internal-plugins'
     targets:
       - fedora-latest-stable
-    use_internal_tf: True
-    fmf_url: "https://gitlab.cee.redhat.com/baseos-qe/tmt.git"
+    use_internal_tf: true
+    fmf_url: 'https://gitlab.cee.redhat.com/baseos-qe/tmt.git'
     # Tag cloud resources for tmt
     tf_extra_params:
-        environments:
-          - settings:
-                provisioning:
-                    tags:
-                        BusinessUnit: tmt
+      environments:
+        - settings:
+            provisioning:
+              tags:
+                BusinessUnit: tmt
 
   # Test internal wow
   - job: tests
     trigger: pull_request
-    identifier: "internal-wow"
+    identifier: 'internal-wow'
     targets:
       - fedora-latest-stable
-    use_internal_tf: True
-    fmf_url: "https://gitlab.cee.redhat.com/baseos-qe/integration_scripts.git"
-    tmt_plan: "/tmt/integration/plan"
+    use_internal_tf: true
+    fmf_url: 'https://gitlab.cee.redhat.com/baseos-qe/integration_scripts.git'
+    tmt_plan: '/tmt/integration/plan'
     tf_extra_params:
-        environments:
-          - settings:
-                provisioning:
-                    tags:
-                        BusinessUnit: tmt
+      environments:
+        - settings:
+            provisioning:
+              tags:
+                BusinessUnit: tmt
 
   # Build commits to main
   - job: copr_build
@@ -81,9 +80,9 @@ jobs:
       - fedora-all
       - epel-8
       - epel-9
-    enable_net: False
-    list_on_homepage: True
-    preserve_project: True
+    enable_net: true
+    list_on_homepage: true
+    preserve_project: true
     owner: psss
     project: tmt
 
@@ -97,8 +96,8 @@ jobs:
 
   - job: koji_build
     trigger: commit
-    allowed_pr_authors: ["packit", "psss", "lzachar"]
-    allowed_committers: ["packit", "psss", "lzachar"]
+    allowed_pr_authors: ['packit', 'psss', 'lzachar']
+    allowed_committers: ['packit', 'psss', 'lzachar']
     dist_git_branches:
       - fedora-all
       - epel-8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,12 @@ repos:
     rev: v1.32.0
     hooks:
       - id: yamllint
-        files: ^tmt/schemas/.*\.yaml
+        types:
+          - text
+        files: '\.(fmf|yaml)$'
+        exclude: '^tmt/(?!schemas/)|tests/.*$'
+        args:
+          ['-d', '{extends: default, rules: {line-length: {max: 120}, document-start: disable}}']
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.274

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,19 +7,19 @@ repos:
       - id: autopep8
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.4.0"
+    rev: 'v4.4.0'
     hooks:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.3.0"
+    rev: 'v1.3.0'
     hooks:
       - id: mypy
-        # Do not install *types-click* - it's not recommended with Click 8 & newer,
-        # which is the version a developer encounters given the requirements are not
-        # frozen.
+        # Do not install *types-click* - it's not recommended
+        # with Click 8 & newer, which is the version a developer
+        # encounters given the requirements are not frozen.
         additional_dependencies:
           - click
           - types-Markdown
@@ -33,10 +33,10 @@ repos:
         args: [--config-file=pyproject.toml]
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: "0.23.1"
+    rev: '0.23.1'
     hooks:
       - id: check-metaschema
-        name: "Check JSON schemas validity"
+        name: 'Check JSON schemas validity'
         files: ^tmt/schemas/.*\.yaml
 
   - repo: https://github.com/adrienverge/yamllint
@@ -56,4 +56,4 @@ repos:
   - repo: https://github.com/teemtee/tmt.git
     rev: 1.24.1
     hooks:
-    - id: tmt-lint
+      - id: tmt-lint

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,35 +1,43 @@
--   id: tmt-lint
-    name: tmt lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt lint --failed-only --source $@" PAD
-    files: '.*\.fmf$'
-    verbose: false
-    pass_filenames: true
-    language: python
-    language_version: python3
+- id: tmt-lint
+  name: tmt lint
+  entry: >
+    bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(),
+    path=\".\").root)')/.fmf/version && tmt lint --failed-only --source $@" PAD
+  files: '.*\.fmf$'
+  verbose: false
+  pass_filenames: true
+  language: python
+  language_version: python3
 
--   id: tmt-tests-lint
-    name: tmt tests lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt tests lint --failed-only --source $@" PAD
-    files: '.*\.fmf$'
-    verbose: false
-    pass_filenames: true
-    language: python
-    language_version: python3
+- id: tmt-tests-lint
+  name: tmt tests lint
+  entry: >
+    bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(),
+    path=\".\").root)')/.fmf/version && tmt tests lint --failed-only --source $@" PAD
+  files: '.*\.fmf$'
+  verbose: false
+  pass_filenames: true
+  language: python
+  language_version: python3
 
--   id: tmt-plans-lint
-    name: tmt plans lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt plans lint --failed-only --source $@" PAD
-    files: '.*\.fmf$'
-    verbose: false
-    pass_filenames: true
-    language: python
-    language_version: python3
+- id: tmt-plans-lint
+  name: tmt plans lint
+  entry: >
+    bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(),
+    path=\".\").root)')/.fmf/version && tmt plans lint --failed-only --source $@" PAD
+  files: '.*\.fmf$'
+  verbose: false
+  pass_filenames: true
+  language: python
+  language_version: python3
 
--   id: tmt-stories-lint
-    name: tmt stories lint
-    entry: bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(), path=\".\").root)')/.fmf/version && tmt stories lint --failed-only --source $@" PAD
-    files: '.*\.fmf$'
-    verbose: false
-    pass_filenames: true
-    language: python
-    language_version: python3
+- id: tmt-stories-lint
+  name: tmt stories lint
+  entry: >
+    bash -c "git ls-files --error-unmatch $(python3 -c 'import tmt; print(tmt.Tree(logger=tmt.Logger.create(),
+    path=\".\").root)')/.fmf/version && tmt stories lint --failed-only --source $@" PAD
+  files: '.*\.fmf$'
+  verbose: false
+  pass_filenames: true
+  language: python
+  language_version: python3

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,11 +1,11 @@
 # Config for building https://tmt.readthedocs.io/
 version: 2
 build:
-    os: ubuntu-22.04
-    tools:
-        python: "3"
+  os: ubuntu-22.04
+  tools:
+    python: '3'
 python:
-    install:
-      - method: pip
-        path: .
-        extra_requirements: [docs]
+  install:
+    - method: pip
+      path: .
+      extra_requirements: [docs]

--- a/examples/ansible/plan.fmf
+++ b/examples/ansible/plan.fmf
@@ -1,6 +1,6 @@
 discover:
-    how: fmf
+  how: fmf
 provision:
-    how: container
+  how: container
 execute:
-    how: tmt
+  how: tmt

--- a/examples/discover/discover.fmf
+++ b/examples/discover/discover.fmf
@@ -1,33 +1,32 @@
-summary:
-    Demonstrate various test discover options
+summary: Demonstrate various test discover options
 execute:
-    how: tmt
+  how: tmt
 provision:
-    how: local
+  how: local
 
 /fmf:
-    /directory:
-        /mini:
-            summary: Minimal from directory
-            discover:
-                how: fmf
-        /full:
-            summary: Full from directory
-            discover:
-                how: fmf
-                ref: devel
-                filter: 'tier: 1'
+  /directory:
+    /mini:
+      summary: Minimal from directory
+      discover:
+        how: fmf
+    /full:
+      summary: Full from directory
+      discover:
+        how: fmf
+        ref: devel
+        filter: 'tier: 1'
 
-    /repository:
-        /mini:
-            summary: Minimal from repository
-            discover:
-                how: fmf
-                url: https://github.com/teemtee/tmt
-        /full:
-            summary: Full from repository
-            discover:
-                how: fmf
-                url: https://github.com/teemtee/tmt
-                ref: devel
-                filter: 'tier: 1'
+  /repository:
+    /mini:
+      summary: Minimal from repository
+      discover:
+        how: fmf
+        url: https://github.com/teemtee/tmt
+    /full:
+      summary: Full from repository
+      discover:
+        how: fmf
+        url: https://github.com/teemtee/tmt
+        ref: devel
+        filter: 'tier: 1'

--- a/examples/environment/main.fmf
+++ b/examples/environment/main.fmf
@@ -1,15 +1,14 @@
 /plan:
-    summary:
-        Environment variable.
-    description:
-        Tests can be provided with a list of environment variables.
-    execute:
-        how: shell
+  summary: Environment variable.
+  description: >
+    Tests can be provided with a list of environment variables.
+  execute:
+    how: shell
 
 /test:
-    summary: Just a simple test
-    test: ./test.sh
-    environment:
-        x: That's nice!
-        y: a b c
-        z: 3
+  summary: Just a simple test
+  test: ./test.sh
+  environment:
+    x: That's nice!
+    y: a b c
+    z: 3

--- a/examples/httpd/smoke.fmf
+++ b/examples/httpd/smoke.fmf
@@ -1,8 +1,7 @@
-summary:
-    Basic smoke test for the httpd web server
+summary: Basic smoke test for the httpd web server
 provision:
-    how: virtual
-    memory: 4096
+  how: virtual
+  memory: 4096
 prepare:
   - name: packages
     how: install
@@ -11,7 +10,7 @@ prepare:
     how: shell
     script: systemctl start httpd
 execute:
-    how: shell
-    script:
-      - echo foo > /var/www/html/index.html
-      - curl http://localhost/ | grep foo
+  how: shell
+  script:
+    - echo foo > /var/www/html/index.html
+    - curl http://localhost/ | grep foo

--- a/examples/inherit/main.fmf
+++ b/examples/inherit/main.fmf
@@ -1,18 +1,18 @@
 discover:
-    how: fmf
-    url: https://github.com/teemtee/tmt
+  how: fmf
+  url: https://github.com/teemtee/tmt
 prepare:
-    how: ansible
-    playbook: ansible/packages.yml
+  how: ansible
+  playbook: ansible/packages.yml
 execute:
-    how: tmt
+  how: tmt
 
 /basic:
-    summary: Quick set of basic functionality tests
-    discover+:
-        filter: tier:1
+  summary: Quick set of basic functionality tests
+  discover+:
+    filter: tier:1
 
 /features:
-    summary: Detailed tests for individual features
-    discover+:
-        filter: tier:2
+  summary: Detailed tests for individual features
+  discover+:
+    filter: tier:2

--- a/examples/l2/artifacts.fmf
+++ b/examples/l2/artifacts.fmf
@@ -1,19 +1,19 @@
 # Basic structure of artifacts and related testsets
 /test:
-    /pull-request:
-        /pep:
-            summary: All code must comply with the PEP8 style guide
-        /lint:
-            summary: Run pylint to catch common problems (no gating)
-    /build:
-        /smoke:
-            summary: Basic smoke test (Tier1)
-        /features:
-            summary: Verify important features
-    /update:
-        /basic:
-            summary: Run all Tier1, Tier2 and Tier3 tests
-        /security:
-            summary: Security tests (extra job to get quick results)
-        /integration:
-            summary: Integration tests with related components
+  /pull-request:
+    /pep:
+      summary: All code must comply with the PEP8 style guide
+    /lint:
+      summary: Run pylint to catch common problems (no gating)
+  /build:
+    /smoke:
+      summary: Basic smoke test (Tier1)
+    /features:
+      summary: Verify important features
+  /update:
+    /basic:
+      summary: Run all Tier1, Tier2 and Tier3 tests
+    /security:
+      summary: Security tests (extra job to get quick results)
+    /integration:
+      summary: Integration tests with related components

--- a/examples/l2/bed.fmf
+++ b/examples/l2/bed.fmf
@@ -1,20 +1,20 @@
 # Tests which need a fresh test bed for each
 /test/build/smoke:
-    summary: Basic smoke test
-    # List tests manually
-    discover:
-        how: list
-        tests:
-            - test/one
-            - test/two
-            - test/three
-    # Setup with ansible
-    prepare:
-        how: ansible
-        playbook:
-            - 'dependencies.yml'
-            - 'selenium.yml'
-    # Use restraint with isolation enabled
-    execute:
-        how: restraint
-        isolate: true
+  summary: Basic smoke test
+  # List tests manually
+  discover:
+    how: list
+    tests:
+      - test/one
+      - test/two
+      - test/three
+  # Setup with ansible
+  prepare:
+    how: ansible
+    playbook:
+      - 'dependencies.yml'
+      - 'selenium.yml'
+  # Use restraint with isolation enabled
+  execute:
+    how: restraint
+    isolate: true

--- a/examples/l2/gating.fmf
+++ b/examples/l2/gating.fmf
@@ -1,30 +1,30 @@
 # Turn on gating for selected testsets (defined inline)
 /test:
-    /pull-request:
-        /pep:
-            summary: All code must comply with the PEP8 style guide
-            # Do not allow ugly code to be merged into the main branch
-            gate:
-                - merge-pull-request
-        /lint:
-            summary: Run pylint to catch common problems (no gating)
-    /build:
-        /smoke:
-            summary: Basic smoke test (Tier1)
-            # Basic smoke test is used by three gates
-            gate:
-                - merge-pull-request
-                - add-build-to-update
-                - add-build-to-compose
-        /features:
-            summary: Verify important features
-    /update:
-        # This enables the 'release-update' gate for all three testsets
-        gate:
-            - release-update
-        /basic:
-            summary: Run all Tier1, Tier2 and Tier3 tests
-        /security:
-            summary: Security tests (extra job to get quick results)
-        /integration:
-            summary: Integration tests with related components
+  /pull-request:
+    /pep:
+      summary: All code must comply with the PEP8 style guide
+      # Do not allow ugly code to be merged into the main branch
+      gate:
+        - merge-pull-request
+    /lint:
+      summary: Run pylint to catch common problems (no gating)
+  /build:
+    /smoke:
+      summary: Basic smoke test (Tier1)
+      # Basic smoke test is used by three gates
+      gate:
+        - merge-pull-request
+        - add-build-to-update
+        - add-build-to-compose
+    /features:
+      summary: Verify important features
+  /update:
+    # This enables the 'release-update' gate for all three testsets
+    gate:
+      - release-update
+    /basic:
+      summary: Run all Tier1, Tier2 and Tier3 tests
+    /security:
+      summary: Security tests (extra job to get quick results)
+    /integration:
+      summary: Integration tests with related components

--- a/examples/l2/rpmdiff.fmf
+++ b/examples/l2/rpmdiff.fmf
@@ -1,20 +1,20 @@
 # Basic example of an rpmdiff per-package config
 /test:
-    /build:
-        /rpmdiff-essential:
-            summary: Essential rpmdiff tests (used for gating)
-            execute:
-                how: rpmdiff
-                tests:
-                    - ABI symbols
-                    - File permissions
-            gate:
-                - add-build-to-update
-                - add-build-to-compose
-        /rpmdiff-additional:
-            summary: Additional rpmdiff tests (informational)
-            execute:
-                how: rpmdiff
-                tests:
-                    - File list
-                    - Specfile checks
+  /build:
+    /rpmdiff-essential:
+      summary: Essential rpmdiff tests (used for gating)
+      execute:
+        how: rpmdiff
+        tests:
+          - ABI symbols
+          - File permissions
+      gate:
+        - add-build-to-update
+        - add-build-to-compose
+    /rpmdiff-additional:
+      summary: Additional rpmdiff tests (informational)
+      execute:
+        how: rpmdiff
+        tests:
+          - File list
+          - Specfile checks

--- a/examples/l2/simple.fmf
+++ b/examples/l2/simple.fmf
@@ -1,16 +1,16 @@
 # Simple use cases should be super simple to write
 /test:
-    /pull-request:
-        /validate:
-            prepare:
-                requires: python3-pep8
-            execute:
-                how: shell
-                command: pep8 *.py
-    /build:
-        /smoke:
-            discover:
-                how: fmf
-                repo: https://src.fedoraproject.org/tests/tar.git
-            execute:
-                how: restraint
+  /pull-request:
+    /validate:
+      prepare:
+        requires: python3-pep8
+      execute:
+        how: shell
+        command: pep8 *.py
+  /build:
+    /smoke:
+      discover:
+        how: fmf
+        repo: https://src.fedoraproject.org/tests/tar.git
+      execute:
+        how: restraint

--- a/examples/l2/tooling.fmf
+++ b/examples/l2/tooling.fmf
@@ -1,32 +1,32 @@
 # Multiple tool support for test discovery & execution
 /test:
-    /build:
-        # Standard Test Inteface
-        /sti:
-            execute:
-                how: sti
-                playbook:
-                    - 'tests.yml'
-                tag:
-                    - 'classic'
-        # Simple shell script
-        /shell:
-            execute:
-                how: shell
-                path: 'tests'
-                test: './test.sh'
-                environment:
-                    PYTHON: 'python2'
-        # Workflow Tomorrow
-        /wow:
-            execute:
-                how: wow
-                options: '--plan 1234 --tags Tier1'
-        # Flexible Metadata Format + Restraint
-        /fmf:
-            discover:
-                how: fmf
-                filter: 'tier: 1, 2'
-                url: https://src.fedoraproject.org/tests/python
-            execute:
-                how: restraint
+  /build:
+    # Standard Test Inteface
+    /sti:
+      execute:
+        how: sti
+        playbook:
+          - 'tests.yml'
+        tag:
+          - 'classic'
+    # Simple shell script
+    /shell:
+      execute:
+        how: shell
+        path: 'tests'
+        test: './test.sh'
+        environment:
+          PYTHON: 'python2'
+    # Workflow Tomorrow
+    /wow:
+      execute:
+        how: wow
+        options: '--plan 1234 --tags Tier1'
+    # Flexible Metadata Format + Restraint
+    /fmf:
+      discover:
+        how: fmf
+        filter: 'tier: 1, 2'
+        url: https://src.fedoraproject.org/tests/python
+      execute:
+        how: restraint

--- a/examples/l2/workflow.fmf
+++ b/examples/l2/workflow.fmf
@@ -1,59 +1,59 @@
 # Workflow steps: discover, provision, prepare, execute, report
 /test:
-    # Discover relevant tests
-    discover:
-        how: fmf
-    # System requirements
-    provision:
+  # Discover relevant tests
+  discover:
+    how: fmf
+  # System requirements
+  provision:
+    memory:
+      min: '1 GB'
+    arch:
+      - 'x86_64'
+  # Machine configuration
+  prepare:
+    ansible:
+      - 'setup.yml'
+  # Test execution
+  execute:
+    how: restraint
+  # Result reporting
+  report:
+    contact: email@address.org
+
+  # Build testing
+  /build:
+    /smoke:
+      summary: Basic smoke test (Tier1)
+      discover+:
+        filter: 'tier: 1'
+    /features:
+      summary: Verify important features
+      discover+:
+        filter: 'tag: functional'
+
+  # Errata testing
+  /update:
+    provision+:
+      arch:
+        - x86_64
+        - ppc64
+        - s390x
+    /basic:
+      summary: Run all Tier1, Tier2 and Tier3 tests
+      discover+:
+        filter: 'tier: 1, 2, 3'
+    /security:
+      summary: Security tests (extra job to get quick results)
+      discover+:
+        filter: 'tag: security'
+    /integration:
+      summary: Integration tests with related components
+      discover+:
+        filter: 'tag: integration'
+      provision+:
         memory:
-            min: '1 GB'
-        arch:
-            - 'x86_64'
-    # Machine configuration
-    prepare:
+          min: '4 GB'
+          max: '8 GB'
+      prepare:
         ansible:
-            - 'setup.yml'
-    # Test execution
-    execute:
-        how: restraint
-    # Result reporting
-    report:
-        contact: email@address.org
-
-    # Build testing
-    /build:
-        /smoke:
-            summary: Basic smoke test (Tier1)
-            discover+:
-                filter: 'tier: 1'
-        /features:
-            summary: Verify important features
-            discover+:
-                filter: 'tag: functional'
-
-    # Errata testing
-    /update:
-        provision+:
-            arch:
-                - x86_64
-                - ppc64
-                - s390x
-        /basic:
-            summary: Run all Tier1, Tier2 and Tier3 tests
-            discover+:
-                filter: 'tier: 1, 2, 3'
-        /security:
-            summary: Security tests (extra job to get quick results)
-            discover+:
-                filter: 'tag: security'
-        /integration:
-            summary: Integration tests with related components
-            discover+:
-                filter: 'tag: integration'
-            provision+:
-                memory:
-                    min: '4 GB'
-                    max: '8 GB'
-            prepare:
-                ansible:
-                    - 'integration.yml'
+          - 'integration.yml'

--- a/examples/local/plan.fmf
+++ b/examples/local/plan.fmf
@@ -1,6 +1,5 @@
-summary:
-    Basic smoke test
+summary: Basic smoke test
 provision:
-    how: local
+  how: local
 execute:
-    script: tmt --help
+  script: tmt --help

--- a/examples/manual/main.fmf
+++ b/examples/manual/main.fmf
@@ -1,16 +1,15 @@
-description:
-    Example demonstrates using MarkDown with defined structure to
-    describe manual test actions necessary for its execution.
-    Adhering to its structure allows export to other formats or
-    services. Note that any sections may contain shell script
-    code which could be used for semi-automated execution in the
-    future.
+description: >
+  Example demonstrates using MarkDown with defined structure to
+  describe manual test actions necessary for its execution.
+  Adhering to its structure allows export to other formats or
+  services. Note that any sections may contain shell script
+  code which could be used for semi-automated execution in the
+  future.
 manual: true
-
 /mini:
-    summary: Minimal manual test
-    test: mini.md
+  summary: Minimal manual test
+  test: mini.md
 
 /full:
-    summary: Longer manual test
-    test: full.md
+  summary: Longer manual test
+  test: full.md

--- a/examples/mini/ci.fmf
+++ b/examples/mini/ci.fmf
@@ -1,2 +1,2 @@
 execute:
-    script: tmt --help
+  script: tmt --help

--- a/examples/multiple/basic.fmf
+++ b/examples/multiple/basic.fmf
@@ -1,9 +1,8 @@
-summary:
-    Support for multiple configurations
-description:
-    All steps support multiple configurations. In this way it is
-    possible for example to discover tests from multiple repos.
-    The 'execute' steps supports only a single configuration.
+summary: Support for multiple configurations
+description: >
+  All steps support multiple configurations. In this way it is
+  possible for example to discover tests from multiple repos.
+  The 'execute' steps supports only a single configuration.
 discover:
   - name: tier0
     how: fmf
@@ -24,4 +23,4 @@ prepare:
     name: services
     script: systemctl start service
 execute:
-    how: tmt
+  how: tmt

--- a/examples/rtt/install.fmf
+++ b/examples/rtt/install.fmf
@@ -1,31 +1,30 @@
-
 # common settings
 discover:
-    summary: Postinstall checks
-    how: list
-    tests: check1, check2, check3
+  summary: Postinstall checks
+  how: list
+  tests: check1, check2, check3
 provision:
-    summary: Special RTT provisioning
-    how: rtt-magic
+  summary: Special RTT provisioning
+  how: rtt-magic
 execute:
-    how: shell
+  how: shell
 
 # pxe install
 /pxe:
-    summary: "Test pxe installation"
+  summary: 'Test pxe installation'
+  provision+:
+    method: pxe
+  /simple:
     provision+:
-        method: pxe
-    /simple:
-        provision+:
-            setup: simple
-    /complex:
-        provision+:
-            setup: complex
+      setup: simple
+  /complex:
+    provision+:
+      setup: complex
 
 # http install
 /http:
-    summary: "Test http installation"
-    provision+:
-        method: http
-    discover+:
-        tests: check1, check2
+  summary: 'Test http installation'
+  provision+:
+    method: http
+  discover+:
+    tests: check1, check2

--- a/examples/rtt/post-install.fmf
+++ b/examples/rtt/post-install.fmf
@@ -1,8 +1,8 @@
 test: ./test.sh
 
 /check1:
-    summary: Post installation check one
+  summary: Post installation check one
 /check2:
-    summary: Post installation check two
+  summary: Post installation check two
 /check3:
-    summary: Post installation check three
+  summary: Post installation check three

--- a/examples/symlinks/plans/basic.fmf
+++ b/examples/symlinks/plans/basic.fmf
@@ -1,8 +1,8 @@
 summary: Basic command line features
-description:
-    Wide set of tests that cover individual steps, commands
-    and features. Tier 2 tests go a bit more into detail and
-    can take a little bit longer to complete.
+description: >
+  Wide set of tests that cover individual steps, commands
+  and features. Tier 2 tests go a bit more into detail and
+  can take a little bit longer to complete.
 discover:
-    how: fmf
-    filter: 'tier: 1, 2'
+  how: fmf
+  filter: 'tier: 1, 2'

--- a/examples/symlinks/plans/core.fmf
+++ b/examples/symlinks/plans/core.fmf
@@ -1,8 +1,8 @@
 summary: Core functionality
-description:
-    Check common options such as --dry & --force, environment
-    variables handling, exploring tests and plans, presence of
-    documentation.
+description: >
+  Check common options such as --dry & --force, environment
+  variables handling, exploring tests and plans, presence of
+  documentation.
 discover:
-    how: fmf
-    filter: 'tier: 0'
+  how: fmf
+  filter: 'tier: 0'

--- a/examples/symlinks/plans/helps.fmf
+++ b/examples/symlinks/plans/helps.fmf
@@ -1,16 +1,16 @@
 summary: Check help messages
-description:
-    A couple of oneline examples showing how simple shell
-    tests can be written directly in the discover step. The
-    last one demonstrates a custom script in given directory.
+description: >
+  A couple of oneline examples showing how simple shell
+  tests can be written directly in the discover step. The
+  last one demonstrates a custom script in given directory.
 discover:
-    tests:
-      - name: /help/main
-        test: tmt --help
-      - name: /help/test
-        test: tmt test --help
-      - name: /help/plan
-        test: tmt plan --help
-      - name: /help/smoke
-        test: ./smoke.sh
-        path: /tests/shell
+  tests:
+    - name: /help/main
+      test: tmt --help
+    - name: /help/test
+      test: tmt test --help
+    - name: /help/plan
+      test: tmt plan --help
+    - name: /help/smoke
+      test: ./smoke.sh
+      path: /tests/shell

--- a/examples/symlinks/plans/install.fmf
+++ b/examples/symlinks/plans/install.fmf
@@ -1,8 +1,8 @@
 summary: Tests needing virtualization support
-description:
-    A couple of installation tests which provision a container
-    to verify that package installation works as expected.
-    Thanks to fetching dnf metadata these can take some time.
+description: >
+  A couple of installation tests which provision a container
+  to verify that package installation works as expected.
+  Thanks to fetching dnf metadata these can take some time.
 discover:
-    how: fmf
-    filter: 'tier: 3'
+  how: fmf
+  filter: 'tier: 3'

--- a/examples/symlinks/plans/main.fmf
+++ b/examples/symlinks/plans/main.fmf
@@ -1,6 +1,6 @@
 # Use localhost by default
 provision:
-    how: local
+  how: local
 
 # Install packages
 #prepare:
@@ -24,4 +24,4 @@ provision:
 #    - sudo dnf install -y tmt
 
 execute:
-    how: tmt
+  how: tmt

--- a/examples/symlinks/plans/smoke.fmf
+++ b/examples/symlinks/plans/smoke.fmf
@@ -1,7 +1,7 @@
 summary: Just a basic smoke test
-description:
-    Simple use cases should be super simple to write. In order
-    to enable at least a very basic testing of your component
-    in the CI the following two lines should be just enough.
+description: >
+  Simple use cases should be super simple to write. In order
+  to enable at least a very basic testing of your component
+  in the CI the following two lines should be just enough.
 execute:
-    script: tmt --help
+  script: tmt --help

--- a/examples/symlinks/plans/unit.fmf
+++ b/examples/symlinks/plans/unit.fmf
@@ -1,11 +1,11 @@
 summary: Python unit tests
-description:
-    Run all available python unit tests using pytest.
+description: >
+  Run all available python unit tests using pytest.
 discover:
-    tests:
-      - name: /unit
-        test: python3 -m pytest
-        path: /tests/unit
+  tests:
+    - name: /unit
+      test: python3 -m pytest
+      path: /tests/unit
 prepare+:
   - name: pytest
     how: install

--- a/examples/symlinks/try/connect/main.fmf
+++ b/examples/symlinks/try/connect/main.fmf
@@ -1,7 +1,7 @@
 # Connect to a running guest
 provision:
-    how: connect
-    guest: my.test.box
+  how: connect
+  guest: my.test.box
 #    key: /home/psss/.ssh/shared_rsa
 #    user: root
 #    password: secret

--- a/examples/symlinks/try/container/main.fmf
+++ b/examples/symlinks/try/container/main.fmf
@@ -1,10 +1,10 @@
 # Run tests in a container
 provision:
-    how: container
+  how: container
 #    image: fedora
 #    pull: false
 
 # Enable special container filter
 /core:
-    discover+:
-        filter: 'tier:0 & tag:container'
+  discover+:
+    filter: 'tier:0 & tag:container'

--- a/examples/symlinks/try/virtual/main.fmf
+++ b/examples/symlinks/try/virtual/main.fmf
@@ -1,6 +1,6 @@
 # Virtual machine via testcloud
 provision:
-    how: virtual
+  how: virtual
 #    image: fedora
 #    memory: 2048
 #    disk: 10

--- a/examples/systemd/ci.fmf
+++ b/examples/systemd/ci.fmf
@@ -1,24 +1,21 @@
-
 # Common configuration
 discover:
-    how: fmf
-    url: "https://github.com/systemd-rhel/tests"
+  how: fmf
+  url: 'https://github.com/systemd-rhel/tests'
 prepare:
-    how: ansible
-    playbook:
-        - ci/rhel-8.yml
+  how: ansible
+  playbook:
+    - ci/rhel-8.yml
 execute:
-    how: tmt
+  how: tmt
 
 # Individual plans
 /pull-request/smoke:
-    summary:
-        Basic set of quick smoke tests for systemd
-    discover+:
-        filter: "tier: 1 & distros: rhel-8"
+  summary: Basic set of quick smoke tests for systemd
+  discover+:
+    filter: 'tier: 1 & distros: rhel-8'
 
 /pull-request/functional:
-    summary:
-        Tier two functional tests
-    discover+:
-        filter: "tier: 2 & distros: rhel-8"
+  summary: Tier two functional tests
+  discover+:
+    filter: 'tier: 2 & distros: rhel-8'

--- a/examples/together/main.fmf
+++ b/examples/together/main.fmf
@@ -2,18 +2,18 @@
 # in just a single file which might be useful for small projects.
 
 /plan:
-    discover:
-        how: fmf
-    prepare:
-        how: ansible
-        playbook: packages.yaml
-    execute:
-        how: shell
+  discover:
+    how: fmf
+  prepare:
+    how: ansible
+    playbook: packages.yaml
+  execute:
+    how: shell
 
 /tests:
-    /smoke:
-        test: python3 -c "import time"
-        path: /
-    /full:
-        test: make check
-        path: /
+  /smoke:
+    test: python3 -c "import time"
+    path: /
+  /full:
+    test: make check
+    path: /

--- a/examples/wow/full/main.fmf
+++ b/examples/wow/full/main.fmf
@@ -1,9 +1,9 @@
 summary: The full user scenario with virtualization
 description: |
-    This is a beakerlib test used to execute all relevant test
-    coverage for local, container and virtual provision methods on
-    a machine with a full virtualization support. It verifies that
-    package dependencies can be installed and that these provision
-    methods work as expected.
+  This is a beakerlib test used to execute all relevant test
+  coverage for local, container and virtual provision methods on
+  a machine with a full virtualization support. It verifies that
+  package dependencies can be installed and that these provision
+  methods work as expected.
 test: ./test.sh
 duration: 3h

--- a/examples/wow/mini/main.fmf
+++ b/examples/wow/mini/main.fmf
@@ -1,7 +1,7 @@
 summary: The minimal user scenario with localhost
 description: |
-    Install the base tmt package.
-    Initialize tree using the base template.
-    Run the example test on the localhost.
+  Install the base tmt package.
+  Initialize tree using the base template.
+  Run the example test on the localhost.
 test: ./test.sh
 duration: 15m

--- a/plans/features/advanced.fmf
+++ b/plans/features/advanced.fmf
@@ -1,17 +1,17 @@
 summary: Advanced tests using virtualization
-description:
-    Tests covering more advanced scenarios, quite often using a
-    container or a virtual machine to verify that package
-    installation works as expected. These can take some time.
+description: >
+  Tests covering more advanced scenarios, quite often using a
+  container or a virtual machine to verify that package
+  installation works as expected. These can take some time.
 discover:
-    how: fmf
-    filter: 'tier: 3'
+  how: fmf
+  filter: 'tier: 3'
 adjust+:
--   when: distro == centos-stream, rhel
+  - when: distro == centos-stream, rhel
     because: pre-commit is not available from epel, use pip instead
     prepare+:
-        -   how: install
-            package: python3-pip
-        -   how: shell
-            script:
-            -   pip3 install --user pre-commit
+      - how: install
+        package: python3-pip
+      - how: shell
+        script:
+          - pip3 install --user pre-commit

--- a/plans/features/basic.fmf
+++ b/plans/features/basic.fmf
@@ -1,8 +1,8 @@
 summary: Basic command line features
-description:
-    Wide set of tests that cover individual steps, commands
-    and features. These tests do not require virtualization,
-    their individual duration should not exceed 5 minutes.
+description: >
+  Wide set of tests that cover individual steps, commands
+  and features. These tests do not require virtualization,
+  their individual duration should not exceed 5 minutes.
 discover:
-    how: fmf
-    filter: 'tier: 2'
+  how: fmf
+  filter: 'tier: 2'

--- a/plans/features/core.fmf
+++ b/plans/features/core.fmf
@@ -1,8 +1,8 @@
 summary: Verify core functionality
-description:
-    Run smoke test, unit tests and check common options such as
-    --dry & --force, environment variables handling, exploring
-    tests and plans, presence of documentation. Usually fast.
+description: >
+  Run smoke test, unit tests and check common options such as
+  --dry & --force, environment variables handling, exploring
+  tests and plans, presence of documentation. Usually fast.
 discover:
-    how: fmf
-    filter: 'tier: 0, 1'
+  how: fmf
+  filter: 'tier: 0, 1'

--- a/plans/features/main.fmf
+++ b/plans/features/main.fmf
@@ -23,4 +23,4 @@ adjust+:
     environment+:
       # Default PATH, spiked with ~/.local/bin for Python packages installed with --user.
       # This is needed on Centos Stream 8 where the user-specific path is not in PATH.
-      PATH: "/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      PATH: '/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'

--- a/plans/install/docs.fmf
+++ b/plans/install/docs.fmf
@@ -1,16 +1,16 @@
 summary: Ensure the docs can be installed successfully
-description:
-    Make sure installing docs to the readthedocs.org site works
-    well and there is no warning displayed during the build.
+description: >
+  Make sure installing docs to the readthedocs.org site works
+  well and there is no warning displayed during the build.
 prepare:
-    how: install
-    package: python3-pip
+  how: install
+  package: python3-pip
 execute:
-    script: |
-        set -ex
-        set -o pipefail
-        pip3 install .[docs]
-        cd docs
-        python3 -m sphinx -T -E -b html -d _build/doctrees \
-            . _build/html 2>&1 | tee output
-        egrep 'ERROR|WARNING' output && exit 1 || exit 0
+  script: |
+    set -ex
+    set -o pipefail
+    pip3 install .[docs]
+    cd docs
+    python3 -m sphinx -T -E -b html -d _build/doctrees \
+        . _build/html 2>&1 | tee output
+    egrep 'ERROR|WARNING' output && exit 1 || exit 0

--- a/plans/install/main.fmf
+++ b/plans/install/main.fmf
@@ -1,5 +1,5 @@
 provision:
-    how: container
+  how: container
 
 # Run only during a full testing
 enabled: false

--- a/plans/install/minimal.fmf
+++ b/plans/install/minimal.fmf
@@ -9,4 +9,4 @@ prepare+:
     order: 90
     script: dnf remove -y 'tmt-*' --exclude tmt
 execute:
-    script: cd $(mktemp -d) && tmt init -t full && tmt
+  script: cd $(mktemp -d) && tmt init -t full && tmt

--- a/plans/install/pip.fmf
+++ b/plans/install/pip.fmf
@@ -6,34 +6,34 @@ prepare:
     script: python3 -m venv /tmp/venv && /tmp/venv/bin/pip install --upgrade pip
     order: 80
 execute:
-    how: tmt
+  how: tmt
 
 /mini:
-    summary+: " (mini)"
-    discover:
-        tests:
-          - name: /install
-            test: /tmp/venv/bin/pip install .
-            require:
-              - gcc
-              - python3
-              - python3-devel
-          - name: /help
-            test: /tmp/venv/bin/tmt --help
+  summary+: ' (mini)'
+  discover:
+    tests:
+      - name: /install
+        test: /tmp/venv/bin/pip install .
+        require:
+          - gcc
+          - python3
+          - python3-devel
+      - name: /help
+        test: /tmp/venv/bin/tmt --help
 
 /full:
-    summary+: " (full)"
-    discover:
-        tests:
-          - name: /install
-            test: /tmp/venv/bin/pip install .[all]
-            require:
-              - gcc
-              - python3
-              - python3-devel
-              - libvirt-devel
-              - krb5-devel
-              - libpq-devel
-              - redhat-rpm-config
-          - name: /help
-            test: /tmp/venv/bin/tmt run --help
+  summary+: ' (full)'
+  discover:
+    tests:
+      - name: /install
+        test: /tmp/venv/bin/pip install .[all]
+        require:
+          - gcc
+          - python3
+          - python3-devel
+          - libvirt-devel
+          - krb5-devel
+          - libpq-devel
+          - redhat-rpm-config
+      - name: /help
+        test: /tmp/venv/bin/tmt run --help

--- a/plans/integration/main.fmf
+++ b/plans/integration/main.fmf
@@ -1,10 +1,10 @@
 summary: Verify integration with other systems
-description:
-    Run integration tests using the requre project for mocking
-    interaction with external systems (e.g. nitrate).
+description: >
+  Run integration tests using the requre project for mocking
+  interaction with external systems (e.g. nitrate).
 discover:
-    how: fmf
-    filter: 'tag: integration'
+  how: fmf
+  filter: 'tag: integration'
 prepare:
   - name: Install pip
     how: install

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,10 +1,10 @@
 # Run on localhost by default
 provision:
-    how: local
+  how: local
 
 # Use the internal executor
 execute:
-    how: tmt
+  how: tmt
 
 # Install packages in full mode
 adjust:

--- a/plans/provision/artemis/sanity.fmf
+++ b/plans/provision/artemis/sanity.fmf
@@ -14,14 +14,14 @@
 summary: Sanity tests of Artemis provision plugin
 
 discover:
-    how: fmf
-    filter: 'tag: artemis & tier: 1'
+  how: fmf
+  filter: 'tag: artemis & tier: 1'
 
 provision:
-    how: artemis
+  how: artemis
 
-    # NOTE: the required keys are missing *on purpose* - they must be given
-    # on command-line.
+  # NOTE: the required keys are missing *on purpose* - they must be given
+  # on command-line.
 
 enabled: false
 adjust:

--- a/plans/provision/beaker.fmf
+++ b/plans/provision/beaker.fmf
@@ -1,23 +1,23 @@
 summary: Beaker machine using mrack plugin
 
-description:
-    Run a simple smoke test on a guest provisioned by Beaker. As
-    for now this plan is to be run only manually as Beaker needs
-    Kerberos ticket to authenticate to BeakerHub.
+description: >
+  Run a simple smoke test on a guest provisioned by Beaker. As
+  for now this plan is to be run only manually as Beaker needs
+  Kerberos ticket to authenticate to BeakerHub.
 
-    Make sure that the beaker client package is installed and
-    configured on the test runner and run 'kinit $USER' command to
-    obtain Kerberos credentials.
+  Make sure that the beaker client package is installed and
+  configured on the test runner and run 'kinit $USER' command to
+  obtain Kerberos credentials.
 
 discover:
-    how: fmf
-    test: /tests/core/smoke
+  how: fmf
+  test: /tests/core/smoke
 
 provision:
-    how: beaker
-    image: fedora
+  how: beaker
+  image: fedora
 
 enabled: false
 adjust:
-    when: how == beaker
-    enabled: true
+  when: how == beaker
+  enabled: true

--- a/plans/provision/connect.fmf
+++ b/plans/provision/connect.fmf
@@ -1,7 +1,7 @@
 summary: Connect to a running guest
 provision:
-    how: connect
-    guest: my.test.box
+  how: connect
+  guest: my.test.box
 #    key: /home/psss/.ssh/devel_rsa
 #    user: root
 #    password: secret

--- a/plans/provision/container.fmf
+++ b/plans/provision/container.fmf
@@ -1,8 +1,8 @@
 summary: Run tests in a container
 discover:
-    how: fmf
-    filter: 'tag: container & tier: 1'
+  how: fmf
+  filter: 'tag: container & tier: 1'
 provision:
-    how: container
+  how: container
 #    image: fedora
 #    pull: false

--- a/plans/provision/main.fmf
+++ b/plans/provision/main.fmf
@@ -1,7 +1,7 @@
 # Select tests which can be run in a virtual machine
 discover:
-    how: fmf
-    filter: 'tag: virtual & tier:1'
+  how: fmf
+  filter: 'tag: virtual & tier:1'
 
 # Run only during a full testing
 enabled: false

--- a/plans/provision/virtual.fmf
+++ b/plans/provision/virtual.fmf
@@ -1,9 +1,9 @@
 summary: Virtual machine via testcloud
 discover:
-    how: fmf
-    filter: 'tag:virtual & tier:1 | tag:provision-virtual-only'
+  how: fmf
+  filter: 'tag:virtual & tier:1 | tag:provision-virtual-only'
 provision:
-    how: virtual
+  how: virtual
 #    image: fedora
 #    memory: 2048
 #    disk: 10

--- a/plans/remote/polarion.fmf
+++ b/plans/remote/polarion.fmf
@@ -1,6 +1,6 @@
 /:
-    inherit: false
+  inherit: false
 plan:
-    import:
-        url: https://github.com/teemtee/tests
-        name: /plans/polarion
+  import:
+    url: https://github.com/teemtee/tests
+    name: /plans/polarion

--- a/plans/sanity/lint.fmf
+++ b/plans/sanity/lint.fmf
@@ -1,8 +1,8 @@
 summary: Metadata used by tmt itself are valid
 discover:
-    how: shell
-    tests:
-      - name: /lint/tests
-        test: tmt tests lint
-      - name: /lint/plans
-        test: tmt plans lint
+  how: shell
+  tests:
+    - name: /lint/tests
+      test: tmt tests lint
+    - name: /lint/plans
+      test: tmt plans lint

--- a/spec/context/dimension.fmf
+++ b/spec/context/dimension.fmf
@@ -1,56 +1,56 @@
 summary: Supported context dimensions
 
-story:
-    As a tester I want to clearly specify dimensions, such as
-    'distro' or 'trigger', so that I can well describe the
-    context in which a test is running.
+story: >
+  As a tester I want to clearly specify dimensions, such as
+  'distro' or 'trigger', so that I can well describe the
+  context in which a test is running.
 
 description: |
-    The following dimensions are reserved for storing dedicated
-    information as described below:
+  The following dimensions are reserved for storing dedicated
+  information as described below:
 
-    distro
-        The operating system distribution on which the application
-        runs (fedora, fedora-33, centos, centos-8, centos-8.4,
-        centos-stream, centos-stream-9, rhel, rhel-8, rhel-8.4).
+  distro
+      The operating system distribution on which the application
+      runs (fedora, fedora-33, centos, centos-8, centos-8.4,
+      centos-stream, centos-stream-9, rhel, rhel-8, rhel-8.4).
 
-    variant
-        The distribution variant (Client, Desktop, Server
-        Workstation, Silverblue, CoreOS).
+  variant
+      The distribution variant (Client, Desktop, Server
+      Workstation, Silverblue, CoreOS).
 
-    arch
-        The guest architecture (aarch64, armhfp, i386, ppc64,
-        ppc64le, s390x, x86_64).
+  arch
+      The guest architecture (aarch64, armhfp, i386, ppc64,
+      ppc64le, s390x, x86_64).
 
-    component
-        Name of the relevant component, should match the source
-        package name (bash, php, httpd).
+  component
+      Name of the relevant component, should match the source
+      package name (bash, php, httpd).
 
-    collection
-        The Red Hat Software Collection name (python27,
-        rh-python34, rh-mariadb100, httpd24).
+  collection
+      The Red Hat Software Collection name (python27,
+      rh-python34, rh-mariadb100, httpd24).
 
-    module
-        Module name with an optional stream specification
-        (mariadb, mariadb:10.5, httpd, httpd:2.4, perl, perl:5.32,
-        ruby, ruby:2.7).
+  module
+      Module name with an optional stream specification
+      (mariadb, mariadb:10.5, httpd, httpd:2.4, perl, perl:5.32,
+      ruby, ruby:2.7).
 
-    initiator
-        Name of the service, pipeline or tool which initiated the
-        testing or special value ``human`` for manual testing. See
-        the :ref:`/spec/context/initiator` section for details.
+  initiator
+      Name of the service, pipeline or tool which initiated the
+      testing or special value ``human`` for manual testing. See
+      the :ref:`/spec/context/initiator` section for details.
 
-    trigger
-        The event which triggered testing, see the
-        :ref:`/spec/context/trigger` section for the full list
-        of supported values.
+  trigger
+      The event which triggered testing, see the
+      :ref:`/spec/context/trigger` section for the full list
+      of supported values.
 
 example: |
-    context:
-        distro: fedora-33
-        variant: Workstation
-        arch: x86_64
+  context:
+    distro: fedora-33
+    variant: Workstation
+    arch: x86_64
 
-    context:
-        product: rhscl
-        collection: httpd24
+  context:
+    product: rhscl
+    collection: httpd24

--- a/spec/context/initiator.fmf
+++ b/spec/context/initiator.fmf
@@ -1,49 +1,49 @@
 summary: Definition of the initiator dimension
 
-story:
-    As a user I want to run a custom set of tests based on the
-    service, pipeline or tool which initiated the testing.
+story: >
+  As a user I want to run a custom set of tests based on the
+  service, pipeline or tool which initiated the testing.
 
 description: |
-    Sometimes it is useful to choose a custom set of tests for
-    particular automation service or when tests are run manually.
-    The following values are defined:
+  Sometimes it is useful to choose a custom set of tests for
+  particular automation service or when tests are run manually.
+  The following values are defined:
 
-    human
-        Test execution was initiated manually by a human.
+  human
+      Test execution was initiated manually by a human.
 
-    packit
-        For jobs initiated by the Packit service.
-        To be implemented.
+  packit
+      For jobs initiated by the Packit service.
+      To be implemented.
 
-    fedora-ci
-        Testing in the Fedora CI pipeline.
-        To be implemented.
+  fedora-ci
+      Testing in the Fedora CI pipeline.
+      To be implemented.
 
-    centos-ci
-        Testing in the CentOS CI pipeline.
-        To be implemented.
+  centos-ci
+      Testing in the CentOS CI pipeline.
+      To be implemented.
 
-    rhel-ci
-        Testing in the RHEL CI pipeline.
-        To be implemented.
+  rhel-ci
+      Testing in the RHEL CI pipeline.
+      To be implemented.
 
-    ewa
-        Errata Workflow Automation jobs.
-        To be implemented.
+  ewa
+      Errata Workflow Automation jobs.
+      To be implemented.
 
-    Each service, pipeline or tool is responsible to set the value
-    to its name. For manual testing ``--context initiator=human``
-    is expected on the command line.
+  Each service, pipeline or tool is responsible to set the value
+  to its name. For manual testing ``--context initiator=human``
+  is expected on the command line.
 
 example: |
-    # Enable the plan only when run manually
-    summary: Tests requiring special environment
-    discover:
-        how: fmf
-        filter: tag:special
-    execute:
-        how: tmt
-    adjust:
-        enabled: false
-        when: initiator != human
+  # Enable the plan only when run manually
+  summary: Tests requiring special environment
+  discover:
+    how: fmf
+    filter: tag:special
+  execute:
+    how: tmt
+  adjust:
+    enabled: false
+    when: initiator != human

--- a/spec/context/main.fmf
+++ b/spec/context/main.fmf
@@ -1,37 +1,37 @@
 summary: Definition of the environment context
 
-story:
-    As a user I want to define a context so that test, plan or
-    story metadata can be adjusted to it accordingly.
+story: >
+  As a user I want to define a context so that test, plan or
+  story metadata can be adjusted to it accordingly.
 
 description: |
-    This specification defines all standard context dimensions
-    which can be used together with the :ref:`/spec/core/adjust`
-    attribute to modify object metadata for particular context.
-    For a detailed description of the concept itself see the fmf
-    `context`__ documentation.
+  This specification defines all standard context dimensions
+  which can be used together with the :ref:`/spec/core/adjust`
+  attribute to modify object metadata for particular context.
+  For a detailed description of the concept itself see the fmf
+  `context`__ documentation.
 
-    The context is usually defined from the command line using the
-    ``--context`` option. All dimensions are optional. It is
-    possible to define your own dimensions to describe the
-    context, just make sure the :ref:`/spec/context/dimension`
-    name does not conflict with reserved names.
+  The context is usually defined from the command line using the
+  ``--context`` option. All dimensions are optional. It is
+  possible to define your own dimensions to describe the
+  context, just make sure the :ref:`/spec/context/dimension`
+  name does not conflict with reserved names.
 
-    Some of the context dimensions can be detected (e.g. distro
-    from the provision step config). Each plan can provide its own
-    :ref:`/spec/plans/context` which will override detected
-    values. Finally, the context definition provided directly on
-    the command line overrides detected and defined dimensions.
+  Some of the context dimensions can be detected (e.g. distro
+  from the provision step config). Each plan can provide its own
+  :ref:`/spec/plans/context` which will override detected
+  values. Finally, the context definition provided directly on
+  the command line overrides detected and defined dimensions.
 
-    __ https://fmf.readthedocs.io/en/latest/context.html
+  __ https://fmf.readthedocs.io/en/latest/context.html
 
 example: |
-    tmt --context distro=fedora-33 run
-    tmt --context product=rhscl run
-    tmt --context trigger=code run
+  tmt --context distro=fedora-33 run
+  tmt --context product=rhscl run
+  tmt --context trigger=code run
 
-    tmt -c distro=fedora test show
-    tmt -c distro=fedora plan show
+  tmt -c distro=fedora test show
+  tmt -c distro=fedora plan show
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/context/trigger.fmf
+++ b/spec/context/trigger.fmf
@@ -1,38 +1,38 @@
 summary: Definition of the trigger dimension
 
-story:
-    As a user I want to run a custom set of tests for
-    different events which trigger the testing.
+story: >
+  As a user I want to run a custom set of tests for
+  different events which trigger the testing.
 
 description: |
-    Testing can be triggered by various events and a different set
-    of tests is usually executed for each of them. The ``trigger``
-    dimension supports the following values:
+  Testing can be triggered by various events and a different set
+  of tests is usually executed for each of them. The ``trigger``
+  dimension supports the following values:
 
-    commit
-        Project source code has changed. This can be either a
-        pull/merge request or a new commit pushed to a branch.
+  commit
+      Project source code has changed. This can be either a
+      pull/merge request or a new commit pushed to a branch.
 
-    build
-        There has been a new package built in koji or brew and is
-        available for testing.
+  build
+      There has been a new package built in koji or brew and is
+      available for testing.
 
-    update
-        A new bodhi update or errata advisory with one or more
-        builds has been created or updated.
+  update
+      A new bodhi update or errata advisory with one or more
+      builds has been created or updated.
 
-    compose
-        There is a new compose ready for integration testing.
+  compose
+      There is a new compose ready for integration testing.
 
-    This context dimension will usually be provided from the
-    command line.
+  This context dimension will usually be provided from the
+  command line.
 
 example: |
-    summary: Full test coverage (takes three days)
-    discover:
-        how: fmf
-    execute:
-        how: tmt
-    adjust:
-        enabled: false
-        when: trigger == code
+  summary: Full test coverage (takes three days)
+  discover:
+    how: fmf
+  execute:
+    how: tmt
+  adjust:
+    enabled: false
+    when: trigger == code

--- a/spec/core/adjust.fmf
+++ b/spec/core/adjust.fmf
@@ -1,83 +1,83 @@
 summary: Adjust metadata based on the given context
 
-story:
-    As a user I want to adjust test, plan or story metadata
-    based on the given context such as product, distribution,
-    architecture or trigger.
+story: >
+  As a user I want to adjust test, plan or story metadata
+  based on the given context such as product, distribution,
+  architecture or trigger.
 
 description: |
-    The ``adjust`` attribute allows to modify arbitrary object
-    metadata based on the context in which they are to be used.
-    For example, tests may be relevant only for given environment,
-    the set of required packages may differ across distributions
-    or there might be a different set of plans executed for pull
-    requests versus for the full compose integration testing.
+  The ``adjust`` attribute allows to modify arbitrary object
+  metadata based on the context in which they are to be used.
+  For example, tests may be relevant only for given environment,
+  the set of required packages may differ across distributions
+  or there might be a different set of plans executed for pull
+  requests versus for the full compose integration testing.
 
-    .. note::
-        The context currently has to be specified explicitly, see
-        the :ref:`/spec/context` documentation for details. In the
-        future, **tmt** will detect (at least some of) the needed
-        information from the environment.
+  .. note::
+      The context currently has to be specified explicitly, see
+      the :ref:`/spec/context` documentation for details. In the
+      future, **tmt** will detect (at least some of) the needed
+      information from the environment.
 
-    The value can be a dictionary or a list of dictionaries which
-    represent individual rules to be applied. Each rule contains
-    metadata to be merged into the original object. The following
-    three keys are reserved for rule evaluation:
+  The value can be a dictionary or a list of dictionaries which
+  represent individual rules to be applied. Each rule contains
+  metadata to be merged into the original object. The following
+  three keys are reserved for rule evaluation:
 
-    when
-        The condition to be evaluated in order to decide if the
-        metadata should be merged. In the expression, you can use
-        any defined context :ref:`/spec/context/dimension`. See
-        the full `condition syntax`__ for details about supported
-        operators. This is a **required** key.
+  when
+      The condition to be evaluated in order to decide if the
+      metadata should be merged. In the expression, you can use
+      any defined context :ref:`/spec/context/dimension`. See
+      the full `condition syntax`__ for details about supported
+      operators. This is a **required** key.
 
-    continue
-        By default, all provided rules are evaluated. When set to
-        ``false``, the first successful rule finishes the
-        evaluation and the rest is ignored. Must be a ``boolean``.
+  continue
+      By default, all provided rules are evaluated. When set to
+      ``false``, the first successful rule finishes the
+      evaluation and the rest is ignored. Must be a ``boolean``.
 
-    because
-        An optional comment with justification of the adjustment.
-        Must be a ``string``.
+  because
+      An optional comment with justification of the adjustment.
+      Must be a ``string``.
 
-    .. note::
-        This covers and extends the original concept of `Test Case
-        Relevancy`__ which is now obsoleted.
+  .. note::
+      This covers and extends the original concept of `Test Case
+      Relevancy`__ which is now obsoleted.
 
-    __ https://fmf.readthedocs.io/en/latest/context.html#syntax
-    __ https://docs.fedoraproject.org/en-US/ci/test-case-relevancy
+  __ https://fmf.readthedocs.io/en/latest/context.html#syntax
+  __ https://docs.fedoraproject.org/en-US/ci/test-case-relevancy
 
 example: |
-    # Disable a test for older distros
-    enabled: true
-    adjust:
-        enabled: false
-        when: distro < fedora-33
-        because: the feature was added in Fedora 33
+  # Disable a test for older distros
+  enabled: true
+  adjust:
+    enabled: false
+    when: distro < fedora-33
+    because: the feature was added in Fedora 33
 
-    # Adjust the required package name
-    require: procps-ng
-    adjust:
-      - require: procps
-        when: distro == centos-6
+  # Adjust the required package name
+  require: procps-ng
+  adjust:
+    - require: procps
+      when: distro == centos-6
 
-    # Extend the environment variables, use multiple rules
-    adjust:
-      - environment+:
-            SH: bash
-        when: component == bash
-        continue: true
-      - when: distro < centos-6
-        enabled: false
+  # Extend the environment variables, use multiple rules
+  adjust:
+    - environment+:
+        SH: bash
+      when: component == bash
+      continue: true
+    - when: distro < centos-6
+      enabled: false
 
-    # Install the fresh pytest from pip on older distros
-    adjust:
-        prepare+:
-         - how: shell
-           name: fresh-pytest
-           order: 90
-           script: 'python3 -m pip install -U pytest'
-        when: distro < rhel-8
+  # Install the fresh pytest from pip on older distros
+  adjust:
+    prepare+:
+      - how: shell
+        name: fresh-pytest
+        order: 90
+        script: 'python3 -m pip install -U pytest'
+    when: distro < rhel-8
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/core/description.fmf
+++ b/spec/core/description.fmf
@@ -1,10 +1,10 @@
 summary: Detailed description of the object
 
-description:
-    Multiline ``string`` describing all important aspects of
-    the object. Usually spans across several paragraphs. For
-    detailed examples using a dedicated attributes 'examples'
-    should be considered.
+description: >
+  Multiline ``string`` describing all important aspects of
+  the object. Usually spans across several paragraphs. For
+  detailed examples using a dedicated attributes 'examples'
+  should be considered.
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/core/enabled.fmf
+++ b/spec/core/enabled.fmf
@@ -1,31 +1,31 @@
 summary: Allow disabling individual tests, plans or stories
 
-story:
-    As a developer or tester I want selected tests or plans to be
-    skipped during test execution.
+story: >
+  As a developer or tester I want selected tests or plans to be
+  skipped during test execution.
 
 description: |
-    When a test or a plan is broken or it is not relevant for
-    given :ref:`/spec/context` it can be disabled so that it's
-    skipped during the execution. For stories, this attribute
-    might be used to mark stories which should be skipped when
-    generating the documentation.
+  When a test or a plan is broken or it is not relevant for
+  given :ref:`/spec/context` it can be disabled so that it's
+  skipped during the execution. For stories, this attribute
+  might be used to mark stories which should be skipped when
+  generating the documentation.
 
-    Must be a ``boolean``. The default value is ``true``.
+  Must be a ``boolean``. The default value is ``true``.
 
 example: |
-    # Mark as disabled
+  # Mark as disabled
+  enabled: false
+
+  # Disable for older distros
+  enabled: true
+  adjust:
     enabled: false
+    when: distro < fedora-33
+    because: the feature was added in Fedora 33
 
-    # Disable for older distros
-    enabled: true
-    adjust:
-        enabled: false
-        when: distro < fedora-33
-        because: the feature was added in Fedora 33
-
-    # List only enabled tests
-    tmt tests ls --filter enabled:true
+  # List only enabled tests
+  tmt tests ls --filter enabled:true
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/core/id.fmf
+++ b/spec/core/id.fmf
@@ -1,28 +1,28 @@
 summary: Persistent unique identifier of the object
 
-story:
-    As a user I want to be able to track execution history of a
-    test even if it is renamed or moved to another repository.
+story: >
+  As a user I want to be able to track execution history of a
+  test even if it is renamed or moved to another repository.
 
 description: |
-    Sometimes tests, plans or stories are renamed or moved across
-    the directory structure, into a different git branch or even
-    to another repository. Any of these changes results into an
-    update of the `fmf identifier`__.
+  Sometimes tests, plans or stories are renamed or moved across
+  the directory structure, into a different git branch or even
+  to another repository. Any of these changes results into an
+  update of the `fmf identifier`__.
 
-    In order to identify objects even after they are renamed or
-    moved the ``id`` attribute can be used to store a unique
-    identifier which does not change and can be used for example
-    to track the complete test execution history even if the test
-    changed the location or name.
+  In order to identify objects even after they are renamed or
+  moved the ``id`` attribute can be used to store a unique
+  identifier which does not change and can be used for example
+  to track the complete test execution history even if the test
+  changed the location or name.
 
-    Must be a uniqe ``string``, using a `uuid`__ is recommended.
+  Must be a uniqe ``string``, using a `uuid`__ is recommended.
 
-    __ https://fmf.readthedocs.io/en/latest/concept.html#identifiers
-    __ https://en.wikipedia.org/wiki/Universally_unique_identifier
+  __ https://fmf.readthedocs.io/en/latest/concept.html#identifiers
+  __ https://en.wikipedia.org/wiki/Universally_unique_identifier
 
 example: |
-    id: af994876-1c68-49a7-90e8-c8d2b189189d
+  id: af994876-1c68-49a7-90e8-c8d2b189189d
 
 link:
   - implemented-by: /tmt/id.py

--- a/spec/core/link.fmf
+++ b/spec/core/link.fmf
@@ -1,114 +1,114 @@
 summary: Link related objects
 
-story:
-    As a user I want to link related tests, stories or external
-    issues so that I can easily find out what the test, plan or
-    story is addressing.
+story: >
+  As a user I want to link related tests, stories or external
+  issues so that I can easily find out what the test, plan or
+  story is addressing.
 
 description: |
-    The core attribute ``link`` is used to track relevant objects
-    such as user stories or external issues verified by the given
-    test, source code implementing particular story, blocking
-    issues or parent-child relations.
+  The core attribute ``link`` is used to track relevant objects
+  such as user stories or external issues verified by the given
+  test, source code implementing particular story, blocking
+  issues or parent-child relations.
 
-    The value can be a single link or a list of links. There are
-    two options how to specify the ``target`` of the reference:
+  The value can be a single link or a list of links. There are
+  two options how to specify the ``target`` of the reference:
 
-    string
-        This can be either a ``name`` of the fmf node within the
-        same metadata tree, a file ``path`` from the tree root to
-        the application or documentation source code or a ``URL``
-        to an external issue tracker.
+  string
+      This can be either a ``name`` of the fmf node within the
+      same metadata tree, a file ``path`` from the tree root to
+      the application or documentation source code or a ``URL``
+      to an external issue tracker.
 
-    dict
-        In order to reference remote fmf objects use a dictionary
-        with the full `fmf identifier`__.
+  dict
+      In order to reference remote fmf objects use a dictionary
+      with the full `fmf identifier`__.
 
-    By default, the link between the two objects is interpreted in
-    a generic way as ``relates``. To explicitly define a different
-    connection to the target reference, use a dictionary and set
-    the key to one of the supported relations:
+  By default, the link between the two objects is interpreted in
+  a generic way as ``relates``. To explicitly define a different
+  connection to the target reference, use a dictionary and set
+  the key to one of the supported relations:
 
-    verifies
-        This object (a test or a plan) verifies functionality
-        defined in the target (a story, an issue, a bug).
+  verifies
+      This object (a test or a plan) verifies functionality
+      defined in the target (a story, an issue, a bug).
 
-    verified-by
-        The functionality (described in a story, an issue or a
-        bug) is verified by the target (a test or a plan).
+  verified-by
+      The functionality (described in a story, an issue or a
+      bug) is verified by the target (a test or a plan).
 
-    implements
-        This object (source code) implements functionality defined
-        in the target (a story describing the feature).
+  implements
+      This object (source code) implements functionality defined
+      in the target (a story describing the feature).
 
-    implemented-by
-        The functionality (described in a story) is implemented by
-        the target (source code).
+  implemented-by
+      The functionality (described in a story) is implemented by
+      the target (source code).
 
-    documents
-        This object (a guide or examples) documents the target (a
-        story).
+  documents
+      This object (a guide or examples) documents the target (a
+      story).
 
-    documented-by
-        The functionality (described in a story) is documented by
-        the target (a guide or examples).
+  documented-by
+      The functionality (described in a story) is documented by
+      the target (a guide or examples).
 
-    blocks
-        This object is blocking the target.
+  blocks
+      This object is blocking the target.
 
-    blocked-by
-        This object is blocked by the target.
+  blocked-by
+      This object is blocked by the target.
 
-    duplicates
-        This object is a duplicate of the target.
+  duplicates
+      This object is a duplicate of the target.
 
-    duplicated-by
-        This object is duplicated by the target.
+  duplicated-by
+      This object is duplicated by the target.
 
-    parent
-        This object is a child of the target parent.
+  parent
+      This object is a child of the target parent.
 
-    child
-        This object is a parent of the target child.
+  child
+      This object is a parent of the target child.
 
-    relates
-        This object relates to the provided target.
-        This is the **default** relation.
+  relates
+      This object relates to the provided target.
+      This is the **default** relation.
 
-    test-script
-        Web link to the location of the testing script, intended
-        for cases where the tests are stored in a different
-        directory or repository than the metadata files.
+  test-script
+      Web link to the location of the testing script, intended
+      for cases where the tests are stored in a different
+      directory or repository than the metadata files.
 
-    An optional key ``note`` can be used to add an arbitrary
-    comment describing the relation.
+  An optional key ``note`` can be used to add an arbitrary
+  comment describing the relation.
 
-    __ https://fmf.readthedocs.io/en/latest/concept.html#identifiers
+  __ https://fmf.readthedocs.io/en/latest/concept.html#identifiers
 
 example: |
-    # A related issue
-    link: https://github.com/teemtee/tmt/issues/461
+  # A related issue
+  link: https://github.com/teemtee/tmt/issues/461
 
-    # A test verifying a story
-    link:
-        verifies: /stories/cli/init/base
+  # A test verifying a story
+  link:
+    verifies: /stories/cli/init/base
 
-    # A test verifying a story and a bug
-    link:
-      - verifies: /stories/cli/init/base
-      - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=1234
+  # A test verifying a story and a bug
+  link:
+    - verifies: /stories/cli/init/base
+    - verifies: https://bugzilla.redhat.com/show_bug.cgi?id=1234
 
-    # An implemented story covered by both tests and docs
-    link:
-      - implemented-by: /tmt/cli.py
-      - verified-by: /tests/init/base
-      - documented-by: /docs/guide.rst
+  # An implemented story covered by both tests and docs
+  link:
+    - implemented-by: /tmt/cli.py
+    - verified-by: /tests/init/base
+    - documented-by: /docs/guide.rst
 
-    # A story blocked by a remote story with optional note
-    link:
-        blocked-by:
-            url: https://github.com/teemtee/fmf
-            name: /stories/select/filter/regexp
-        note: Need to get the regexp filter working first.
+  # A story blocked by a remote story with optional note
+  link:
+    blocked-by:
+      url: https://github.com/teemtee/fmf
+      name: /stories/select/filter/regexp
+    note: Need to get the regexp filter working first.
 link:
   - implemented-by: /tmt/base.py

--- a/spec/core/main.fmf
+++ b/spec/core/main.fmf
@@ -1,3 +1,3 @@
-story:
-    I want to have common core attributes used consistently
-    across all metadata levels.
+story: >
+  I want to have common core attributes used consistently
+  across all metadata levels.

--- a/spec/core/order.fmf
+++ b/spec/core/order.fmf
@@ -1,15 +1,15 @@
 summary: Order in which the object should be handled
 
-description:
-    Sometimes it is important in which order objects are
-    processed. For example when running tests we need to
-    execute some tests first or when exporting stories we need
-    to arrange content in the right sequence to create a
-    meaningful documentation. Must be an ``integer``, negative
-    values are allowed as well. The default value is ``50``.
+description: >
+  Sometimes it is important in which order objects are
+  processed. For example when running tests we need to
+  execute some tests first or when exporting stories we need
+  to arrange content in the right sequence to create a
+  meaningful documentation. Must be an ``integer``, negative
+  values are allowed as well. The default value is ``50``.
 
 example: |
-    order: 30
+  order: 30
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/core/summary.fmf
+++ b/spec/core/summary.fmf
@@ -1,9 +1,9 @@
 summary: Concise summary describing purpose of the object
 
-description:
-    Must be a one-line ``string``, should be up to 50 characters
-    long. It is challenging to be both concise and descriptive,
-    but that is what a well-written summary should do.
+description: >
+  Must be a one-line ``string``, should be up to 50 characters
+  long. It is challenging to be both concise and descriptive,
+  but that is what a well-written summary should do.
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/core/tag.fmf
+++ b/spec/core/tag.fmf
@@ -1,15 +1,15 @@
 summary: Free form tags for easy filtering
 
-story:
-    As a user I want to run only a subset of available tests,
-    plans or stories.
+story: >
+  As a user I want to run only a subset of available tests,
+  plans or stories.
 
-description:
-    Throughout the years, free-form tags proved to be useful for
-    many, many scenarios. Primarily to provide an easy way how to
-    select a subset of objects. Tags are case-sensitive. Using
-    lowercase is recommended. Must be a ``string`` or a ``list
-    of strings``. Tag name must not contain spaces or commas.
+description: >
+  Throughout the years, free-form tags proved to be useful for
+  many, many scenarios. Primarily to provide an easy way how to
+  select a subset of objects. Tags are case-sensitive. Using
+  lowercase is recommended. Must be a ``string`` or a ``list
+  of strings``. Tag name must not contain spaces or commas.
 
 example:
   - |

--- a/spec/core/tier.fmf
+++ b/spec/core/tier.fmf
@@ -1,16 +1,16 @@
 summary: Name of the tier set this the object belongs to
 
-story:
-    As a tester testing a security advisory I want to run the
-    stable set of important tests which cover the most essential
-    functionality and can provide test results in a short time.
+story: >
+  As a tester testing a security advisory I want to run the
+  stable set of important tests which cover the most essential
+  functionality and can provide test results in a short time.
 
-description:
-    It's quite common to organize tests or plans into "tiers"
-    based on their importance, stability, duration and other
-    aspects. For this tags have been used quite often in the past,
-    now there is a dedicated field for this use case. Should be a
-    ``string``.
+description: >
+  It's quite common to organize tests or plans into "tiers"
+  based on their importance, stability, duration and other
+  aspects. For this tags have been used quite often in the past,
+  now there is a dedicated field for this use case. Should be a
+  ``string``.
 
 example:
   - |

--- a/spec/hardware/arch.fmf
+++ b/spec/hardware/arch.fmf
@@ -1,5 +1,4 @@
-summary:
-    Select the desired architecture
+summary: Select the desired architecture
 example:
   - |
     # Architecture (any of well-known short architecture names,

--- a/spec/hardware/boot.fmf
+++ b/spec/hardware/boot.fmf
@@ -1,14 +1,13 @@
-summary:
-    Features related to machine boot
+summary: Features related to machine boot
 example:
   - |
     # Guest with BIOS
     boot:
-        method: bios
+      method: bios
 
   - |
     # Guest with UEFI
     boot:
-        method: uefi
+      method: uefi
 link:
   - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/hardware/compatible.fmf
+++ b/spec/hardware/compatible.fmf
@@ -1,14 +1,13 @@
-summary:
-    Select guest based on given compatibility
-description:
-    Pick only guests compatible with given operating system
-    distribution. See the context :ref:`/spec/context/dimension`
-    definitions for the list of supported values of the ``distro``
-    key. Must be a list of strings.
+summary: Select guest based on given compatibility
+description: >
+  Pick only guests compatible with given operating system
+  distribution. See the context :ref:`/spec/context/dimension`
+  definitions for the list of supported values of the ``distro``
+  key. Must be a list of strings.
 example:
   - |
     # Select a guest compatible with both rhel-8 and rhel-9
     compatible:
-        distro:
-          - rhel-8
-          - rhel-9
+      distro:
+        - rhel-8
+        - rhel-9

--- a/spec/hardware/cpu.fmf
+++ b/spec/hardware/cpu.fmf
@@ -1,36 +1,35 @@
-summary:
-    Choose system according to the processor features
+summary: Choose system according to the processor features
 example:
   - |
     # Processor-related stuff grouped together
     cpu:
-        # The total number of various CPU components in the system.
-        sockets: 1
-        cores: 4
-        threads: 8
+      # The total number of various CPU components in the system.
+      sockets: 1
+      cores: 4
+      threads: 8
 
-        # Ther number of various CPU components per their parent.
-        cores-per-socket: 4
-        threads-per-core: 2
+      # Ther number of various CPU components per their parent.
+      cores-per-socket: 4
+      threads-per-core: 2
 
-        # The total number of logical CPUs.
-        processors: 8
+      # The total number of logical CPUs.
+      processors: 8
 
-        # CPU model name. Usually reported as such by /proc/cpuinfo or lscpu.
-        model-name: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
-        # CPU model number.
-        model: 142
-        # CPU family name.
-        family-name: Comet Lake
-        # CPU family number.
-        family: 6
+      # CPU model name. Usually reported as such by /proc/cpuinfo or lscpu.
+      model-name: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+      # CPU model number.
+      model: 142
+      # CPU family name.
+      family-name: Comet Lake
+      # CPU family number.
+      family: 6
 
-        # CPU flag(s) as reported with /proc/cpuinfo
-        # Field applies an implicit "and" to listed flags
-        # Supported operators: "=" and "!="
-        flag:
-          - avx
-          - avx2
-          - "!= smep"
+      # CPU flag(s) as reported with /proc/cpuinfo
+      # Field applies an implicit "and" to listed flags
+      # Supported operators: "=" and "!="
+      flag:
+        - avx
+        - avx2
+        - "!= smep"
 link:
   - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/hardware/disk.fmf
+++ b/spec/hardware/disk.fmf
@@ -1,5 +1,4 @@
-summary:
-    Choose the disk size
+summary: Choose the disk size
 example:
   - |
     # Disk group used to allow possible future extensions

--- a/spec/hardware/hostname.fmf
+++ b/spec/hardware/hostname.fmf
@@ -1,5 +1,4 @@
-summary:
-    Select specific guest by its hostname
+summary: Select specific guest by its hostname
 example:
   - |
     # Choose machine with given hostname

--- a/spec/hardware/main.fmf
+++ b/spec/hardware/main.fmf
@@ -1,156 +1,155 @@
-story:
-    As a tester I want to specify detailed hardware requirements
-    for the guest on which the tests will be executed.
+story: >
+  As a tester I want to specify detailed hardware requirements
+  for the guest on which the tests will be executed.
 
 description: |
-    As part of the :ref:`/spec/plans/provision` step it is
-    possible to use the ``hardware`` key to specify additional
-    requirements for the testing environment. This provides a
-    generic and an extensible way to write down essential hardware
-    requirements. For example one consistent way how to specify
-    `at least 2 GB of RAM` for all supported provisioners.
+  As part of the :ref:`/spec/plans/provision` step it is
+  possible to use the ``hardware`` key to specify additional
+  requirements for the testing environment. This provides a
+  generic and an extensible way to write down essential hardware
+  requirements. For example one consistent way how to specify
+  `at least 2 GB of RAM` for all supported provisioners.
 
-    Introduction
-    ^^^^^^^^^^^^
+  Introduction
+  ^^^^^^^^^^^^
 
-    Individual requirements are provided as a simple ``key:
-    value`` pairs, for example the minimum amount of
-    :ref:`/spec/hardware/memory`, or the related information is
-    grouped under a common parent, for example ``cores`` or
-    ``model`` under the :ref:`/spec/hardware/cpu` key.
+  Individual requirements are provided as a simple ``key:
+  value`` pairs, for example the minimum amount of
+  :ref:`/spec/hardware/memory`, or the related information is
+  grouped under a common parent, for example ``cores`` or
+  ``model`` under the :ref:`/spec/hardware/cpu` key.
 
-    Comparison operators
-    --------------------
+  Comparison operators
+  --------------------
 
-    The ``value`` part of the constraint follows the schema ``[operator] actual-value``.
-    The ``operator`` is optional, it may be any of the following: ``=``, ``!=``,
-    ``>``, ``>=``, ``<``, ``>=``, ``~`` (regex match), and ``!~`` (regex *not*
-    matches). When operator is omitted, ``=`` is assumed.
+  The ``value`` part of the constraint follows the schema ``[operator] actual-value``.
+  The ``operator`` is optional, it may be any of the following: ``=``, ``!=``,
+  ``>``, ``>=``, ``<``, ``>=``, ``~`` (regex match), and ``!~`` (regex *not*
+  matches). When operator is omitted, ``=`` is assumed.
 
-    .. note::
+  .. note::
 
-        It is **highly** recommended to wrap values with single or double quotes,
-        i.e. ``memory: '>= 8 GiB'`` rather than ``memory: >= 8 GiB``. This should
-        prevent any unexpected processing by parsers loading the fmf content.
-        Without explicit quotes, some operators might lead to unexpected outcome.
+      It is **highly** recommended to wrap values with single or double quotes,
+      i.e. ``memory: '>= 8 GiB'`` rather than ``memory: >= 8 GiB``. This should
+      prevent any unexpected processing by parsers loading the fmf content.
+      Without explicit quotes, some operators might lead to unexpected outcome.
 
-        .. code-block:: yaml
+      .. code-block:: yaml
 
-            # This...
-            memory: '8 GB'
-            # ... is the same as this:
-            memory: '= 8 GB'
+          # This...
+          memory: '8 GB'
+          # ... is the same as this:
+          memory: '= 8 GB'
 
-            # Optional operators at the start of the value
-            memory: '!= 8 GB'
-            memory: '> 8 GB'
-            memory: '>= 8 GB'
-            memory: '< 8 GB'
-            memory: '<= 8 GB'
+          # Optional operators at the start of the value
+          memory: '!= 8 GB'
+          memory: '> 8 GB'
+          memory: '>= 8 GB'
+          memory: '< 8 GB'
+          memory: '<= 8 GB'
 
-    Search
-    ------
+  Search
+  ------
 
-    Regular expressions can be used for selected fields such as
-    the :ref:`/spec/hardware/cpu` model name or
-    :ref:`/spec/hardware/hostname`. Use ``~`` for positive and
-    ``!~`` for negative regular expressions at the beginning of
-    the string. Any leading or trailing white space from the
-    search string is removed.
+  Regular expressions can be used for selected fields such as
+  the :ref:`/spec/hardware/cpu` model name or
+  :ref:`/spec/hardware/hostname`. Use ``~`` for positive and
+  ``!~`` for negative regular expressions at the beginning of
+  the string. Any leading or trailing white space from the
+  search string is removed.
 
-    Please note, that the full extent of regular expressions might
-    not be supported across all provision implementations. The
-    ``.*`` notation, however, should be supported everywhere:
+  Please note, that the full extent of regular expressions might
+  not be supported across all provision implementations. The
+  ``.*`` notation, however, should be supported everywhere:
 
-    .. code-block:: yaml
+  .. code-block:: yaml
 
-        # Search for processors using a cpu model name
-        cpu:
-            model-name: "~ AMD"
+      # Search for processors using a cpu model name
+      cpu:
+          model-name: "~ AMD"
 
-        # Select guests with a non-matching hostname
-        hostname: "!~ kvm-01.*"
+      # Select guests with a non-matching hostname
+      hostname: "!~ kvm-01.*"
 
-    Logic operators
-    ---------------
+  Logic operators
+  ---------------
 
-    When multiple environment requirements are provided the
-    provision implementation should attempt to satisfy all of
-    them. It is also possible to write this explicitly using the
-    ``and`` operator containing a list of dictionaries with
-    individual requirements. When the ``or`` operator is used, any
-    of the alternatives provided in the list should be
-    sufficient:
+  When multiple environment requirements are provided the
+  provision implementation should attempt to satisfy all of
+  them. It is also possible to write this explicitly using the
+  ``and`` operator containing a list of dictionaries with
+  individual requirements. When the ``or`` operator is used, any
+  of the alternatives provided in the list should be
+  sufficient:
 
-    .. code-block:: yaml
+  .. code-block:: yaml
 
-        # By default exact value expected, these are equivalent:
-        cpu:
-            model: 37
-        cpu:
-            model: '= 37'
+      # By default exact value expected, these are equivalent:
+      cpu:
+          model: 37
+      cpu:
+          model: '= 37'
 
-        # Using advanced logic operators
-        and:
-          - cpu:
-                family: 15
-          - or:
-              - cpu:
-                    model: 65
-              - cpu:
-                    model: 67
-              - cpu:
-                    model: 69
+      # Using advanced logic operators
+      and:
+        - cpu:
+              family: 15
+        - or:
+            - cpu:
+                  model: 65
+            - cpu:
+                  model: 67
+            - cpu:
+                  model: 69
 
-    Units
-    -----
+  Units
+  -----
 
-    The `pint`__ library is used for processing various units,
-    both decimal and binary prefixes can be used:
+  The `pint`__ library is used for processing various units,
+  both decimal and binary prefixes can be used:
 
-    .. code-block::
+  .. code-block::
 
-        1 MB = 1 000 000 B
-        1 MiB = 1 048 576 B
+      1 MB = 1 000 000 B
+      1 MiB = 1 048 576 B
 
-    __ https://pint.readthedocs.io/
+  __ https://pint.readthedocs.io/
 
-    Notes
-    -----
+  Notes
+  -----
 
-    The implementation for this common ``hardware`` key is in
-    progress. Features under this section marked as implemented
-    are already supported by the ``artemis`` plugin. Support in
-    other provision plugins is on the way.  Check individual
-    plugin documentation for additional information on the
-    hardware requirement support.
+  The implementation for this common ``hardware`` key is in
+  progress. Features under this section marked as implemented
+  are already supported by the ``artemis`` plugin. Support in
+  other provision plugins is on the way.  Check individual
+  plugin documentation for additional information on the
+  hardware requirement support.
 
-    .. note::
+  .. note::
 
-        Some plugins may require additional configuration. For
-        example, Artemis can provision machines with disks of a
-        particular size, but to do so, Artemis maintainers must
-        configure disk sizes for various AWS / OpenStack / Azure
-        flavors. The constraint is supported and implemented, but
-        it will not deliver the required virtual machine when the
-        plugin's backend, the Artemis deployment, isn't configured
-        correctly.
+      Some plugins may require additional configuration. For
+      example, Artemis can provision machines with disks of a
+      particular size, but to do so, Artemis maintainers must
+      configure disk sizes for various AWS / OpenStack / Azure
+      flavors. The constraint is supported and implemented, but
+      it will not deliver the required virtual machine when the
+      plugin's backend, the Artemis deployment, isn't configured
+      correctly.
 
-    .. note::
+  .. note::
 
-        Some plugins may support requirements that are impossible
-        to satisfy, e.g. the :ref:`/spec/plans/provision/local`
-        plugin can support the ``cpu.family`` requirement, but it
-        is hard-locked to the CPU of one's own machine.
-
+      Some plugins may support requirements that are impossible
+      to satisfy, e.g. the :ref:`/spec/plans/provision/local`
+      plugin can support the ``cpu.family`` requirement, but it
+      is hard-locked to the CPU of one's own machine.
 
 example:
   - |
     # Use the artemis plugin to provision the latest Fedora on
     # a guest with the x86_64 architecture and 8 GB of memory
     provision:
-        how: artemis
-        image: fedora
-        hardware:
-            arch: x86_64
-            memory: 8 GB
+      how: artemis
+      image: fedora
+      hardware:
+        arch: x86_64
+        memory: 8 GB

--- a/spec/hardware/memory.fmf
+++ b/spec/hardware/memory.fmf
@@ -1,5 +1,4 @@
-summary:
-    Select the desired amount of memory
+summary: Select the desired amount of memory
 example:
   - |
     # Require an exact amount of memory

--- a/spec/hardware/network.fmf
+++ b/spec/hardware/network.fmf
@@ -1,5 +1,4 @@
-summary:
-    Select guests with given network devices
+summary: Select guests with given network devices
 example:
   - |
     # Select by vendor and device name

--- a/spec/hardware/system.fmf
+++ b/spec/hardware/system.fmf
@@ -1,12 +1,11 @@
-summary:
-    Select machine with given system attributes
-description:
-    Use the ``vendor`` key to choose system by specific vendor,
-    ``model`` to provide system's model name, ``numa-nodes``
-    to select systems with a given number of NUMA nodes.
+summary: Select machine with given system attributes
+description: >
+  Use the ``vendor`` key to choose system by specific vendor,
+  ``model`` to provide system's model name, ``numa-nodes``
+  to select systems with a given number of NUMA nodes.
 example:
   - |
     system:
-        vendor: HPE
-        model: ProLiant DL385 Gen10
-        numa-nodes: '>= 2'
+      vendor: HPE
+      model: ProLiant DL385 Gen10
+      numa-nodes: '>= 2'

--- a/spec/hardware/tpm.fmf
+++ b/spec/hardware/tpm.fmf
@@ -1,9 +1,8 @@
-summary:
-    Require the `Trusted Platform Module` features
-description:
-    Use the ``version`` key to select the desired ``tpm`` version,
-    its value must be a ``string``.
+summary: Require the `Trusted Platform Module` features
+description: >
+  Use the ``version`` key to select the desired ``tpm`` version,
+  its value must be a ``string``.
 example:
   - |
     tpm:
-        version: "2.0"
+      version: "2.0"

--- a/spec/hardware/virtualization.fmf
+++ b/spec/hardware/virtualization.fmf
@@ -1,19 +1,18 @@
-summary:
-    Features related to virtualization
-description:
-    This section allows to select guests which are virtualized or
-    support virtualization. Use the ``hypervisor`` key to select
-    specific implementation, for example ``hyperv``, ``kvm``,
-    ``nitro``, ``powerkvm``, ``powervm``, ``vmware`` or ``xen``.
+summary: Features related to virtualization
+description: >
+  This section allows to select guests which are virtualized or
+  support virtualization. Use the ``hypervisor`` key to select
+  specific implementation, for example ``hyperv``, ``kvm``,
+  ``nitro``, ``powerkvm``, ``powervm``, ``vmware`` or ``xen``.
 example:
   - |
     # Require a guest which supports virtualization
     virtualization:
-        is-supported: true
+      is-supported: true
   - |
     # Ask for a virtualized guest using kvm hypervisor
     virtualization:
-        is-virtualized: true
-        hypervisor: kvm
+      is-virtualized: true
+      hypervisor: kvm
 link:
   - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/plans/context.fmf
+++ b/spec/plans/context.fmf
@@ -1,15 +1,15 @@
 summary: Definition of the test execution context
 
-story:
-    As a user I want to define the default context in which tests
-    included in given plan should be executed.
+story: >
+  As a user I want to define the default context in which tests
+  included in given plan should be executed.
 
 description: |
-    Define the default context values for all tests executed under
-    the given plan. Can be overriden by context provided directly
-    on the command line. See the :ref:`/spec/context` definition
-    for the full list of supported context dimensions. Must be a
-    ``dictionary``.
+  Define the default context values for all tests executed under
+  the given plan. Can be overriden by context provided directly
+  on the command line. See the :ref:`/spec/context` definition
+  for the full list of supported context dimensions. Must be a
+  ``dictionary``.
 
 example:
   - |

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -1,308 +1,308 @@
 summary: Discover tests relevant for execution
 
 description: |
-    Gather information about tests which are supposed to be run.
-    Provide method ``tests()`` returning a list of discovered
-    tests and ``requires()`` returning a list of all required
-    packages aggregated from the `require`_ attribute of the
-    individual test metadata.
+  Gather information about tests which are supposed to be run.
+  Provide method ``tests()`` returning a list of discovered
+  tests and ``requires()`` returning a list of all required
+  packages aggregated from the `require`_ attribute of the
+  individual test metadata.
 
-    .. _require: https://tmt.readthedocs.io/en/latest/spec/tests.html#require
+  .. _require: https://tmt.readthedocs.io/en/latest/spec/tests.html#require
 
-    Store the list of aggregated tests with their corresponding
-    metadata in the ``tests.yaml`` file. The format must be a
-    list of dictionaries structured in the following way:
+  Store the list of aggregated tests with their corresponding
+  metadata in the ``tests.yaml`` file. The format must be a
+  list of dictionaries structured in the following way:
 
-    .. code-block:: yaml
+  .. code-block:: yaml
 
-        - name: /test/one
-          summary: Short test summary.
-          description: Long test description.
-          contact: Petr Šplíchal <psplicha@redhat.com>
-          component: [tmt]
-          test: tmt --help
-          path: /test/path/
-          require: [package1, package2]
-          environment:
-              key1: value1
-              key2: value2
-              key3: value3
-          duration: 5m
-          enabled: true
-          result: respect
-          tag: [tag]
-          tier: 1
-          serialnumber: 1
+      - name: /test/one
+        summary: Short test summary.
+        description: Long test description.
+        contact: Petr Šplíchal <psplicha@redhat.com>
+        component: [tmt]
+        test: tmt --help
+        path: /test/path/
+        require: [package1, package2]
+        environment:
+            key1: value1
+            key2: value2
+            key3: value3
+        duration: 5m
+        enabled: true
+        result: respect
+        tag: [tag]
+        tier: 1
+        serialnumber: 1
 
-        - name: /test/two
-          summary: Short test summary.
-          description: Long test description.
-          ...
+      - name: /test/two
+        summary: Short test summary.
+        description: Long test description.
+        ...
 
 /shell:
-    summary: Provide a manual list of shell test cases
-    description: |
-        List of test cases to be executed can be defined manually
-        directly in the plan as a list of dictionaries containing
-        test ``name`` and actual ``test`` script. Optionally it is
-        possible to define any other :ref:`/spec/tests` attributes
-        such as ``path`` or ``duration`` here as well. The default
-        :ref:`/spec/tests/duration` for tests defined directly in
-        the discover step is ``1h``.
+  summary: Provide a manual list of shell test cases
+  description: |
+    List of test cases to be executed can be defined manually
+    directly in the plan as a list of dictionaries containing
+    test ``name`` and actual ``test`` script. Optionally it is
+    possible to define any other :ref:`/spec/tests` attributes
+    such as ``path`` or ``duration`` here as well. The default
+    :ref:`/spec/tests/duration` for tests defined directly in
+    the discover step is ``1h``.
 
-        It is possible to fetch code from a remote git repository
-        using ``url``. In that case repository is cloned and all
-        paths are relative to the remote git root. Using remote
-        repo and local test code at the same time is not possible
-        within the same discover config, use
-        :ref:`multiple-configs` instead.
+    It is possible to fetch code from a remote git repository
+    using ``url``. In that case repository is cloned and all
+    paths are relative to the remote git root. Using remote
+    repo and local test code at the same time is not possible
+    within the same discover config, use
+    :ref:`multiple-configs` instead.
 
-        url
-            Git repository, used directly as a git clone argument.
+    url
+        Git repository, used directly as a git clone argument.
 
-        ref
-            Branch, tag or commit specifying the desired git
-            revision. Defaults to the remote repository's default
-            branch.
+    ref
+        Branch, tag or commit specifying the desired git
+        revision. Defaults to the remote repository's default
+        branch.
 
-        keep-git-metadata
-            By default the ``.git`` directory is removed to save
-            disk space. Set to ``true`` to sync the git metadata
-            to guest as well.
+    keep-git-metadata
+        By default the ``.git`` directory is removed to save
+        disk space. Set to ``true`` to sync the git metadata
+        to guest as well.
 
-        There is a support for discovering tests from extracted
-        (rpm) sources. Needs to run on top of the supported
-        DistGit (Fedora, CentOS), ``url`` can be used to point to
-        such repository, ``path`` denotes path to the metadata
-        tree root within extracted sources. At this moment no
-        patches are applied, only tarball extraction happens.
+    There is a support for discovering tests from extracted
+    (rpm) sources. Needs to run on top of the supported
+    DistGit (Fedora, CentOS), ``url`` can be used to point to
+    such repository, ``path`` denotes path to the metadata
+    tree root within extracted sources. At this moment no
+    patches are applied, only tarball extraction happens.
 
-        dist-git-source
-            Set to ``true`` to enable extracting sources.
-        dist-git-type
-            The DistGit auto detection is based on git remotes.
-            Use this option to specify it directly. At least
-            ``Fedora`` and ``CentOS`` are supported as values,
-            help will print all possible values.
+    dist-git-source
+        Set to ``true`` to enable extracting sources.
+    dist-git-type
+        The DistGit auto detection is based on git remotes.
+        Use this option to specify it directly. At least
+        ``Fedora`` and ``CentOS`` are supported as values,
+        help will print all possible values.
 
-    example:
-      - |
-        # Define several local tests
-        discover:
-            how: shell
-            tests:
-              - name: /help/main
-                test: tmt --help
-              - name: /help/test
-                test: tmt test --help
-              - name: /help/smoke
-                test: ./smoke.sh
-                path: /tests/shell
-                duration: 1m
-      - |
-        # Fetch tests from a remote repository
-        discover:
-            how: shell
-            url: https://github.com/teemtee/tmt
-            tests:
-              - name: Use tests/full/test.sh from the remote repo
-                path: /tests/full
-                test: ./test.sh
+  example:
+    - |
+      # Define several local tests
+      discover:
+          how: shell
+          tests:
+            - name: /help/main
+              test: tmt --help
+            - name: /help/test
+              test: tmt test --help
+            - name: /help/smoke
+              test: ./smoke.sh
+              path: /tests/shell
+              duration: 1m
+    - |
+      # Fetch tests from a remote repository
+      discover:
+          how: shell
+          url: https://github.com/teemtee/tmt
+          tests:
+            - name: Use tests/full/test.sh from the remote repo
+              path: /tests/full
+              test: ./test.sh
 
-    link:
-      - implemented-by: /tmt/steps/discover/shell.py
+  link:
+    - implemented-by: /tmt/steps/discover/shell.py
 
 /fmf:
-    summary: Discover available tests using the fmf format
-    description: |
-        Use the `Flexible Metadata Format`_ to explore all
-        available tests in given repository. The following
-        parameters are supported:
+  summary: Discover available tests using the fmf format
+  description: |
+    Use the `Flexible Metadata Format`_ to explore all
+    available tests in given repository. The following
+    parameters are supported:
 
-        url
-            Git repository containing the metadata tree.
-            Current git repository used by default.
-        ref
-            Branch, tag or commit specifying the desired git
-            revision. Defaults to the remote repository's default
-            branch if url given or to the current ``HEAD`` if url
-            not provided.
+    url
+        Git repository containing the metadata tree.
+        Current git repository used by default.
+    ref
+        Branch, tag or commit specifying the desired git
+        revision. Defaults to the remote repository's default
+        branch if url given or to the current ``HEAD`` if url
+        not provided.
 
-            Additionally, one can set ``ref`` dynamically. This is
-            possible using a special file in tmt format stored in
-            the *default* branch of a tests repository. This special
-            file should contain rules assigning attribute ``ref``
-            in an `adjust` block, for example depending on a test
-            run context.
+        Additionally, one can set ``ref`` dynamically. This is
+        possible using a special file in tmt format stored in
+        the *default* branch of a tests repository. This special
+        file should contain rules assigning attribute ``ref``
+        in an `adjust` block, for example depending on a test
+        run context.
 
-            Dynamic ``ref`` assignment is enabled whenever a test
-            plan reference has the format ``ref: @FILEPATH``.
-        path
-            Path to the metadata tree root. Must be relative to
-            the git repository root if url provided, absolute
-            local filesystem path otherwise. By default ``.`` is
-            used.
+        Dynamic ``ref`` assignment is enabled whenever a test
+        plan reference has the format ``ref: @FILEPATH``.
+    path
+        Path to the metadata tree root. Must be relative to
+        the git repository root if url provided, absolute
+        local filesystem path otherwise. By default ``.`` is
+        used.
 
-        See also the `fmf identifier`_ documentation for details.
-        Use the following keys to limit the test discovery by test
-        name, an advanced filter or link:
+    See also the `fmf identifier`_ documentation for details.
+    Use the following keys to limit the test discovery by test
+    name, an advanced filter or link:
 
-        test
-            List of test names or regular expressions used to
-            select tests by name. Duplicate test names are allowed
-            to enable repetitive test execution, preserving the
-            listed test order.
-        link
-            Select tests using the :ref:`/spec/core/link` keys.
-            Values must be in the form of ``RELATION:TARGET``,
-            tests containing at least one of them are selected.
-            Regular expressions are supported for both relation
-            and target. Relation part can be omitted to match all
-            relations.
-        filter
-            Apply advanced filter based on test metadata
-            attributes. See ``pydoc fmf.filter`` for more info.
-        exclude
-            Exclude tests which match a regular expression.
+    test
+        List of test names or regular expressions used to
+        select tests by name. Duplicate test names are allowed
+        to enable repetitive test execution, preserving the
+        listed test order.
+    link
+        Select tests using the :ref:`/spec/core/link` keys.
+        Values must be in the form of ``RELATION:TARGET``,
+        tests containing at least one of them are selected.
+        Regular expressions are supported for both relation
+        and target. Relation part can be omitted to match all
+        relations.
+    filter
+        Apply advanced filter based on test metadata
+        attributes. See ``pydoc fmf.filter`` for more info.
+    exclude
+        Exclude tests which match a regular expression.
 
-        It is also possible to limit tests only to those that have
-        changed in git since a given revision. This can be
-        particularly useful when testing changes to tests
-        themselves (e.g. in a pull request CI). Related config
-        options (all optional) are:
+    It is also possible to limit tests only to those that have
+    changed in git since a given revision. This can be
+    particularly useful when testing changes to tests
+    themselves (e.g. in a pull request CI). Related config
+    options (all optional) are:
 
-        modified-only
-            Set to True if you want to filter modified tests only.
-            The test is modified if its name starts with the name
-            of any directory modified since modified-ref.
-        modified-url
-            An additional remote repository to be used as the
-            reference for comparison. Will be fetched as a
-            ``reference`` remote in the test dir.
-        modified-ref
-            The ref to compare against. Defaults to the local
-            repository's default branch. Note that you need to
-            specify ``reference/<branch>`` to compare to a branch
-            from the repository specified in ``modified-url``.
+    modified-only
+        Set to True if you want to filter modified tests only.
+        The test is modified if its name starts with the name
+        of any directory modified since modified-ref.
+    modified-url
+        An additional remote repository to be used as the
+        reference for comparison. Will be fetched as a
+        ``reference`` remote in the test dir.
+    modified-ref
+        The ref to compare against. Defaults to the local
+        repository's default branch. Note that you need to
+        specify ``reference/<branch>`` to compare to a branch
+        from the repository specified in ``modified-url``.
 
-        There is a support for discovering tests from extracted
-        (rpm) sources. Needs to run on top of the supported
-        DistGit (Fedora, CentOS), ``url`` can be used to point to
-        such repository, ``path`` denotes path to the metadata
-        tree root within extracted sources. At this moment no
-        patches are applied, only tarball extraction happens.
+    There is a support for discovering tests from extracted
+    (rpm) sources. Needs to run on top of the supported
+    DistGit (Fedora, CentOS), ``url`` can be used to point to
+    such repository, ``path`` denotes path to the metadata
+    tree root within extracted sources. At this moment no
+    patches are applied, only tarball extraction happens.
 
-        dist-git-source
-            Set to ``true`` to enable extracting sources.
-        dist-git-type
-            The DistGit auto detection is based on git remotes.
-            Use this option to specify it directly. At least
-            ``Fedora`` and ``CentOS`` are supported as values,
-            help will print all possible values.
+    dist-git-source
+        Set to ``true`` to enable extracting sources.
+    dist-git-type
+        The DistGit auto detection is based on git remotes.
+        Use this option to specify it directly. At least
+        ``Fedora`` and ``CentOS`` are supported as values,
+        help will print all possible values.
 
-        .. _fmf identifier: https://fmf.readthedocs.io/en/latest/concept.html#identifiers
-        .. _Flexible Metadata Format: https://fmf.readthedocs.io/
-    example: |
-        # Discover all fmf tests in the current repository
-        discover:
-            how: fmf
+    .. _fmf identifier: https://fmf.readthedocs.io/en/latest/concept.html#identifiers
+    .. _Flexible Metadata Format: https://fmf.readthedocs.io/
+  example: |
+    # Discover all fmf tests in the current repository
+    discover:
+      how: fmf
 
-        # Fetch tests from a remote repo, filter by name/tier
-        discover:
-            how: fmf
-            url: https://github.com/teemtee/tmt
-            ref: main
-            path: /metadata/tree/path
-            test: [regexp]
-            filter: tier:1
+    # Fetch tests from a remote repo, filter by name/tier
+    discover:
+        how: fmf
+        url: https://github.com/teemtee/tmt
+        ref: main
+        path: /metadata/tree/path
+        test: [regexp]
+        filter: tier:1
 
-        # Choose tests verifying given issue
-        discover:
-            how: fmf
-            link: verifies:issues/123$
+    # Choose tests verifying given issue
+    discover:
+        how: fmf
+        link: verifies:issues/123$
 
-        # Select only tests which have been modified
-        discover:
-            how: fmf
-            modified-only: true
-            modified-url: https://github.com/teemtee/tmt-official
-            modified-ref: reference/main
+    # Select only tests which have been modified
+    discover:
+        how: fmf
+        modified-only: true
+        modified-url: https://github.com/teemtee/tmt-official
+        modified-ref: reference/main
 
-        # Extract tests from the distgit sources
-        discover:
-            how: fmf
-            dist-git-source: true
-    link:
-      - implemented-by: /tmt/steps/discover/fmf.py
+    # Extract tests from the distgit sources
+    discover:
+        how: fmf
+        dist-git-source: true
+  link:
+    - implemented-by: /tmt/steps/discover/fmf.py
 
 /where:
-    summary: Execute tests on selected guests
-    description: |
-        In the :ref:`/spec/plans/provision/multihost` scenarios it
-        is often necessary to execute test code on selected guests
-        only or execute different test code on individual guests.
-        The ``where`` key allows to select guests where the tests
-        should be executed by providing their ``name`` or the
-        ``role`` they play in the scenario. Use a list to specify
-        multiple names or roles. By default, when the ``where`` key
-        is not defined, tests are executed on all provisioned
-        guests.
+  summary: Execute tests on selected guests
+  description: |
+    In the :ref:`/spec/plans/provision/multihost` scenarios it
+    is often necessary to execute test code on selected guests
+    only or execute different test code on individual guests.
+    The ``where`` key allows to select guests where the tests
+    should be executed by providing their ``name`` or the
+    ``role`` they play in the scenario. Use a list to specify
+    multiple names or roles. By default, when the ``where`` key
+    is not defined, tests are executed on all provisioned
+    guests.
 
-        There is also an alternative to the syntax using a ``where``
-        dictionary encapsulating the ``discover`` config under keys
-        corresponding to guest names or roles. This can result in
-        much more concise config especially when defining several
-        shell scripts for each guest or role.
+    There is also an alternative to the syntax using a ``where``
+    dictionary encapsulating the ``discover`` config under keys
+    corresponding to guest names or roles. This can result in
+    much more concise config especially when defining several
+    shell scripts for each guest or role.
 
-    example:
-      - |
-        # Run different script for each guest or role
-        discover:
-            how: shell
-            tests:
-              - name: run-the-client-code
-                test: client.py
-                where: client
-              - name: run-the-server-code
-                test: server.py
-                where: server
+  example:
+    - |
+      # Run different script for each guest or role
+      discover:
+          how: shell
+          tests:
+            - name: run-the-client-code
+              test: client.py
+              where: client
+            - name: run-the-server-code
+              test: server.py
+              where: server
 
-      - |
-        # Filter different set of tests for each guest or role
-        discover:
-          - how: fmf
-            filter: tag:client-tests
-            where: client
-          - how: fmf
-            filter: tag:server-tests
-            where: server
+    - |
+      # Filter different set of tests for each guest or role
+      discover:
+        - how: fmf
+          filter: tag:client-tests
+          where: client
+        - how: fmf
+          filter: tag:server-tests
+          where: server
 
-      - |
-        # Alternative syntax using the 'where' dictionary
-        # encapsulating for tests defined by fmf
-        discover:
-            where:
-                client:
-                  - how: fmf
-                    filter: tag:client-tests
-                server:
-                  - how: fmf
-                    filter: tag:server-tests
+    - |
+      # Alternative syntax using the 'where' dictionary
+      # encapsulating for tests defined by fmf
+      discover:
+          where:
+              client:
+                - how: fmf
+                  filter: tag:client-tests
+              server:
+                - how: fmf
+                  filter: tag:server-tests
 
-      - |
-        # Alternative syntax using the 'where' dictionary
-        # encapsulating for shell script tests
-        discover:
-            where:
-                server:
-                    how: shell
-                    tests:
-                      - test: first server script
-                      - test: second server script
-                      - test: third server script
-                client:
-                    how: shell
-                    tests:
-                      - test: first client script
-                      - test: second client script
-                      - test: third client script
+    - |
+      # Alternative syntax using the 'where' dictionary
+      # encapsulating for shell script tests
+      discover:
+          where:
+              server:
+                  how: shell
+                  tests:
+                    - test: first server script
+                    - test: second server script
+                    - test: third server script
+              client:
+                  how: shell
+                  tests:
+                    - test: first client script
+                    - test: second client script
+                    - test: third client script

--- a/spec/plans/environment-file.fmf
+++ b/spec/plans/environment-file.fmf
@@ -1,28 +1,28 @@
 summary: Environment variables from files
 
-description:
-    In addition to the :ref:`/spec/plans/environment` key it is
-    also possible to provide environment variables in a file.
-    Supported formats are dotenv/shell with ``KEY=VALUE`` pairs
-    and ``yaml``. Full `url` can be used to fetch variables from a
-    remote source. The ``environment`` key has a higher priority.
-    File path must be relative to the metadata tree root.
+description: >
+  In addition to the :ref:`/spec/plans/environment` key it is
+  also possible to provide environment variables in a file.
+  Supported formats are dotenv/shell with ``KEY=VALUE`` pairs
+  and ``yaml``. Full `url` can be used to fetch variables from a
+  remote source. The ``environment`` key has a higher priority.
+  File path must be relative to the metadata tree root.
 example: |
-    # Load from a dotenv/shell format
-    /plan:
-        environment-file:
-          - env
+  # Load from a dotenv/shell format
+  /plan:
+      environment-file:
+        - env
 
-    # Load from a yaml format
-    /plan:
-        environment-file:
-          - environment.yml
-          - environment.yaml
+  # Load from a yaml format
+  /plan:
+      environment-file:
+        - environment.yml
+        - environment.yaml
 
-    # Fetch from remote source
-    /plan:
-        environment-file:
-          - https://example.org/project/environment.yaml
+  # Fetch from remote source
+  /plan:
+      environment-file:
+        - https://example.org/project/environment.yaml
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/plans/environment.fmf
+++ b/spec/plans/environment.fmf
@@ -1,16 +1,16 @@
 summary: Environment variables
 
-description:
-    Specifies environment variables available in all steps.
-    Plugins need to include these environment variables while
-    running commands or other programs. These environment
-    variables override test :ref:`/spec/tests/environment` if
-    present. Command line option ``--environment`` can be used to
-    override environment variables defined in both tests and plan.
-    Use the :ref:`/spec/plans/environment-file` key to load
-    variables from files. The ``environment+`` notation can be
-    used to extend environment defined in the parent plan, see
-    also the :ref:`inherit-plans` section for more examples.
+description: >
+  Specifies environment variables available in all steps.
+  Plugins need to include these environment variables while
+  running commands or other programs. These environment
+  variables override test :ref:`/spec/tests/environment` if
+  present. Command line option ``--environment`` can be used to
+  override environment variables defined in both tests and plan.
+  Use the :ref:`/spec/plans/environment-file` key to load
+  variables from files. The ``environment+`` notation can be
+  used to extend environment defined in the parent plan, see
+  also the :ref:`inherit-plans` section for more examples.
 example:
   - |
     # Environment variables defined in a plan

--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -1,281 +1,280 @@
 summary: Define how tests should be executed
 
 description: |
-    Execute discovered tests in the provisioned environment using
-    selected test executor. By default tests are executed using
-    the internal ``tmt`` executor which allows to show detailed
-    progress of the testing and supports interactive debugging.
+  Execute discovered tests in the provisioned environment using
+  selected test executor. By default tests are executed using
+  the internal ``tmt`` executor which allows to show detailed
+  progress of the testing and supports interactive debugging.
 
-    This is a **required** attribute. Each plan has to define this
-    step.
+  This is a **required** attribute. Each plan has to define this
+  step.
 
-    For each test, a separate directory is created for storing
-    artifacts related to the test execution. Its path is
-    constructed from the test name and it's stored under the
-    ``execute/data`` directory. It contains a ``metadata.yaml``
-    file with the aggregated L1 metadata which can be used by the
-    test :ref:`/spec/tests/framework`. In addition to supported
-    :ref:`/spec/tests` attributes it also contains fmf ``name`` of
-    the test.
+  For each test, a separate directory is created for storing
+  artifacts related to the test execution. Its path is
+  constructed from the test name and it's stored under the
+  ``execute/data`` directory. It contains a ``metadata.yaml``
+  file with the aggregated L1 metadata which can be used by the
+  test :ref:`/spec/tests/framework`. In addition to supported
+  :ref:`/spec/tests` attributes it also contains fmf ``name`` of
+  the test.
 
-    In each plan, the execute step must produce a ``results.yaml`` file
-    with results for executed tests. The format of the file is described
-    at :ref:`/spec/plans/results`.
+  In each plan, the execute step must produce a ``results.yaml`` file
+  with results for executed tests. The format of the file is described
+  at :ref:`/spec/plans/results`.
 
 /upgrade:
-    summary: Perform system upgrades during testing
-    story:
-        As a tester I want to verify that a configured application
-        or service still correctly works after the system upgrade.
-    description: |
-        In order to enable developing tests for upgrade testing, we
-        need to provide a way how to execute these tests easily.
-        This does not cover unit tests for individual actors but
-        rather system tests which verify the whole upgrade story.
+  summary: Perform system upgrades during testing
+  story: >
+    As a tester I want to verify that a configured application
+    or service still correctly works after the system upgrade.
+  description: |
+    In order to enable developing tests for upgrade testing, we
+    need to provide a way how to execute these tests easily.
+    This does not cover unit tests for individual actors but
+    rather system tests which verify the whole upgrade story.
 
-        The ``upgrade`` executor runs the discovered tests (using
-        the internal executor, hence the same config options can
-        be used), then performs a set of upgrade tasks from
-        a remote repository, and finally, re-runs the tests on
-        the upgraded system.
+    The ``upgrade`` executor runs the discovered tests (using
+    the internal executor, hence the same config options can
+    be used), then performs a set of upgrade tasks from
+    a remote repository, and finally, re-runs the tests on
+    the upgraded system.
 
-        The ``IN_PLACE_UPGRADE`` environment variable is set during
-        the test execution to differentiate between the stages of
-        the test. It is set to ``old`` during the first execution
-        and ``new`` during the second execution. Test names are
-        prefixed with this value to make the names unique.
-        Based on this variable, the test can perform appropriate
-        actions.
+    The ``IN_PLACE_UPGRADE`` environment variable is set during
+    the test execution to differentiate between the stages of
+    the test. It is set to ``old`` during the first execution
+    and ``new`` during the second execution. Test names are
+    prefixed with this value to make the names unique.
+    Based on this variable, the test can perform appropriate
+    actions.
 
-        old
-            setup, test
-        new
-            test, cleanup
-        without
-            setup, test, cleanup
+    old
+        setup, test
+    new
+        test, cleanup
+    without
+        setup, test, cleanup
 
-        The upgrade tasks performing the actual system upgrade are
-        taken from a remote repository (specified by the ``url`` key)
-        based on an upgrade path (specified by the ``upgrade-path`` key)
-        or other filters (e.g. specified by the ``filter`` key).
-        If both ``upgrade-path`` and extra filters are specified,
-        the discover keys in the remote upgrade path plan are overridden
-        by the filters specified in the local plan.
+    The upgrade tasks performing the actual system upgrade are
+    taken from a remote repository (specified by the ``url`` key)
+    based on an upgrade path (specified by the ``upgrade-path`` key)
+    or other filters (e.g. specified by the ``filter`` key).
+    If both ``upgrade-path`` and extra filters are specified,
+    the discover keys in the remote upgrade path plan are overridden
+    by the filters specified in the local plan.
 
-        The upgrade path must correspond to a plan name in the remote
-        repository whose discover selects tests (upgrade tasks).
-        The environment variables defined in the upgrade path are passed
-        to the upgrade tasks.
-    example:
-      - |
-        # Main testing plan
-        discover:
-            how: fmf
-        execute:
-            how: upgrade
-            url: https://github.com/teemtee/upgrade
-            upgrade-path: /paths/fedora35to36
+    The upgrade path must correspond to a plan name in the remote
+    repository whose discover selects tests (upgrade tasks).
+    The environment variables defined in the upgrade path are passed
+    to the upgrade tasks.
+  example:
+    - |
+      # Main testing plan
+      discover:
+          how: fmf
+      execute:
+          how: upgrade
+          url: https://github.com/teemtee/upgrade
+          upgrade-path: /paths/fedora35to36
 
-      - |
-        # Upgrade path /paths/fedora35to36.fmf in the remote repository
-        discover: # Selects appropriate upgrade tasks (L1 tests)
-            how: fmf
-            filter: "tag:fedora"
-        environment: # This is passed to upgrade tasks
-            SOURCE: 35
-            TARGET: 36
-        execute:
-            how: tmt
+    - |
+      # Upgrade path /paths/fedora35to36.fmf in the remote repository
+      discover: # Selects appropriate upgrade tasks (L1 tests)
+          how: fmf
+          filter: "tag:fedora"
+      environment: # This is passed to upgrade tasks
+          SOURCE: 35
+          TARGET: 36
+      execute:
+          how: tmt
 
-      - |
-        # Alternative main testing plan, without upgrade path
-        execute:
-            how: upgrade
-            url: https://github.com/teemtee/upgrade
-            filter: "tag:fedora"
+    - |
+      # Alternative main testing plan, without upgrade path
+      execute:
+          how: upgrade
+          url: https://github.com/teemtee/upgrade
+          filter: "tag:fedora"
 
-      - |
-        # A simple beakerlib test using the $IN_PLACE_UPGRADE variable
-        . /usr/share/beakerlib/beakerlib.sh || exit 1
+    - |
+      # A simple beakerlib test using the $IN_PLACE_UPGRADE variable
+      . /usr/share/beakerlib/beakerlib.sh || exit 1
 
-        VENV_PATH=/var/tmp/venv_test
+      VENV_PATH=/var/tmp/venv_test
 
-        rlJournalStart
-            # Perform the setup only for the old distro
-            if [[ "$IN_PLACE_UPGRADE" !=  "new" ]]; then
-                rlPhaseStartSetup
-                    rlRun "python3.9 -m venv $VENV_PATH"
-                    rlRun "$VENV_PATH/bin/pip install pyjokes"
-                rlPhaseEnd
-            fi
+      rlJournalStart
+          # Perform the setup only for the old distro
+          if [[ "$IN_PLACE_UPGRADE" !=  "new" ]]; then
+              rlPhaseStartSetup
+                  rlRun "python3.9 -m venv $VENV_PATH"
+                  rlRun "$VENV_PATH/bin/pip install pyjokes"
+              rlPhaseEnd
+          fi
 
-            # Execute the test for both old & new distro
-            rlPhaseStartTest
-                rlAsssertExists "$VENV_PATH/bin/pyjoke"
-                rlRun "$VENV_PATH/bin/pyjoke"
-            rlPhaseEnd
+          # Execute the test for both old & new distro
+          rlPhaseStartTest
+              rlAsssertExists "$VENV_PATH/bin/pyjoke"
+              rlRun "$VENV_PATH/bin/pyjoke"
+          rlPhaseEnd
 
-            # Skip the cleanup phase when on the old distro
-            if [[ "$IN_PLACE_UPGRADE" !=  "old" ]]; then
-                rlPhaseStartCleanup
-                    rlRun "rm -rf $VENV_PATH"
-                rlPhaseEnd
-            fi
-        rlJournalEnd
+          # Skip the cleanup phase when on the old distro
+          if [[ "$IN_PLACE_UPGRADE" !=  "old" ]]; then
+              rlPhaseStartCleanup
+                  rlRun "rm -rf $VENV_PATH"
+              rlPhaseEnd
+          fi
+      rlJournalEnd
 
-    link:
-      - implemented-by: /tmt/steps/execute/upgrade.py
-      - verified-by: /tests/execute/upgrade
-
+  link:
+    - implemented-by: /tmt/steps/execute/upgrade.py
+    - verified-by: /tests/execute/upgrade
 
 /isolate:
-    summary: Run tests in an isolated environment
-    description:
-        Optional boolean attribute `isolate` can be used to
-        request a clean test environment for each test.
-    example: |
-        execute:
-            how: tmt
-            isolate: true
+  summary: Run tests in an isolated environment
+  description: >
+    Optional boolean attribute `isolate` can be used to
+    request a clean test environment for each test.
+  example: |
+    execute:
+        how: tmt
+        isolate: true
 
 /exit-first:
-    summary: Stop execution after a test fails
-    story:
-        As a user I want to avoid waiting for all discovered
-        tests to finish if one of them fails.
-    description:
-        Optional boolean attribute `exit-first` can be used to
-        make the executor stop executing tests once a test
-        failure is encountered.
-    example: |
-        execute:
-            how: tmt
-            exit-first: true
-    link:
-      - implemented-by: /tmt/steps/execute/internal.py
-      - verified-by: /tests/execute/exit-first
+  summary: Stop execution after a test fails
+  story: >
+    As a user I want to avoid waiting for all discovered
+    tests to finish if one of them fails.
+  description: >
+    Optional boolean attribute `exit-first` can be used to
+    make the executor stop executing tests once a test
+    failure is encountered.
+  example: |
+    execute:
+        how: tmt
+        exit-first: true
+  link:
+    - implemented-by: /tmt/steps/execute/internal.py
+    - verified-by: /tests/execute/exit-first
 
 /tmt:
-    summary: Internal test executor
-    story: As a user I want to execute tests directly from tmt.
-    description: |
-        The internal ``tmt`` executor runs tests in the
-        provisioned environment one by one directly from the
-        tmt code which allows features such as showing live
-        :ref:`/stories/cli/steps/execute/progress` or the
-        :ref:`/stories/cli/steps/execute/interactive` session .
-        This is the default execute step implementation.
+  summary: Internal test executor
+  story: As a user I want to execute tests directly from tmt.
+  description: |
+    The internal ``tmt`` executor runs tests in the
+    provisioned environment one by one directly from the
+    tmt code which allows features such as showing live
+    :ref:`/stories/cli/steps/execute/progress` or the
+    :ref:`/stories/cli/steps/execute/interactive` session .
+    This is the default execute step implementation.
 
-        The executor provides following shell scripts which can
-        be used by the tests for certain operations.
+    The executor provides following shell scripts which can
+    be used by the tests for certain operations.
 
-        ``tmt-file-submit``
-            Archive the given file in the tmt test data directory.
-            See the :ref:`/stories/features/report-log` section
-            for more details.
+    ``tmt-file-submit``
+        Archive the given file in the tmt test data directory.
+        See the :ref:`/stories/features/report-log` section
+        for more details.
 
-        ``tmt-reboot``
-            Soft reboot the machine from inside the test. After reboot
-            the execution starts from the test which rebooted the machine.
-            An environment variable ``TMT_REBOOT_COUNT`` is provided which
-            the test can use to handle the reboot. The variable holds the
-            number of reboots performed by the test. For more information
-            see the :ref:`/stories/features/reboot` feature documentation.
+    ``tmt-reboot``
+        Soft reboot the machine from inside the test. After reboot
+        the execution starts from the test which rebooted the machine.
+        An environment variable ``TMT_REBOOT_COUNT`` is provided which
+        the test can use to handle the reboot. The variable holds the
+        number of reboots performed by the test. For more information
+        see the :ref:`/stories/features/reboot` feature documentation.
 
-        ``tmt-report-result``
-            Generate a result report file from inside the test. Can be
-            called multiple times by the test. The generated report
-            file will be overwritten if a higher hierarchical result is
-            reported by the test. The hierarchy is as follows:
-            SKIP, PASS, WARN, FAIL.
-            For more information see the
-            :ref:`/stories/features/report-result` feature documentation.
+    ``tmt-report-result``
+        Generate a result report file from inside the test. Can be
+        called multiple times by the test. The generated report
+        file will be overwritten if a higher hierarchical result is
+        reported by the test. The hierarchy is as follows:
+        SKIP, PASS, WARN, FAIL.
+        For more information see the
+        :ref:`/stories/features/report-result` feature documentation.
 
-        ``tmt-abort``
-            Generate an abort file from inside the test. This will
-            set the current test result to failed and terminate
-            the execution of subsequent tests.
-            For more information see the
-            :ref:`/stories/features/abort` feature documentation.
+    ``tmt-abort``
+        Generate an abort file from inside the test. This will
+        set the current test result to failed and terminate
+        the execution of subsequent tests.
+        For more information see the
+        :ref:`/stories/features/abort` feature documentation.
 
-    example: |
-        execute:
-            how: tmt
-    link:
-      - implemented-by: /tmt/steps/execute/internal.py
-      - verified-by: /tests/execute/framework
+  example: |
+    execute:
+        how: tmt
+  link:
+    - implemented-by: /tmt/steps/execute/internal.py
+    - verified-by: /tests/execute/framework
 
 /script:
-    summary: Execute shell scripts
-    story: As a user I want to easily run shell script as a test.
+  summary: Execute shell scripts
+  story: As a user I want to easily run shell script as a test.
+  description: |
+    Execute arbitratry shell commands and check their exit
+    code which is used as a test result. The ``script`` field
+    is provided to cover simple test use cases only and must
+    not be combined with the :ref:`/spec/plans/discover` step
+    which is more suitable for more complex test scenarios.
+
+    Default shell options are applied to the script, see
+    :ref:`/spec/tests/test` for more details. The default
+    :ref:`/spec/tests/duration` for tests defined directly
+    under the execute step is ``1h``. Use the ``duration``
+    attribute to modify the default limit.
+
+  example:
+    - |
+      # Run a simple smoke test
+      execute:
+          how: tmt
+          script: tmt --help
+    - |
+      # Modify the default maximum duration
+      execute:
+          how: tmt
+          script: a-long-test-suite
+          duration: 3h
+  link:
+    - implemented-by: /tmt/steps/execute/internal.py
+
+  /simple:
+    summary: Simple use case should be super simple to write
+    title: The simplest usage
     description: |
-        Execute arbitratry shell commands and check their exit
-        code which is used as a test result. The ``script`` field
-        is provided to cover simple test use cases only and must
-        not be combined with the :ref:`/spec/plans/discover` step
-        which is more suitable for more complex test scenarios.
+      As the `how` keyword can be omitted when using the
+      default executor you can just define the shell
+      `script` to be run. This is how a minimal smoke test
+      configuration for the `tmt` command can look like:
+    example: |
+      execute:
+          script: tmt --help
 
-        Default shell options are applied to the script, see
-        :ref:`/spec/tests/test` for more details. The default
-        :ref:`/spec/tests/duration` for tests defined directly
-        under the execute step is ``1h``. Use the ``duration``
-        attribute to modify the default limit.
+  /several:
+    summary: Multiple shell commands
+    title: Multiple commands
+    description: >
+      You can also include several commands as a list.
+      Executor will run commands one-by-one and check exit
+      code of each.
+    example: |
+      execute:
+          script:
+            - dnf -y install httpd curl
+            - systemctl start httpd
+            - echo foo > /var/www/html/index.html
+            - curl http://localhost/ | grep foo
 
-    example:
-      - |
-        # Run a simple smoke test
-        execute:
-            how: tmt
-            script: tmt --help
-      - |
-        # Modify the default maximum duration
-        execute:
-            how: tmt
-            script: a-long-test-suite
-            duration: 3h
-    link:
-      - implemented-by: /tmt/steps/execute/internal.py
-
-    /simple:
-        summary: Simple use case should be super simple to write
-        title: The simplest usage
-        description: |
-            As the `how` keyword can be omitted when using the
-            default executor you can just define the shell
-            `script` to be run. This is how a minimal smoke test
-            configuration for the `tmt` command can look like:
-        example: |
-            execute:
-                script: tmt --help
-
-    /several:
-        summary: Multiple shell commands
-        title: Multiple commands
-        description:
-            You can also include several commands as a list.
-            Executor will run commands one-by-one and check exit
-            code of each.
-        example: |
-            execute:
-                script:
-                  - dnf -y install httpd curl
-                  - systemctl start httpd
-                  - echo foo > /var/www/html/index.html
-                  - curl http://localhost/ | grep foo
-
-    /multi:
-        summary: Multi-line shell script
-        title: Multi-line script
-        description:
-            Providing a multi-line shell script is also supported.
-            Note that the first command with non-zero exit code
-            will finish the execution. See the
-            :ref:`/spec/tests/test` key for details about default
-            shell options.
-        example: |
-            execute:
-                script: |
-                    dnf -y install httpd curl
-                    systemctl start httpd
-                    echo foo > /var/www/html/index.html
-                    curl http://localhost/ | grep foo
+  /multi:
+    summary: Multi-line shell script
+    title: Multi-line script
+    description: >
+      Providing a multi-line shell script is also supported.
+      Note that the first command with non-zero exit code
+      will finish the execution. See the
+      :ref:`/spec/tests/test` key for details about default
+      shell options.
+    example: |
+      execute:
+          script: |
+              dnf -y install httpd curl
+              systemctl start httpd
+              echo foo > /var/www/html/index.html
+              curl http://localhost/ | grep foo

--- a/spec/plans/finish.fmf
+++ b/spec/plans/finish.fmf
@@ -1,55 +1,53 @@
 summary: Finishing tasks
 
-description:
-    Additional actions to be performed after the test execution
-    has been completed.  Counterpart of the ``prepare`` step
-    useful for various cleanup actions. Use the
-    :ref:`/spec/core/order` attribute to select in which order
-    finishing tasks should happen if there are multiple configs.
-    Default order is ``50``.
+description: >
+  Additional actions to be performed after the test execution
+  has been completed.  Counterpart of the ``prepare`` step
+  useful for various cleanup actions. Use the
+  :ref:`/spec/core/order` attribute to select in which order
+  finishing tasks should happen if there are multiple configs.
+  Default order is ``50``.
 
 example: |
-    finish:
-        how: shell
-        script: upload-logs.sh
+  finish:
+      how: shell
+      script: upload-logs.sh
 
 /shell:
-    summary:
-        Perform finishing tasks using shell (bash) scripts
-    description:
-        Execute arbitrary shell commands to finish the testing.
+  summary: Perform finishing tasks using shell (bash) scripts
+  description: >
+    Execute arbitrary shell commands to finish the testing.
 
-        Default shell options are applied to the script, see the
-        :ref:`/spec/tests/test` key specification for more
-        details.
+    Default shell options are applied to the script, see the
+    :ref:`/spec/tests/test` key specification for more
+    details.
 
-    example: |
-        finish:
-            how: shell
-            script:
-            - upload-logs.sh || true
-            - rm -rf /tmp/temporary-files
-    link:
-      - implemented-by: /tmt/steps/finish/shell.py
+  example: |
+    finish:
+        how: shell
+        script:
+        - upload-logs.sh || true
+        - rm -rf /tmp/temporary-files
+  link:
+    - implemented-by: /tmt/steps/finish/shell.py
 
 /ansible:
-    summary:
-        Perform finishing tasks using ansible
-    description: |
-        One or more playbooks can be provided as a list under the
-        ``playbook`` attribute.  Each of them will be applied
-        using ``ansible-playbook`` in the given order. The path
-        must be relative to the metadata tree root.
+  summary: Perform finishing tasks using ansible
+  description: |
+    One or more playbooks can be provided as a list under the
+    ``playbook`` attribute.  Each of them will be applied
+    using ``ansible-playbook`` in the given order. The path
+    must be relative to the metadata tree root.
 
-        Remote playbooks can be referenced as well as the local ones,
-        and both kinds can be used at the same time.
+    Remote playbooks can be referenced as well as the local ones,
+    and both kinds can be used at the same time.
 
-    example: |
-        finish:
-            how: ansible
-            playbook:
-                - playbooks/common.yml
-                - playbooks/os/rhel7.yml
-                - https://foo.bar/rhel7-final-touches.yml
-    link:
-      - implemented-by: /tmt/steps/finish/ansible.py
+  example: |
+    finish:
+        how: ansible
+        playbook:
+            - playbooks/common.yml
+            - playbooks/os/rhel7.yml
+            - https://foo.bar/rhel7-final-touches.yml
+  link:
+    - implemented-by: /tmt/steps/finish/ansible.py

--- a/spec/plans/gate.fmf
+++ b/spec/plans/gate.fmf
@@ -1,48 +1,48 @@
 summary: Gates relevant for testing
 
 description: |
-    Multiple gates can be defined in the process of releasing a change.
-    Currently we define the following gates:
+  Multiple gates can be defined in the process of releasing a change.
+  Currently we define the following gates:
 
-    merge-pull-request
-        block merging a pull request into a git branch
-    add-build-to-update
-        attaching a build to an erratum / bodhi update
-    add-build-to-compose
-        block adding a build to a compose
-    release-update
-        block releasing an erratum / bodhi update
+  merge-pull-request
+      block merging a pull request into a git branch
+  add-build-to-update
+      attaching a build to an erratum / bodhi update
+  add-build-to-compose
+      block adding a build to a compose
+  release-update
+      block releasing an erratum / bodhi update
 
-    Each plan can define one or more gates it should be blocking.
-    Attached is an example of configuring multiple gates.
+  Each plan can define one or more gates it should be blocking.
+  Attached is an example of configuring multiple gates.
 
 example: |
-    /test:
-        /pull-request:
-            /pep:
-                summary: All code must comply with the PEP8 style guide
-                # Do not allow ugly code to be merged into the main branch
-                gate:
-                    - merge-pull-request
-            /lint:
-                summary: Run pylint to catch common problems (no gating)
-        /build:
-            /smoke:
-                summary: Basic smoke test (Tier1)
-                # Basic smoke test is used by three gates
-                gate:
-                    - merge-pull-request
-                    - add-build-to-update
-                    - add-build-to-compose
-            /features:
-                summary: Verify important features
-        /update:
-            # This enables the 'release-update' gate for all three plans
-            gate:
-                - release-update
-            /basic:
-                summary: Run all Tier1, Tier2 and Tier3 tests
-            /security:
-                summary: Security tests (extra job to get quick results)
-            /integration:
-                summary: Integration tests with related components
+  /test:
+      /pull-request:
+          /pep:
+              summary: All code must comply with the PEP8 style guide
+              # Do not allow ugly code to be merged into the main branch
+              gate:
+                  - merge-pull-request
+          /lint:
+              summary: Run pylint to catch common problems (no gating)
+      /build:
+          /smoke:
+              summary: Basic smoke test (Tier1)
+              # Basic smoke test is used by three gates
+              gate:
+                  - merge-pull-request
+                  - add-build-to-update
+                  - add-build-to-compose
+          /features:
+              summary: Verify important features
+      /update:
+          # This enables the 'release-update' gate for all three plans
+          gate:
+              - release-update
+          /basic:
+              summary: Run all Tier1, Tier2 and Tier3 tests
+          /security:
+              summary: Security tests (extra job to get quick results)
+          /integration:
+              summary: Integration tests with related components

--- a/spec/plans/guest-topology.fmf
+++ b/spec/plans/guest-topology.fmf
@@ -3,104 +3,104 @@ title: Guest Topology Format
 order: 95
 
 description: |
-    The following text defines structure of files tmt uses for exposing
-    guest names, roles and other properties to tests and steps that run
-    on a guest (:ref:`prepare </spec/plans/prepare>`,
-    :ref:`execute </spec/plans/execute>`, :ref:`finish </spec/plans/finish>`).
-    tmt saves these files on every guest used, and exposes their paths to
-    processes started by tmt on these guests through environment variables:
+  The following text defines structure of files tmt uses for exposing
+  guest names, roles and other properties to tests and steps that run
+  on a guest (:ref:`prepare </spec/plans/prepare>`,
+  :ref:`execute </spec/plans/execute>`, :ref:`finish </spec/plans/finish>`).
+  tmt saves these files on every guest used, and exposes their paths to
+  processes started by tmt on these guests through environment variables:
 
-    * ``TMT_TOPOLOGY_YAML`` for a YAML file
-    * ``TMT_TOPOLOGY_BASH`` for a shell-friendly ``NAME=VALUE`` file
+  * ``TMT_TOPOLOGY_YAML`` for a YAML file
+  * ``TMT_TOPOLOGY_BASH`` for a shell-friendly ``NAME=VALUE`` file
 
-    Both files are always available, and both carry the same information.
+  Both files are always available, and both carry the same information.
 
-    .. warning::
+  .. warning::
 
-        The shell-friendly file contains arrays, therefore it's compatible
-        with Bash 4.x and newer.
+      The shell-friendly file contains arrays, therefore it's compatible
+      with Bash 4.x and newer.
 
-    .. note::
+  .. note::
 
-        The shell-friendly file is easy to ingest for a shell-based tests,
-        it can be simply ``source``-ed. For parsing the YAML file in shell,
-        pure shell parsers like https://github.com/sopos/yash can be used.
+      The shell-friendly file is easy to ingest for a shell-based tests,
+      it can be simply ``source``-ed. For parsing the YAML file in shell,
+      pure shell parsers like https://github.com/sopos/yash can be used.
 
-    .. code-block:: yaml
-        :caption: TMT_TOPOLOGY_YAML
+  .. code-block:: yaml
+      :caption: TMT_TOPOLOGY_YAML
 
-        # Guest on which the test or script is running.
-        guest:
-            name: ...
-            role: ...
-            hostname: ...
+      # Guest on which the test or script is running.
+      guest:
+          name: ...
+          role: ...
+          hostname: ...
 
-        # List of names of all provisioned guests.
-        guest-names:
-          - guest1
-          - guest2
+      # List of names of all provisioned guests.
+      guest-names:
+        - guest1
+        - guest2
+        ...
+
+      # Same as `guest`, but one for each provisioned guest, with guest names
+      # as keys.
+      guests:
+          guest1:
+              name: guest1
+              role: ...
+              hostname: ...
+          guest2:
+              name: guest2
+              role: ...
+              hostname: ...
           ...
 
-        # Same as `guest`, but one for each provisioned guest, with guest names
-        # as keys.
-        guests:
-            guest1:
-                name: guest1
-                role: ...
-                hostname: ...
-            guest2:
-                name: guest2
-                role: ...
-                hostname: ...
+      # List of all known roles.
+      role-names:
+        - role1
+        - role2
+        ...
+
+      # Roles and their guests, with role names as keys.
+      roles:
+          role1:
+            - guest1
+            - guest2
+            - ...
+          role2:
+            - guestN
             ...
 
-        # List of all known roles.
-        role-names:
-          - role1
-          - role2
-          ...
+  .. code-block:: bash
+      :caption: TMT_TOPOLOGY_BASH
 
-        # Roles and their guests, with role names as keys.
-        roles:
-            role1:
-              - guest1
-              - guest2
-              - ...
-            role2:
-              - guestN
-              ...
+      # Guest on which the test is running.
+      declare -A TMT_GUEST
+      TMT_GUEST[name]="..."
+      TMT_GUEST[role]="..."
+      TMT_GUEST[hostname]="..."
 
-    .. code-block:: bash
-        :caption: TMT_TOPOLOGY_BASH
+      # Space-separated list of names of all provisioned guests.
+      TMT_GUEST_NAMES="guest1 guest2 ..."
 
-        # Guest on which the test is running.
-        declare -A TMT_GUEST
-        TMT_GUEST[name]="..."
-        TMT_GUEST[role]="..."
-        TMT_GUEST[hostname]="..."
+      # Same as `guest`, but one for each provisioned guest. Keys are constructed
+      # from guest name and the property name.
+      declare -A TMT_GUESTS
+      TMT_GUESTS[guest1.name]="guest1"
+      TMT_GUESTS[guest1.role]="..."
+      TMT_GUESTS[guest1.hostname]="..."
+      TMT_GUESTS[guest2.name]="guest2"
+      TMT_GUESTS[guest2.role]="..."
+      TMT_GUESTS[guest2.hostname]="..."
+      ...
 
-        # Space-separated list of names of all provisioned guests.
-        TMT_GUEST_NAMES="guest1 guest2 ..."
+      # Space-separated list of all known roles.
+      TMT_ROLE_NAMES="client server"
 
-        # Same as `guest`, but one for each provisioned guest. Keys are constructed
-        # from guest name and the property name.
-        declare -A TMT_GUESTS
-        TMT_GUESTS[guest1.name]="guest1"
-        TMT_GUESTS[guest1.role]="..."
-        TMT_GUESTS[guest1.hostname]="..."
-        TMT_GUESTS[guest2.name]="guest2"
-        TMT_GUESTS[guest2.role]="..."
-        TMT_GUESTS[guest2.hostname]="..."
-        ...
-
-        # Space-separated list of all known roles.
-        TMT_ROLE_NAMES="client server"
-
-        # Roles and their guests, with role names as keys.
-        declare -A TMT_ROLES
-        TMT_ROLES[role1]="guest1 guest2 ..."
-        TMT_ROLES[role2]="guestN ..."
-        ...
+      # Roles and their guests, with role names as keys.
+      declare -A TMT_ROLES
+      TMT_ROLES[role1]="guest1 guest2 ..."
+      TMT_ROLES[role2]="guestN ..."
+      ...
 
 example:
   - |

--- a/spec/plans/import.fmf
+++ b/spec/plans/import.fmf
@@ -2,36 +2,36 @@ summary: Importing plans from a remote repository
 title: Import Plans
 order: 90
 
-story:
-    As a user I want to reference a plan from a remote repository
-    in order to prevent duplication and minimize maintenance.
+story: >
+  As a user I want to reference a plan from a remote repository
+  in order to prevent duplication and minimize maintenance.
 
 description: |
-    In some cases the configuration stored in a plan can be quite
-    large, for example the :ref:`/spec/plans/prepare` step can
-    define complex scripts to set up the guest for testing. Using
-    a reference to a remote plan makes it possible to reuse the
-    same config on multiple places without the need to duplicate
-    the information. This can be useful for example when enabling
-    integration testing between related components.
+  In some cases the configuration stored in a plan can be quite
+  large, for example the :ref:`/spec/plans/prepare` step can
+  define complex scripts to set up the guest for testing. Using
+  a reference to a remote plan makes it possible to reuse the
+  same config on multiple places without the need to duplicate
+  the information. This can be useful for example when enabling
+  integration testing between related components.
 
-    Remote plans are identified by the ``plan`` key which must
-    contain an ``import`` dictionary with an `fmf identifier`__ of
-    the remote plan. The ``url`` and ``name`` keys have to be
-    defined, ``ref`` and ``path`` are optional. Only one remote
-    plan can be referenced and a full plan ``name`` must be used
-    (no string matching is applied).
+  Remote plans are identified by the ``plan`` key which must
+  contain an ``import`` dictionary with an `fmf identifier`__ of
+  the remote plan. The ``url`` and ``name`` keys have to be
+  defined, ``ref`` and ``path`` are optional. Only one remote
+  plan can be referenced and a full plan ``name`` must be used
+  (no string matching is applied).
 
-    Plan steps must not be defined in the remote plan reference.
-    Inheriting or overriding remote plan config with local plan
-    steps might be possible in the future but currently is not
-    supported. The only way how to modify imported plan is via
-    environment variables. Variables defined in the plan override
-    any variables defined in the remote plan.
+  Plan steps must not be defined in the remote plan reference.
+  Inheriting or overriding remote plan config with local plan
+  steps might be possible in the future but currently is not
+  supported. The only way how to modify imported plan is via
+  environment variables. Variables defined in the plan override
+  any variables defined in the remote plan.
 
-    .. versionadded:: 1.19
+  .. versionadded:: 1.19
 
-    __ https://fmf.readthedocs.io/en/latest/concept.html#identifiers
+  __ https://fmf.readthedocs.io/en/latest/concept.html#identifiers
 
 example:
   - |

--- a/spec/plans/main.fmf
+++ b/spec/plans/main.fmf
@@ -1,60 +1,60 @@
-story:
-    As a tester I want to easily execute selected tests or
-    selected test steps in given environment.
+story: >
+  As a tester I want to easily execute selected tests or
+  selected test steps in given environment.
 
 description: |
-    **Plans**, also called L2 metadata, are used to group relevant
-    tests and enable the CI. They describe how to `discover` tests
-    for execution, how to `provision` the environment, how to
-    `prepare` it for testing, how to `execute` tests, `report`
-    results and finally how to `finish` the test job.
+  **Plans**, also called L2 metadata, are used to group relevant
+  tests and enable the CI. They describe how to `discover` tests
+  for execution, how to `provision` the environment, how to
+  `prepare` it for testing, how to `execute` tests, `report`
+  results and finally how to `finish` the test job.
 
-    Each of the six steps mentioned above supports multiple
-    implementations.  The default methods are listed below.
+  Each of the six steps mentioned above supports multiple
+  implementations.  The default methods are listed below.
 
-     * :ref:`/spec/plans/discover`: shell
-     * :ref:`/spec/plans/provision`: virtual
-     * :ref:`/spec/plans/prepare`: shell
-     * :ref:`/spec/plans/execute`: tmt
-     * :ref:`/spec/plans/report`: display
-     * :ref:`/spec/plans/finish`: shell
+   * :ref:`/spec/plans/discover`: shell
+   * :ref:`/spec/plans/provision`: virtual
+   * :ref:`/spec/plans/prepare`: shell
+   * :ref:`/spec/plans/execute`: tmt
+   * :ref:`/spec/plans/report`: display
+   * :ref:`/spec/plans/finish`: shell
 
-    Thanks to clearly separated test steps it is possible to run
-    only selected steps, for example ``tmt run discover`` to see
-    which tests would be executed.
+  Thanks to clearly separated test steps it is possible to run
+  only selected steps, for example ``tmt run discover`` to see
+  which tests would be executed.
 
-    In addition to the attributes defined here, plans also support
-    common :ref:`/spec/core` attributes which are shared across
-    all metadata levels.
+  In addition to the attributes defined here, plans also support
+  common :ref:`/spec/core` attributes which are shared across
+  all metadata levels.
 
 example: |
-    # Enabled a minimal smoke test
-    execute:
-        script: foo --version
+  # Enabled a minimal smoke test
+  execute:
+      script: foo --version
 
-    # Run tier one tests in a container
-    discover:
-        how: fmf
-        filter: tier:1
-    provision:
-        how: container
-    execute:
-        how: tmt
+  # Run tier one tests in a container
+  discover:
+      how: fmf
+      filter: tier:1
+  provision:
+      how: container
+  execute:
+      how: tmt
 
-    # Verify that apache can serve pages
-    summary: Basic httpd smoke test
-    provision:
-        how: virtual
-        memory: 4096
-    prepare:
-      - name: packages
-        how: install
-        package: [httpd, curl]
-      - name: service
-        how: shell
-        script: systemctl start httpd
-    execute:
-        how: shell
-        script:
-        - echo foo > /var/www/html/index.html
-        - curl http://localhost/ | grep foo
+  # Verify that apache can serve pages
+  summary: Basic httpd smoke test
+  provision:
+      how: virtual
+      memory: 4096
+  prepare:
+    - name: packages
+      how: install
+      package: [httpd, curl]
+    - name: service
+      how: shell
+      script: systemctl start httpd
+  execute:
+      how: shell
+      script:
+      - echo foo > /var/www/html/index.html
+      - curl http://localhost/ | grep foo

--- a/spec/plans/prepare.fmf
+++ b/spec/plans/prepare.fmf
@@ -1,171 +1,168 @@
 summary: Prepare the environment for testing
 
 description: |
-    The ``prepare`` step is used to define how the guest
-    environment should be prepared so that the tests can be
-    successfully executed.
+  The ``prepare`` step is used to define how the guest
+  environment should be prepared so that the tests can be
+  successfully executed.
 
-    The :ref:`/spec/plans/prepare/install` plugin provides an easy
-    way to install required or recommended packages from disk and
-    from the offical distribution or copr repositories. Use the
-    :ref:`/spec/plans/prepare/ansible` plugin for applying custom
-    playbooks or execute :ref:`/spec/plans/prepare/shell` scripts
-    to perform arbitrary preparation tasks.
+  The :ref:`/spec/plans/prepare/install` plugin provides an easy
+  way to install required or recommended packages from disk and
+  from the offical distribution or copr repositories. Use the
+  :ref:`/spec/plans/prepare/ansible` plugin for applying custom
+  playbooks or execute :ref:`/spec/plans/prepare/shell` scripts
+  to perform arbitrary preparation tasks.
 
-    Use the ``order`` attribute to select in which order the
-    preparation should happen if there are multiple configs.
-    Default order is ``50``. For installation of required packages
-    gathered from the :ref:`/spec/tests/require` attribute of
-    individual tests order ``70`` is used, for recommended
-    packages it is ``75``.
+  Use the ``order`` attribute to select in which order the
+  preparation should happen if there are multiple configs.
+  Default order is ``50``. For installation of required packages
+  gathered from the :ref:`/spec/tests/require` attribute of
+  individual tests order ``70`` is used, for recommended
+  packages it is ``75``.
 
-    .. note::
+  .. note::
 
-        If you want to use the ``prepare`` step to generate data
-        files needed for testing during the ``execute`` step,
-        move or copy them into ``${TMT_PLAN_DATA}`` directory. Only
-        files in this directory are guaranteed to be preserved.
+      If you want to use the ``prepare`` step to generate data
+      files needed for testing during the ``execute`` step,
+      move or copy them into ``${TMT_PLAN_DATA}`` directory. Only
+      files in this directory are guaranteed to be preserved.
 
 example: |
-    # Install fresh packages from a custom copr repository
-    prepare:
-      - how: install
-        copr: psss/tmt
-        package: tmt-all
+  # Install fresh packages from a custom copr repository
+  prepare:
+    - how: install
+      copr: psss/tmt
+      package: tmt-all
 
-    # Install required packages and start the service
-    prepare:
-      - name: packages
-        how: install
-        package: [httpd, curl]
-      - name: service
-        how: shell
-        script: systemctl start httpd
+  # Install required packages and start the service
+  prepare:
+    - name: packages
+      how: install
+      package: [httpd, curl]
+    - name: service
+      how: shell
+      script: systemctl start httpd
 
 /shell:
-    summary:
-        Prepare system using shell (bash) commands
-    description:
-        Execute arbitrary shell commands to set up the system.
+  summary: Prepare system using shell (bash) commands
+  description: >
+    Execute arbitrary shell commands to set up the system.
 
-        Default shell options are applied to the script, see the
-        :ref:`/spec/tests/test` key specification for more
-        details.
+    Default shell options are applied to the script, see the
+    :ref:`/spec/tests/test` key specification for more
+    details.
 
-    example: |
-        prepare:
-            how: shell
-            script: dnf install -y httpd
-    link:
-      - implemented-by: /tmt/steps/provision
+  example: |
+    prepare:
+        how: shell
+        script: dnf install -y httpd
+  link:
+    - implemented-by: /tmt/steps/provision
 
 /ansible:
-    summary:
-        Apply ansible playbook to get the desired final state.
-    description:
-        One or more playbooks can be provided as a list under the
-        ``playbook`` attribute.  Each of them will be applied
-        using ``ansible-playbook`` in the given order. The path
-        must be relative to the metadata tree root.
+  summary: Apply ansible playbook to get the desired final state.
+  description: >
+    One or more playbooks can be provided as a list under the
+    ``playbook`` attribute.  Each of them will be applied
+    using ``ansible-playbook`` in the given order. The path
+    must be relative to the metadata tree root.
 
-        Use ``extra-args`` attribute to enable optional arguments for
-        ``ansible-playbook``.
+    Use ``extra-args`` attribute to enable optional arguments for
+    ``ansible-playbook``.
 
-        Remote playbooks can be referenced as well as the local ones,
-        and both kinds can be used at the same time.
+    Remote playbooks can be referenced as well as the local ones,
+    and both kinds can be used at the same time.
 
-    example: |
-        prepare:
-            how: ansible
-            playbook:
-                - playbooks/common.yml
-                - playbooks/os/rhel7.yml
-                - https://foo.bar/rhel7-final-touches.yml
-            extra-args: '-vvv'
-    link:
-      - implemented-by: /tmt/steps/provision
-      - verified-by: /tests/prepare/ansible
+  example: |
+    prepare:
+        how: ansible
+        playbook:
+            - playbooks/common.yml
+            - playbooks/os/rhel7.yml
+            - https://foo.bar/rhel7-final-touches.yml
+        extra-args: '-vvv'
+  link:
+    - implemented-by: /tmt/steps/provision
+    - verified-by: /tests/prepare/ansible
 
 /install:
-    summary:
-        Install packages on the guest
-    description: |
-        One or more RPM packages can be specified under the
-        ``package`` attribute. The packages will be installed
-        on the guest. They can either be specified using their
-        names, paths to local rpm files or urls to remote rpms.
+  summary: Install packages on the guest
+  description: |
+    One or more RPM packages can be specified under the
+    ``package`` attribute. The packages will be installed
+    on the guest. They can either be specified using their
+    names, paths to local rpm files or urls to remote rpms.
 
-        Additionaly, the ``directory`` attribute can be used to
-        install all packages from the given directory. Copr
-        repositories can be enabled using the ``copr`` attribute.
-        Use the ``exclude`` option to skip selected packages from
-        installation (globbing characters are supported as well).
+    Additionaly, the ``directory`` attribute can be used to
+    install all packages from the given directory. Copr
+    repositories can be enabled using the ``copr`` attribute.
+    Use the ``exclude`` option to skip selected packages from
+    installation (globbing characters are supported as well).
 
-        It's possible to change the behaviour when a package is
-        missing using the ``missing`` attribute. The missing
-        packages can either be silently ignored ('skip') or a
-        preparation error is thrown ('fail'), which is the default
-        behaviour.
+    It's possible to change the behaviour when a package is
+    missing using the ``missing`` attribute. The missing
+    packages can either be silently ignored ('skip') or a
+    preparation error is thrown ('fail'), which is the default
+    behaviour.
 
-    example:
-      - |
-        # Install local rpms using file path
-        prepare:
-            how: install
-            package:
-              - tmp/RPMS/noarch/tmt-0.15-1.fc31.noarch.rpm
-              - tmp/RPMS/noarch/python3-tmt-0.15-1.fc31.noarch.rpm
+  example:
+    - |
+      # Install local rpms using file path
+      prepare:
+          how: install
+          package:
+            - tmp/RPMS/noarch/tmt-0.15-1.fc31.noarch.rpm
+            - tmp/RPMS/noarch/python3-tmt-0.15-1.fc31.noarch.rpm
 
-      - |
-        # Install remote packages using url
-        prepare:
-            how: install
-            package:
-              - https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-              - https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-8.noarch.rpm
+    - |
+      # Install remote packages using url
+      prepare:
+          how: install
+          package:
+            - https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+            - https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-8.noarch.rpm
 
-      - |
-        # Install the whole directory, exclude selected packages
-        prepare:
-            how: install
-            directory:
-              - tmp/RPMS/noarch
-            exclude:
-              - tmt-all
-              - tmt-provision-virtual
+    - |
+      # Install the whole directory, exclude selected packages
+      prepare:
+          how: install
+          directory:
+            - tmp/RPMS/noarch
+          exclude:
+            - tmt-all
+            - tmt-provision-virtual
 
-      - |
-        # Enable copr repository, skip missing packages
-        prepare:
-            how: install
-            copr: psss/tmt
-            package: tmt-all
-            missing: skip
+    - |
+      # Enable copr repository, skip missing packages
+      prepare:
+          how: install
+          copr: psss/tmt
+          package: tmt-all
+          missing: skip
 
-    link:
-      - implemented-by: /tmt/steps/provision
-      - verified-by: /tests/prepare/install
+  link:
+    - implemented-by: /tmt/steps/provision
+    - verified-by: /tests/prepare/install
 
 /where:
-    summary: Apply preparation on selected guests
-    description: |
-        In the :ref:`/spec/plans/provision/multihost` scenarios it
-        is often necessary to perform different preparation tasks on
-        individual guests. The ``where`` key allows to select guests
-        where the preparation should be applied by providing their
-        ``name`` or the ``role`` they play in the scenario. Use a
-        list to specify multiple names or roles. By default, when
-        the ``where`` key is not defined, preparation is done on all
-        provisioned guests.
-    example: |
-        # Start Apache on the server
-        prepare:
-          - how: shell
-            script: systemctl start httpd
-            where: server
+  summary: Apply preparation on selected guests
+  description: |
+    In the :ref:`/spec/plans/provision/multihost` scenarios it
+    is often necessary to perform different preparation tasks on
+    individual guests. The ``where`` key allows to select guests
+    where the preparation should be applied by providing their
+    ``name`` or the ``role`` they play in the scenario. Use a
+    list to specify multiple names or roles. By default, when
+    the ``where`` key is not defined, preparation is done on all
+    provisioned guests.
+  example: |
+    # Start Apache on the server
+    prepare:
+      - how: shell
+        script: systemctl start httpd
+        where: server
 
-        # Apply common setup on the primary server and all replicas
-        prepare:
-          - how: ansible
-            playbook: common.yaml
-            where: [primary, replica]
+    # Apply common setup on the primary server and all replicas
+    prepare:
+      - how: ansible
+        playbook: common.yaml
+        where: [primary, replica]

--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -1,213 +1,211 @@
 summary: Provision a system for testing
 
 description: |
-    Describes what environment is needed for testing and how it
-    should be provisioned. There are several provision plugins
-    supporting multiple ways to provision the environment for
-    testing, for example
-    :ref:`/spec/plans/provision/virtual`,
-    :ref:`/spec/plans/provision/container`,
-    :ref:`/spec/plans/provision/connect`,
-    :ref:`/spec/plans/provision/local` or
-    :ref:`/spec/plans/provision/artemis`.
-    See individual plugin documentation for details about
-    supported options.
+  Describes what environment is needed for testing and how it
+  should be provisioned. There are several provision plugins
+  supporting multiple ways to provision the environment for
+  testing, for example
+  :ref:`/spec/plans/provision/virtual`,
+  :ref:`/spec/plans/provision/container`,
+  :ref:`/spec/plans/provision/connect`,
+  :ref:`/spec/plans/provision/local` or
+  :ref:`/spec/plans/provision/artemis`.
+  See individual plugin documentation for details about
+  supported options.
 
-    As part of the provision step it is also possible to specify
-    detailed hardware requirements for the testing environment.
-    See the :ref:`/spec/hardware` specification section for
-    details.
+  As part of the provision step it is also possible to specify
+  detailed hardware requirements for the testing environment.
+  See the :ref:`/spec/hardware` specification section for
+  details.
 
-    As part of the provision step it is also possible to specify
-    kickstart file used during the installation.
-    See the :ref:`/spec/plans/provision/kickstart` specification
-    section for details.
+  As part of the provision step it is also possible to specify
+  kickstart file used during the installation.
+  See the :ref:`/spec/plans/provision/kickstart` specification
+  section for details.
 
 example: |
-    # Provision a local virtual machine with the latest Fedora
+  # Provision a local virtual machine with the latest Fedora
+  provision:
+      how: virtual
+      image: fedora
+
+/virtual:
+  summary: Provision a virtual machine (default)
+  description: >
+    Create a new virtual machine on the localhost using
+    testcloud (libvirt). Testcloud takes care of downloading
+    an image and making necessary changes to it for optimal
+    experience (such as disabling UseDNS and GSSAPI for SSH).
+  example: |
     provision:
         how: virtual
         image: fedora
-
-/virtual:
-    summary: Provision a virtual machine (default)
-    description:
-        Create a new virtual machine on the localhost using
-        testcloud (libvirt). Testcloud takes care of downloading
-        an image and making necessary changes to it for optimal
-        experience (such as disabling UseDNS and GSSAPI for SSH).
-    example: |
-        provision:
-            how: virtual
-            image: fedora
-    link:
-      - implemented-by: /tmt/steps/provision/testcloud.py
+  link:
+    - implemented-by: /tmt/steps/provision/testcloud.py
 
 /local:
-    summary: Use the localhost for testing
-    description:
-        Do not provision any system. Tests will be executed
-        directly on the localhost. Note that for some actions like
-        installing additional packages you need root permission or
-        enabled sudo.
-    example: |
-        provision:
-            how: local
-    link:
-      - implemented-by: /tmt/steps/provision/local.py
-      - verified-by: /tests/init/base
+  summary: Use the localhost for testing
+  description: >
+    Do not provision any system. Tests will be executed
+    directly on the localhost. Note that for some actions like
+    installing additional packages you need root permission or
+    enabled sudo.
+  example: |
+    provision:
+        how: local
+  link:
+    - implemented-by: /tmt/steps/provision/local.py
+    - verified-by: /tests/init/base
 
 /container:
-    summary: Provision a container
-    description:
-        Download (if necessary) and start a new container using
-        podman or docker.
-    example: |
-        provision:
-            how: container
-            image: fedora:latest
-    link:
-      - implemented-by: /tmt/steps/provision/podman.py
+  summary: Provision a container
+  description: >
+    Download (if necessary) and start a new container using
+    podman or docker.
+  example: |
+    provision:
+        how: container
+        image: fedora:latest
+  link:
+    - implemented-by: /tmt/steps/provision/podman.py
 
 /openstack:
-    summary: Provision a virtual machine in OpenStack
-    description:
-        Create a virtual machine using OpenStack.
-    example: |
-        provision:
-            how: openstack
-            image: f31
+  summary: Provision a virtual machine in OpenStack
+  description: >
+    Create a virtual machine using OpenStack.
+  example: |
+    provision:
+        how: openstack
+        image: f31
 
 /beaker:
-    summary: Provision a machine in Beaker
-    description: |
-        Reserve a machine from the Beaker pool using the ``mrack``
-        plugin.  `mrack`__ is a multicloud provisioning library
-        supporting multiple cloud services including Beaker.
+  summary: Provision a machine in Beaker
+  description: |
+    Reserve a machine from the Beaker pool using the ``mrack``
+    plugin.  `mrack`__ is a multicloud provisioning library
+    supporting multiple cloud services including Beaker.
 
-        The following two files are used for configuration:
+    The following two files are used for configuration:
 
-        /etc/tmt/mrack.conf
-            for basic configuration
+    /etc/tmt/mrack.conf
+        for basic configuration
 
-        /etc/tmt/provisioning-config.yaml
-            configuration per supported provider
+    /etc/tmt/provisioning-config.yaml
+        configuration per supported provider
 
-        Beaker installs distribution specified by the ``image``
-        key. If the image can not be translated using the
-        ``provisioning-config.yaml`` file mrack passes the image
-        value to Beaker hub and tries to request distribution
-        based on the image value. This way we can bypass default
-        translations and use desired distribution specified like
-        the one in the example below.
+    Beaker installs distribution specified by the ``image``
+    key. If the image can not be translated using the
+    ``provisioning-config.yaml`` file mrack passes the image
+    value to Beaker hub and tries to request distribution
+    based on the image value. This way we can bypass default
+    translations and use desired distribution specified like
+    the one in the example below.
 
-        __ https://github.com/neoave/mrack
+    __ https://github.com/neoave/mrack
 
-        .. note::
+    .. note::
 
-            The beaker provision plugin is not available for
-            ``rhel-8`` or ``centos-stream-8``.
+        The beaker provision plugin is not available for
+        ``rhel-8`` or ``centos-stream-8``.
 
-        .. versionadded:: 1.22
+    .. versionadded:: 1.22
 
-    example:
-      - |
-        # Use image name translation
-        provision:
-            how: beaker
-            image: fedora
-      - |
-        # Specify the distro directly
-        provision:
-            how: beaker
-            image: Fedora-37%
+  example:
+    - |
+      # Use image name translation
+      provision:
+          how: beaker
+          image: fedora
+    - |
+      # Specify the distro directly
+      provision:
+          how: beaker
+          image: Fedora-37%
 
-    link:
-      - implemented-by: /tmt/steps/provision/mrack.py
-      - verified-by: /tests/provision/beaker
-
+  link:
+    - implemented-by: /tmt/steps/provision/mrack.py
+    - verified-by: /tests/provision/beaker
 
 /connect:
-    summary: Connect to a provisioned box
-    description: |
-        Do not provision a new system. Instead, use provided
-        authentication data to connect to a running machine.
+  summary: Connect to a provisioned box
+  description: |
+    Do not provision a new system. Instead, use provided
+    authentication data to connect to a running machine.
 
-        guest
-            hostname or ip address of the box
-        user
-            user name to be used to log in, ``root`` by default
-        password
-            user password to be used to log in
-        key
-            path to the file with private key
-        port
-            use specific port to connect to
-    link:
-      - implemented-by: /tmt/steps/provision/connect.py
+    guest
+        hostname or ip address of the box
+    user
+        user name to be used to log in, ``root`` by default
+    password
+        user password to be used to log in
+    key
+        path to the file with private key
+    port
+        use specific port to connect to
+  link:
+    - implemented-by: /tmt/steps/provision/connect.py
 
-    example: |
-        provision:
-            how: connect
-            guest: hostname or ip address
-            user: username
-            password: password
+  example: |
+    provision:
+        how: connect
+        guest: hostname or ip address
+        user: username
+        password: password
 
-        provision:
-            how: connect
-            guest: hostname or ip address
-            key: private-key-path
-
+    provision:
+        how: connect
+        guest: hostname or ip address
+        key: private-key-path
 
 /multihost:
-    summary: Multihost testing specification
+  summary: Multihost testing specification
 
-    description: |
-        .. versionchanged:: 1.24
+  description: |
+    .. versionchanged:: 1.24
 
-        As a part of the provision step it is possible to request
-        multiple guests to be provisioned for testing. Each guest
-        has to be assigned a unique ``name`` which is used to
-        identify it.
+    As a part of the provision step it is possible to request
+    multiple guests to be provisioned for testing. Each guest
+    has to be assigned a unique ``name`` which is used to
+    identify it.
 
-        The optional parameter ``role`` can be used to mark
-        related guests so that common actions can be applied to
-        all such guests at once. An example role name can be
-        `client` or `server` but arbitrary identifier can be used.
+    The optional parameter ``role`` can be used to mark
+    related guests so that common actions can be applied to
+    all such guests at once. An example role name can be
+    `client` or `server` but arbitrary identifier can be used.
 
-        Both `name` and `role` can be used together with the
-        ``where`` key to select guests on which the
-        :ref:`preparation</spec/plans/prepare/where>`
-        tasks should be applied or where the test
-        :ref:`execution</spec/plans/discover/where>` should
-        take place.
+    Both `name` and `role` can be used together with the
+    ``where`` key to select guests on which the
+    :ref:`preparation</spec/plans/prepare/where>`
+    tasks should be applied or where the test
+    :ref:`execution</spec/plans/discover/where>` should
+    take place.
 
-        See :ref:`/spec/plans/guest-topology` for details on how
-        this information is exposed to tests and ``prepare`` and
-        ``finish`` tasks.
+    See :ref:`/spec/plans/guest-topology` for details on how
+    this information is exposed to tests and ``prepare`` and
+    ``finish`` tasks.
 
-    example: |
-        # Request two guests
-        provision:
-          - name: server
-            how: virtual
-          - name: client
-            how: virtual
+  example: |
+    # Request two guests
+    provision:
+      - name: server
+        how: virtual
+      - name: client
+        how: virtual
 
-        # Assign role to guests
-        provision:
-          - name: main-server
-            role: primary
-          - name: backup-one
-            role: replica
-          - name: backup-two
-            role: replica
-          - name: tester-one
-            role: client
-          - name: tester-two
-            role: client
+    # Assign role to guests
+    provision:
+      - name: main-server
+        role: primary
+      - name: backup-one
+        role: replica
+      - name: backup-two
+        role: replica
+      - name: tester-one
+        role: client
+      - name: tester-two
+        role: client
 
-    link:
-      - implemented-by: /tmt/steps/__init__.py
-      - implemented-by: /tmt/queue.py
-      - verified-by: /tests/multihost
+  link:
+    - implemented-by: /tmt/steps/__init__.py
+    - implemented-by: /tmt/queue.py
+    - verified-by: /tests/multihost

--- a/spec/plans/provision/artemis.fmf
+++ b/spec/plans/provision/artemis.fmf
@@ -1,25 +1,25 @@
 summary: Provision a guest via an Artemis service
 description: |
-    Reserve a machine using the Artemis service.
-    Users can specify many requirements, mostly regarding the
-    desired OS, RAM, disk size and more. Most of the HW specifications
-    defined in the :ref:`/spec/hardware` are supported. Including the
-    :ref:`/spec/plans/provision/kickstart`.
+  Reserve a machine using the Artemis service.
+  Users can specify many requirements, mostly regarding the
+  desired OS, RAM, disk size and more. Most of the HW specifications
+  defined in the :ref:`/spec/hardware` are supported. Including the
+  :ref:`/spec/plans/provision/kickstart`.
 
-    Artemis takes machines from AWS, OpenStack, Beaker or Azure.
-    By default, Artemis handles the selection of a cloud provider
-    to its best abilities and the required specification. However, it
-    is possible to specify the keyword ``pool`` and select the
-    desired cloud provider.
+  Artemis takes machines from AWS, OpenStack, Beaker or Azure.
+  By default, Artemis handles the selection of a cloud provider
+  to its best abilities and the required specification. However, it
+  is possible to specify the keyword ``pool`` and select the
+  desired cloud provider.
 
-    Artemis project:
-    https://gitlab.com/testing-farm/artemis
+  Artemis project:
+  https://gitlab.com/testing-farm/artemis
 
-    .. note::
+  .. note::
 
-        When used together with TF infrastructure
-        some of the options from the first example below
-        will be filled for you by the TF service.
+      When used together with TF infrastructure
+      some of the options from the first example below
+      will be filled for you by the TF service.
 
 example:
   - |

--- a/spec/plans/provision/kickstart.fmf
+++ b/spec/plans/provision/kickstart.fmf
@@ -1,48 +1,48 @@
-story:
-    As a tester I want to specify detailed installation of a guest
-    using the kickstart script.
+story: >
+  As a tester I want to specify detailed installation of a guest
+  using the kickstart script.
 
 description: |
-    As part of the :ref:`/spec/plans/provision` step it is possible to
-    use the ``kickstart`` key to specify additional requirements for the
-    installation of a guest. It is possible to specify a kickstart
-    script that will for example specify specific partitioning.
+  As part of the :ref:`/spec/plans/provision` step it is possible to
+  use the ``kickstart`` key to specify additional requirements for the
+  installation of a guest. It is possible to specify a kickstart
+  script that will for example specify specific partitioning.
 
-    The structure of a kickstart file is separated into several
-    sections.
+  The structure of a kickstart file is separated into several
+  sections.
 
-    pre-install
-        Corresponds to the ``%pre`` section of a file.  It can contain
-        ``bash`` commands, this part is run before the installation of a
-        guest.
+  pre-install
+      Corresponds to the ``%pre`` section of a file.  It can contain
+      ``bash`` commands, this part is run before the installation of a
+      guest.
 
-    post-install
-        Corresponds to the ``%post`` section of a file.  It can contain
-        ``bash`` commands, this part is run after the installation of a
-        guest.
+  post-install
+      Corresponds to the ``%post`` section of a file.  It can contain
+      ``bash`` commands, this part is run after the installation of a
+      guest.
 
-    script
-        Contains the kickstart specific commands that are run during the
-        installation of a guest.
+  script
+      Contains the kickstart specific commands that are run during the
+      installation of a guest.
 
-    It is also possible to specify ``metadata``. This part may be
-    interpreted differently for each of the pools that the guest is
-    created from. For example, in Beaker this section can be used to
-    modify the default kickstart template used by Beaker.  Similarly
-    works the ``kernel-options`` and ``kernel-options-post``.  Kernel
-    options are passed on the kernel command line when the installer is
-    booted.  Post-install kernel options are set in the boot loader
-    configuration, to be passed on the kernel command line after
-    installation.
+  It is also possible to specify ``metadata``. This part may be
+  interpreted differently for each of the pools that the guest is
+  created from. For example, in Beaker this section can be used to
+  modify the default kickstart template used by Beaker.  Similarly
+  works the ``kernel-options`` and ``kernel-options-post``.  Kernel
+  options are passed on the kernel command line when the installer is
+  booted.  Post-install kernel options are set in the boot loader
+  configuration, to be passed on the kernel command line after
+  installation.
 
-    .. note::
+  .. note::
 
-        The implementation for the ``kickstart`` key is in progress.
-        Support of a kickstart file is currently limited to Beaker
-        provisioning, as implemented by tmt's beaker and artemis
-        plugins, and may not be fully supported by other provisioning
-        plugins in the future.  Check individual plugin documentation
-        for additional information on the kickstart support.
+      The implementation for the ``kickstart`` key is in progress.
+      Support of a kickstart file is currently limited to Beaker
+      provisioning, as implemented by tmt's beaker and artemis
+      plugins, and may not be fully supported by other provisioning
+      plugins in the future.  Check individual plugin documentation
+      for additional information on the kickstart support.
 
 example:
   - |

--- a/spec/plans/report.fmf
+++ b/spec/plans/report.fmf
@@ -1,190 +1,191 @@
 summary: Report test results
-story:
-    As a tester I want to have a nice overview of results once
-    the testing if finished.
-description:
-    Report test results according to user preferences.
+story: >
+  As a tester I want to have a nice overview of results once
+  the testing if finished.
+description: >
+  Report test results according to user preferences.
 
 /display:
-    summary: Show results in the terminal window
-    story:
-        As a tester I want to see test results in the plain text
-        form in my shell session.
-    description:
-        Test results will be displayed as part of the command line
-        tool output directly in the terminal. Allows to select the
-        desired level of verbosity
-    example: |
-        tmt run -l report        # overall summary only
-        tmt run -l report -v     # individual test results
-        tmt run -l report -vv    # show full paths to logs
-        tmt run -l report -vvv   # provide complete test output
-    link:
-      - implemented-by: /tmt/steps/report/display.py
+  summary: Show results in the terminal window
+  story: >
+    As a tester I want to see test results in the plain text
+    form in my shell session.
+  description: >
+    Test results will be displayed as part of the command line
+    tool output directly in the terminal. Allows to select the
+    desired level of verbosity
+  example: |
+    tmt run -l report        # overall summary only
+    tmt run -l report -v     # individual test results
+    tmt run -l report -vv    # show full paths to logs
+    tmt run -l report -vvv   # provide complete test output
+  link:
+    - implemented-by: /tmt/steps/report/display.py
 
 /html:
-    summary: Generate a web page with test results
-    story:
-        As a tester I want to review results in a nicely arranged
-        web page with links to detailed test output.
-    description:
-        Create a local ``html`` file with test results arranged in
-        a table. Optionally open the page in the default browser.
-    example: |
-        # Enable html report from the command line
-        tmt run --all report --how html
-        tmt run --all report --how html --open
-        tmt run -l report -h html -o
+  summary: Generate a web page with test results
+  story: >
+    As a tester I want to review results in a nicely arranged
+    web page with links to detailed test output.
+  description: >
+    Create a local ``html`` file with test results arranged in
+    a table. Optionally open the page in the default browser.
+  example: |
+    # Enable html report from the command line
+    tmt run --all report --how html
+    tmt run --all report --how html --open
+    tmt run -l report -h html -o
 
-        # Use html as the default report for given plan
-        report:
-            how: html
-            open: true
-    link:
-      - implemented-by: /tmt/steps/report/html.py
+    # Use html as the default report for given plan
+    report:
+        how: html
+        open: true
+  link:
+    - implemented-by: /tmt/steps/report/html.py
 
 /junit:
-    summary: Generate a JUnit report file
-    story:
-        As a tester I want to review results in a JUnit xml file.
-    description:
-        Create a JUnit file ``junit.xml`` with test results.
-    example: |
-        # Enable junit report from the command line
-        tmt run --all report --how junit
-        tmt run --all report --how junit --file test.xml
+  summary: Generate a JUnit report file
+  story: >
+    As a tester I want to review results in a JUnit xml file.
+  description: >
+    Create a JUnit file ``junit.xml`` with test results.
+  example: |
+    # Enable junit report from the command line
+    tmt run --all report --how junit
+    tmt run --all report --how junit --file test.xml
 
-        # Use junit as the default report for given plan
-        report:
-            how: junit
-            file: test.xml
-    link:
-        - implemented-by: /tmt/steps/report/junit.py
+    # Use junit as the default report for given plan
+    report:
+        how: junit
+        file: test.xml
+  link:
+    - implemented-by: /tmt/steps/report/junit.py
 
 /polarion:
-    summary: Generate a xUnit file and export it into Polarion
-    story:
-        As a tester I want to review tests in Polarion
-        and have all results linked to existing test cases there.
-    description:
-        Create a xUnit file ``xunit.xml`` with test results
-        and Polarion properties so the xUnit can then be
-        exported into Polarion.
-    example: |
-        # Enable polarion report from the command line
-        tmt run --all report --how polarion --project-id TMT
-        tmt run --all report --how polarion --project-id TMT --no-upload --file test.xml
+  summary: Generate a xUnit file and export it into Polarion
+  story: >
+    As a tester I want to review tests in Polarion
+    and have all results linked to existing test cases there.
+  description: >
+    Create a xUnit file ``xunit.xml`` with test results
+    and Polarion properties so the xUnit can then be
+    exported into Polarion.
+  example: |
+    # Enable polarion report from the command line
+    tmt run --all report --how polarion --project-id TMT
+    tmt run --all report --how polarion --project-id TMT --no-upload --file test.xml
 
-        # Use polarion as the default report for given plan
-        report:
-            how: polarion
-            file: test.xml
-            project-id: TMT
-            title: tests_that_pass
-            planned-in: RHEL-9.1.0
-            pool-team: sst_tmt
-    link:
-        - implemented-by: /tmt/steps/report/polarion.py
+    # Use polarion as the default report for given plan
+    report:
+      how: polarion
+      file: test.xml
+      project-id: TMT
+      title: tests_that_pass
+      planned-in: RHEL-9.1.0
+      pool-team: sst_tmt
+  link:
+    - implemented-by: /tmt/steps/report/polarion.py
 
 /reportportal:
-    summary: Report test results to a ReportPortal instance
-    story:
-        As a tester I want to review results in a nicely arranged
-        web page, filter them via context attributes and get links
-        to detailed test output and other test information.
-    description:
-        Fill json with test results and other fmf data per each plan,
-        and send it to a Report Portal instance via its API.
-    example:
-      - |
-        # Set environment variables with the server url and token
-        export TMT_REPORT_REPORTPORTAL_URL=<url-to-RP-instance>
-        export TMT_REPORT_REPORTPORTAL_TOKEN=<token-from-RP-profile>
-      - |
-        # Enable ReportPortal report from the command line
-        tmt run --all report --how reportportal --project=baseosqe
-        tmt run --all report --how reportportal --project=baseosqe --exclude-variables="^(TMT|PACKIT|TESTING_FARM).*"
-        tmt run --all report --how reportportal --project=baseosqe --launch=test_plan
-        tmt run --all report --how reportportal --project=baseosqe --url=... --token=...
-      - |
-        # Use ReportPortal as the default report for given plan
-        report:
-            how: reportportal
-            project: baseosqe
+  summary: Report test results to a ReportPortal instance
+  story: >
+    As a tester I want to review results in a nicely arranged
+    web page, filter them via context attributes and get links
+    to detailed test output and other test information.
+  description: >
+    Fill json with test results and other fmf data per each plan,
+    and send it to a Report Portal instance via its API.
+  example:
+    - |
+      # Set environment variables with the server url and token
+      export TMT_REPORT_REPORTPORTAL_URL=<url-to-RP-instance>
+      export TMT_REPORT_REPORTPORTAL_TOKEN=<token-from-RP-profile>
+    - |
+      # Enable ReportPortal report from the command line
+      tmt run --all report --how reportportal --project=baseosqe
+      tmt run --all report --how reportportal --project=baseosqe --exclude-variables="^(TMT|PACKIT|TESTING_FARM).*"
+      tmt run --all report --how reportportal --project=baseosqe --launch=test_plan
+      tmt run --all report --how reportportal --project=baseosqe --url=... --token=...
+    - |
+      # Use ReportPortal as the default report for given plan
+      report:
+        how: reportportal
+        project: baseosqe
 
-        # Report context attributes for given plan
-        context:
-            ...
-      - |
-        # Report description, contact, id and environment variables for given test
-        summary: ...
-        contact: ...
-        id: ...
-        environment:
-            ...
-    link:
-        - implemented-by: /tmt/steps/report/reportportal.py
+      # Report context attributes for given plan
+      context:
+          ...
+    - |
+      # Report description, contact, id and environment variables for given test
+      summary: ...
+      contact: ...
+      id: ...
+      environment:
+          ...
+  link:
+    - implemented-by: /tmt/steps/report/reportportal.py
 
 /file:
-    description: |
+  description: |
 
-        Save the report into a ``report.yaml`` file with the
-        following format:
+    Save the report into a ``report.yaml`` file with the
+    following format:
 
-        .. code-block:: yaml
+    .. code-block:: yaml
 
-            result: OVERALL_RESULT
-            plans:
-                /plan/one:
-                    result: PLAN_RESULT
-                    tests:
-                        /test/one:
-                            result: TEST_RESULT
-                            log:
-                              - LOG_PATH
+        result: OVERALL_RESULT
+        plans:
+          /plan/one:
+            result: PLAN_RESULT
+            tests:
+              /test/one:
+                result: TEST_RESULT
+                log:
+                  - LOG_PATH
 
-                        /test/two:
-                            result: TEST_RESULT
-                            log:
-                                - LOG_PATH
-                                - LOG_PATH
-                                - LOG_PATH
-                /plan/two:
-                    result: PLAN_RESULT
-                        /test/one:
-                            result: TEST_RESULT
-                            log:
-                              - LOG_PATH
+              /test/two:
+                result: TEST_RESULT
+                log:
+                  - LOG_PATH
+                  - LOG_PATH
+                  - LOG_PATH
+          /plan/two:
+            result: PLAN_RESULT
+            tests:
+              /test/one:
+                result: TEST_RESULT
+                log:
+                  - LOG_PATH
 
-        Where ``OVERALL_RESULT`` is the overall result of all plan
-        results. It is counted the same way as ``PLAN_RESULT``.
+    Where ``OVERALL_RESULT`` is the overall result of all plan
+    results. It is counted the same way as ``PLAN_RESULT``.
 
-        Where ``TEST_RESULT`` is the same as in `execute`_ step
-        definition:
+    Where ``TEST_RESULT`` is the same as in `execute`_ step
+    definition:
 
-            * info - test finished and produced only information
-              message
-            * passed - test finished and passed
-            * failed - test finished and failed
-            * error - a problem encountered during test execution
+        * info - test finished and produced only information
+          message
+        * passed - test finished and passed
+        * failed - test finished and failed
+        * error - a problem encountered during test execution
 
-        Note the priority  of test results is as written above,
-        with ``info`` having the lowest priority and ``error`` has
-        the highest. This is important for ``PLAN_RESULT``.
+    Note the priority  of test results is as written above,
+    with ``info`` having the lowest priority and ``error`` has
+    the highest. This is important for ``PLAN_RESULT``.
 
-        Where ``PLAN_RESULT`` is the overall result or all test
-        results for the plan run. It has the same values as
-        ``TEST_RESULT``. Plan result is counted according to the
-        priority of the test outcome values. For example:
+    Where ``PLAN_RESULT`` is the overall result or all test
+    results for the plan run. It has the same values as
+    ``TEST_RESULT``. Plan result is counted according to the
+    priority of the test outcome values. For example:
 
-            * if the test results are info, passed, passed - the
-              plan result will be passed
-            * if the test results are info, passed, failed - the
-              plan result will be failed
-            * if the test results are failed, error, passed - the
-              plan result will be error
+        * if the test results are info, passed, passed - the
+          plan result will be passed
+        * if the test results are info, passed, failed - the
+          plan result will be failed
+        * if the test results are failed, error, passed - the
+          plan result will be error
 
-        Where ``LOG_PATH`` is the test log output path, relative
-        to the execute step plan run directory. The ``log`` key
-        will be a list of such paths, even if there is just a single
-        log.
+    Where ``LOG_PATH`` is the test log output path, relative
+    to the execute step plan run directory. The ``log`` key
+    will be a list of such paths, even if there is just a single
+    log.

--- a/spec/plans/results.fmf
+++ b/spec/plans/results.fmf
@@ -3,125 +3,125 @@ title: Results Format
 order: 90
 
 description: |
-    The following text defines a YAML file structure tmt uses for storing
-    results. tmt itself will use it when saving results of ``execute`` step,
-    and custom test results are required to follow it when creating their
-    ``results.yaml`` file.
+  The following text defines a YAML file structure tmt uses for storing
+  results. tmt itself will use it when saving results of ``execute`` step,
+  and custom test results are required to follow it when creating their
+  ``results.yaml`` file.
 
-    Tests may choose JSON instead of YAML for their custom results file and
-    create ``results.json`` file, but tmt itself will always stick to YAML,
-    the final results would be provided in ``results.yaml`` file in any case.
+  Tests may choose JSON instead of YAML for their custom results file and
+  create ``results.json`` file, but tmt itself will always stick to YAML,
+  the final results would be provided in ``results.yaml`` file in any case.
 
-    Results are saved as a single list of dictionaries, each describing
-    a single test result.
+  Results are saved as a single list of dictionaries, each describing
+  a single test result.
 
-    .. code-block::
+  .. code-block::
 
-       # String, name of the test.
+     # String, name of the test.
+     name: /test/one
+
+     # fmf ID of the test.
+     fmf_id:
+       url: http://some.git.host.com/project/tests.git
        name: /test/one
+       path: /
 
-       # fmf ID of the test.
-       fmf_id:
-         url: http://some.git.host.com/project/tests.git
-         name: /test/one
-         path: /
+     # String, outcome of the test execution.
+     result: "pass"|"fail"|"info"|"warn"|"error"
 
-       # String, outcome of the test execution.
-       result: "pass"|"fail"|"info"|"warn"|"error"
+     # String, optional comment to report with the result.
+     note: "Things were great."
 
-       # String, optional comment to report with the result.
-       note: "Things were great."
+     # List of strings, paths to file logs.
+     log:
+       - path/to/log1
+       - path/to/log1
+         ...
 
-       # List of strings, paths to file logs.
-       log:
-         - path/to/log1
-         - path/to/log1
-           ...
+     # Mapping, collection of various test IDs, if there are any to track.
+     ids:
+       some-id: foo
+       another-id: bar
 
-       # Mapping, collection of various test IDs, if there are any to track.
-       ids:
-         some-id: foo
-         another-id: bar
+     # String, when the test started, in an ISO 8601 format.
+     starttime: "yyyy-mm-ddThh:mm:ss.mmmmm+ZZ:ZZ"
 
-       # String, when the test started, in an ISO 8601 format.
-       starttime: "yyyy-mm-ddThh:mm:ss.mmmmm+ZZ:ZZ"
+     # String, when the test finished, in an ISO 8601 format.
+     endtime: "yyyy-mm-ddThh:mm:ss.mmmmm+ZZ:ZZ"
 
-       # String, when the test finished, in an ISO 8601 format.
-       endtime: "yyyy-mm-ddThh:mm:ss.mmmmm+ZZ:ZZ"
+     # String, how long did the test run.
+     duration: hh:mm:ss
 
-       # String, how long did the test run.
-       duration: hh:mm:ss
+     # Integer, serial number of the test in the sequence of all tests of a plan.
+     serialnumber: 1
 
-       # Integer, serial number of the test in the sequence of all tests of a plan.
-       serialnumber: 1
+     # Mapping, describes the guest on which the test was executed.
+     guest:
+       name: client-1
+       role: clients
 
-       # Mapping, describes the guest on which the test was executed.
-       guest:
-         name: client-1
-         role: clients
+  The ``result`` key can have the following values:
 
-    The ``result`` key can have the following values:
+  pass
+      Test execution successfully finished and passed.
 
-    pass
-        Test execution successfully finished and passed.
+  info
+      Test finished but only produced an informational
+      message. Represents a soft pass, used for skipped
+      tests and for tests with the :ref:`/spec/tests/result`
+      attribute set to ``ignore``. Automation must treat
+      this as a passed test.
 
-    info
-        Test finished but only produced an informational
-        message. Represents a soft pass, used for skipped
-        tests and for tests with the :ref:`/spec/tests/result`
-        attribute set to ``ignore``. Automation must treat
-        this as a passed test.
+  warn
+      A problem appeared during test execution which does
+      not affect test results but might be worth checking
+      and fixing. For example test cleanup phase failed.
+      Automation must treat this as a failed test.
 
-    warn
-        A problem appeared during test execution which does
-        not affect test results but might be worth checking
-        and fixing. For example test cleanup phase failed.
-        Automation must treat this as a failed test.
+  error
+      Undefined problem encountered during test execution.
+      Human inspection is needed to investigate whether it
+      was a test bug, infrastructure error or a real test
+      failure. Automation must treat it as a failed test.
 
-    error
-        Undefined problem encountered during test execution.
-        Human inspection is needed to investigate whether it
-        was a test bug, infrastructure error or a real test
-        failure. Automation must treat it as a failed test.
+  fail
+      Test execution successfully finished and failed.
 
-    fail
-        Test execution successfully finished and failed.
+  The ``name`` and ``result`` keys are required. Custom result files
+  may omit all other keys, although tmt plugins will strive to provide
+  as many keys as possible.
 
-    The ``name`` and ``result`` keys are required. Custom result files
-    may omit all other keys, although tmt plugins will strive to provide
-    as many keys as possible.
+  When importing the :ref:`custom results file </spec/tests/result>`, each
+  test name referenced in the file by the ``name`` key would be prefixed by
+  the original test name. A special case, ``name: /``, sets the result for
+  the original test itself.
 
-    When importing the :ref:`custom results file </spec/tests/result>`, each
-    test name referenced in the file by the ``name`` key would be prefixed by
-    the original test name. A special case, ``name: /``, sets the result for
-    the original test itself.
+  The ``log`` key must list **relative** paths. Paths in the custom
+  results file are treated as relative to ``${TMT_TEST_DATA}`` path.
+  Paths in the final results file, saved by the execute step, will be
+  relative to the location of the results file itself.
 
-    The ``log`` key must list **relative** paths. Paths in the custom
-    results file are treated as relative to ``${TMT_TEST_DATA}`` path.
-    Paths in the final results file, saved by the execute step, will be
-    relative to the location of the results file itself.
+  The first ``log`` item is considered to be the "main" log, presented
+  to the user by default.
 
-    The first ``log`` item is considered to be the "main" log, presented
-    to the user by default.
+  The ``serialnumber``, ``guest`` and ``fmf_id`` keys, if present in the
+  custom results file, will be overwritten by tmt during their import after
+  test completes. This happens on purpose, to assure this vital
+  information is correct.
 
-    The ``serialnumber``, ``guest`` and ``fmf_id`` keys, if present in the
-    custom results file, will be overwritten by tmt during their import after
-    test completes. This happens on purpose, to assure this vital
-    information is correct.
+  Similarly, the ``duration``, ``starttime`` and ``endtime`` keys, if
+  present in the special custom result, representing the original test
+  itself - ``name: /`` -, will be overwritten by tmt with actual
+  observed values. This also happens on purpose: while tmt cannot
+  tell how long it took to produce various custom results, it is still
+  able to report the duration of the whole test.
 
-    Similarly, the ``duration``, ``starttime`` and ``endtime`` keys, if
-    present in the special custom result, representing the original test
-    itself - ``name: /`` -, will be overwritten by tmt with actual
-    observed values. This also happens on purpose: while tmt cannot
-    tell how long it took to produce various custom results, it is still
-    able to report the duration of the whole test.
+  See also the complete `JSON schema`__.
 
-    See also the complete `JSON schema`__.
+  For custom results files in JSON format, the same rules and schema
+  apply.
 
-    For custom results files in JSON format, the same rules and schema
-    apply.
-
-    __ https://github.com/teemtee/tmt/blob/main/tmt/schemas/results.yaml
+  __ https://github.com/teemtee/tmt/blob/main/tmt/schemas/results.yaml
 
 example:
   - |

--- a/spec/plans/summary.fmf
+++ b/spec/plans/summary.fmf
@@ -1,22 +1,22 @@
 summary: Concise summary describing the plan
 
-description:
-    Should shortly describe purpose of the test plan. Must be a
-    one-line ``string``, should be up to 50 characters long. It
-    is challenging to be both concise and descriptive, but that is
-    what a well-written summary should do.
+description: >
+  Should shortly describe purpose of the test plan. Must be a
+  one-line ``string``, should be up to 50 characters long. It
+  is challenging to be both concise and descriptive, but that is
+  what a well-written summary should do.
 
 example: |
-    /pull-request:
-        /pep:
-            summary: All code must comply with the PEP8 style guide
-        /lint:
-            summary: Run pylint to catch common problems (no gating)
-    /build:
-        /smoke:
-            summary: Basic smoke test (Tier1)
-        /features:
-            summary: Verify important features
+  /pull-request:
+    /pep:
+      summary: All code must comply with the PEP8 style guide
+    /lint:
+      summary: Run pylint to catch common problems (no gating)
+  /build:
+    /smoke:
+      summary: Basic smoke test (Tier1)
+    /features:
+      summary: Verify important features
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/stories/example.fmf
+++ b/spec/stories/example.fmf
@@ -1,38 +1,38 @@
 summary: Instructive examples of real-life usage.
 
 description: |
-    One example is worth thousand words. Providing a few,
-    well selected, examples helps to understand quickly
-    and get inspiration for initial experimenting.
+  One example is worth thousand words. Providing a few,
+  well selected, examples helps to understand quickly
+  and get inspiration for initial experimenting.
 
-    One or more examples can be defined, each of them is rendered
-    into a separate box during export. Must be a ``string`` or a
-    ``list of strings``.
+  One or more examples can be defined, each of them is rendered
+  into a separate box during export. Must be a ``string`` or a
+  ``list of strings``.
 
 example:
-    - |
-        # Short one-line example
-        example: tmt run discover
-    - |
-        # Preserve line breaks using the '|' modifier
-        example: |
-            tmt run --until execute
-            tmt run --last report
-    - |
-        # Use a list to define multiple examples
-        example:
-          - tmt run --until execute
-          - tmt run --last report
+  - |
+    # Short one-line example
+    example: tmt run discover
+  - |
+    # Preserve line breaks using the '|' modifier
+    example: |
+        tmt run --until execute
+        tmt run --last report
+  - |
+    # Use a list to define multiple examples
+    example:
+      - tmt run --until execute
+      - tmt run --last report
 
-    - |
-        # Several multiline examples
-        example:
-            - |
-                # Check validity of the plans
-                tmt plan lint
-            - |
-                # Check which tests would be run
-                tmt run discover
+  - |
+    # Several multiline examples
+    example:
+        - |
+            # Check validity of the plans
+            tmt plan lint
+        - |
+            # Check which tests would be run
+            tmt run discover
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/stories/main.fmf
+++ b/spec/stories/main.fmf
@@ -1,31 +1,31 @@
-story:
-    As a developer I want to define application features and track
-    which have been already implemented, verified and documented.
+story: >
+  As a developer I want to define application features and track
+  which have been already implemented, verified and documented.
 
 description: |
-    Stories, which implement the L3 metadata, can be used to track
-    implementation, test and documentation coverage for individual
-    features or requirements. Thanks to this you can track
-    everything in one place, including the project implementation
-    progress.
+  Stories, which implement the L3 metadata, can be used to track
+  implementation, test and documentation coverage for individual
+  features or requirements. Thanks to this you can track
+  everything in one place, including the project implementation
+  progress.
 
-    In addition to the attributes defined here, stories also
-    support common :ref:`/spec/core` attributes which are shared
-    across all metadata levels.
+  In addition to the attributes defined here, stories also
+  support common :ref:`/spec/core` attributes which are shared
+  across all metadata levels.
 
 example: |
-    story:
-        As a user I want to see more detailed information for
-        particular command.
-    description:
-        Different verbose levels can be enabled by using the
-        option several times.
-    example:
-      - tmt test show -v
-      - tmt test show -vvv
-      - tmt test show --verbose
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /tmt/cli.py
-      - verified-by: /tests/core/dry
-    priority: must have
+  story: >
+      As a user I want to see more detailed information for
+      particular command.
+  description: >
+      Different verbose levels can be enabled by using the
+      option several times.
+  example:
+    - tmt test show -v
+    - tmt test show -vvv
+    - tmt test show --verbose
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /tmt/cli.py
+    - verified-by: /tests/core/dry
+  priority: must have

--- a/spec/stories/priority.fmf
+++ b/spec/stories/priority.fmf
@@ -1,47 +1,46 @@
-summary:
-    User story priority
+summary: User story priority
 
-story:
-    As a stakeholder I want to define priority for each user story
-    so that it's clear which user stories are essential and must
-    be implemented, which are important and which are desirable
-    but not necessary.
+story: >
+  As a stakeholder I want to define priority for each user story
+  so that it's clear which user stories are essential and must
+  be implemented, which are important and which are desirable
+  but not necessary.
 
 description: |
-    All user stories are important, but they are prioritized to
-    deliver the greatest and most immediate benefits early. When
-    working on implementation developers should prioritize their
-    tasks to cover the most important features first.
+  All user stories are important, but they are prioritized to
+  deliver the greatest and most immediate benefits early. When
+  working on implementation developers should prioritize their
+  tasks to cover the most important features first.
 
-    The following four values based on the `MoSCoW method`__ are
-    supported:
+  The following four values based on the `MoSCoW method`__ are
+  supported:
 
-    must have
-        critical for the project success, must be delivered on
-        time in order to consider the implementation as successful
+  must have
+      critical for the project success, must be delivered on
+      time in order to consider the implementation as successful
 
-    should have
-        important stories which need to be covered but are not as
-        time-critical and can be delivered later if there are not
-        enough resources
+  should have
+      important stories which need to be covered but are not as
+      time-critical and can be delivered later if there are not
+      enough resources
 
-    could have
-        desirable but not necessary and could improve the user
-        experience or customer satisfaction for a little
-        development cost
+  could have
+      desirable but not necessary and could improve the user
+      experience or customer satisfaction for a little
+      development cost
 
-    will not have
-        least-critical, lowest-payback items, not planned into the
-        current schedule, might be dropped or reconsidered for
-        inclusion in a later timebox
+  will not have
+      least-critical, lowest-payback items, not planned into the
+      current schedule, might be dropped or reconsidered for
+      inclusion in a later timebox
 
-    Must be a ``string`` with one of the above-mentioned values.
+  Must be a ``string`` with one of the above-mentioned values.
 
-    __ https://en.wikipedia.org/wiki/MoSCoW_method
+  __ https://en.wikipedia.org/wiki/MoSCoW_method
 
 example: |
-    # This is an essential feature
-    priority: must have
+  # This is an essential feature
+  priority: must have
 
 link:
   - implemented-by: /tmp/base.py

--- a/spec/stories/story.fmf
+++ b/spec/stories/story.fmf
@@ -1,14 +1,13 @@
-summary:
-    User story describing the feature to be implemented
+summary: User story describing the feature to be implemented
 
-description:
-    This is a **required** attribute. Each story has to define or
-    inherit a ``story`` definition.
+description: >
+  This is a **required** attribute. Each story has to define or
+  inherit a ``story`` definition.
 
 example: |
-    story:
-        As a user I want the application to do this and that
-        so that I can achieve this and that.
+  story: >
+      As a user I want the application to do this and that
+      so that I can achieve this and that.
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/stories/title.fmf
+++ b/spec/stories/title.fmf
@@ -1,19 +1,18 @@
-summary:
-    Title to be used when generating documentation
+summary: Title to be used when generating documentation
 
-story:
-    As a story writer I want to specify a title which should be
-    used when generating online documentation from user stories.
+story: >
+  As a story writer I want to specify a title which should be
+  used when generating online documentation from user stories.
 
-description:
-    When converting user stories into the reStructuredText format
-    in order to render content into online documentation it is
-    sometimes useful to provide a custom user story title rather
-    then using the story name which can be too short to describe
-    well the section content. Must be a ``string``.
+description: >
+  When converting user stories into the reStructuredText format
+  in order to render content into online documentation it is
+  sometimes useful to provide a custom user story title rather
+  then using the story name which can be too short to describe
+  well the section content. Must be a ``string``.
 
 example: |
-    title: Nice title
+  title: Nice title
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/tests/component.fmf
+++ b/spec/tests/component.fmf
@@ -1,17 +1,17 @@
 summary: Relevant fedora/rhel source package names
 
-story:
-    As a SELinux tester testing the 'checkpolicy' component I want
-    to run Tier 1 tests for all SELinux components plus all
-    checkpolicy tests.
+story: >
+  As a SELinux tester testing the 'checkpolicy' component I want
+  to run Tier 1 tests for all SELinux components plus all
+  checkpolicy tests.
 
-description:
-    It's useful to be able to easily select all tests relevant for
-    given component or package. As they do not always have to be
-    stored in the same repository and because many tests cover
-    multiple components a dedicated field is needed. Must be a
-    ``string`` or a ``list of strings``. Component name usually
-    corresponds to the source package name.
+description: >
+  It's useful to be able to easily select all tests relevant for
+  given component or package. As they do not always have to be
+  stored in the same repository and because many tests cover
+  multiple components a dedicated field is needed. Must be a
+  ``string`` or a ``list of strings``. Component name usually
+  corresponds to the source package name.
 
 example:
   - |

--- a/spec/tests/contact.fmf
+++ b/spec/tests/contact.fmf
@@ -1,15 +1,15 @@
 summary: Test maintainer contact
 
-story:
-    As a developer reviewing a complex test which failed I would
-    like to contact the person who maintains the code and
-    understands it well.
+story: >
+  As a developer reviewing a complex test which failed I would
+  like to contact the person who maintains the code and
+  understands it well.
 
-description:
-    When there are several people collaborating on tests it's
-    useful to have a way how find who is responsible for what.
-    Must be a ``string`` or a ``list of strings`` (email address
-    format with name and surname).
+description: >
+  When there are several people collaborating on tests it's
+  useful to have a way how find who is responsible for what.
+  Must be a ``string`` or a ``list of strings`` (email address
+  format with name and surname).
 
 example:
   - |

--- a/spec/tests/description.fmf
+++ b/spec/tests/description.fmf
@@ -1,24 +1,24 @@
 summary: Detailed description of what the test does
 
-story:
-    As a developer I review existing test coverage for my
-    component and would like to get an overall idea what is
-    covered without having to read the whole test code.
+story: >
+  As a developer I review existing test coverage for my
+  component and would like to get an overall idea what is
+  covered without having to read the whole test code.
 
-description:
-    For complex tests it makes sense to provide more detailed
-    description to better clarify what is covered by the test.
-    This can be useful for test writer as well when reviewing a
-    test written long time ago. Must be a ``string`` (multi line,
-    plain text).
+description: >
+  For complex tests it makes sense to provide more detailed
+  description to better clarify what is covered by the test.
+  This can be useful for test writer as well when reviewing a
+  test written long time ago. Must be a ``string`` (multi line,
+  plain text).
 
 example: |
-    description:
-        This test checks all available wget options related to
-        downloading files recursively. First a tree directory
-        structure is created for testing. Then a file download
-        is performed for different recursion depth specified by
-        the "--level=depth" option.
+  description: >
+      This test checks all available wget options related to
+      downloading files recursively. First a tree directory
+      structure is created for testing. Then a file download
+      is performed for different recursion depth specified by
+      the "--level=depth" option.
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/tests/duration.fmf
+++ b/spec/tests/duration.fmf
@@ -1,15 +1,15 @@
 summary: Maximum time for test execution
 
-story:
-    As a test harness I need to know after how long time I should
-    kill test if it is still running to prevent resource wasting.
+story: >
+  As a test harness I need to know after how long time I should
+  kill test if it is still running to prevent resource wasting.
 
-description:
-    In order to prevent stuck tests consuming resources we define a
-    maximum time for test execution. If the limit is exceeded the
-    running test is killed by the test harness. Use the same
-    format as the ``sleep`` command. Must be a ``string``. The
-    default value is ``5m``.
+description: >
+  In order to prevent stuck tests consuming resources we define a
+  maximum time for test execution. If the limit is exceeded the
+  running test is killed by the test harness. Use the same
+  format as the ``sleep`` command. Must be a ``string``. The
+  default value is ``5m``.
 
 example:
   - |
@@ -34,7 +34,6 @@ example:
     adjust:
         duration+: 15m
         when: arch == aarch64
-
 
 link:
   - implemented-by: /tmt/base

--- a/spec/tests/environment.fmf
+++ b/spec/tests/environment.fmf
@@ -1,22 +1,22 @@
 summary: Environment variables to be set before running the test
 
-story:
-    As a tester I need to pass environment variables to my test
-    script to properly execute the desired test scenario.
+story: >
+  As a tester I need to pass environment variables to my test
+  script to properly execute the desired test scenario.
 
-description:
-    Test scripts might require certain environment variables to be
-    set.  Although this can be done on the shell command line as
-    part of the ``test`` attribute it makes sense to have a
-    dedicated field for this, especially when the number of
-    parameters grows. This might be useful for virtual test cases
-    as well. Plan :ref:`/spec/plans/environment` overrides test
-    environment. Must be a ``dictionary``.
+description: >
+  Test scripts might require certain environment variables to be
+  set.  Although this can be done on the shell command line as
+  part of the ``test`` attribute it makes sense to have a
+  dedicated field for this, especially when the number of
+  parameters grows. This might be useful for virtual test cases
+  as well. Plan :ref:`/spec/plans/environment` overrides test
+  environment. Must be a ``dictionary``.
 
 example: |
-    environment:
-        PACKAGE: python37
-        PYTHON: python3.7
+  environment:
+      PACKAGE: python37
+      PYTHON: python3.7
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/tests/framework.fmf
+++ b/spec/tests/framework.fmf
@@ -1,31 +1,31 @@
 summary: Test framework defining how tests should be executed
 
-story:
-    As a tester I want to include tests using different test
-    execution framework in a single plan.
+story: >
+  As a tester I want to include tests using different test
+  execution framework in a single plan.
 
 description: |
-    The framework defines how test code should be executed and how
-    test results should be interpreted (e.g. checking exit code of
-    a shell test versus checking beakerlib test results file). It
-    also determines possible additional required packages to be
-    installed on the test environment.
+  The framework defines how test code should be executed and how
+  test results should be interpreted (e.g. checking exit code of
+  a shell test versus checking beakerlib test results file). It
+  also determines possible additional required packages to be
+  installed on the test environment.
 
-    Currently ``shell`` and ``beakerlib`` are supported. Each
-    `execute` step plugin must list which frameworks it supports
-    and raise an error when an unsupported framework is detected.
+  Currently ``shell`` and ``beakerlib`` are supported. Each
+  `execute` step plugin must list which frameworks it supports
+  and raise an error when an unsupported framework is detected.
 
-    Must be a ``string``, by default ``shell`` is used.
+  Must be a ``string``, by default ``shell`` is used.
 
-    shell
-        Only the exit code determines the test result. Exit code
-        ``0`` is handled as a test ``pass``, exit code ``1`` is
-        considered to be a test ``fail`` and any other exit code
-        is interpreted as an ``error``.
+  shell
+      Only the exit code determines the test result. Exit code
+      ``0`` is handled as a test ``pass``, exit code ``1`` is
+      considered to be a test ``fail`` and any other exit code
+      is interpreted as an ``error``.
 
-    beakerlib
-        Exit code and BeakerLib's ``TestResults`` file determine
-        the test result.
+  beakerlib
+      Exit code and BeakerLib's ``TestResults`` file determine
+      the test result.
 
 example:
   - |

--- a/spec/tests/main.fmf
+++ b/spec/tests/main.fmf
@@ -1,23 +1,23 @@
-story:
-    As a tester I want to store test metadata close to the test
-    source code.
+story: >
+  As a tester I want to store test metadata close to the test
+  source code.
 
 description: |
-    Tests, or L1 metadata, define attributes which are closely
-    related to individual test cases such :ref:`/spec/tests/test`
-    script, :ref:`/spec/tests/framework`, directory
-    :ref:`/spec/tests/path` where the test should be executed,
-    maximum test :ref:`/spec/tests/duration` or packages required
-    to run the test.
+  Tests, or L1 metadata, define attributes which are closely
+  related to individual test cases such :ref:`/spec/tests/test`
+  script, :ref:`/spec/tests/framework`, directory
+  :ref:`/spec/tests/path` where the test should be executed,
+  maximum test :ref:`/spec/tests/duration` or packages required
+  to run the test.
 
-    In addition to the attributes defined here, tests also support
-    common :ref:`/spec/core` attributes which are shared across
-    all metadata levels.
+  In addition to the attributes defined here, tests also support
+  common :ref:`/spec/core` attributes which are shared across
+  all metadata levels.
 
 example: |
-    summary: Check the man page
-    test: man tmt | grep friendly
-    require: grep
-    duration: 1m
-    tier: 1
-    tag: docs
+  summary: Check the man page
+  test: man tmt | grep friendly
+  require: grep
+  duration: 1m
+  tier: 1
+  tag: docs

--- a/spec/tests/manual.fmf
+++ b/spec/tests/manual.fmf
@@ -1,76 +1,76 @@
 summary: Test automation state
 
-story:
-    As a tester I need to store detailed manual instructions covering
-    test scenario I have to perform manually.
+story: >
+  As a tester I need to store detailed manual instructions covering
+  test scenario I have to perform manually.
 
 description: |
-    Attribute marks whether this test needs human interaction
-    during its execution.  Such tests are not likely to be
-    executed in automation pipelines. In the future they can be
-    executed in a semi-automated way, waiting on human
-    interaction.
+  Attribute marks whether this test needs human interaction
+  during its execution.  Such tests are not likely to be
+  executed in automation pipelines. In the future they can be
+  executed in a semi-automated way, waiting on human
+  interaction.
 
-    It's value must be a ``boolean``. The default value is
-    ``false``. When set to ``true``, the :ref:`/spec/tests/test`
-    attribute must point to a Markdown document following the
-    `CommonMark`__ specification.
+  It's value must be a ``boolean``. The default value is
+  ``false``. When set to ``true``, the :ref:`/spec/tests/test`
+  attribute must point to a Markdown document following the
+  `CommonMark`__ specification.
 
-    __ https://spec.commonmark.org/0.29
+  __ https://spec.commonmark.org/0.29
 
-    This is a minimal example of a manual test document containing
-    a single test with one test step and one expected result:
+  This is a minimal example of a manual test document containing
+  a single test with one test step and one expected result:
 
-    .. code-block:: markdown
+  .. code-block:: markdown
 
-        # Test
+      # Test
 
-        ## Step
-        Do this and that.
+      ## Step
+      Do this and that.
 
-        ## Expect
-        Check this and that.
+      ## Expect
+      Check this and that.
 
-    The following sections are recognized by tmt and have a
-    special meaning. Any other features of Markdown can be used,
-    but tmt will just show them.
+  The following sections are recognized by tmt and have a
+  special meaning. Any other features of Markdown can be used,
+  but tmt will just show them.
 
-    Setup
-        Optional heading ``# Setup`` under which any necessary
-        preparation actions are documented. These actions are not
-        part of the test itself.
+  Setup
+      Optional heading ``# Setup`` under which any necessary
+      preparation actions are documented. These actions are not
+      part of the test itself.
 
-    Test
-        Required level 1 heading ``# Test`` or ``# Test .*``
-        starting with the word 'Test' marks beginning of the test
-        itself. Multiple Test sections can be defined in a single
-        document.
+  Test
+      Required level 1 heading ``# Test`` or ``# Test .*``
+      starting with the word 'Test' marks beginning of the test
+      itself. Multiple Test sections can be defined in a single
+      document.
 
-    Step
-        Required level 2 heading ``## Step`` or ``## Test Step``
-        marking a single step of the test, must be in pair with
-        the Expect section which follows it. Cannot be used
-        outside of test sections.
+  Step
+      Required level 2 heading ``## Step`` or ``## Test Step``
+      marking a single step of the test, must be in pair with
+      the Expect section which follows it. Cannot be used
+      outside of test sections.
 
-    Expect
-        Required level 2 heading ``## Expect``, ``## Result`` or
-        ``## Expected Result`` marking expected outcome of the
-        previous step. Cannot be used outside of test sections.
+  Expect
+      Required level 2 heading ``## Expect``, ``## Result`` or
+      ``## Expected Result`` marking expected outcome of the
+      previous step. Cannot be used outside of test sections.
 
-    Cleanup
-        Optional heading ``# Cleanup`` under which any cleanup
-        actions which are not part of the test itself are
-        documented.
+  Cleanup
+      Optional heading ``# Cleanup`` under which any cleanup
+      actions which are not part of the test itself are
+      documented.
 
-    Code block
-        Optional, can be used in any section to mark code
-        snippets. Code type specification (bash, python...) is
-        recommended. It can be used for syntax highlighting and in
-        the future for the semi-automated test execution as well.
+  Code block
+      Optional, can be used in any section to mark code
+      snippets. Code type specification (bash, python...) is
+      recommended. It can be used for syntax highlighting and in
+      the future for the semi-automated test execution as well.
 
-    See the `manual test examples`__ to get a better idea.
+  See the `manual test examples`__ to get a better idea.
 
-    __ https://github.com/teemtee/tmt/tree/main/examples/manual/
+  __ https://github.com/teemtee/tmt/tree/main/examples/manual/
 
 example: |
   manual: true

--- a/spec/tests/path.fmf
+++ b/spec/tests/path.fmf
@@ -1,22 +1,22 @@
 summary: Directory to be entered before executing the test
 
-story:
-    As a test writer I want to define the directory from which the
-    test script should be executed.
+story: >
+  As a test writer I want to define the directory from which the
+  test script should be executed.
 
 description: |
-    In order to have all files which are needed for testing
-    prepared for execution and available on locations expected by
-    the test script, automation changes the current working
-    directory to the provided ``path`` before running the test.
+  In order to have all files which are needed for testing
+  prepared for execution and available on locations expected by
+  the test script, automation changes the current working
+  directory to the provided ``path`` before running the test.
 
-    It must be a ``string`` containing path from the metadata
-    :ref:`tree root<tree>` to the desired directory and must
-    start with a slash. If path is not defined, the directory
-    where the test metadata are stored is used as a default.
+  It must be a ``string`` containing path from the metadata
+  :ref:`tree root<tree>` to the desired directory and must
+  start with a slash. If path is not defined, the directory
+  where the test metadata are stored is used as a default.
 
 example: |
-    path: /protocols/https
+  path: /protocols/https
 
 link:
   - implemented-by: /tmt/base.py

--- a/spec/tests/recommend.fmf
+++ b/spec/tests/recommend.fmf
@@ -1,32 +1,32 @@
 summary: Packages or libraries recommended for the test execution
 
-story:
-    As a tester I want to specify additional packages which should
-    be installed on the system if available and no error should be
-    reported if they cannot be installed.
+story: >
+  As a tester I want to specify additional packages which should
+  be installed on the system if available and no error should be
+  reported if they cannot be installed.
 
 description: |
-    Sometimes there can be additional packages which are not
-    strictly needed to run tests but can improve test execution in
-    some way, for example provide better results presentation.
+  Sometimes there can be additional packages which are not
+  strictly needed to run tests but can improve test execution in
+  some way, for example provide better results presentation.
 
-    Also package names can differ across product versions. Using
-    this attribute it is possible to specify all possible package
-    names and only those which are available will be installed.
+  Also package names can differ across product versions. Using
+  this attribute it is possible to specify all possible package
+  names and only those which are available will be installed.
 
-    If possible, for the second use case it is recommended to
-    specify such packages using the :ref:`/spec/plans/prepare`
-    step configuration which is usually branched according to the
-    version and thus can better ensure that the right packages are
-    correctly installed as expected.
+  If possible, for the second use case it is recommended to
+  specify such packages using the :ref:`/spec/plans/prepare`
+  step configuration which is usually branched according to the
+  version and thus can better ensure that the right packages are
+  correctly installed as expected.
 
-    Note that beakerlib libraries are supported by this attribute
-    as well. See the :ref:`/spec/tests/require` attribute for more
-    details about available reference options.
+  Note that beakerlib libraries are supported by this attribute
+  as well. See the :ref:`/spec/tests/require` attribute for more
+  details about available reference options.
 
-    Must be a ``string`` or a ``list of strings`` using package
-    specification supported by ``dnf`` which takes care of the
-    installation.
+  Must be a ``string`` or a ``list of strings`` using package
+  specification supported by ``dnf`` which takes care of the
+  installation.
 
 example:
   - |

--- a/spec/tests/require.fmf
+++ b/spec/tests/require.fmf
@@ -1,58 +1,58 @@
 summary: Packages, libraries or files required for test execution
 
-story:
-    As a tester I want to specify packages, libraries and files
-    which are required by the test and need to be installed on or
-    copied over to the system so that the test can be successfully
-    executed.
+story: >
+  As a tester I want to specify packages, libraries and files
+  which are required by the test and need to be installed on or
+  copied over to the system so that the test can be successfully
+  executed.
 
 description: |
-    In order to execute the test, additional packages may need to
-    be installed on the system. For example `gcc` and `make` are
-    needed to compile tests written in C on the target machine. If
-    the package cannot be installed test execution must result
-    in an ``error``.
+  In order to execute the test, additional packages may need to
+  be installed on the system. For example `gcc` and `make` are
+  needed to compile tests written in C on the target machine. If
+  the package cannot be installed test execution must result
+  in an ``error``.
 
-    For tests shared across multiple components or product
-    versions where required packages have different names it is
-    recommended to use the :ref:`/spec/plans/prepare` step
-    configuration to specify required packages for each component
-    or product version individually.
+  For tests shared across multiple components or product
+  versions where required packages have different names it is
+  recommended to use the :ref:`/spec/plans/prepare` step
+  configuration to specify required packages for each component
+  or product version individually.
 
-    When referencing beakerlib libraries it is possible to use
-    both the backward-compatible syntax ``library(repo/lib)``
-    which fetches libraries from the `default location`__ as well
-    as provide a ``dictionary`` with a full `fmf identifier`__.
-    For the latter case specify ``type: library``.
+  When referencing beakerlib libraries it is possible to use
+  both the backward-compatible syntax ``library(repo/lib)``
+  which fetches libraries from the `default location`__ as well
+  as provide a ``dictionary`` with a full `fmf identifier`__.
+  For the latter case specify ``type: library``.
 
-    When referencing local files or directories use ``type: file``
-    and define list of paths relative to the fmf root directory.
-    These can be regular expressions to match multiple files or
-    directories or just a single file or directory name. By
-    default everything under test :ref:`/spec/tests/path` is
-    copied over to the system.
+  When referencing local files or directories use ``type: file``
+  and define list of paths relative to the fmf root directory.
+  These can be regular expressions to match multiple files or
+  directories or just a single file or directory name. By
+  default everything under test :ref:`/spec/tests/path` is
+  copied over to the system.
 
-    For now everything is still copied over to the system,
-    this addition is just giving you the ability to change
-    your metadata to reflect required files for your tests/libraries,
-    before the pruning is actually done.
+  For now everything is still copied over to the system,
+  this addition is just giving you the ability to change
+  your metadata to reflect required files for your tests/libraries,
+  before the pruning is actually done.
 
-    By default, fetched repositories are stored in the discover
-    step workdir under the ``libs`` directory. Use optional key
-    ``destination`` to choose a different location. The ``nick``
-    key can be used to override the default git repository name.
+  By default, fetched repositories are stored in the discover
+  step workdir under the ``libs`` directory. Use optional key
+  ``destination`` to choose a different location. The ``nick``
+  key can be used to override the default git repository name.
 
-    For debugging beakerlib libraries it is useful to reference
-    the development version directly from the local filesystem.
-    Use the ``path`` key to specify a full path to the library.
+  For debugging beakerlib libraries it is useful to reference
+  the development version directly from the local filesystem.
+  Use the ``path`` key to specify a full path to the library.
 
-    Must be a ``string`` or a ``list of strings`` using package
-    specification supported by ``dnf`` which takes care of the
-    installation or a ``dictionary`` if using fmf identifier to
-    fetch dependent repositories.
+  Must be a ``string`` or a ``list of strings`` using package
+  specification supported by ``dnf`` which takes care of the
+  installation or a ``dictionary`` if using fmf identifier to
+  fetch dependent repositories.
 
-    __ https://github.com/beakerlib/
-    __ https://fmf.readthedocs.io/en/latest/concept.html#identifiers
+  __ https://github.com/beakerlib/
+  __ https://fmf.readthedocs.io/en/latest/concept.html#identifiers
 
 example:
   - |

--- a/spec/tests/result.fmf
+++ b/spec/tests/result.fmf
@@ -1,29 +1,29 @@
 summary: Specify how test result should be interpreted
 
-story:
-    As a tester I want to regularly execute the test but
-    temporarily ignore test result until more investigation is
-    done and the test can be fixed properly.
+story: >
+  As a tester I want to regularly execute the test but
+  temporarily ignore test result until more investigation is
+  done and the test can be fixed properly.
 
 description: |
-    Even if a test fails it might makes sense to execute it to be
-    able to manually review the results (ignore test result) or
-    ensure the behaviour has not unexpectedly changed and the test
-    is still failing (expected fail). The following values are
-    supported:
+  Even if a test fails it might makes sense to execute it to be
+  able to manually review the results (ignore test result) or
+  ensure the behaviour has not unexpectedly changed and the test
+  is still failing (expected fail). The following values are
+  supported:
 
-    respect
-        test result is respected (fails when test failed) - default value
-    xfail
-        expected fail (pass when test fails, fail when test passes)
-    pass, info, warn, error, fail
-        ignore the actual test result and always report provided
-        value instead
-    custom
-        test needs to create its own ``results.yaml`` or
-        ``results.json`` file in the ``${TMT_TEST_DATA}``
-        directory. The format of the file, notes and detailed examples
-        are documented at :ref:`/spec/plans/results`.
+  respect
+      test result is respected (fails when test failed) - default value
+  xfail
+      expected fail (pass when test fails, fail when test passes)
+  pass, info, warn, error, fail
+      ignore the actual test result and always report provided
+      value instead
+  custom
+      test needs to create its own ``results.yaml`` or
+      ``results.json`` file in the ``${TMT_TEST_DATA}``
+      directory. The format of the file, notes and detailed examples
+      are documented at :ref:`/spec/plans/results`.
 
 example:
   - |

--- a/spec/tests/summary.fmf
+++ b/spec/tests/summary.fmf
@@ -1,16 +1,16 @@
 summary: Concise summary of what the test does
 
-story:
-    As a developer reviewing multiple failed tests I would like to
-    get quickly an idea of what my change broke.
+story: >
+  As a developer reviewing multiple failed tests I would like to
+  get quickly an idea of what my change broke.
 
-description:
-    In order to efficiently collaborate on test maintenance it's
-    crucial to have a short summary of what the test does. Must be a one-line
-    ``string``, should be up to 50 characters long.
+description: >
+  In order to efficiently collaborate on test maintenance it's
+  crucial to have a short summary of what the test does. Must be a one-line
+  ``string``, should be up to 50 characters long.
 
 example: |
-    summary: Test wget recursive download options
+  summary: Test wget recursive download options
 
 link:
   - https://stackoverflow.com/questions/2290016/git-commit-messages-50-72-formatting

--- a/spec/tests/test.fmf
+++ b/spec/tests/test.fmf
@@ -1,25 +1,25 @@
 summary: Shell command which executes the test
 
-story:
-    As a test writer I want to run a single test script in
-    multiple ways (e.g. by providing different parameters).
+story: >
+  As a test writer I want to run a single test script in
+  multiple ways (e.g. by providing different parameters).
 
 description: |
-    This attribute defines how the test is to be executed.
-    Allows to parametrize a single test script and in this way
-    create virtual test cases.
+  This attribute defines how the test is to be executed.
+  Allows to parametrize a single test script and in this way
+  create virtual test cases.
 
-    If the test is :ref:`/spec/tests/manual`, it points to the
-    document describing the manual test case steps in Markdown
-    format with defined structure.
+  If the test is :ref:`/spec/tests/manual`, it points to the
+  document describing the manual test case steps in Markdown
+  format with defined structure.
 
-    Must be a ``string``. This is a **required** attribute.
+  Must be a ``string``. This is a **required** attribute.
 
-    ``Bash`` is used as shell and options ``errexit`` and ``pipefail``
-    are applied using ``set -eo pipefail`` to avoid potential errors
-    going unnoticed. You may revert this setting by explicitly
-    using ``set +eo pipefail``. These options are not applied when
-    ``beakerlib`` is used as the :ref:`/spec/tests/framework`.
+  ``Bash`` is used as shell and options ``errexit`` and ``pipefail``
+  are applied using ``set -eo pipefail`` to avoid potential errors
+  going unnoticed. You may revert this setting by explicitly
+  using ``set +eo pipefail``. These options are not applied when
+  ``beakerlib`` is used as the :ref:`/spec/tests/framework`.
 
 example:
   - |

--- a/stories/cli/common.fmf
+++ b/stories/cli/common.fmf
@@ -1,87 +1,87 @@
-story:
-    I want to have common command line options consistenly
-    used across all supported commands and subcommands.
+story: >
+  I want to have common command line options consistenly
+  used across all supported commands and subcommands.
 
 /verbose:
-    summary: Enable verbose output of the command
-    story:
-        As a user I want to see more detailed information for
-        particular command.
-    description: |
-        Different verbose levels can be enabled by using the
-        option several times. For example, discover step shows
-        only number of tests by default, list of tests in verbose
-        level one and could show some further test details in
-        higher verbose levels.
-    example:
-        - tmt test show -v
-        - tmt test show -vvv
-        - tmt test show --verbose
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /tmt/cli.py
-      - verified-by: /tests/core/dry
+  summary: Enable verbose output of the command
+  story: >
+    As a user I want to see more detailed information for
+    particular command.
+  description: |
+    Different verbose levels can be enabled by using the
+    option several times. For example, discover step shows
+    only number of tests by default, list of tests in verbose
+    level one and could show some further test details in
+    higher verbose levels.
+  example:
+    - tmt test show -v
+    - tmt test show -vvv
+    - tmt test show --verbose
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /tmt/cli.py
+    - verified-by: /tests/core/dry
 
 /quiet:
-    summary: Enable quiet mode of the command
-    example:
-        - tmt test show -q
-        - tmt test show --quiet
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /tmt/cli.py
+  summary: Enable quiet mode of the command
+  example:
+    - tmt test show -q
+    - tmt test show --quiet
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /tmt/cli.py
 
 /force:
-    summary: Force dangerous operations like overwriting files
-    example:
-        - tmt test create -f
-        - tmt test create --force
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /tmt/cli.py
-      - relates: /stories/cli/test/create
+  summary: Force dangerous operations like overwriting files
+  example:
+    - tmt test create -f
+    - tmt test create --force
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /tmt/cli.py
+    - relates: /stories/cli/test/create
 
 /format:
-    summary: Provide machine readable output in given format
-    example:
-        - tmt test ls --format json
-        - tmt plan show --format yaml
-        - tmt story export --format rst
-    link:
-      - implemented-by: /tmt/cli.py
-      - implemented-by: /tmt/base.py
-      - documented-by: /tmt/cli.py
+  summary: Provide machine readable output in given format
+  example:
+    - tmt test ls --format json
+    - tmt plan show --format yaml
+    - tmt story export --format rst
+  link:
+    - implemented-by: /tmt/cli.py
+    - implemented-by: /tmt/base.py
+    - documented-by: /tmt/cli.py
 
 /debug:
-    summary: Print additional information for debugging
-    story:
-        As a tmt developer I want to see as much details about
-        what's happening during execution so that I can easily
-        reveal bugs in the code.
-    description:
-        Debug level can be used to show detailed implementation
-        steps, revealing what's happening under the hood, so that
-        tool developers are able to more easily find bugs in the
-        code. Use the option multiple times to increase verbosity.
-    example:
-        - tmt run -d
-        - tmt run -ddd
-        - tmt run --debug
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /tmt/cli.py
-      - verified-by: /tests/core/dry
+  summary: Print additional information for debugging
+  story: >
+    As a tmt developer I want to see as much details about
+    what's happening during execution so that I can easily
+    reveal bugs in the code.
+  description: >
+    Debug level can be used to show detailed implementation
+    steps, revealing what's happening under the hood, so that
+    tool developers are able to more easily find bugs in the
+    code. Use the option multiple times to increase verbosity.
+  example:
+    - tmt run -d
+    - tmt run -ddd
+    - tmt run --debug
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /tmt/cli.py
+    - verified-by: /tests/core/dry
 
 /dry:
-    summary: Run in dry mode, just let me know what would be done
-    story:
-        As a user I want to run commands in dry mode so that I can
-        see what would happen if I run the command but no actions
-        are performed or changes saved to disk.
-    example:
-        - tmt run -n
-        - tmt run --dry
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /tmt/cli.py
-      - verified-by: /tests/core/dry
+  summary: Run in dry mode, just let me know what would be done
+  story: >
+    As a user I want to run commands in dry mode so that I can
+    see what would happen if I run the command but no actions
+    are performed or changes saved to disk.
+  example:
+    - tmt run -n
+    - tmt run --dry
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /tmt/cli.py
+    - verified-by: /tests/core/dry

--- a/stories/cli/config.fmf
+++ b/stories/cli/config.fmf
@@ -1,59 +1,59 @@
-story:
-    As a user I want to store configuration so that I don't have
-    to always provide my preferred default options on the command
-    line.
+story: >
+  As a user I want to store configuration so that I don't have
+  to always provide my preferred default options on the command
+  line.
 
-description:
-    Configuration should be stored as an ``fmf`` metadata tree
-    according to ``L2 Metadata`` specification. Default values
-    from it would be used if value is not specified in the plan.
+description: >
+  Configuration should be stored as an ``fmf`` metadata tree
+  according to ``L2 Metadata`` specification. Default values
+  from it would be used if value is not specified in the plan.
 
 /system:
-    summary: System wide configuration
-    description:
-        Global default values common for all users on the system
-        should be stored under the ``/etc/tmt`` folder. It is
-        overriden by user configuration if present.
-    example: |
-        provision:
-            how: container
+  summary: System wide configuration
+  description: >
+    Global default values common for all users on the system
+    should be stored under the ``/etc/tmt`` folder. It is
+    overriden by user configuration if present.
+  example: |
+    provision:
+        how: container
 
 /user:
-    summary: User configuration
-    description:
-        Configuration for individual users should be stored under
-        the ``~/.config/tmt`` folder. Overrides global system
-        configuration.
-    example: |
-        provision:
-            image: fedora:33
-        report:
-            how: irc
-            channel: #tmt
+  summary: User configuration
+  description: >
+    Configuration for individual users should be stored under
+    the ``~/.config/tmt`` folder. Overrides global system
+    configuration.
+  example: |
+    provision:
+        image: fedora:33
+    report:
+        how: irc
+        channel: #tmt
 
 /levels:
-    summary: Configuration levels
-    description: |
-        There are several levels of test execution data
-        configuration.
+  summary: Configuration levels
+  description: |
+    There are several levels of test execution data
+    configuration.
 
-        default
-            global default settings (common for most instances)
-        detect
-            detect from previous steps output (e.g. distro from
-            build)
-        define
-            allow to override value by explicit user configuration
+    default
+        global default settings (common for most instances)
+    detect
+        detect from previous steps output (e.g. distro from
+        build)
+    define
+        allow to override value by explicit user configuration
 
-        Let's demonstrate these on a simple example with a
-        distribution compose (C) and the amount of memory (M).
+    Let's demonstrate these on a simple example with a
+    distribution compose (C) and the amount of memory (M).
 
-        * CI system is configured by ``default`` to use compose
-          ``C1`` installed on machines with ``M1`` GB of memory.
-        * When inspecting an artifact CI can ``detect`` that for
-          this particular build target, compose ``C2`` is a much
-          better choice, and memory is fine as it is.
-        * User can still explicitly ``define`` in the
-          configuration that at least ``M2`` GB of memory is
-          needed for successful test execution which overrides
-          both default and detected values.
+    * CI system is configured by ``default`` to use compose
+      ``C1`` installed on machines with ``M1`` GB of memory.
+    * When inspecting an artifact CI can ``detect`` that for
+      this particular build target, compose ``C2`` is a much
+      better choice, and memory is fine as it is.
+    * User can still explicitly ``define`` in the
+      configuration that at least ``M2`` GB of memory is
+      needed for successful test execution which overrides
+      both default and detected values.

--- a/stories/cli/init.fmf
+++ b/stories/cli/init.fmf
@@ -5,19 +5,19 @@ link:
   - verified-by: /tests/unit
 
 /empty:
-    summary: Create an empty metadata tree
-    example: tmt init
+  summary: Create an empty metadata tree
+  example: tmt init
 
 /mini:
-    summary: Create a tree with simple examples
-    example: tmt init --template mini
+  summary: Create a tree with simple examples
+  example: tmt init --template mini
 
 /base:
-    summary: Create a tree with some examples
-    example: tmt init --template base
-    link+:
-      - verified-by: /tests/init/base
+  summary: Create a tree with some examples
+  example: tmt init --template base
+  link+:
+    - verified-by: /tests/init/base
 
 /full:
-    summary: Create a tree with full examples
-    example: tmt init --template full
+  summary: Create a tree with full examples
+  example: tmt init --template full

--- a/stories/cli/main.fmf
+++ b/stories/cli/main.fmf
@@ -1,2 +1,1 @@
-story:
-    As a user I want to have an intuitive command line interface.
+story: As a user I want to have an intuitive command line interface.

--- a/stories/cli/plan.fmf
+++ b/stories/cli/plan.fmf
@@ -1,56 +1,56 @@
 story: 'As a user I want to comfortably work with plans'
 
 /ls:
-    story: 'List available plans'
-    example: tmt plan ls
-    link:
-      - implemented-by: /tmt/cli.py
-      - verified-by: /tests/core/ls
-      - documented-by: /docs/examples.rst#explore-plans
+  story: 'List available plans'
+  example: tmt plan ls
+  link:
+    - implemented-by: /tmt/cli.py
+    - verified-by: /tests/core/ls
+    - documented-by: /docs/examples.rst#explore-plans
 
 /show:
-    story: 'Show plan configuration'
-    example: tmt plan show
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /docs/examples.rst#explore-plans
-      - verified-by: /tests/plans/select
+  story: 'Show plan configuration'
+  example: tmt plan show
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /docs/examples.rst#explore-plans
+    - verified-by: /tests/plans/select
 
 /filter:
-    story: 'Filter available plans'
-    description:
-        Search plans using a regular expression or a filter.
-        Use ``.`` to select plans under the current directory.
-    example:
-        - tmt plan ls .
-        - tmt plan ls REGEXP
-        - tmt plan show --filter artifact:build
-    link:
-      - implemented-by: /tmt/base.py
-      - documented-by: /docs/examples.rst#explore-plans
-      - verified-by: /tests/plans/select
+  story: 'Filter available plans'
+  description: >
+    Search plans using a regular expression or a filter.
+    Use ``.`` to select plans under the current directory.
+  example:
+    - tmt plan ls .
+    - tmt plan ls REGEXP
+    - tmt plan show --filter artifact:build
+  link:
+    - implemented-by: /tmt/base.py
+    - documented-by: /docs/examples.rst#explore-plans
+    - verified-by: /tests/plans/select
 
 /lint:
-    story: 'Check plan against the L2 metadata specification'
-    description:
-        Verify that plan metadata are aligned with the
-        specification, e.g. that all required attributes are
-        present and that all attributes have correct type.
-    example: tmt plan lint
-    link:
-      - implemented-by: /tmt/cli.py
-      - verified-by: /tests/plan/lint
+  story: 'Check plan against the L2 metadata specification'
+  description: >
+    Verify that plan metadata are aligned with the
+    specification, e.g. that all required attributes are
+    present and that all attributes have correct type.
+  example: tmt plan lint
+  link:
+    - implemented-by: /tmt/cli.py
+    - verified-by: /tests/plan/lint
 
 /create:
-    story: 'As a developer I want to easily enable CI'
-    description:
-        Provide a super-easy and user-friendly way how to
-        enable tests in the CI. Several templates should be
-        supported to cover common use cases.
-    example:
-        - tmt plan create /plans/smoke --template=mini
-        - tmt plan create /plans/features --template=full
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /docs/examples.rst#create-plans
-      - verified-by: /tests/plan/create
+  story: 'As a developer I want to easily enable CI'
+  description: >
+    Provide a super-easy and user-friendly way how to
+    enable tests in the CI. Several templates should be
+    supported to cover common use cases.
+  example:
+    - tmt plan create /plans/smoke --template=mini
+    - tmt plan create /plans/features --template=full
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /docs/examples.rst#create-plans
+    - verified-by: /tests/plan/create

--- a/stories/cli/run.fmf
+++ b/stories/cli/run.fmf
@@ -1,285 +1,282 @@
 story: 'As a user I want to execute tests easily'
 
 /default:
-    /run:
-        summary: 'Default should cover the most common use case'
-        story:
-            As a user I want to easily and safely execute all
-            available tests in the default environment.
-        description:
-            Run all relevant tests in a local virtual machine so
-            that the test environment can be safely prepared and
-            adjusted as needed without affecting or possibly
-            breaking user environment such as laptop.
-        link:
-          - implemented-by: /tmt/base.py
-          - documented-by: /docs/examples.rst#run
-          - documented-by: /docs/guide.rst
-        example: tmt run
-    /plan:
-        summary: 'Plan should not be required for test execution'
-        story:
-            As a tester I want to execute tests in the default
-            environment without having to define a plan.
-        description: |
-            Even if there are no :ref:`/spec/plans` defined it is
-            still possible to execute tests and custom scripts. In
-            that case the default :ref:`/spec/plans` configuration
-            is applied and tests are executed using the ``shell``
-            method.
+  /run:
+    summary: 'Default should cover the most common use case'
+    story: >
+      As a user I want to easily and safely execute all
+      available tests in the default environment.
+    description: >
+      Run all relevant tests in a local virtual machine so
+      that the test environment can be safely prepared and
+      adjusted as needed without affecting or possibly
+      breaking user environment such as laptop.
+    link:
+      - implemented-by: /tmt/base.py
+      - documented-by: /docs/examples.rst#run
+      - documented-by: /docs/guide.rst
+    example: tmt run
+  /plan:
+    summary: 'Plan should not be required for test execution'
+    story: >
+      As a tester I want to execute tests in the default
+      environment without having to define a plan.
+    description: |
+      Even if there are no :ref:`/spec/plans` defined it is
+      still possible to execute tests and custom scripts. In
+      that case the default :ref:`/spec/plans` configuration
+      is applied and tests are executed using the ``shell``
+      method.
 
-            In order to discover available tests, the ``fmf``
-            method is used if metadata tree is detected otherwise
-            test discovery defaults to the ``shell`` method as well.
+      In order to discover available tests, the ``fmf``
+      method is used if metadata tree is detected otherwise
+      test discovery defaults to the ``shell`` method as well.
 
-            Individual steps of the default plan can be adjusted
-            as needed in the same way as if it was a real plans.
-            For example use ``execute -h beakerlib`` to execute
-            tests using the beakerlib method.
-        example: |
-            /plans/default:
-                summary:
-                    Default plan when fmf metadata found
-                discover:
-                    how: fmf
-                execute:
-                    how: shell
+      Individual steps of the default plan can be adjusted
+      as needed in the same way as if it was a real plans.
+      For example use ``execute -h beakerlib`` to execute
+      tests using the beakerlib method.
+    example: |
+      /plans/default:
+          summary:
+              Default plan when fmf metadata found
+          discover:
+              how: fmf
+          execute:
+              how: shell
 
-            /plans/default:
-                summary:
-                    Default plan when no fmf metadata around
-                discover:
-                    how: shell
-                execute:
-                    how: shell
-        link:
-          - implemented-by: /tmt/base.py
-          - verified-by: /tests/run/default
-          - documented-by: /docs/examples.rst#run
+      /plans/default:
+          summary:
+              Default plan when no fmf metadata around
+          discover:
+              how: shell
+          execute:
+              how: shell
+    link:
+      - implemented-by: /tmt/base.py
+      - verified-by: /tests/run/default
+      - documented-by: /docs/examples.rst#run
 
 /select:
-    story: 'Select multiple steps to be executed'
+  story: 'Select multiple steps to be executed'
 
-    link:
-      - implemented-by: /tmt/base.py
-      - verified-by: /tests/steps/select
-      - documented-by: /docs/examples.rst#select-steps
+  link:
+    - implemented-by: /tmt/base.py
+    - verified-by: /tests/steps/select
+    - documented-by: /docs/examples.rst#select-steps
 
-    /pick:
-        story: 'Choose steps to be executed'
-        example:
-            - tmt run provision prepare
-            - tmt run discover provision prepare
-    /until:
-        story: 'Run given step and all preceding steps.'
-        example:
-            - tmt run --until prepare
-            - tmt run --until execute
-    /since:
-        story: 'Run given step and all following steps.'
-        example:
-            - tmt run --since prepare
-            - tmt run --since execute
-    /skip:
-        story: 'Skip given step during execution'
-        example:
-            - tmt run --skip prepare
-            - tmt run --skip finish
-    /all:
-        story: 'Run all test steps, customize some'
-        example:
-            - tmt run --all provision --how=container
+  /pick:
+    story: 'Choose steps to be executed'
+    example:
+      - tmt run provision prepare
+      - tmt run discover provision prepare
+  /until:
+    story: 'Run given step and all preceding steps.'
+    example:
+      - tmt run --until prepare
+      - tmt run --until execute
+  /since:
+    story: 'Run given step and all following steps.'
+    example:
+      - tmt run --since prepare
+      - tmt run --since execute
+  /skip:
+    story: 'Skip given step during execution'
+    example:
+      - tmt run --skip prepare
+      - tmt run --skip finish
+  /all:
+    story: 'Run all test steps, customize some'
+    example:
+      - tmt run --all provision --how=container
 
 /interactive:
-    story: 'Provide way similar to git rebase --interactive'
-    description:
-        Provide users with list of steps and let them edit them.
-        Allow adding commands between, or at least interactive "pause".
-        When user would be finished with single step, just continue recipe.
-        Do not force users to remember all steps when working with them.
-        Make it possible to repeat single step or abort current run.
-        Allow repeating some steps just by repeating lines with task.
-    example:
-        - tmt run --all --interactive
-        - tmt run --continue
-        - tmt run --abort
+  story: 'Provide way similar to git rebase --interactive'
+  description: >
+    Provide users with list of steps and let them edit them.
+    Allow adding commands between, or at least interactive "pause".
+    When user would be finished with single step, just continue recipe.
+    Do not force users to remember all steps when working with them.
+    Make it possible to repeat single step or abort current run.
+    Allow repeating some steps just by repeating lines with task.
+  example:
+    - tmt run --all --interactive
+    - tmt run --continue
+    - tmt run --abort
 
 /shortcuts:
-    story: 'Provide shortcuts for common scenarios'
-    /container:
-        example:
-            - tmt run --container=fedora:rawhide
-            - tmt run --container=fedora:rawhide --cap-add=SYS_ADMIN
-    /mock:
-        example:
-            - tmt --mock fedora-31-x86_64
-            - tmt --mock fedora-31-x86_64 --no-clean --enable-network
-            - tmt --mock fedora-31-x86_64 --enablerepo=updates-testing
+  story: 'Provide shortcuts for common scenarios'
+  /container:
+    example:
+      - tmt run --container=fedora:rawhide
+      - tmt run --container=fedora:rawhide --cap-add=SYS_ADMIN
+  /mock:
+    example:
+      - tmt --mock fedora-31-x86_64
+      - tmt --mock fedora-31-x86_64 --no-clean --enable-network
+      - tmt --mock fedora-31-x86_64 --enablerepo=updates-testing
 
 /filter:
-    /plan:
-        story: 'Select plans for execution'
-        example:
-            - tmt run plan --name=NAME
-            - tmt run plan --filter=FILTER
-            - tmt run plan --condition=CONDITION
-        link:
-          - implemented-by: /tmt/base.py
-          - documented-by: /docs/examples.rst#select-plans
-          - verified-by: /tests/plan/select
-    /test:
-        story: 'Select tests for execution'
-        example:
-            - tmt run test --name=NAME
-            - tmt run test --filter=FILTER
-            - tmt run test --condition=CONDITION
-            - tmt run plan --name=NAME2 test --name=NAME1
-        link:
-          - implemented-by: /tmt/base.py
-          - documented-by: /docs/examples.rst#select-tests
-          - verified-by: /tests/test/select
-
-/keep:
-    story: Store test step status, keep machines running
+  /plan:
+    story: 'Select plans for execution'
     example:
-        - tmt run --id ID provision prepare
-        - tmt run --id ID discover execute
-        - tmt run --id ID execute
-        - tmt run --id ID execute
-    link:
-      - implemented-by: /tmp/base.py
-      - documented-by: /docs/examples.rst#debug-tests
-
-/debug:
-    summary: Handsfree debugging
-    story:
-        As a test developer I want to automatically execute
-        tests upon saving the updated test code to disk.
-    description: |
-        A very common loop of modifying the source code and
-        re-executing the test should be accessible without
-        subsequent user interaction with the tool.
-
-        * run the tool once, keep it running
-        * observe the execution results
-        * open an editor in a separate window
-        * modify the file, save the changes
-        * observe the updated execution results
-        * ...
-
-        Prioritize latency and reuse as much as possible from the
-        previous execution. Ideally, start the re-execution from
-        the modified line.
-    example:
-        tmt run debug
-
-/smoke:
-    story:
-        As a developer I want to do a quick smoke test of my
-        freshly built rpm package.
-    example: |
-        tmt run --all \
-        prepare -h install -p tmt-0.4-1.fc29.noarch.rpm \
-        execute -h tmt --script 'tmt --help'
-    link:
-      - implemented-by: /tmt/steps/execute
-      - implemented-by: /tmt/steps/prepare/install.py
-
-/restraint:
-    story:
-        As a tester I want the option to execute tests using the
-        Restraint harness.
-    description:
-        Restraint is the default harness in beaker for RHEL8 and
-        beyond. In order to provide compatibility with beaker
-        style tests, I would like a way to invoke ``tmt`` using
-        the Restaint harness. This would enable Restraint tests to
-        be invoked by ``tmt`` without modification. Some common
-        commands include ``rstrnt-reboot``, ``rstrnt-abort``, and
-        ``rstrnt-report-result``.
-    example:
-        - tmt run --all execute --how restraint
-
-/last:
-    story: 'As a user I want to rerun tests easily'
-    description: |
-        Execute previous run without the need to specify the
-        previous run id. The command is a shortcut for:
-
-        .. code-block:: shell
-
-            tmt run --id PREVIOUS_RUN
-
-        Note that ``tmt`` saves last run id on each new execution.
+      - tmt run plan --name=NAME
+      - tmt run plan --filter=FILTER
+      - tmt run plan --condition=CONDITION
     link:
       - implemented-by: /tmt/base.py
-      - documented-by: /docs/examples.rst#debug-tests
+      - documented-by: /docs/examples.rst#select-plans
+      - verified-by: /tests/plan/select
+  /test:
+    story: 'Select tests for execution'
     example:
-        - tmt run -l
-        - tmt run --last
+      - tmt run test --name=NAME
+      - tmt run test --filter=FILTER
+      - tmt run test --condition=CONDITION
+      - tmt run plan --name=NAME2 test --name=NAME1
+    link:
+      - implemented-by: /tmt/base.py
+      - documented-by: /docs/examples.rst#select-tests
+      - verified-by: /tests/test/select
+
+/keep:
+  story: Store test step status, keep machines running
+  example:
+    - tmt run --id ID provision prepare
+    - tmt run --id ID discover execute
+    - tmt run --id ID execute
+    - tmt run --id ID execute
+  link:
+    - implemented-by: /tmp/base.py
+    - documented-by: /docs/examples.rst#debug-tests
+
+/debug:
+  summary: Handsfree debugging
+  story: >
+    As a test developer I want to automatically execute
+    tests upon saving the updated test code to disk.
+  description: |
+    A very common loop of modifying the source code and
+    re-executing the test should be accessible without
+    subsequent user interaction with the tool.
+
+    * run the tool once, keep it running
+    * observe the execution results
+    * open an editor in a separate window
+    * modify the file, save the changes
+    * observe the updated execution results
+    * ...
+
+    Prioritize latency and reuse as much as possible from the
+    previous execution. Ideally, start the re-execution from
+    the modified line.
+  example: tmt run debug
+
+/smoke:
+  story: >
+    As a developer I want to do a quick smoke test of my
+    freshly built rpm package.
+  example: |
+    tmt run --all \
+    prepare -h install -p tmt-0.4-1.fc29.noarch.rpm \
+    execute -h tmt --script 'tmt --help'
+  link:
+    - implemented-by: /tmt/steps/execute
+    - implemented-by: /tmt/steps/prepare/install.py
+
+/restraint:
+  story: >
+    As a tester I want the option to execute tests using the
+    Restraint harness.
+  description: >
+    Restraint is the default harness in beaker for RHEL8 and
+    beyond. In order to provide compatibility with beaker
+    style tests, I would like a way to invoke ``tmt`` using
+    the Restaint harness. This would enable Restraint tests to
+    be invoked by ``tmt`` without modification. Some common
+    commands include ``rstrnt-reboot``, ``rstrnt-abort``, and
+    ``rstrnt-report-result``.
+  example:
+    - tmt run --all execute --how restraint
+
+/last:
+  story: 'As a user I want to rerun tests easily'
+  description: |
+    Execute previous run without the need to specify the
+    previous run id. The command is a shortcut for:
+
+    .. code-block:: shell
+
+        tmt run --id PREVIOUS_RUN
+
+    Note that ``tmt`` saves last run id on each new execution.
+  link:
+    - implemented-by: /tmt/base.py
+    - documented-by: /docs/examples.rst#debug-tests
+  example:
+    - tmt run -l
+    - tmt run --last
 
 /login:
-    summary: 'Easily login into a provisioned guest'
-    story:
-        As a user I want to log into the provisioned guest so
-        that I can adjust the environment before the test is run
-        or investigate what happened after the test is finished.
+  summary: 'Easily login into a provisioned guest'
+  story: >
+    As a user I want to log into the provisioned guest so
+    that I can adjust the environment before the test is run
+    or investigate what happened after the test is finished.
 
-    link:
-      - implemented-by: /tmt/step
-      - verified-by: /tests/login
-      - documented-by: /docs/examples.rst#guest-login
+  link:
+    - implemented-by: /tmt/step
+    - verified-by: /tests/login
+    - documented-by: /docs/examples.rst#guest-login
 
-    /last:
-        summary: 'Log in at the end of the last enabled step'
-        story:
-            As a user I want to log into the provisioned guest
-            to investigate once the test execution has finished.
-        example:
-            tmt run --until execute login
+  /last:
+    summary: 'Log in at the end of the last enabled step'
+    story: >
+      As a user I want to log into the provisioned guest
+      to investigate once the test execution has finished.
+    example: tmt run --until execute login
 
-    /select:
-        summary: 'Log in at the end of the selected step'
-        story:
-            As a user I want to finish the guest preparation
-            manually at the end of the prepare step.
-        example: |
-            tmt run login --step prepare
-            tmt run login --step prepare:end
-            tmt run login --step prepare:90
+  /select:
+    summary: 'Log in at the end of the selected step'
+    story: >
+      As a user I want to finish the guest preparation
+      manually at the end of the prepare step.
+    example: |
+      tmt run login --step prepare
+      tmt run login --step prepare:end
+      tmt run login --step prepare:90
 
-    /start:
-        summary: 'Log in at the start of the selected step'
-        story:
-            As a user I want to manually enable extra package
-            repositories before the prepare step is run.
-        example: |
-            tmt run login --step prepare:start
-            tmt run login --step prepare:10
+  /start:
+    summary: 'Log in at the start of the selected step'
+    story: >
+      As a user I want to manually enable extra package
+      repositories before the prepare step is run.
+    example: |
+      tmt run login --step prepare:start
+      tmt run login --step prepare:10
 
-    /order:
-        summary: 'Log in at the selected phase of a step'
-        story:
-            As a user I want to select the exact phase during the
-            step execution to log into the guest.
-        example:
-            tmt run login --step prepare:75
+  /order:
+    summary: 'Log in at the selected phase of a step'
+    story: >
+      As a user I want to select the exact phase during the
+      step execution to log into the guest.
+    example: tmt run login --step prepare:75
 
-    /status:
-        summary: 'Log in when a test finished with given status'
-        story:
-            As a user I want to quickly investigate what exactly
-            happened on the guest if any test failed.
-        example: |
-            tmt run login --step execute --when fail
-            tmt run login --step execute --when error
-            tmt run login --step execute --when fail --when error
+  /status:
+    summary: 'Log in when a test finished with given status'
+    story: >
+      As a user I want to quickly investigate what exactly
+      happened on the guest if any test failed.
+    example: |
+      tmt run login --step execute --when fail
+      tmt run login --step execute --when error
+      tmt run login --step execute --when fail --when error
 
-    /experiment:
-        summary: 'Provision an environment for experimenting'
-        story:
-            As a user I want to easily provision a clean and safe
-            environment for experimenting and remove it when done.
-        example: |
-            tmt run provision login
-            tmt run --last finish
+  /experiment:
+    summary: 'Provision an environment for experimenting'
+    story: >
+      As a user I want to easily provision a clean and safe
+      environment for experimenting and remove it when done.
+    example: |
+      tmt run provision login
+      tmt run --last finish

--- a/stories/cli/steps.fmf
+++ b/stories/cli/steps.fmf
@@ -1,165 +1,165 @@
 /discover:
-    story: 'Select or adjust the discover step'
-    description:
-        Defines which tests should be executed.
-    example:
-        - tmt run discover
-        - tmt run discover --how=fmf
-        - tmt run discover --how=fmf --url=url
-        - tmt run discover --how=shell
-    link:
-      - implemented-by: /tmt/steps/discover
+  story: 'Select or adjust the discover step'
+  description: >
+    Defines which tests should be executed.
+  example:
+    - tmt run discover
+    - tmt run discover --how=fmf
+    - tmt run discover --how=fmf --url=url
+    - tmt run discover --how=shell
+  link:
+    - implemented-by: /tmt/steps/discover
 
 /provision:
-    story: 'Select or adjust the provision step'
-    description:
-        Describes what environment is needed for testing and
-        how it should provisioned.
+  story: 'Select or adjust the provision step'
+  description: >
+    Describes what environment is needed for testing and
+    how it should provisioned.
+  example:
+    - tmt run provision
+    - tmt run provision --how=virtual
+    - tmt run provision --how=testing-farm --memory=2048MB
+    - tmt run provision --how=container
+    - tmt run provision --how=container --image=fedora:rawhide
+    - tmt run provision --how=local
+
+  /default:
+    story: 'Use default config or provision a virtual machine'
+    example: tmt run provision
+    link:
+      - implemented-by: /tmt/steps/provision
+      - documented-by: /docs/examples.rst#provision-options
+
+  /local:
+    story: 'Use localhost for testing'
+    example: tmt run provision --how=local
+    link:
+      - implemented-by: /tmt/steps/provision/localhost.py
+      - documented-by: /docs/examples.rst#provision-options
+      - verified-by: /tests/init/base
+
+  /virtual:
+    story: 'Provision a virtual machine'
+    example: tmt run provision --how=virtual --image=fedora/31-cloud-base
+    link:
+      - implemented-by: /tmt/steps/provision/testcloud.py
+      - documented-by: /docs/examples.rst#provision-options
+
+  /container:
+    story: 'Provision a container'
+    example: tmt run provision --how=container --image=fedora:latest
+    link:
+      - implemented-by: /tmt/steps/provision/podman.py
+      - documented-by: /docs/examples.rst#provision-options
+
+  /connect:
+    story: 'Connect to a provisioned box'
+    description: >
+      Do not provision a new system. Instead, use provided
+      authentication data to connect to a running machine.
+    link:
+      - implemented-by: /tmt/steps/provision/vagrant.py
+      - documented-by: /docs/examples.rst#provision-options
     example:
-        - tmt run provision
-        - tmt run provision --how=virtual
-        - tmt run provision --how=testing-farm --memory=2048MB
-        - tmt run provision --how=container
-        - tmt run provision --how=container --image=fedora:rawhide
-        - tmt run provision --how=local
-
-    /default:
-        story: 'Use default config or provision a virtual machine'
-        example: tmt run provision
-        link:
-          - implemented-by: /tmt/steps/provision
-          - documented-by: /docs/examples.rst#provision-options
-
-    /local:
-        story: 'Use localhost for testing'
-        example: tmt run provision --how=local
-        link:
-          - implemented-by: /tmt/steps/provision/localhost.py
-          - documented-by: /docs/examples.rst#provision-options
-          - verified-by: /tests/init/base
-
-    /virtual:
-        story: 'Provision a virtual machine'
-        example: tmt run provision --how=virtual --image=fedora/31-cloud-base
-        link:
-          - implemented-by: /tmt/steps/provision/testcloud.py
-          - documented-by: /docs/examples.rst#provision-options
-
-    /container:
-        story: 'Provision a container'
-        example: tmt run provision --how=container --image=fedora:latest
-        link:
-          - implemented-by: /tmt/steps/provision/podman.py
-          - documented-by: /docs/examples.rst#provision-options
-
-    /connect:
-        story: 'Connect to a provisioned box'
-        description:
-            Do not provision a new system. Instead, use provided
-            authentication data to connect to a running machine.
-        link:
-          - implemented-by: /tmt/steps/provision/vagrant.py
-          - documented-by: /docs/examples.rst#provision-options
-        example:
-            - tmt run provision --how=connect --guest=name-or-ip --user=login --password=secret
-            - tmt run provision --how=connect --guest=name-or-ip --key=private-key-path
+      - tmt run provision --how=connect --guest=name-or-ip --user=login --password=secret
+      - tmt run provision --how=connect --guest=name-or-ip --key=private-key-path
 
 /prepare:
-    story: 'Select or adjust the prepare step'
-    description:
-        Additional configuration of the provisioned
-        environment needed for testing.
-    example:
-        - tmt run prepare
-        - tmt run prepare --how=install
-        - tmt run prepare --how=install --package=fresh.rpm
-        - tmt run prepare --how=ansible
-        - tmt run prepare --how=ansible --playbook=server.yaml
-    link:
-      - implemented-by: /tmt/steps/prepare
+  story: 'Select or adjust the prepare step'
+  description: >
+    Additional configuration of the provisioned
+    environment needed for testing.
+  example:
+    - tmt run prepare
+    - tmt run prepare --how=install
+    - tmt run prepare --how=install --package=fresh.rpm
+    - tmt run prepare --how=ansible
+    - tmt run prepare --how=ansible --playbook=server.yaml
+  link:
+    - implemented-by: /tmt/steps/prepare
 
 /execute:
-    story: 'Select or adjust the execute step'
-    description:
-        Specification of the executor which should run tests.
+  story: 'Select or adjust the execute step'
+  description: >
+    Specification of the executor which should run tests.
+  example:
+    - tmt run execute
+    - tmt run execute --how=tmt
+    - tmt run execute --how=restraint
+
+  /progress:
+    summary: Watch test execution progress
+    story: >
+      As a user I want to watch live test execution
+      including the complete test output.
+    description: >
+      In order to see progress of the testing use the
+      ``--verbose`` or ``-v`` switch. Applying the option
+      multiple times increases verbosity. This is supported
+      by the :ref:`/spec/plans/execute/tmt` executor only.
     example:
-        - tmt run execute
-        - tmt run execute --how=tmt
-        - tmt run execute --how=restraint
+      - tmt run -v
+      - tmt run -vv
+      - tmt run -vvv
+      - tmt run --all execute -vvv
+    link:
+      - implemented-by: /tmt/steps/execute/internal.py
 
-    /progress:
-        summary: Watch test execution progress
-        story:
-            As a user I want to watch live test execution
-            including the complete test output.
-        description:
-            In order to see progress of the testing use the
-            ``--verbose`` or ``-v`` switch. Applying the option
-            multiple times increases verbosity. This is supported
-            by the :ref:`/spec/plans/execute/tmt` executor only.
-        example:
-          - tmt run -v
-          - tmt run -vv
-          - tmt run -vvv
-          - tmt run --all execute -vvv
-        link:
-          - implemented-by: /tmt/steps/execute/internal.py
+  /interactive:
+    summary: Interactive test debugging
+    story: >
+      As a user I want to interactively debug tests in the
+      middle of their execution.
+    description: >
+      To debug a test use the ``--interactive`` option which
+      disables output capturing and allows to interact
+      directly with the test from the terminal. For example,
+      for tests written in shell you can insert a ``bash``
+      command in the middle of the script and investigate.
+      Supported by the :ref:`/spec/plans/execute/tmt`
+      executor only.
+    example:
+      - tmt run --all execute --how tmt --interactive
+    link:
+      - implemented-by: /tmt/steps/execute/internal.py
+      - documented-by: /docs/examples.rst
 
-    /interactive:
-        summary: Interactive test debugging
-        story:
-            As a user I want to interactively debug tests in the
-            middle of their execution.
-        description:
-            To debug a test use the ``--interactive`` option which
-            disables output capturing and allows to interact
-            directly with the test from the terminal. For example,
-            for tests written in shell you can insert a ``bash``
-            command in the middle of the script and investigate.
-            Supported by the :ref:`/spec/plans/execute/tmt`
-            executor only.
-        example:
-          - tmt run --all execute --how tmt --interactive
-        link:
-          - implemented-by: /tmt/steps/execute/internal.py
-          - documented-by: /docs/examples.rst
-
-    /exit-first:
-        summary: Stop execution after a test fails
-        story:
-            As a user I want to avoid waiting for all discovered
-            tests to finish if one of them fails.
-        description:
-            To interrupt test execution after a test fails use the
-            ``--exit-first`` (or ``-x``) option. This option is
-            accepted by both the execute step and the plugins implementing
-            the execute step.
-        example:
-          - tmt run -a execute --exit-first
-          - tmt run -a execute -h tmt -x
-        link:
-          - implemented-by: /tmt/steps/execute/internal.py
-          - verified-by: /tests/execute/exit-first
+  /exit-first:
+    summary: Stop execution after a test fails
+    story: >
+      As a user I want to avoid waiting for all discovered
+      tests to finish if one of them fails.
+    description: >
+      To interrupt test execution after a test fails use the
+      ``--exit-first`` (or ``-x``) option. This option is
+      accepted by both the execute step and the plugins implementing
+      the execute step.
+    example:
+      - tmt run -a execute --exit-first
+      - tmt run -a execute -h tmt -x
+    link:
+      - implemented-by: /tmt/steps/execute/internal.py
+      - verified-by: /tests/execute/exit-first
 
 /report:
-    story: 'Select or adjust the report step'
-    description:
-        Adjusting notifications about the test progress and
-        results.
-    example:
-        - tmt run report
-        - tmt run report --how=html
-        - tmt run report --how=html --open
-    link:
-      - implemented-by: /tmt/steps/report
+  story: 'Select or adjust the report step'
+  description: >
+    Adjusting notifications about the test progress and
+    results.
+  example:
+    - tmt run report
+    - tmt run report --how=html
+    - tmt run report --how=html --open
+  link:
+    - implemented-by: /tmt/steps/report
 
 /finish:
-    story: 'Select or adjust the finish step'
-    description:
-        Additional actions to be performed after the test
-        execution has been completed. Counterpart of the
-        prepare step useful for various cleanup actions.
-    example:
-        - tmt run finish
-    link:
-      - implemented-by: /tmt/steps/finish
+  story: 'Select or adjust the finish step'
+  description: >
+    Additional actions to be performed after the test
+    execution has been completed. Counterpart of the
+    prepare step useful for various cleanup actions.
+  example:
+    - tmt run finish
+  link:
+    - implemented-by: /tmt/steps/finish

--- a/stories/cli/story.fmf
+++ b/stories/cli/story.fmf
@@ -1,103 +1,103 @@
 story: 'As a developer I want to comfortably work with stories'
 
 /ls:
-    story: 'List available stories'
-    example: tmt story ls
-    link:
-      - implemented-by: /tmt/cli.py
-      - verified-by: /tests/core/ls
-      - documented-by: /docs/examples.rst#explore-stories
+  story: 'List available stories'
+  example: tmt story ls
+  link:
+    - implemented-by: /tmt/cli.py
+    - verified-by: /tests/core/ls
+    - documented-by: /docs/examples.rst#explore-stories
 
 /show:
-    story: 'Show story details'
-    example: tmt story show
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /docs/examples.rst#explore-stories
+  story: 'Show story details'
+  example: tmt story show
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /docs/examples.rst#explore-stories
 
 /filter:
-    story: 'Search available stories'
-    description:
-        Search stories using a regular expression, a filter or
-        coverage status. Use ``.`` to select stories under the
-        current directory.
-    example:
-        - tmt story ls .
-        - tmt story ls REGEXP
-        - tmt story ls --implemented
-        - tmt story ls --unimplemented
-        - tmt story ls --verified
-        - tmt story ls --unverified
-        - tmt story ls --documented
-        - tmt story ls --undocumented
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /docs/examples.rst#filter-stories
+  story: 'Search available stories'
+  description: >
+    Search stories using a regular expression, a filter or
+    coverage status. Use ``.`` to select stories under the
+    current directory.
+  example:
+    - tmt story ls .
+    - tmt story ls REGEXP
+    - tmt story ls --implemented
+    - tmt story ls --unimplemented
+    - tmt story ls --verified
+    - tmt story ls --unverified
+    - tmt story ls --documented
+    - tmt story ls --undocumented
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /docs/examples.rst#filter-stories
 
 /create:
-    story: 'As a developer I want to easily create new story.'
-    description:
-        Provide an easy way how to create a new story.
-        Several templates should be provided to choose from.
-    example:
-        - tmt story create /stories/area/story
-        - tmt story create /stories/area/story --template mini
-        - tmt story create /stories/area/story --template mini --force
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /docs/examples.rst#create-stories
+  story: 'As a developer I want to easily create new story.'
+  description: >
+    Provide an easy way how to create a new story.
+    Several templates should be provided to choose from.
+  example:
+    - tmt story create /stories/area/story
+    - tmt story create /stories/area/story --template mini
+    - tmt story create /stories/area/story --template mini --force
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /docs/examples.rst#create-stories
 
 /coverage:
-    summary: 'Show story coverage'
-    story:
-        As a developer I want to easily view which stories
-        have been implemented, are covered by tests and
-        documented and which still need work to be done.
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /docs/examples.rst#story-coverage
+  summary: 'Show story coverage'
+  story: >
+    As a developer I want to easily view which stories
+    have been implemented, are covered by tests and
+    documented and which still need work to be done.
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /docs/examples.rst#story-coverage
 
-    /overview:
-        summary: 'General coverage overview'
-        description:
-            Complete overview of the story coverage including
-            implementation, testing and documentation status.
-        example: tmt story coverage
+  /overview:
+    summary: 'General coverage overview'
+    description: >
+      Complete overview of the story coverage including
+      implementation, testing and documentation status.
+    example: tmt story coverage
 
-    /code:
-        summary: 'View code implementation status'
-        example:
-            - tmt story coverage -c
-            - tmt story coverage --code
+  /code:
+    summary: 'View code implementation status'
+    example:
+      - tmt story coverage -c
+      - tmt story coverage --code
 
-    /test:
-        summary: 'View test coverage status'
-        example:
-            - tmt story coverage -t
-            - tmt story coverage --test
+  /test:
+    summary: 'View test coverage status'
+    example:
+      - tmt story coverage -t
+      - tmt story coverage --test
 
-    /docs:
-        summary: 'View documentation status'
-        example:
-            - tmt story coverage -d
-            - tmt story coverage --docs
+  /docs:
+    summary: 'View documentation status'
+    example:
+      - tmt story coverage -d
+      - tmt story coverage --docs
 
 /export:
-    story: 'I need to convert stories into a beautiful format'
+  story: 'I need to convert stories into a beautiful format'
 
-    /rst:
-        story: 'Export stories into reStructuredText'
-        description:
-            So that they can be included in tmt documentation.
-        example: tmt story export --rst
-        link:
-          - implemented-by: /tmt/cli.py
-          - implemented-by: /tmt/base.py
+  /rst:
+    story: 'Export stories into reStructuredText'
+    description: >
+      So that they can be included in tmt documentation.
+    example: tmt story export --rst
+    link:
+      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/base.py
 
-    /html:
-        story: 'Export stories into html'
-        description:
-            So that they can be quickly reviewed in a web
-            browser. Optionally a simple python httpd server
-            could be started to serve the page or pages.
-        example: tmt story export --html --server
+  /html:
+    story: 'Export stories into html'
+    description: >
+      So that they can be quickly reviewed in a web
+      browser. Optionally a simple python httpd server
+      could be started to serve the page or pages.
+    example: tmt story export --html --server

--- a/stories/cli/test.fmf
+++ b/stories/cli/test.fmf
@@ -1,124 +1,124 @@
 story: 'As a user I want to comfortably work with tests'
 
 /ls:
-    story: 'List available tests'
-    example: tmt test ls
-    link:
-      - implemented-by: /tmt/cli.py
-      - verified-by: /tests/core/ls
-      - documented-by: /docs/examples.rst#explore-tests
+  story: 'List available tests'
+  example: tmt test ls
+  link:
+    - implemented-by: /tmt/cli.py
+    - verified-by: /tests/core/ls
+    - documented-by: /docs/examples.rst#explore-tests
 
 /show:
-    story: 'Show test metadata'
-    example: tmt test show
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /docs/examples.rst#explore-tests
+  story: 'Show test metadata'
+  example: tmt test show
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /docs/examples.rst#explore-tests
 
 /lint:
-    story: 'Check test against the L1 metadata specification'
-    description:
-        Verify that test metadata are aligned with the
-        specification, e.g. that all required attributes are
-        present and that all attributes have correct type.
-    example: tmt test lint
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /docs/examples.rst#lint-tests
+  story: 'Check test against the L1 metadata specification'
+  description: >
+    Verify that test metadata are aligned with the
+    specification, e.g. that all required attributes are
+    present and that all attributes have correct type.
+  example: tmt test lint
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /docs/examples.rst#lint-tests
 
 /create:
-    story: 'Create a new test skeleton'
-    description:
-        Provide an easy way how to create a new test. Ideally
-        with support for multiple test skeletons. Similarly as
-        beaker-wizard (which should be obsoleted by this) the
-        tool should prompt for required values if not provided
-        on the command line.
-    example:
-        - tmt test create
-        - tmt test create /tests/area/feature
-        - tmt test create /tests/area/feature --skeleton beakerlib
-        - tmt test create /tests/area/feature --duration=1h
-    link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /docs/examples.rst#create-tests
+  story: 'Create a new test skeleton'
+  description: >
+    Provide an easy way how to create a new test. Ideally
+    with support for multiple test skeletons. Similarly as
+    beaker-wizard (which should be obsoleted by this) the
+    tool should prompt for required values if not provided
+    on the command line.
+  example:
+    - tmt test create
+    - tmt test create /tests/area/feature
+    - tmt test create /tests/area/feature --skeleton beakerlib
+    - tmt test create /tests/area/feature --duration=1h
+  link:
+    - implemented-by: /tmt/cli.py
+    - documented-by: /docs/examples.rst#create-tests
 
 /import:
-    story: 'As a tester I want to import test metadata.'
-    example: tmt test import
-    link:
-      - implemented-by: /tmt/convert.py
-      - verified-by: /tests/test_convert
-      - documented-by: /docs/examples.rst#convert-tests
+  story: 'As a tester I want to import test metadata.'
+  example: tmt test import
+  link:
+    - implemented-by: /tmt/convert.py
+    - verified-by: /tests/test_convert
+    - documented-by: /docs/examples.rst#convert-tests
 
 /export:
-    story: 'As a tester I want to export test metadata.'
+  story: 'As a tester I want to export test metadata.'
 
-    /format:
-        story: 'I want to export test metadata into given format.'
-        example: tmt test export --format yaml
-        link:
-          - implemented-by: /tmt/base.py
-
-    /nitrate:
-        story: 'I want to export test metadata into nitrate.'
-        example: tmt test export --nitrate
-        description: |
-            In order to keep metadata in sync with the old test
-            case management system we need to export selected set
-            of attributes back to nitrate. The full fmf object
-            identifier should be added to the structured field
-            under the key ``fmf``. A warning should be added to
-            the structured field informing users that the test
-            metadata are now maintained in git.
-
-            Below is the list of supported ``fmf`` attributes and
-            corresponding nitrate fields:
-
-            * component — components tab
-            * contact — default tester
-            * description — purpose-file in the structured field
-            * duration — estimated time
-            * enabled — status
-            * environment — arguments
-            * path — not synced
-            * result — not synced
-            * summary — description in the structured field
-            * tag — tags tab
-            * test — not synced
-            * tier — tags (e.g. ``1`` synced to the ``Tier1`` tag)
-
-            The following attributes, if present, should be
-            exported as well:
-
-            * extra-summary — test case summary
-            * extra-hardware — hardware in the structured field
-            * extra-pepa — pepa in the structured field
-
-            They have the ``extra`` prefix as they are not part of
-            the L1 Metadata Specification and are supposed to be
-            synced temporarily to keep backward compatibility.
-
-            After a successful export, special tag ``fmf-export``
-            should be added to the nitrate test case in order to
-            allow easy search for migrated test cases directly
-            from the web interface.
-        link:
-          - implemented-by: /tmt/export.py
-          - documented-by: /docs/questions#nitrate-migration
-
-/filter:
-    story: 'Filter available tests'
-    description:
-        Search tests using a regular expression or a filter.
-        Use ``.`` to select tests under the current directory.
-    example:
-        - tmt test ls .
-        - tmt test ls REGEXP
-        - tmt test show --filter tier:1
-        - tmt test show --condition 'int(tier) < 2'
-        - tmt test show --condition '"gcc" in require'
+  /format:
+    story: 'I want to export test metadata into given format.'
+    example: tmt test export --format yaml
     link:
       - implemented-by: /tmt/base.py
-      - documented-by: /docs/examples.rst#filter-tests
-      - verified-by: /tests/test/select
+
+  /nitrate:
+    story: 'I want to export test metadata into nitrate.'
+    example: tmt test export --nitrate
+    description: |
+      In order to keep metadata in sync with the old test
+      case management system we need to export selected set
+      of attributes back to nitrate. The full fmf object
+      identifier should be added to the structured field
+      under the key ``fmf``. A warning should be added to
+      the structured field informing users that the test
+      metadata are now maintained in git.
+
+      Below is the list of supported ``fmf`` attributes and
+      corresponding nitrate fields:
+
+      * component — components tab
+      * contact — default tester
+      * description — purpose-file in the structured field
+      * duration — estimated time
+      * enabled — status
+      * environment — arguments
+      * path — not synced
+      * result — not synced
+      * summary — description in the structured field
+      * tag — tags tab
+      * test — not synced
+      * tier — tags (e.g. ``1`` synced to the ``Tier1`` tag)
+
+      The following attributes, if present, should be
+      exported as well:
+
+      * extra-summary — test case summary
+      * extra-hardware — hardware in the structured field
+      * extra-pepa — pepa in the structured field
+
+      They have the ``extra`` prefix as they are not part of
+      the L1 Metadata Specification and are supposed to be
+      synced temporarily to keep backward compatibility.
+
+      After a successful export, special tag ``fmf-export``
+      should be added to the nitrate test case in order to
+      allow easy search for migrated test cases directly
+      from the web interface.
+    link:
+      - implemented-by: /tmt/export.py
+      - documented-by: /docs/questions#nitrate-migration
+
+/filter:
+  story: 'Filter available tests'
+  description: >
+    Search tests using a regular expression or a filter.
+    Use ``.`` to select tests under the current directory.
+  example:
+    - tmt test ls .
+    - tmt test ls REGEXP
+    - tmt test show --filter tier:1
+    - tmt test show --condition 'int(tier) < 2'
+    - tmt test show --condition '"gcc" in require'
+  link:
+    - implemented-by: /tmt/base.py
+    - documented-by: /docs/examples.rst#filter-tests
+    - verified-by: /tests/test/select

--- a/stories/cli/usability.fmf
+++ b/stories/cli/usability.fmf
@@ -1,26 +1,24 @@
-story:
-    As a user I want to type as little as possible.
+story: As a user I want to type as little as possible.
 
 /abbreviation:
+  /commands:
+    summary: Allow command abbreviation
+    example:
+      - tmt story show
+      - tmt st sh
+      - tmt s s
+    link:
+      - implemented-by: /tmt/cli.py
 
-    /commands:
-        summary: Allow command abbreviation
-        example:
-            - tmt story show
-            - tmt st sh
-            - tmt s s
-        link:
-          - implemented-by: /tmt/cli.py
-
-    /options:
-        summary: Allow option abbreviation
-        example:
-            - tmt story ls --implemented
-            - tmt story ls --impl
-            - tmt story ls --i
+  /options:
+    summary: Allow option abbreviation
+    example:
+      - tmt story ls --implemented
+      - tmt story ls --impl
+      - tmt story ls --i
 
 /completion:
-    summary: Support bash completion
-    example: tmt st<tabl> sh<tab>
-    link:
-      - implemented-by: /tmt.spec
+  summary: Support bash completion
+  example: tmt st<tabl> sh<tab>
+  link:
+    - implemented-by: /tmt.spec

--- a/stories/docs.fmf
+++ b/stories/docs.fmf
@@ -1,65 +1,65 @@
-story:
-    As a command line user I want to have all essential
-    documentation at hand.
+story: >
+  As a command line user I want to have all essential
+  documentation at hand.
 
 /help:
-    story:
-        As a command line user I want to quickly check all
-        available options and supported commands.
-    description:
-        All available options should be easily discoverable
-        directly from the command line using the ``--help``
-        option.
-    example:
-        - tmt --help
-        - tmt run --help
-        - tmt test import --help
-    link:
-      - verified-by: /tests/core/docs
-      - implemented-by: /tmt/cli.py
+  story: >
+    As a command line user I want to quickly check all
+    available options and supported commands.
+  description: >
+    All available options should be easily discoverable
+    directly from the command line using the ``--help``
+    option.
+  example:
+    - tmt --help
+    - tmt run --help
+    - tmt test import --help
+  link:
+    - verified-by: /tests/core/docs
+    - implemented-by: /tmt/cli.py
 
 /man:
-    story:
-        As a command line user I want to check the man page to get
-        a basic overview about the tool.
-    description:
-        There should be a manual page availabe in the package.
-        Man page should contain brief introduction about the tool
-        and a list of essential commands and options.
-    example:
-        - man tmt
-    link:
-      - verified-by: /tests/core/docs
-      - implemented-by: /README.rst
+  story: >
+    As a command line user I want to check the man page to get
+    a basic overview about the tool.
+  description: >
+    There should be a manual page available in the package.
+    Man page should contain brief introduction about the tool
+    and a list of essential commands and options.
+  example:
+    - man tmt
+  link:
+    - verified-by: /tests/core/docs
+    - implemented-by: /README.rst
 
 /examples:
-    story:
-        As a new user I would like to experiment with the tool.
-    description:
-        A couple of instructive examples should be included in the
-        package for easy first experimenting. Examples should be
-        stored under the ``/usr/share/doc`` directory.
-    example: |
-        cd /usr/share/doc/tmt/examples
-        ls
-        cd mini
-        tmt test ls
-        tmt plan ls
-        tmt run
-    link:
-      - verified-by: /tests/core/docs
-      - implemented-by: /examples
+  story: >
+    As a new user I would like to experiment with the tool.
+  description: >
+    A couple of instructive examples should be included in the
+    package for easy first experimenting. Examples should be
+    stored under the ``/usr/share/doc`` directory.
+  example: |
+    cd /usr/share/doc/tmt/examples
+    ls
+    cd mini
+    tmt test ls
+    tmt plan ls
+    tmt run
+  link:
+    - verified-by: /tests/core/docs
+    - implemented-by: /examples
 
 /guide:
-    story:
-        As a user migrating from old tools I want to quickly
-        learn how to achieve my common daily tasks with the new
-        tooling.
-    description:
-        Provide a Quick Start Guide describing the most common
-        scenarios and showing mapping of old command to the new
-        syntax.
-    example:
-      - How do I do '1minutetip fedora' with tmt?
-      - How do I do 'wow --reserve' with tmt?
-      - How do I do 'make run' with tmt?
+  story: >
+    As a user migrating from old tools I want to quickly
+    learn how to achieve my common daily tasks with the new
+    tooling.
+  description: >
+    Provide a Quick Start Guide describing the most common
+    scenarios and showing mapping of old command to the new
+    syntax.
+  example:
+    - How do I do '1minutetip fedora' with tmt?
+    - How do I do 'wow --reserve' with tmt?
+    - How do I do 'make run' with tmt?

--- a/stories/features/abort.fmf
+++ b/stories/features/abort.fmf
@@ -1,21 +1,21 @@
 title: Abort test execution
-story:
-    As a tester I want to abort current, and all subsequent,
-    test executions using a shell command during test
-    execution.
+story: >
+  As a tester I want to abort current, and all subsequent,
+  test executions using a shell command during test
+  execution.
 
 description: |
-    The ``tmt-abort`` command can be used to abort the current
-    test execution. This command together with the
-    ``rstrnt-abort`` and ``rhts-abort`` aliases provides a
-    backward-compatible way to execute tests written for the
-    `restraint`__ framework. These scripts are installed on the
-    guest and overwrite any existing scripts with the same name.
+  The ``tmt-abort`` command can be used to abort the current
+  test execution. This command together with the
+  ``rstrnt-abort`` and ``rhts-abort`` aliases provides a
+  backward-compatible way to execute tests written for the
+  `restraint`__ framework. These scripts are installed on the
+  guest and overwrite any existing scripts with the same name.
 
-    __ https://restraint.readthedocs.io/en/latest/commands.html#rstrnt-abort
+  __ https://restraint.readthedocs.io/en/latest/commands.html#rstrnt-abort
 
 example: |
-        tmt-abort
+  tmt-abort
 
 link:
   - implemented-by: /tmt/steps/execute/internal.py

--- a/stories/features/coverage.fmf
+++ b/stories/features/coverage.fmf
@@ -1,73 +1,70 @@
 title: Test Coverage
-story:
-    As a tester I want to document the test coverage, so that it
-    can be easily tracked which user stories are covered by which
-    test case and vice-versa.
+story: >
+  As a tester I want to document the test coverage, so that it
+  can be easily tracked which user stories are covered by which
+  test case and vice-versa.
 
 /relevancy:
-    summary:
-        Story relevancy
-    story:
-        As a product owner I want to connect user stories with
-        products or versions, so that I can filter out items
-        relevant (or not relevant) for a particular product.
-    description:
-        Relevancy is an easy way to bind stories to particular
-        product(s). The same relevancy rules as for tests should
-        be also used for stories.
-    example: |
-        story:
-            As an admin I want product A doing B, so that I can
-            use it for C.
-        adjust:
-          - enabled: False
-            when: distro < fedora-28
-    priority: should have
+  summary: Story relevancy
+  story: >
+    As a product owner I want to connect user stories with
+    products or versions, so that I can filter out items
+    relevant (or not relevant) for a particular product.
+  description: >
+    Relevancy is an easy way to bind stories to particular
+    product(s). The same relevancy rules as for tests should
+    be also used for stories.
+  example: |
+    story: >
+        As an admin I want product A doing B, so that I can
+        use it for C.
+    adjust:
+      - enabled: False
+        when: distro < fedora-28
+  priority: should have
 
 /reference:
-    summary:
-        Referencing remote repositories
-    story:
-        As a tester I want to reference not only local objects,
-        so that user stories can be covered by test cases from a
-        different repository.
-    description:
-        It is possible to use a full fmf identifier in the
-        :ref:`/spec/core/link` attribute.
-    example: |
-        verified-by:
-            url: https://github.com/teemtee/fmf
-            ref: main
-            name: /tests/basic/repo
-    priority: should have
+  summary: Referencing remote repositories
+  story: >
+    As a tester I want to reference not only local objects,
+    so that user stories can be covered by test cases from a
+    different repository.
+  description: >
+    It is possible to use a full fmf identifier in the
+    :ref:`/spec/core/link` attribute.
+  example: |
+    verified-by:
+        url: https://github.com/teemtee/fmf
+        ref: main
+        name: /tests/basic/repo
+  priority: should have
 
 /filter:
-    /repo:
-        summary:
-            Filtering based on fmf identifiers
-        story:
-            As a tester I want to filter based on reference
-            identifiers, so that I can learn where the tests are
-            implemented/maintained.
-        description:
-            There should be an easy way to filter based on fmf
-            identifiers.
-        example: |
-            tmt story ls --filter "url:https://gitlab/project"
-            tmt story ls --filter "url:https://gitlab/project & ref:main name:/tests/smoke"
-        priority: should have
+  /repo:
+    summary: Filtering based on fmf identifiers
+    story: >
+      As a tester I want to filter based on reference
+      identifiers, so that I can learn where the tests are
+      implemented/maintained.
+    description: >
+      There should be an easy way to filter based on fmf
+      identifiers.
+    example: |
+      tmt story ls --filter "url:https://gitlab/project"
+      tmt story ls --filter "url:https://gitlab/project & ref:main name:/tests/smoke"
+    priority: should have
 
-    /tags:
-        summary: Filtering based on test tags
-        story:
-            As a tester I want to filter user stories based on the
-            referenced tests tags, so that I can see what coverage
-            the stories have.
-        description:
-            There should be an easy way to filter based on tests
-            tags.
-        example: |
-            tmt story ls --filter "tag:fast"
-        priority: should have
-        link:
-          - implemented-by: /tmt/base.py
+  /tags:
+    summary: Filtering based on test tags
+    story: >
+      As a tester I want to filter user stories based on the
+      referenced tests tags, so that I can see what coverage
+      the stories have.
+    description: >
+      There should be an easy way to filter based on tests
+      tags.
+    example: |
+      tmt story ls --filter "tag:fast"
+    priority: should have
+    link:
+      - implemented-by: /tmt/base.py

--- a/stories/features/prepare/all.fmf
+++ b/stories/features/prepare/all.fmf
@@ -1,36 +1,35 @@
-summary:
-    Install all packages from a given source
-story:
-    As a developer I would like to install all packages from a
-    given source.
+summary: Install all packages from a given source
+story: >
+  As a developer I would like to install all packages from a
+  given source.
 description: |
-    In case of execution from CI, I want all packages from a given
-    Koji build to be installed, even if they have same or lower
-    NVR. In case of COPR repository, I want all packages from a
-    given repository to be installed, in the latest version
-    available in the given repository. In case of already existing
-    repository, I want to install all packages from the given
-    repository.
+  In case of execution from CI, I want all packages from a given
+  Koji build to be installed, even if they have same or lower
+  NVR. In case of COPR repository, I want all packages from a
+  given repository to be installed, in the latest version
+  available in the given repository. In case of already existing
+  repository, I want to install all packages from the given
+  repository.
 
-    I don't have conflicting subpackages in my repository, or I'm
-    excluding packages explicitly to solve those conflicts. All
-    installation conflicts abort the installation and fail the
-    run. If no packages are found the install fails as well. In
-    case of CI, I want to be able override default behaviour, and
-    install all packages instead.
+  I don't have conflicting subpackages in my repository, or I'm
+  excluding packages explicitly to solve those conflicts. All
+  installation conflicts abort the installation and fail the
+  run. If no packages are found the install fails as well. In
+  case of CI, I want to be able override default behaviour, and
+  install all packages instead.
 example: |
-    /plan/install-all-copr:
-        prepare:
-        - how: install-all
-          copr: psss/tmt
+  /plan/install-all-copr:
+      prepare:
+      - how: install-all
+        copr: psss/tmt
 
-    /plan/install-all-repository:
-        prepare:
-        - how: install-all
-          repository: my-enabled-repo
+  /plan/install-all-repository:
+      prepare:
+      - how: install-all
+        repository: my-enabled-repo
 
-    /plan/install-all-ci:
-        prepare:
-        - how: install-all
+  /plan/install-all-ci:
+      prepare:
+      - how: install-all
 
-    tmt run -a prepare -h install-all -D my_packages/
+  tmt run -a prepare -h install-all -D my_packages/

--- a/stories/features/prepare/main.fmf
+++ b/stories/features/prepare/main.fmf
@@ -1,5 +1,5 @@
 title: Package Preparation
 summary: Preparing packages for testing
-story:
-    As a user, I want a flexible and comfortable way to prepare
-    packages on the guest for testing.
+story: >
+  As a user, I want a flexible and comfortable way to prepare
+  packages on the guest for testing.

--- a/stories/features/prepare/minimal.fmf
+++ b/stories/features/prepare/minimal.fmf
@@ -1,15 +1,14 @@
-summary:
-    Install a minimal set of freshly built required packages
-story:
-    As a developer who has just built fresh rpms in given local
-    directory I want to prepare on the guest only the minimal set
-    of required packages.
-description:
-    After building new rpm packages locally there should be an
-    easy way to install on the guest only those packages which are
-    actually required by tests or are explicitly requested in the
-    prepare step.
+summary: Install a minimal set of freshly built required packages
+story: >
+  As a developer who has just built fresh rpms in given local
+  directory I want to prepare on the guest only the minimal set
+  of required packages.
+description: >
+  After building new rpm packages locally there should be an
+  easy way to install on the guest only those packages which are
+  actually required by tests or are explicitly requested in the
+  prepare step.
 example: |
-    make rpm
-    tmt run test --name smoke \
-        prepare --how install --directory fresh/rpms
+  make rpm
+  tmt run test --name smoke \
+      prepare --how install --directory fresh/rpms

--- a/stories/features/prepare/repository.fmf
+++ b/stories/features/prepare/repository.fmf
@@ -1,17 +1,16 @@
-summary:
-    Add artifact repository for installation
-story:
-    As a CI system I want to be able to add a repository with high
-    priority from which all subsequent packages will be installed,
-    updated, downgraded or reinstalled.
-description:
-    In case of Fedora CI we want the packages to be from the
-    artifact repository which the CI system provides. Due to
-    support of dist-git pull requests we need to support cases
-    when the artifact repository contains packages with lower or
-    the same version, which is quite common in case of scratch
-    builds.
+summary: Add artifact repository for installation
+story: >
+  As a CI system I want to be able to add a repository with high
+  priority from which all subsequent packages will be installed,
+  updated, downgraded or reinstalled.
+description: >
+  In case of Fedora CI we want the packages to be from the
+  artifact repository which the CI system provides. Due to
+  support of dist-git pull requests we need to support cases
+  when the artifact repository contains packages with lower or
+  the same version, which is quite common in case of scratch
+  builds.
 example: |
-    tmt run -a prepare --how repository --order 1 \
-        --base-url file:///repository --priority 999 \
-        plan --name some-plan
+  tmt run -a prepare --how repository --order 1 \
+      --base-url file:///repository --priority 999 \
+      plan --name some-plan

--- a/stories/features/prepare/required.fmf
+++ b/stories/features/prepare/required.fmf
@@ -1,16 +1,15 @@
-summary:
-    Install a minimal set of required packages
-story:
-    As a tester who uses VM or container with relevant
-    repositories enabled and whose packages are not part of the
-    default installation I want to prepare the guest with the
-    minimal set of required packages.
-description:
-    Only packages which are actually required by tests or are
-    explicitly requested in the prepare step are installed. This
-    allows to test the installation itself and also verify
-    functionality without hidden requires.
+summary: Install a minimal set of required packages
+story: >
+  As a tester who uses VM or container with relevant
+  repositories enabled and whose packages are not part of the
+  default installation I want to prepare the guest with the
+  minimal set of required packages.
+description: >
+  Only packages which are actually required by tests or are
+  explicitly requested in the prepare step are installed. This
+  allows to test the installation itself and also verify
+  functionality without hidden requires.
 example: |
-    tmt run plan --name install/dependencies
+  tmt run plan --name install/dependencies
 link:
   - implemented-by: /tmt/steps/prepare/install.py

--- a/stories/features/prepare/selected.fmf
+++ b/stories/features/prepare/selected.fmf
@@ -1,20 +1,19 @@
-summary:
-    Install specific packages
-story:
-    As a developer I would like to install certain packages
-    required for testing.
-description:
-    In case of execution from CI I want these packages to be
-    installed from a given Koji build, even if they have same or
-    lower NVR. I have conflicting subpackages in my package. The
-    specification for local execution and CI should be the same.
+summary: Install specific packages
+story: >
+  As a developer I would like to install certain packages
+  required for testing.
+description: >
+  In case of execution from CI I want these packages to be
+  installed from a given Koji build, even if they have same or
+  lower NVR. I have conflicting subpackages in my package. The
+  specification for local execution and CI should be the same.
 example: |
-    /plan/curl:
-        prepare:
-        - how: install
-          package: curl
+  /plan/curl:
+      prepare:
+      - how: install
+        package: curl
 
-    /plan/curl-minimal:
-        prepare:
-        - how: install
-          package: curl-minimal
+  /plan/curl-minimal:
+      prepare:
+      - how: install
+        package: curl-minimal

--- a/stories/features/reboot.fmf
+++ b/stories/features/reboot.fmf
@@ -1,52 +1,52 @@
 title: Reboot during test
-story:
-    As a tester I need to reboot the guest during a test and then
-    resume the test execution.
+story: >
+  As a tester I need to reboot the guest during a test and then
+  resume the test execution.
 description: |
-    Some tests may require a reboot as a part of them, e.g.
-    upgrading the system, rebooting and then running some checks.
-    The ``tmt-reboot`` command can be used to request the guest
-    reboot from the test and the ``TMT_REBOOT_COUNT`` environment
-    variable provides number of successfully completed reboots.
+  Some tests may require a reboot as a part of them, e.g.
+  upgrading the system, rebooting and then running some checks.
+  The ``tmt-reboot`` command can be used to request the guest
+  reboot from the test and the ``TMT_REBOOT_COUNT`` environment
+  variable provides number of successfully completed reboots.
 
-    Note that this only works with guests provisioned by tmt, e.g.
-    ``container`` or ``virtual``, and doesn't work with the
-    ``local`` provision method. Support of the ``connect``
-    provision is on a best effort basis and will not work on
-    machines where ``reboot`` command is not available.
+  Note that this only works with guests provisioned by tmt, e.g.
+  ``container`` or ``virtual``, and doesn't work with the
+  ``local`` provision method. Support of the ``connect``
+  provision is on a best effort basis and will not work on
+  machines where ``reboot`` command is not available.
 
-    When a custom command for rebooting is required, the ``-c``
-    option of the reboot script can be used, e.g. ``tmt-reboot -c
-    "dnf system-upgrade reboot"``.
+  When a custom command for rebooting is required, the ``-c``
+  option of the reboot script can be used, e.g. ``tmt-reboot -c
+  "dnf system-upgrade reboot"``.
 
-    In some scenarios, rebooting may take longer than usual. The
-    default timeout used in tmt can be overriden using the ``-t``
-    option of the reboot script, e.g. ``tmt-reboot -t 3600`` to
-    wait for up to an hour for the guest to come back up.
+  In some scenarios, rebooting may take longer than usual. The
+  default timeout used in tmt can be overriden using the ``-t``
+  option of the reboot script, e.g. ``tmt-reboot -t 3600`` to
+  wait for up to an hour for the guest to come back up.
 
-    On machines booted in UEFI mode, by default, the *BootNext*
-    property shall be set to the value of *BootCurrent*. The
-    ``-e`` option of the reboot script can be used to prevent
-    this from being set, e.g. ``tmt-reboot -e``.
+  On machines booted in UEFI mode, by default, the *BootNext*
+  property shall be set to the value of *BootCurrent*. The
+  ``-e`` option of the reboot script can be used to prevent
+  this from being set, e.g. ``tmt-reboot -e``.
 
-    For backward-compatibility with the `restraint`__ framework
-    the ``rstrnt-reboot`` and ``rhts-reboot`` commands are provided
-    as well together with the ``RSTRNT_REBOOTCOUNT`` and ``REBOOTCOUNT``
-    environment variables. Calling the script kills the parent process
-    (the running test). Please note that the content of these
-    scripts is not preserved, ``tmt`` overwrites them.
+  For backward-compatibility with the `restraint`__ framework
+  the ``rstrnt-reboot`` and ``rhts-reboot`` commands are provided
+  as well together with the ``RSTRNT_REBOOTCOUNT`` and ``REBOOTCOUNT``
+  environment variables. Calling the script kills the parent process
+  (the running test). Please note that the content of these
+  scripts is not preserved, ``tmt`` overwrites them.
 
-    __ https://restraint.readthedocs.io/en/latest/commands.html#rstrnt-reboot
+  __ https://restraint.readthedocs.io/en/latest/commands.html#rstrnt-reboot
 
 example: |
-    # syntax: shell
+  # syntax: shell
 
-    if [ "$TMT_REBOOT_COUNT" -eq 0 ]; then
-        rlRun "echo 'Before the reboot'"
-        rlRun "tmt-reboot" 0 "Reboot the machine"
-    elif [ "$TMT_REBOOT_COUNT" -eq 1 ]; then
-        rlRun "echo 'After the reboot'"
-    fi
+  if [ "$TMT_REBOOT_COUNT" -eq 0 ]; then
+      rlRun "echo 'Before the reboot'"
+      rlRun "tmt-reboot" 0 "Reboot the machine"
+  elif [ "$TMT_REBOOT_COUNT" -eq 1 ]; then
+      rlRun "echo 'After the reboot'"
+  fi
 link:
-    - implemented-by: /tmt/steps/execute/internal.py
-    - verified-by: /tests/execute/reboot
+  - implemented-by: /tmt/steps/execute/internal.py
+  - verified-by: /tests/execute/reboot

--- a/stories/features/report-log.fmf
+++ b/stories/features/report-log.fmf
@@ -1,25 +1,25 @@
 title: Save a log file
-story:
-    As a tester I want to save a log from a test using the
-    restraint command during test execution.
+story: >
+  As a tester I want to save a log from a test using the
+  restraint command during test execution.
 
 description: |
-    The ``tmt-file-submit`` command can be used to save a log
-    file specified during test execution. This command together
-    with ``rstrnt-report-log``, ``rhts-submit-log`` and
-    ``rhts_submit_log`` provides a backward-compatible way to
-    execute tests written for the `restraint`__ framework.
-    These scripts are installed on the guest and overwrite
-    any existing scripts with the same name.
+  The ``tmt-file-submit`` command can be used to save a log
+  file specified during test execution. This command together
+  with ``rstrnt-report-log``, ``rhts-submit-log`` and
+  ``rhts_submit_log`` provides a backward-compatible way to
+  execute tests written for the `restraint`__ framework.
+  These scripts are installed on the guest and overwrite
+  any existing scripts with the same name.
 
-    The command can be called multiple times for a single test,
-    if a log of that name already exists then it will be
-    overwritten.
+  The command can be called multiple times for a single test,
+  if a log of that name already exists then it will be
+  overwritten.
 
-    __ https://restraint.readthedocs.io/en/latest/commands.html#rstrnt-report-log
+  __ https://restraint.readthedocs.io/en/latest/commands.html#rstrnt-report-log
 
 example: |
-        tmt-file-submit -l /path/to/log/log.txt
+  tmt-file-submit -l /path/to/log/log.txt
 
 link:
   - implemented-by: /tmt/steps/execute/internal.py

--- a/stories/features/report-result.fmf
+++ b/stories/features/report-result.fmf
@@ -1,27 +1,27 @@
 title: Report test result
-story:
-    As a tester I want to report test results using the restraint
-    command during test execution.
+story: >
+  As a tester I want to report test results using the restraint
+  command during test execution.
 
 description: |
-    The ``tmt-report-result`` command can be used to report result
-    of the test during its execution. This command together with
-    ``rstrnt-report-result`` and ``rhts-report-result`` provides a
-    backward-compatible way to execute tests written for the
-    `restraint`__ framework. These scripts are installed on the
-    guest and overwrite any existing scripts with the same name.
+  The ``tmt-report-result`` command can be used to report result
+  of the test during its execution. This command together with
+  ``rstrnt-report-result`` and ``rhts-report-result`` provides a
+  backward-compatible way to execute tests written for the
+  `restraint`__ framework. These scripts are installed on the
+  guest and overwrite any existing scripts with the same name.
 
-    The command can be called multiple times for a single test,
-    the final result will be the most severe rating. Available
-    values ordered by severity are SKIP, PASS, WARN and FAIL.
-    Note, that the only value currently processed by ``tmt`` is
-    the test result, other options are silently ignored.
+  The command can be called multiple times for a single test,
+  the final result will be the most severe rating. Available
+  values ordered by severity are SKIP, PASS, WARN and FAIL.
+  Note, that the only value currently processed by ``tmt`` is
+  the test result, other options are silently ignored.
 
-    __ https://restraint.readthedocs.io/en/latest/commands.html#rstrnt-report-result
+  __ https://restraint.readthedocs.io/en/latest/commands.html#rstrnt-report-result
 
 example: |
-    # syntax: shell
-    tmt-report-result /test/name PASS
+  # syntax: shell
+  tmt-report-result /test/name PASS
 
 link:
   - implemented-by: /tmt/steps/execute/internal.py

--- a/stories/install.fmf
+++ b/stories/install.fmf
@@ -5,11 +5,11 @@ link:
   - documented-by: /docs/guide.rst
 
 /minimal:
-    summary: Minimal tmt installation with core features only
-    example: dnf install tmt
-    link+:
-      - verified-by: /plans/install/minimal
+  summary: Minimal tmt installation with core features only
+  example: dnf install tmt
+  link+:
+    - verified-by: /plans/install/minimal
 
 /all:
-    summary: Install tmt with all available plugins and dependencies
-    example: dnf install tmt-all
+  summary: Install tmt with all available plugins and dependencies
+  example: dnf install tmt-all

--- a/tmt/steps/provision/mrack/mrack-provisioning-config.yaml
+++ b/tmt/steps/provision/mrack/mrack-provisioning-config.yaml
@@ -3,86 +3,86 @@
 static: {}
 
 beaker:
-    strategy: abort  # possible values: (retry|abort)
-    # max_retry: 2  #  if retry is set
+  strategy: abort  # possible values: (retry|abort)
+  # max_retry: 2  #  if retry is set
 
-    distros:
-        c9s: CentOS-Stream-9%
-        rhel-6.10: RHEL-6.10%
-        rhel-7.6: RHEL-7.6%
-        rhel-7.7: RHEL-7.7%
-        rhel-7.8: RHEL-7.8%
-        rhel-7.9: RHEL-7.9%
-        rhel-7.9-nightly: RHEL-7.9%
-        rhel-8.0: RHEL-8.0%
-        rhel-8.1: RHEL-8.1%
-        rhel-8.2: RHEL-8.2%
-        rhel-8.3: RHEL-8.3%
-        rhel-8.3-nightly: RHEL-8.3%
-        rhel-8.4: RHEL-8.4%
-        rhel-8.4-nightly: RHEL-8.4%
-        rhel-8.5: RHEL-8.5%
-        rhel-8.5-nightly: RHEL-8.5%
-        rhel-8.6: RHEL-8.6%
-        rhel-8.6-nightly: RHEL-8.6%
-        rhel-8.7: RHEL-8.7%
-        rhel-8.7-nightly: RHEL-8.7%
-        rhel-8.8: RHEL-8.8%
-        rhel-8.8-nightly: RHEL-8.8%
-        rhel-9.0: RHEL-9.0%
-        rhel-9.0-nightly: RHEL-9.0%
-        rhel-9.1: RHEL-9.1%
-        rhel-9.1-nightly: RHEL-9.1%
-        rhel-9.2: RHEL-9.2%
-        rhel-9.2-nightly: RHEL-9.2%
-        rhel-9-beta: RHEL-9.0%
-        rhel-9-beta-nightly: RHEL-9.0%
-        fedora-30: Fedora-30%
-        fedora-31: Fedora-31%
-        fedora-32: Fedora-32%
-        fedora-33: Fedora-33%
-        fedora-34: Fedora-34%
-        fedora-35: Fedora-35%
-        fedora-36: Fedora-36%
-        fedora-37: Fedora-37%
-        fedora-latest: Fedora-37%
-        fedora: Fedora-37%
-        fedora-rawhide: Fedora-Rawhide-%
+  distros:
+    c9s: CentOS-Stream-9%
+    rhel-6.10: RHEL-6.10%
+    rhel-7.6: RHEL-7.6%
+    rhel-7.7: RHEL-7.7%
+    rhel-7.8: RHEL-7.8%
+    rhel-7.9: RHEL-7.9%
+    rhel-7.9-nightly: RHEL-7.9%
+    rhel-8.0: RHEL-8.0%
+    rhel-8.1: RHEL-8.1%
+    rhel-8.2: RHEL-8.2%
+    rhel-8.3: RHEL-8.3%
+    rhel-8.3-nightly: RHEL-8.3%
+    rhel-8.4: RHEL-8.4%
+    rhel-8.4-nightly: RHEL-8.4%
+    rhel-8.5: RHEL-8.5%
+    rhel-8.5-nightly: RHEL-8.5%
+    rhel-8.6: RHEL-8.6%
+    rhel-8.6-nightly: RHEL-8.6%
+    rhel-8.7: RHEL-8.7%
+    rhel-8.7-nightly: RHEL-8.7%
+    rhel-8.8: RHEL-8.8%
+    rhel-8.8-nightly: RHEL-8.8%
+    rhel-9.0: RHEL-9.0%
+    rhel-9.0-nightly: RHEL-9.0%
+    rhel-9.1: RHEL-9.1%
+    rhel-9.1-nightly: RHEL-9.1%
+    rhel-9.2: RHEL-9.2%
+    rhel-9.2-nightly: RHEL-9.2%
+    rhel-9-beta: RHEL-9.0%
+    rhel-9-beta-nightly: RHEL-9.0%
+    fedora-30: Fedora-30%
+    fedora-31: Fedora-31%
+    fedora-32: Fedora-32%
+    fedora-33: Fedora-33%
+    fedora-34: Fedora-34%
+    fedora-35: Fedora-35%
+    fedora-36: Fedora-36%
+    fedora-37: Fedora-37%
+    fedora-latest: Fedora-37%
+    fedora: Fedora-37%
+    fedora-rawhide: Fedora-Rawhide-%
 
-    distro_variants:
-        default: BaseOS
-        RHEL-6.10%: Server
-        RHEL-7.6%: Server
-        RHEL-7.7%: Server
-        RHEL-7.8%: Server
-        RHEL-7.9%: Server
-        Fedora-30%: Server
-        Fedora-31%: Server
-        Fedora-32%: Server
-        Fedora-33%: Server
-        Fedora-34%: Server
-        Fedora-35%: Server
-        Fedora-36%: Server
-        Fedora-37%: Server
+  distro_variants:
+    default: BaseOS
+    RHEL-6.10%: Server
+    RHEL-7.6%: Server
+    RHEL-7.7%: Server
+    RHEL-7.8%: Server
+    RHEL-7.9%: Server
+    Fedora-30%: Server
+    Fedora-31%: Server
+    Fedora-32%: Server
+    Fedora-33%: Server
+    Fedora-34%: Server
+    Fedora-35%: Server
+    Fedora-36%: Server
+    Fedora-37%: Server
 
-    distro_tags:
-        RHEL-9.0%:
-            - CTS_NIGHTLY
-        CentOS-Stream-9%:
-            - RC-0.1
-        RHEL-9.1%:
-            - CTS_NIGHTLY
-        RHEL-9.2%:
-            - CTS_NIGHTLY
+  distro_tags:
+    RHEL-9.0%:
+      - CTS_NIGHTLY
+    CentOS-Stream-9%:
+      - RC-0.1
+    RHEL-9.1%:
+      - CTS_NIGHTLY
+    RHEL-9.2%:
+      - CTS_NIGHTLY
 
-    reserve_duration: 86400
-    # the phase timeout is 14400s which is 240 mins so give 10 mins to phase env to get ready
-    timeout: 230 # in minutes
+  reserve_duration: 86400
+  # the phase timeout is 14400s which is 240 mins so give 10 mins to phase env to get ready
+  timeout: 230 # in minutes
 
-    tasks:
-        default: [ {"name": "/distribution/dummy", "role": "STANDALONE"} ]
-
-
+  tasks:
+    default:
+      - 'name': '/distribution/dummy'
+      - 'role': 'STANDALONE'
 # mrack inventory layout setup
 # =========================================
 # inventory_layout:

--- a/tmt/templates.py
+++ b/tmt/templates.py
@@ -62,42 +62,40 @@ rlJournalEnd
 DEFAULT_PLAN_NAME = "/plans/default"
 DEFAULT_PLAN = f"""
 {DEFAULT_PLAN_NAME}:
-    discover:
-        how: fmf
-    execute:
-        how: tmt
+  discover:
+    how: fmf
+  execute:
+    how: tmt
 """.lstrip()
 
 PLAN: Dict[str, str] = {}
 
 PLAN['mini'] = """
-summary:
-    Basic smoke test
+summary: Basic smoke test
 execute:
-    how: tmt
-    script: tmt --help
+  how: tmt
+  script: tmt --help
 """.lstrip()
 
 PLAN['base'] = """
-summary:
-    Basic smoke test
+summary: Basic smoke test
 discover:
-    how: fmf
+  how: fmf
 execute:
-    how: tmt
+  how: tmt
 """.lstrip()
 
 PLAN['full'] = """
 summary:
-    Essential command line features
+  Essential command line features
 discover:
-    how: fmf
-    url: https://github.com/teemtee/tmt
+  how: fmf
+  url: https://github.com/teemtee/tmt
 prepare:
-    how: ansible
-    playbook: ansible/packages.yml
+  how: ansible
+  playbook: ansible/packages.yml
 execute:
-    how: tmt
+  how: tmt
 """.lstrip()
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -112,28 +110,26 @@ example: One example is worth thousand words.
 """.lstrip()
 
 STORY['base'] = """
-summary:
-    Short description summarizing the story
-story:
-    As a user I want to do this and that
-    so that I can achieve this.
+summary: Short description summarizing the story
+story: >
+  As a user I want to do this and that
+  so that I can achieve this.
 example:
-    - One example is worth thousand words.
-    - Of course, there can be more than one.
+  - One example is worth thousand words.
+  - Of course, there can be more than one.
 """.lstrip()
 
 STORY['full'] = """
-summary:
-    Short description summarizing the story
-story:
-    As a user I want to do this and that
-    so that I can achieve this.
-description:
-    Text describing all important aspects of the object.
-    Usually spans across several paragraphs. It should not
-    contain detailed examples. Those should be stored
-    under the 'examples' attribute.
+summary: Short description summarizing the story
+story: >
+  As a user I want to do this and that
+  so that I can achieve this.
+description: >
+  Text describing all important aspects of the object.
+  Usually spans across several paragraphs. It should not
+  contain detailed examples. Those should be stored
+  under the 'examples' attribute.
 example:
-    - One example is worth thousand words.
-    - Of course, there can be more than one.
+  - One example is worth thousand words.
+  - Of course, there can be more than one.
 """.lstrip()


### PR DESCRIPTION
Continuing from discussion #2164.

The goal of this is to have fmf files in this repo consistently formatted. Most importantly, those used to generate documentation in order to avoid confusing newcomers.

To give an example, one of the first things in [tmt docs Examples](https://tmt.readthedocs.io/en/stable/examples.html) section includes:
```
summary: Simple smoke test
description: |
    Just run 'tmt --help' to make sure the binary is sane.
    This is really that simple. Nothing more here. Really.
component:
- tmt
test: ./runtest.sh
require:
- fmf
environment:
    TEXT: Text with spaces
    X: '1'
duration: 5m
enabled: true
tag:
- NoRHEL4
- NoRHEL5
adjust:
  - enabled: false
    when: distro ~= rhel-4, rhel-5
```  
Some lists have 0 spaces indentation, some 2, other entries have 4, but sometimes only 2... 
When a newcomer sees this and does not know the yaml syntax well, it can be unnecessarily difficult to understand.

I've spent a weekend learning all things yaml, what formatting to use and propose this:

### Indentation
One can argue is a personal preference, however I've also looked to other projects and communities for references and recommendation:
[Ansible](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html) 
[Kubernetes](https://kubernetes.io/docs/)
[google/yamlfmt](https://github.com/google/yamlfmt)
[prettier](https://github.com/prettier/prettier)
[yamllint.com](https://www.yamllint.com/)
All uses 2 spaces indent, or rather offset=2, mapping=2, sequence=4, so this is what I used here, being objective.

fyi, [yaml.org ](https://yaml.org/) website for example also uses 2 spaces, but offset=0, sequence=2. I suppose it's not terrible.


### Multiline text blocks
This is crazy. I recommend reading this [stack-overflow answer](https://stackoverflow.com/a/21699210)
What I've done is:
 - If the text is not super long, always do single-line.
    from:
    ```
    summary: 
        The minimal user scenario with localhost
    ```
    to: 
    `summary: The minimal user scenario with localhost`

 - If text needs to be split into multiple lines, use either `>` or `|`.
     from:
     ```
     description:
        Tests covering more advanced scenarios, quite often using a
        container or a virtual machine to verify that package
        installation works as expected. These can take some time.
    ```
    to:
    ```
    description: >
      Tests covering more advanced scenarios, quite often using a
      container or a virtual machine to verify that package
      installation works as expected. These can take some time.
    ```
    `|` being used when author want to preserve line breaks


### Single-quotes
Difference between single and double quotes described in [yaml spec](https://yaml.org/spec/1.2.2/#rule-c-quoted-quote)
[Ansible docs](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html#gotchas)
I believe single is a better option for the fmf use-cases. They were already most common anyway.


### Tools
I've experimented with may yaml formatters:

 - **yamlfix**
  Accepts configuration in pyproject.toml, which would be nice-to-have:
    ```
    [tool.yamlfix]
    explicit_start = "false"  # '---' at the beggining of the file
    line_length = 62  # 62 makes multiline text blocks <= 72 chars
    preserve_quotes = "true"  # can remove necessary quotes
    #indent_offset = 2
    #indent_mapping = 2
    #indent_sequence = 4
    comments_require_starting_space = "false"
    whitelines = 1 # allow no more than n whiteline(s)
    comments_whitelines = 1
    section_whitelines = 0  # force n whitelines between top-level sections
    sequence_style = "keep_style"  # "block_style" to force idented lists
    ```
  I've [fixed](https://github.com/lyz-code/yamlfix/pull/251) the tool removing existing whitelines, but there are still issues with yamlfix. For example it insist to keep replacing `>` with `>-` and `|` with `|-`, without any way to disable it. Also, the project is in maintenance mode.


 - **google/yamlfmt**
   Keeps trying to re-indent the text blocks, also doesn't respect existing whitelines. 
   Requires additional [config file](https://github.com/google/yamlfmt/blob/main/docs/config-file.md)

- **pre-commit-hook-yamlfmt**
  Does not require additional config file, as the pre-commit hook accepts `args: [--mapping, '2', --sequence, '4', --offset, '2', --implicit_start, --preserve_null, --preserve-quotes, --width,
          '120']`
  It's a no-go, as this is what it did with one of the files:
    ```
    /file:
      description: |
    
        Save the report into a ``report.yaml`` file with the
        following format:
    ```    
    
    ```
    /file:
      description: |4
    
        Save the report into a ``report.yaml`` file with the
        following format:
    ```

 - **prettier**
   This is what I ultimately used for the formatting, before checking the changed the files individually.
   Downside is that it requires a separate [configuration file](https://prettier.io/docs/en/configuration.html).
   [With it and the following pre-commit hook](https://github.com/martinhoyer/tmt/blob/prettier/.pre-commit-config.yaml) works with the formatting changes done:
   ```
     - repo: https://github.com/pre-commit/mirrors-prettier
       rev: 'v3.0.0-alpha.9-for-vscode'
       hooks:
         - id: prettier
           name: 'format fmf, yaml files'
           types:
             - text
           files: '\.(fmf|yaml)$'
           exclude: '(tmt|tests)/.*'
    ```
    It is not included in this PR though as it was agreed to focus only on linting, not formatting in pre-commit.

 - **yamllint**
   The existing pre-commit check was focused on tmt/schemas/*yaml files. I've extended it to all .fmf and .yaml files, excluding tests/ and tmt/ dirs (except schemas/) 
   - max line-length changed to 120 to accommodate fmf files not suitable for reformatting.
   - document-start disabled as it is warning-only anyway, it just prints a lot of warnings when there is an error and pre-commit check fails. 


### Notes
 - tests/ directory is omitted, as it would mean hundreds of additional changed files.
 - I'm not comfortable with doing thousands of changed lines with only formatting changes. Don't want the credit nor git blame. Not sure if there is other way to do this.
 - I believe the order of pre-commit checks should be modified, not in scope of this PR though.
   