### PR TITLE
Add `role` to the Beaker provision plugin schema

### DIFF
--- a/tmt/schemas/provision/beaker.yaml
+++ b/tmt/schemas/provision/beaker.yaml
@@ -37,5 +37,8 @@ properties:
   hardware:
     $ref: "/schemas/provision/hardware#/definitions/hardware"
 
+  role:
+    $ref: "/schemas/common#/definitions/role"
+
 required:
   - how


### PR DESCRIPTION
Fixes: #2204 