### PR TITLE
Separate value formatting from key/value nature of tmt.utils.format()

### DIFF
--- a/tests/core/fmf-id/test.sh
+++ b/tests/core/fmf-id/test.sh
@@ -23,9 +23,9 @@ rlJournalStart
 
         rlRun -s "tmt test -vvvv show /test-with-valid-ref"
         rlAssertNotGrep "warn:" $rlRun_LOG
-        rlAssertGrep "{'ref': 'branch-or-tag-ref', 'type': 'library'}" $rlRun_LOG
-        rlAssertGrep "{'ref': '8deadbeaf8', 'type': 'library'}" $rlRun_LOG
-        rlAssertGrep "some-package" $rlRun_LOG
+        rlRun "grep -Pzo \"(?s)- ref: branch-or-tag-ref.*?\\s*type: library\" $rlRun_LOG > /dev/null"
+        rlRun "grep -Pzo \"(?s)- ref: 8deadbeaf8.*?\\s*type: library\" $rlRun_LOG > /dev/null"
+        rlAssertGrep "- some-package" $rlRun_LOG
 
         rlRun -s "tmt test -vvvv show /test-with-invalid-ref" 2
         rlAssertGrep "warn: /test-with-invalid-ref:require .* is not valid under any of the given schemas" $rlRun_LOG

--- a/tests/plan/context/test.sh
+++ b/tests/plan/context/test.sh
@@ -8,34 +8,35 @@ rlJournalStart
 
     rlPhaseStartTest "Plan with a good context"
         rlRun -s "tmt -c distro=rhel9 -c arch=aarch64,x86_64 plan show good"
-        rlAssertGrep "foo: \['bar'\]" $rlRun_LOG
-        rlAssertGrep "baz: \['qux', 'fred'\]" $rlRun_LOG
-        rlAssertGrep "distro: \['rhel9'\]" $rlRun_LOG
-        rlAssertGrep "arch: \['aarch64', 'x86_64'\]" $rlRun_LOG
+        rlAssertGrep "foo: bar" $rlRun_LOG
+        rlAssertGrep "baz: 'qux' and 'fred'" $rlRun_LOG
+        rlAssertGrep "distro: rhel9" $rlRun_LOG
+        rlAssertGrep "arch: 'aarch64' and 'x86_64'" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Plan with a bad context"
         rlRun -s "tmt -c distro=rhel9 -c arch=aarch64,x86_64 plan show bad"
-        rlAssertGrep "distro: \['rhel9'\]" $rlRun_LOG
-        rlAssertGrep "arch: \['aarch64', 'x86_64'\]" $rlRun_LOG
+        rlAssertGrep "distro: rhel9" $rlRun_LOG
+        rlAssertGrep "arch: 'aarch64' and 'x86_64'" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Plan with a good context, overwritten by command line"
         rlRun -s "tmt -c distro=rhel9 -c arch=aarch64,x86_64 -c baz=something,different plan show good"
-        rlAssertGrep "foo: \['bar'\]" $rlRun_LOG
-        rlAssertGrep "baz: \['something', 'different'\]" $rlRun_LOG
-        rlAssertGrep "distro: \['rhel9'\]" $rlRun_LOG
-        rlAssertGrep "arch: \['aarch64', 'x86_64'\]" $rlRun_LOG
+        rlAssertGrep "foo: bar" $rlRun_LOG
+        rlAssertGrep "baz: 'something' and 'different'" $rlRun_LOG
+        rlAssertGrep "distro: rhel9" $rlRun_LOG
+        rlAssertGrep "arch: 'aarch64' and 'x86_64'" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Plan with broken values"
         rlRun -s "tmt -c distro=rhel9 -c arch=aarch64,x86_64 plan show bad-values"
         cp $rlRun_LOG /tmp/tmp.txt
-        rlAssertGrep "foo: \['foo'\]" $rlRun_LOG
-        rlAssertGrep "bar: \['1'\]" $rlRun_LOG
-        rlAssertGrep "baz: \['False'\]" $rlRun_LOG
-        rlAssertGrep "distro: \['rhel9'\]" $rlRun_LOG
-        rlAssertGrep "arch: \['aarch64', 'x86_64'\]" $rlRun_LOG
+        rlAssertGrep "foo: foo" $rlRun_LOG
+        rlAssertGrep "bar: 1" $rlRun_LOG
+        rlAssertGrep "baz: False" $rlRun_LOG
+        rlAssertGrep "dud: {'how': 'about'}" $rlRun_LOG
+        rlAssertGrep "distro: rhel9" $rlRun_LOG
+        rlAssertGrep "arch: 'aarch64' and 'x86_64'" $rlRun_LOG
         rlAssertGrep "warn: /bad-values:context.baz - False is not valid under any of the given schemas" $rlRun_LOG
         rlAssertGrep "warn: /bad-values:context.dud - {'how': 'about'} is not valid under any of the given schemas" $rlRun_LOG
         rlAssertGrep "warn: /bad-values:context.bar - 1 is not valid under any of the given schemas" $rlRun_LOG

--- a/tests/plan/show/test.sh
+++ b/tests/plan/show/test.sh
@@ -135,7 +135,7 @@ rlJournalStart
 
         # Extra
         rlAssertGrep "environment KEY: VAL" $rlRun_LOG
-        rlAssertGrep "context distro: \['fedora'\]" $rlRun_LOG
+        rlAssertGrep "context distro: fedora" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "List all plans by default"

--- a/tests/test/import/test.sh
+++ b/tests/test/import/test.sh
@@ -120,7 +120,7 @@ rlJournalStart
         rlRun -s "$import --type all"
         rlAssertGrep "tag: Multihost Sanity KernelTier1" $rlRun_LOG
         rlRun -s 'tmt test show'
-        rlAssertGrep "tag Multihost, Sanity and KernelTier1" $rlRun_LOG
+        rlAssertGrep "tag 'Multihost', 'Sanity' and 'KernelTier1'" $rlRun_LOG
         rlRun -s "$import --type KernelTier1"
         rlAssertGrep 'tag: KernelTier1$' $rlRun_LOG
         rlRun -s 'tmt test show'

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1815,8 +1815,12 @@ class Plan(
             echo(tmt.utils.format(
                 'environment', self.environment, key_color='blue'))
         if self._fmf_context:
-            echo(tmt.utils.format(
-                'context', self._fmf_context, key_color='blue'))
+            echo(
+                tmt.utils.format(
+                    'context',
+                    self._fmf_context,
+                    key_color='blue',
+                    list_format=tmt.utils.ListFormat.SHORT))
 
         # The rest
         echo(tmt.utils.format('enabled', self.enabled, key_color='cyan'))
@@ -2445,6 +2449,9 @@ class Story(
             if key == 'priority' and value is not None:
                 value = cast(StoryPriority, value).value
             if key == 'order' and value == DEFAULT_ORDER:
+                continue
+            if key == 'example' and value:
+                echo(tmt.utils.format(key, value, wrap=False))
                 continue
             if value is not None and value != []:
                 wrap: tmt.utils.FormatWrap = False if key == 'example' else 'auto'


### PR DESCRIPTION
Value formatting alone can be very useful in other places as well, but
`format()` does a lot more, including wrapping and indentation. Patch
extracts the value formatting code for others to use - mostly logging may
need to emit nicely formatted structures.
