### PR TITLE
Fix test checking custom destination for libraries

### DIFF
--- a/tests/discover/libraries/data/certificate.fmf
+++ b/tests/discover/libraries/data/certificate.fmf
@@ -46,8 +46,8 @@ test: ./certificate.sh
         The optional key 'destination' can be used to store
         fetched content to a custom directory.
     require:
-      - url: https://github.com/beakerlib/openssl
-        name: /certgen
+      - url: https://github.com/beakerlib/example
+        name: /file
         destination: custom
         type: library
 

--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -32,8 +32,9 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Destination"
-        rlRun -s "$tmt destination" 0
-        rlAssertGrep 'Cloning into.*custom/openssl' $rlRun_LOG
+        rlRun -s "tmt run --id $tmp/destination --keep discover -vvvddd plan --name destination"
+        rlAssertGrep "custom/example" $rlRun_LOG -s
+        rlAssertExists "$tmp/destination/plan/certificate/destination/discover/default-0/custom/example/file/lib.sh"
     rlPhaseEnd
 
     rlPhaseStartTest "Missing"


### PR DESCRIPTION
The `/tests/discover/libraries` test, which is only run in the `how=full` context, was failing because of change of the way how libraries are copied. Update the `rlAssertGrep` pattern and check that the library is placed into the expected location.