### PR TITLE
Add support for rendering error tracebacks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -387,7 +387,7 @@ TMT_FORCE_COLOR
 TMT_SHOW_TRACEBACK
     By default, when tmt reports an error, the corresponding
     traceback is not printed out. When ``TMT_SHOW_TRACEBACK`` is
-    set to any string except ``0``, tracebac would be printed out.
+    set to any string except ``0``, traceback would be printed out.
 
 
 Step Variables

--- a/README.rst
+++ b/README.rst
@@ -384,6 +384,12 @@ TMT_FORCE_COLOR
     and ``TMT_NO_COLOR``. If user tries both to disable and enable
     colorization, output would be colorized.
 
+TMT_SHOW_TRACEBACK
+    By default, when tmt reports an error, the corresponding
+    traceback is not printed out. When ``TMT_SHOW_TRACEBACK`` is
+    set to any string except ``0``, tracebac would be printed out.
+    If set to anything but ``0``, when tmt reports an error, its
+
 
 Step Variables
 --------------

--- a/README.rst
+++ b/README.rst
@@ -388,7 +388,6 @@ TMT_SHOW_TRACEBACK
     By default, when tmt reports an error, the corresponding
     traceback is not printed out. When ``TMT_SHOW_TRACEBACK`` is
     set to any string except ``0``, tracebac would be printed out.
-    If set to anything but ``0``, when tmt reports an error, its
 
 
 Step Variables

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1581,7 +1581,7 @@ def render_exception(exception: BaseException) -> List[str]:
             *render_run_exception(exception)
             ]
 
-    if 'TMT_SHOW_TRACEBACK' in os.environ and os.environ['TMT_SHOW_TRACEBACK'] != '0':
+    if os.getenv('TMT_SHOW_TRACEBACK', '0') != '0':
         formatted_exc = traceback.format_exception(
             type(exception),
             exception,

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -19,6 +19,7 @@ import sys
 import tempfile
 import textwrap
 import time
+import traceback
 import unicodedata
 import urllib.parse
 from collections import OrderedDict
@@ -1563,6 +1564,13 @@ def render_run_exception(exception: RunError) -> List[str]:
 def render_exception(exception: BaseException) -> List[str]:
     """ Render the exception and its causes for printing """
 
+    def _indent(iterable: Iterable[str]) -> List[str]:
+        return [
+            f'{INDENT * " "}{line}'
+            for item in iterable
+            for line in item.splitlines()
+            ]
+
     lines = [
         click.style(str(exception), fg='red')
         ]
@@ -1573,15 +1581,24 @@ def render_exception(exception: BaseException) -> List[str]:
             *render_run_exception(exception)
             ]
 
+    if 'TMT_SHOW_TRACEBACK' in os.environ and os.environ['TMT_SHOW_TRACEBACK'] != '0':
+        formatted_exc = traceback.format_exception(
+            type(exception),
+            exception,
+            exception.__traceback__,
+            chain=False)
+
+        lines += [
+            '',
+            *_indent(formatted_exc)]
+
     # Follow the chain and render all causes
     def _render_cause(number: int, cause: BaseException) -> List[str]:
         return [
             '',
             f'Cause number {number}:',
-            ''
-            ] + [
-            f'{INDENT * " "}{line}' for line in render_exception(cause)
-            ]
+            '',
+            *_indent(render_exception(cause))]
 
     def _render_causes(causes: List[BaseException]) -> List[str]:
         lines: List[str] = [


### PR DESCRIPTION
tmt does not show tracebacks at all, yet it's often usefull in development. Patch adds an environment variable to enable traceback reporting.