### PR TITLE
No more need to install `pre-commit` using `pip`

### DIFF
--- a/plans/features/advanced.fmf
+++ b/plans/features/advanced.fmf
@@ -6,12 +6,3 @@ description:
 discover:
     how: fmf
     filter: 'tier: 4'
-adjust+:
--   when: distro == centos-stream, rhel
-    because: pre-commit is not available from epel, use pip instead
-    prepare+:
-        -   how: install
-            package: python3-pip
-        -   how: shell
-            script:
-            -   pip3 install --user pre-commit

--- a/tests/precommit/main.fmf
+++ b/tests/precommit/main.fmf
@@ -4,11 +4,3 @@ require:
 - git-core
 - tmt
 tier: 4
-adjust:
--   when: distro is not defined
-    enabled: false
-    because: Cannot adjust properly
--   when: distro == centos-stream, rhel
-    require-:
-    -   pre-commit
-    because: pre-commit has to be installed from PyPI (is missing in EPEL)


### PR DESCRIPTION
After we drop `el8` support there should be no more need to install `pre-commit` from the `PyPI` repository as the `el9` build is there: https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2023-6ab9066c39