### PR TITLE
Git tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ docs: man
 man: source
 	cp docs/header.txt $(TMP)/man.rst
 	tail -n+8 README.rst >> $(TMP)/man.rst
+	# TODO rst2man cannot process this directive, removed for now
 	sed '/versionadded::/d' -i $(TMP)/man.rst
 	rst2man $(TMP)/man.rst > $(TMP)/$(PACKAGE)/tmt.1
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ docs: man
 man: source
 	cp docs/header.txt $(TMP)/man.rst
 	tail -n+8 README.rst >> $(TMP)/man.rst
+	sed '/versionadded::/d' -i $(TMP)/man.rst
 	rst2man $(TMP)/man.rst > $(TMP)/$(PACKAGE)/tmt.1
 
 

--- a/README.rst
+++ b/README.rst
@@ -389,8 +389,8 @@ TMT_SHOW_TRACEBACK
     traceback is not printed out. When ``TMT_SHOW_TRACEBACK`` is
     set to any string except ``0``, traceback would be printed out.
 
-TMT_GIT_CREDENTIALS_URL\_, TMT_GIT_CREDENTIALS_VALUE\_
-    Prefixes of variable pairs used to provide credentials to clone git
+TMT_GIT_CREDENTIALS_URL_<suffix>, TMT_GIT_CREDENTIALS_VALUE_<suffix>
+    Variable pairs used to provide credentials to clone git
     repositories. Suffix identifies the pair and determines the order in which URL regexp is tried.
 
     The ``TMT_GIT_CREDENTIALS_URL_<suffix>`` contains regexp to search against

--- a/README.rst
+++ b/README.rst
@@ -389,6 +389,29 @@ TMT_SHOW_TRACEBACK
     traceback is not printed out. When ``TMT_SHOW_TRACEBACK`` is
     set to any string except ``0``, traceback would be printed out.
 
+TMT_GIT_CREDENTIALS_URL\_, TMT_GIT_CREDENTIALS_VALUE\_
+    Prefixes of variable pairs used to provide credentials to clone git
+    repositories. Suffix identifies the pair and determines the order in which URL regexp is tried.
+
+    The ``TMT_GIT_CREDENTIALS_URL_<suffix>`` contains regexp to search against
+    url to clone. For first successful search the content of the ``TMT_GIT_CREDENTIALS_VALUE_<suffix>``
+    variable is used as the credential value. When it is set to an empty string, unmodified url is used.
+
+    Example usage:
+
+    `GitLab`__ credentials need to contain nonempty username followed by colon and token value::
+
+        TMT_GIT_CREDENTIALS_URL_lab='gitlab.com/mysecretproject'
+        TMT_GIT_CREDENTIALS_VALUE_lab='foo:secrettoken'
+
+    `GitHub`__ credentials contain just the token value::
+
+        TMT_GIT_CREDENTIALS_URL_hub='github.com/teemtee'
+        TMT_GIT_CREDENTIALS_VALUE_hub='secrettoken'
+
+__ https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#clone-repository-using-personal-access-token
+__ https://github.blog/2012-09-21-easier-builds-and-deployments-using-git-over-https-and-oauth/
+.. versionadded:: 1.26
 
 Step Variables
 --------------

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -31,6 +31,7 @@ from tmt.utils import (
     clonable_git_url,
     duration_to_seconds,
     filter_paths,
+    inject_auth_git_url,
     listify,
     public_git_url,
     validate_git_status,
@@ -142,6 +143,40 @@ def test_clonable_git_url():
         == 'git+ssh://pkgs.devel.redhat.com/tests/bash'
     assert clonable_git_url('git://example.com') \
         == 'git://example.com'
+
+
+def test_inject_auth_git_url(monkeypatch) -> None:
+    """ Verify injecting tokens """
+
+    # empty environment
+    monkeypatch.setattr('os.environ', {})
+    assert inject_auth_git_url('input_text') == 'input_text'
+
+    suffix = '_glab'
+    # https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#clone-repository-using-personal-access-token
+    # username can be anything but cannot be an empty string
+    monkeypatch.setattr('os.environ', {
+        f'{tmt.utils.INJECT_CREDENTIALS_URL_PREFIX}{suffix}': 'https://gitlab.com/namespace/project',
+        f'{tmt.utils.INJECT_CREDENTIALS_VALUE_PREFIX}{suffix}': 'foo:abcdefgh',
+        f'{tmt.utils.INJECT_CREDENTIALS_VALUE_PREFIX}___': 'FAKE',
+        })
+    assert inject_auth_git_url('https://gitlab.com/namespace/project') \
+        == 'https://foo:abcdefgh@gitlab.com/namespace/project'
+
+    suffix = '_ghub'
+    # https://github.blog/2012-09-21-easier-builds-and-deployments-using-git-over-https-and-oauth/
+    # just token or username is used (value before @)
+    monkeypatch.setattr('os.environ', {
+        f'{tmt.utils.INJECT_CREDENTIALS_URL_PREFIX}{suffix}': 'https://github.com/namespace/project',
+        f'{tmt.utils.INJECT_CREDENTIALS_VALUE_PREFIX}{suffix}': 'abcdefgh',
+        f'{tmt.utils.INJECT_CREDENTIALS_VALUE_PREFIX}___': 'FAKE',
+        f'{tmt.utils.INJECT_CREDENTIALS_URL_PREFIX}{suffix}_2': 'https://github.com/other_namespace',
+        f'{tmt.utils.INJECT_CREDENTIALS_VALUE_PREFIX}{suffix}_2': 'xyzabcde',
+        })
+    assert inject_auth_git_url('https://github.com/namespace/project') \
+        == 'https://abcdefgh@github.com/namespace/project'
+    assert inject_auth_git_url('https://github.com/other_namespace/project') \
+        == 'https://xyzabcde@github.com/other_namespace/project'
 
 
 def test_listify():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -172,11 +172,15 @@ def test_inject_auth_git_url(monkeypatch) -> None:
         f'{tmt.utils.INJECT_CREDENTIALS_VALUE_PREFIX}___': 'FAKE',
         f'{tmt.utils.INJECT_CREDENTIALS_URL_PREFIX}{suffix}_2': 'https://github.com/other_namespace',
         f'{tmt.utils.INJECT_CREDENTIALS_VALUE_PREFIX}{suffix}_2': 'xyzabcde',
+        f'{tmt.utils.INJECT_CREDENTIALS_URL_PREFIX}{suffix}_3': 'https://example.com/broken',
         })
     assert inject_auth_git_url('https://github.com/namespace/project') \
         == 'https://abcdefgh@github.com/namespace/project'
     assert inject_auth_git_url('https://github.com/other_namespace/project') \
         == 'https://xyzabcde@github.com/other_namespace/project'
