### PR TITLE
Override packit actions for `propose_downstream`

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -94,6 +94,8 @@ jobs:
       - fedora-all
       - epel-8
       - epel-9
+    actions:
+        post-upstream-clone: []
 
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
Bumping version to y+1.dev is not desired when doing the release

Fixes: #2196