### PR TITLE
Lock the `click` version to < 8.1.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,14 +14,14 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.3.0"
+    rev: "v1.4.1"
     hooks:
       - id: mypy
         # Do not install *types-click* - it's not recommended with Click 8 & newer,
         # which is the version a developer encounters given the requirements are not
         # frozen.
         additional_dependencies:
-          - click
+          - click<8.1.4  # TODO github.com/pallets/click/issues/2558
           - types-Markdown
           - types-requests
           - types-setuptools

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ __scripts__ = ['bin/tmt']
 # Prepare install requires and extra requires
 install_requires = [
     'fmf>=1.2.1',
-    'click',
+    'click<8.1.4',
     'requests',
     'urllib3',
     'ruamel.yaml',


### PR DESCRIPTION
Fixes: #2194
8.1.4 introduced type annotation changes which breaks pre-commit mypy checks.
This is more of a hotfix to make the CI pass, rather then permanent solution.