+
+    with pytest.raises(tmt.utils.GitUrlError):
+        inject_auth_git_url('https://example.com/broken/something')
 
 
 def test_listify():

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2919,11 +2919,13 @@ def inject_auth_git_url(url: str) -> str:
         # First one which matches url is taken into the account
         if name.startswith(INJECT_CREDENTIALS_URL_PREFIX) and re.search(value, url):
             unique_suffix = name[len(INJECT_CREDENTIALS_URL_PREFIX):]
+            variable_with_value = f'{INJECT_CREDENTIALS_VALUE_PREFIX}{unique_suffix}'
             # Get credentials value
             try:
-                creds = os.environ[f'{INJECT_CREDENTIALS_VALUE_PREFIX}{unique_suffix}']
+                creds = os.environ[variable_with_value]
             except KeyError:
-                raise GitUrlError(f'Missing variable with credentials for "{url}"')
+                raise GitUrlError(
+                    f'Missing "{variable_with_value}" variable with credentials for "{url}"')
             # Return original url if credentials is an empty value
             if not creds:
                 return url

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2928,7 +2928,7 @@ def inject_auth_git_url(url: str) -> str:
             if not creds:
                 return url
             # Finally inject credentials into the url and return it
-            return re.sub(r'([^/]+://)([^/]+)', r'\1' + f'{creds}@' + r'\2', url)
+            return re.sub(r'([^/]+://)([^/]+)', rf'\1{creds}@\2', url)
     # Otherwise return unmodified
     return url
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2901,6 +2901,38 @@ def rewrite_git_url(url: str, patterns: List[Tuple[str, str]]) -> str:
     return url
 
 
+# Environment variable prefixes
+INJECT_CREDENTIALS_URL_PREFIX = 'TMT_GIT_CREDENTIALS_URL_'
+INJECT_CREDENTIALS_VALUE_PREFIX = 'TMT_GIT_CREDENTIALS_VALUE_'
+
+
+def inject_auth_git_url(url: str) -> str:
+    """
+    Inject username or token to the git url
+
+    :param url: original git repo url
+    :returns: URL with injected authentification based on pattern from the environment
+        or unmodified URL
+    """
+    # Try all environement variables sorted by their name
+    for name, value in sorted(os.environ.items(), key=lambda x: x[0]):
+        # First one which matches url is taken into the account
+        if name.startswith(INJECT_CREDENTIALS_URL_PREFIX) and re.search(value, url):
+            unique_suffix = name[len(INJECT_CREDENTIALS_URL_PREFIX):]
+            # Get credentials value
+            try:
+                creds = os.environ[f'{INJECT_CREDENTIALS_VALUE_PREFIX}{unique_suffix}']
+            except KeyError:
+                raise GitUrlError(f'Missing variable with credentials for "{url}"')
+            # Return original url if credentials is an empty value
+            if not creds:
+                return url
+            # Finally inject credentials into the url and return it
+            return re.sub(r'([^/]+://)([^/]+)', r'\1' + f'{creds}@' + r'\2', url)
+    # Otherwise return unmodified
+    return url
+
+
 CLONABLE_GIT_URL_PATTERNS: List[Tuple[str, str]] = [
     # git:// protocol is not possible for r/o access
     # old: git://pkgs.devel.redhat.com/tests/bash
@@ -2916,8 +2948,8 @@ def clonable_git_url(url: str) -> str:
     """
     Modify the git repo url so it can be cloned
     """
-    # TODO - inject oauth2 tokens for github/gitlab private repos
-    return rewrite_git_url(url, CLONABLE_GIT_URL_PATTERNS)
+    url = rewrite_git_url(url, CLONABLE_GIT_URL_PATTERNS)
+    return inject_auth_git_url(url)
 
 
 def web_git_url(url: str, ref: str, path: Optional[Path] = None) -> str:


### PR DESCRIPTION
WDYT?

Needs #2223 to be merged first.
I've tried with my token and the plan:
```
execute:
    how: tmt
discover:
    how: fmf
    url: https://gitlab.com/redhat/rhel/tests/python
```

The NAME cannot be empty but its value is ignored (says gitlab docs)
```
$ TMT_GIT_TOKEN_URL_gl='gitlab.com/redhat/rhel' TMT_GIT_TOKEN_NAME_gl='foo' TMT_GIT_TOKEN_VALUE_gl='SECRET_TOKEN' tmt run discover
/var/tmp/tmt/run-065

/p
    discover
        how: fmf
        url: https://gitlab.com/redhat/rhel/tests/python
        summary: 1102 tests selected
```

Needs more docs and examples. Should be create teemtee private repo and token to test this or is unit test enough? 

* [x] implement the feature
* [x] write documentation
* [x] extend the test coverage
* [x] add a usage example
* [x] mention version
