### PR TITLE
ReST export plugin should accept --template option

### DIFF
--- a/tests/plan/export/test.sh
+++ b/tests/plan/export/test.sh
@@ -71,7 +71,7 @@ rlJournalStart
             # different wording & quotes.
             rlAssertgrep "Error: Invalid value for \"-h\" / \"--how\": invalid choice: weird. (choose from dict, json, yaml)" $rlRun_LOG
         else
-            rlAssertGrep "Error: Invalid value for '-h' / '--how': 'weird' is not one of 'dict', 'json', 'yaml'." $rlRun_LOG
+            rlAssertGrep "Error: Invalid value for '-h' / '--how': 'weird' is not one of 'dict', 'json', 'template', 'yaml'." $rlRun_LOG
         fi
     rlPhaseEnd
 

--- a/tests/test/export/test.sh
+++ b/tests/test/export/test.sh
@@ -45,7 +45,7 @@ rlJournalStart
             # different wording & quotes.
             rlAssertgrep "Error: Invalid value for \"-h\" / \"--how\": invalid choice: weird. (choose from dict, json, nitrate, polarion, yaml)" $rlRun_LOG
         else
-            rlAssertGrep "Error: Invalid value for '-h' / '--how': 'weird' is not one of 'dict', 'json', 'nitrate', 'polarion', 'yaml'." $rlRun_LOG
+            rlAssertGrep "Error: Invalid value for '-h' / '--how': 'weird' is not one of 'dict', 'json', 'nitrate', 'polarion', 'template', 'yaml'." $rlRun_LOG
         fi
     rlPhaseEnd
 

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -773,7 +773,7 @@ _test_export_default = 'yaml'
 # TODO: move to `template` export plugin options
 @option(
     '--template', metavar='PATH',
-    help="Path to a template to use for rendering the export. Used with '--how=template' only."
+    help="Path to a template to use for rendering the export. Used with '--how=rst|template' only."
     )
 def tests_export(
         context: Context,
@@ -1004,7 +1004,7 @@ _plan_export_default = 'yaml'
 # TODO: move to `template` export plugin options
 @option(
     '--template', metavar='PATH',
-    help="Path to a template to use for rendering the export. Used with '--how=template' only."
+    help="Path to a template to use for rendering the export. Used with '--how=rst|template' only."
     )
 def plans_export(
         context: Context,
@@ -1260,7 +1260,7 @@ _story_export_default = 'yaml'
 # TODO: move to `template` export plugin options
 @option(
     '--template', metavar='PATH',
-    help="Path to a template to use for rendering the export. Used with '--how=template' only."
+    help="Path to a template to use for rendering the export. Used with '--how=rst|template' only."
     )
 def stories_export(
         context: Context,

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -773,7 +773,7 @@ _test_export_default = 'yaml'
 # TODO: move to `template` export plugin options
 @option(
     '--template', metavar='PATH',
-    help="Path to a template to use for rendering the export. Used with '--how=rst|template' only."
+    help="Path to a template to use for rendering the export. Used with '--how=template' only."
     )
 def tests_export(
         context: Context,
@@ -1004,7 +1004,7 @@ _plan_export_default = 'yaml'
 # TODO: move to `template` export plugin options
 @option(
     '--template', metavar='PATH',
-    help="Path to a template to use for rendering the export. Used with '--how=rst|template' only."
+    help="Path to a template to use for rendering the export. Used with '--how=template' only."
     )
 def plans_export(
         context: Context,

--- a/tmt/export/rst.py
+++ b/tmt/export/rst.py
@@ -4,6 +4,7 @@ import tmt.base
 import tmt.export
 import tmt.export.template
 import tmt.utils
+from tmt.utils import Path
 
 
 @tmt.base.Story.provides_export('rst')
@@ -12,8 +13,10 @@ class RestructuredExporter(tmt.export.ExportPlugin):
     def export_story(cls,
                      story: tmt.base.Story,
                      keys: Optional[List[str]] = None,
+                     template: Optional[Path] = None,
                      include_title: bool = True) -> str:
         return tmt.export.template.TemplateExporter.render_template(
+            template_filepath=template,
             default_template_filename='default-story.rst.j2',
             keys=keys,
             STORY=story,
@@ -23,7 +26,9 @@ class RestructuredExporter(tmt.export.ExportPlugin):
     def export_story_collection(cls,
                                 stories: List[tmt.base.Story],
                                 keys: Optional[List[str]] = None,
+                                template: Optional[Path] = None,
                                 include_title: bool = True,
                                 **kwargs: Any) -> str:
-        return '\n\n'.join([cls.export_story(story, keys=keys, include_title=include_title)
-                           for story in stories])
+        return '\n\n'.join([
+            cls.export_story(story, keys=keys, template=template, include_title=include_title)
+            for story in stories])

--- a/tmt/export/template.py
+++ b/tmt/export/template.py
@@ -6,6 +6,9 @@ import tmt.utils
 from tmt.utils import Path
 
 
+@tmt.base.FmfId.provides_export('template')
+@tmt.base.Test.provides_export('template')
+@tmt.base.Plan.provides_export('template')
 @tmt.base.Story.provides_export('template')
 class TemplateExporter(tmt.export.ExportPlugin):
     @classmethod

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -5142,6 +5142,10 @@ def render_template_file(
 
         return template.render(**variables).strip()
 
+    except FileNotFoundError as exc:
+        raise GeneralError(
+            f"Could not open template '{template_filepath}'.") from exc
+
     except jinja2.exceptions.TemplateSyntaxError as exc:
         raise GeneralError(
             f"Could not parse template '{template_filepath}' at line {exc.lineno}.") from exc


### PR DESCRIPTION
The option was accepted by `template` plugin only, but it absolutely makes sense for `-h rst` to accept it as well. There is a default story template, and no other template can be used...