### PR TITLE
Render `link` fields in tmt stories and specs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -266,6 +266,7 @@ tmt.plugins.explore_export_package(logger)
 
 # Generate stories
 tree = tmt.Tree(logger=logger, path=Path.cwd())
+story_template_filepath = Path('story.rst.j2')
 
 areas = {
     '/stories/docs': 'Documentation',
@@ -289,9 +290,16 @@ for area in areas:
         doc.write(f"{areas[area]}\n{'=' * len(areas[area])}\n")
         # Included stories
         for story in tree.stories(names=[area], whole=True):
-            if story.enabled:
-                doc.write(story.export(format='rst', include_title=story.name != area))
-                doc.write('\n\n')
+            if not story.enabled:
+                continue
+
+            rendered = story.export(
+                format='rst',
+                include_title=story.name != area,
+                template=story_template_filepath)
+
+            doc.write(rendered)
+            doc.write('\n\n')
 
 
 # Render list of lint checks

--- a/docs/story.rst.j2
+++ b/docs/story.rst.j2
@@ -1,0 +1,194 @@
+{#
+    A Jinja2 template for rendering stories in tmt's own docs.
+
+    The template is based on a template bundled with tmt as an
+    example on template/rst export. The difference is how links
+    are rendered: the default template renders just the very basic
+    info about idea vs. implemented/verified, this template tries
+    to render links related to tmt docs and sources as usable HTTP
+    links.
+#}
+
+{% macro render_example(example) %}
+    {% set example = example.strip() %}
+    {% set syntax = example | regex_search('^# syntax: ([a-z]+)') %}
+    {% if syntax %}
+        {% set example = '\n'.join(example.splitlines()[1:]) %}
+        {% set syntax = syntax[0] %}
+    {% else %}
+        {% set syntax = 'yaml' %}
+    {% endif %}
+
+.. code-block:: {{ syntax }}
+
+   {{ example | indent(width=3, first=False, blank=False) | trim }}
+{% endmacro %}
+
+{#
+    Convert link relation into a nicely formatted string.
+
+    :param link: tmt.base.Link instance.
+#}
+{% macro printable_relation(link) %}{{ link.relation.replace('relates', 'relates-to').replace('-', ' ').capitalize() }}{% endmacro %}
+
+{#
+    Emit a remote link.
+
+    :param link: tmt.base.Link instance.
+    :param label: HTML link label.
+    :param url: HTML link URL.
+#}
+{% macro _emit_remote_link(link, label, url) %}
+* {{ printable_relation(link) }} `{{ label }} <{{ url }}>`_ {% if link.note %}({{ link.note }}){% endif %}
+{% endmacro %}
+
+{#
+    Emit a link leading to tmt's upstream repository.
+
+    :param link: tmt.base.Link instance.
+    :param pattern: used to extract link label from its target. It shall include
+        one capturing group, representing the label.
+    :param suffix: optional suffix to attach to link's target.
+#}
+{% macro emit_tmt_repo_link(link, pattern, suffix) %}
+{{ _emit_remote_link(link, link.target, "https://github.com/teemtee/tmt/tree/main/" + link.target.lstrip('/') + (suffix or '')) }}
+{% endmacro %}
+
+{#
+    Emit a link leading to an object in tmt's upstream repository - a test,
+    story, source file.
+
+    If we're able to identify the object in story's tree, we will use its
+    :py:meth:`Core.web_link` method to get the proper URL. Othwerise, a URL
+    would be constructed from link's target.
+
+    :param link: tmt.base.Link instance.
+    :param pattern: used to extract link label from its target. It shall include
+        one capturing group, representing the label.
+    :param suffix: optional suffix to attach to link's target.
+#}
+{% macro emit_tmt_object_link(link, suffix) %}
+{% if link.target.startswith('/tests') %}
+  {% set objects = STORY.tree.tests(names=["^" + link.target + "$"]) %}
+{% elif link.target.startswith('/plans') %}
+  {% set objects = STORY.tree.plans(names=["^" + link.target + "$"]) %}
+{% else %}
+  {% set objects = [] %}
+{% endif %}
+{% if objects %}
+  {% set url = objects[0].web_link() %}
+{% else %}
+  {% set url = "https://github.com/teemtee/tmt/tree/main/" + link.target.lstrip('/') + (suffix or default('')) %}
+{% endif %}
+{{ _emit_remote_link(link, link.target, url) }}
+{% endmacro %}
+
+{#
+    Emit a link leading to tmt's own docs/ directory.
+
+    :param link: tmt.base.Link instance.
+    :param pattern: used to extract page and fragment from link's target. It
+        shall include two capturing groups, representing the page and optional
+        fragment.
+#}
+{% macro emit_docs_link(link) %}
+{% set matched = link.target | match('^/docs/(.+?)\\.rst(?:#([a-z\-]+))?$') %}
+* {{ printable_relation(link) }} :ref:`{{ matched.group(1) }}{# {% if matched.group(2) %}:{{ matched.group(2).replace('-', ' ') }}{% endif %} #}`
+{% endmacro %}
+
+{% if INCLUDE_TITLE %}
+{% set depth = STORY.name | findall('/') | length - 1 %}
+{% set title_underline = '=~^:-><'[depth] %}
+{% if STORY.title and STORY.title != STORY.node.parent.get('title') %}
+    {% set title = STORY.title %}
+{% else %}
+    {% set title = STORY.name | regex_replace('.*/', '') %}
+{% endif %}
+
+.. _{{ STORY.name | strip }}:
+
+{{ title | strip }}
+{{ title_underline * title | length }}
+{% endif %}
+
+{# Summary, story and description #}
+{% if STORY.summary and STORY.summary != STORY.node.parent.get('summary') %}
+{{ STORY.summary | strip }}
+{% endif %}
+
+{% if STORY.story != STORY.node.parent.get('story') %}
+*{{ STORY.story | strip }}*
+{% endif %}
+
+{# Insert note about unimplemented feature (leaf nodes only) #}
+{% if not STORY.node.children and not STORY.implemented %}
+.. note:: This is a draft, the story is not implemented yet.
+{% endif %}
+
+{% if STORY.description and STORY.description != STORY.node.parent.get('description') %}
+{{ STORY.description }}
+{% endif %}
+
+{# Examples #}
+{% if STORY.example and STORY.example != STORY.node.parent.get('example') %}
+    {% for example in STORY.example %}
+        {% if example == STORY.example | first %}
+**Examples:**
+        {% endif %}
+
+{{ render_example(example) }}
+    {% endfor %}
+{% endif %}
+
+{# Status #}
+{% if not STORY.node.children %}
+    {% if STORY.status %}
+**Status:** {{ STORY.status | listed }}
+    {% else %}
+**Status:** idea
+    {% endif %}
+{% endif %}
+
+{# Links #}
+{% for link in STORY.link.get() %}
+{# Links pointing to docs #}
+{% if link.target | match('^/docs/') %}
+{{ emit_docs_link(link) }}
+
+{# Links pointing to step core implementation #}
+{% elif link.target | match('^/tmt/steps(?:/__init__.py)?$') %}
+{{ emit_tmt_repo_link(link, '/tmt/(steps)(?:/__init__.py)?') }}
+
+{# Links pointing to step implementations #}
+{% elif link.target | match('^/tmt/steps/([a-z_]+)(?:$|(?:/__init__.py))$') %}
+{{ emit_tmt_repo_link(link, '/tmt/steps/([a-z_]+)(?:$|(?:/__init__.py))') }}
+
+{# Links pointing to step plugins #}
+{% elif link.target | match('^/tmt/steps/([a-z_]+/[a-z_]+)\\.py$') %}
+{{ emit_tmt_repo_link(link, '/tmt/steps/([a-z_]+/[a-z_]+)\\.py') }}
+
+{# Links pointing to other tmt code #}
+{% elif link.target.startswith('/tmt') %}
+{{ emit_tmt_repo_link(link, '/(.*)') }}
+
+{# Links pointing to stories #}
+{% elif link.target | match('^/stories') %}
+* {{ printable_relation(link) }} :ref:`{{ link.target }}`
+
+{# Links pointing to tests #}
+{% elif link.target | match ('^/tests') %}
+{{ emit_tmt_object_link(link, '.fmf') }}
+
+{# Links pointing to plans #}
+{% elif link.target | match ('^/plans') %}
+{{ emit_tmt_object_link(link, '.fmf') }}
+
+{# Links pointing to websites #}
+{% elif link.target | match('^https?://') %}
+* {{ printable_relation(link) }} `{{ link.target}} <{{ link.target }}>`_
+
+{# Links pointing to anything else #}
+{% else %}
+* {{ printable_relation(link) }} ``{{ link.target }}``
+{% endif %}
+{% endfor %}

--- a/spec/hardware/compatible.fmf
+++ b/spec/hardware/compatible.fmf
@@ -12,3 +12,6 @@ example:
         distro:
           - rhel-8
           - rhel-9
+
+link:
+  - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/hardware/cpu.fmf
+++ b/spec/hardware/cpu.fmf
@@ -34,3 +34,4 @@ example:
           - "!= smep"
 link:
   - implemented-by: /tmt/steps/provision/artemis.py
+    note: "``cpu.flag`` not supported yet"

--- a/spec/hardware/network.fmf
+++ b/spec/hardware/network.fmf
@@ -7,3 +7,6 @@ example:
       - type: eth
         vendor-name: ~ ^Broadcom
         device-name: ~ ^NetXtreme II BCM
+link:
+  - implemented-by: /tmt/steps/provision/artemis.py
+    note: "``network.type`` only"

--- a/spec/hardware/tpm.fmf
+++ b/spec/hardware/tpm.fmf
@@ -7,3 +7,5 @@ example:
   - |
     tpm:
         version: "2.0"
+link:
+  - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/plans/guest-topology.fmf
+++ b/spec/plans/guest-topology.fmf
@@ -111,4 +111,4 @@ example:
 
 link:
   - verified-by: /tests/multihost/complete
-  - implemented-by: /tmp/steps/__init__.py
+  - implemented-by: /tmt/steps/__init__.py

--- a/spec/plans/import.fmf
+++ b/spec/plans/import.fmf
@@ -63,4 +63,4 @@ example:
 link:
   - relates: https://github.com/teemtee/tmt/issues/975
   - verified-by: /tests/plan/import
-  - implemented-by: /tmp/base.py
+  - implemented-by: /tmt/base.py

--- a/spec/plans/results.fmf
+++ b/spec/plans/results.fmf
@@ -195,4 +195,4 @@ example:
 
 link:
   - verified-by: /tests/execute/result
-  - implemented-by: /tmp/result.py
+  - implemented-by: /tmt/result.py

--- a/spec/stories/priority.fmf
+++ b/spec/stories/priority.fmf
@@ -44,5 +44,5 @@ example: |
     priority: must have
 
 link:
-  - implemented-by: /tmp/base.py
+  - implemented-by: /tmt/base.py
   - verified-by: /tests/story/priority

--- a/spec/tests/duration.fmf
+++ b/spec/tests/duration.fmf
@@ -37,6 +37,6 @@ example:
 
 
 link:
-  - implemented-by: /tmt/base
+  - implemented-by: /tmt/base.py
   - verified-by: /tests/discover/duration
   - verified-by: /tests/execute/duration

--- a/spec/tests/manual.fmf
+++ b/spec/tests/manual.fmf
@@ -77,4 +77,4 @@ example: |
   test: manual.md
 
 link:
-  - implemented-by: /tmp/base.py
+  - implemented-by: /tmt/base.py

--- a/stories/cli/test.fmf
+++ b/stories/cli/test.fmf
@@ -105,7 +105,7 @@ story: 'As a user I want to comfortably work with tests'
             from the web interface.
         link:
           - implemented-by: /tmt/export.py
-          - documented-by: /docs/questions#nitrate-migration
+          - documented-by: /docs/questions.rst#nitrate-migration
 
 /filter:
     story: 'Filter available tests'

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -650,6 +650,7 @@ class Core(
     def __init__(self,
                  *,
                  node: fmf.Tree,
+                 tree: Optional['Tree'] = None,
                  parent: Optional[tmt.utils.Common] = None,
                  logger: tmt.log.Logger,
                  **kwargs: Any) -> None:
@@ -657,6 +658,7 @@ class Core(
         super().__init__(node=node, logger=logger, parent=parent, name=node.name, **kwargs)
 
         self.node = node
+        self.tree = tree
 
         # Verify id is not inherited from parent.
         if self.id and not tmt.utils.is_key_origin(node, 'id'):
@@ -1054,6 +1056,7 @@ class Test(
             self,
             *,
             node: fmf.Tree,
+            tree: Optional['Tree'] = None,
             skip_validation: bool = False,
             raise_on_validation_error: bool = False,
             logger: tmt.log.Logger,
@@ -1084,6 +1087,7 @@ class Test(
 
         super().__init__(
             node=node,
+            tree=tree,
             logger=logger,
             skip_validation=skip_validation,
             raise_on_validation_error=raise_on_validation_error,
@@ -1442,6 +1446,7 @@ class Plan(
             self,
             *,
             node: fmf.Tree,
+            tree: Optional['Tree'] = None,
             run: Optional['Run'] = None,
             skip_validation: bool = False,
             raise_on_validation_error: bool = False,
@@ -1451,6 +1456,7 @@ class Plan(
         kwargs.setdefault('run', run)
         super().__init__(
             node=node,
+            tree=tree,
             logger=logger,
             parent=run,
             skip_validation=skip_validation,
@@ -2297,13 +2303,19 @@ class Story(
             self,
             *,
             node: fmf.Tree,
+            tree: Optional['Tree'] = None,
             skip_validation: bool = False,
             raise_on_validation_error: bool = False,
             logger: tmt.log.Logger,
             **kwargs: Any) -> None:
         """ Initialize the story """
-        super().__init__(node=node, logger=logger, skip_validation=skip_validation,
-                         raise_on_validation_error=raise_on_validation_error, **kwargs)
+        super().__init__(
+            node=node,
+            tree=tree,
+            logger=logger,
+            skip_validation=skip_validation,
+            raise_on_validation_error=raise_on_validation_error,
+            **kwargs)
         self._update_metadata()
 
     # Override the parent implementation - it would try to call `Tree.storys()`...
@@ -2684,6 +2696,7 @@ class Tree(tmt.utils.Common):
                     selected_tests = [
                         Test(
                             node=test,
+                            tree=self,
                             logger=logger.descend(
                                 logger_name=test.get('name', None)
                                 )  # .apply_verbosity_options(**self._options),
@@ -2694,6 +2707,7 @@ class Tree(tmt.utils.Common):
                 selected_tests = [
                     Test(
                         node=test,
+                        tree=self,
                         logger=logger.descend(
                             logger_name=test.get('name', None)
                             )  # .apply_verbosity_options(**self._options),
@@ -2750,6 +2764,7 @@ class Tree(tmt.utils.Common):
         plans = [
             Plan(
                 node=plan,
+                tree=self,
                 logger=logger.descend(
                     logger_name=plan.get('name', None),
                     extra_shift=0
@@ -2817,7 +2832,7 @@ class Tree(tmt.utils.Common):
 
         # Build the list, convert to objects, sort and filter
         stories = [
-            Story(node=story, logger=logger.descend()) for story
+            Story(node=story, tree=self, logger=logger.descend()) for story
             in self.tree.prune(keys=keys, names=names, whole=whole, sources=sources)]
         return self._filters_conditions(
             sorted(stories, key=lambda story: story.order),


### PR DESCRIPTION
The `link` key was inspected only to reveal whether a story is implemented or not. The patch adds rendering of various links in tmt docs, specs and stories, providing nice cross-linking between docs and other resources.