### PR TITLE
Remove `epel-8` and `python-3.6` specifics

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -29,7 +29,6 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-all
-      - epel-8
       - epel-9
     enable_net: False
 
@@ -38,7 +37,6 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-all
-      - epel-8
       - epel-9
 
   # Test internal plugins
@@ -79,7 +77,6 @@ jobs:
     branch: main
     targets:
       - fedora-all
-      - epel-8
       - epel-9
     enable_net: False
     list_on_homepage: True
@@ -92,7 +89,6 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-all
-      - epel-8
       - epel-9
     actions:
         post-upstream-clone: []
@@ -103,12 +99,10 @@ jobs:
     allowed_committers: ["packit", "psss", "lzachar"]
     dist_git_branches:
       - fedora-all
-      - epel-8
       - epel-9
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
       - fedora-branched
-      - epel-8
       - epel-9

--- a/README.rst
+++ b/README.rst
@@ -239,10 +239,6 @@ For CentOS and RHEL, first make sure that you have available the
 `EPEL <https://docs.fedoraproject.org/en-US/epel/>`_ repository.
 You might also have to enable additional repositories::
 
-    sudo dnf config-manager --enable powertools  # CentOS 8
-    sudo dnf config-manager --enable rhel-CRB    # RHEL 8
-    sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-
     sudo dnf config-manager --enable crb         # CentOS 9
     sudo dnf config-manager --enable rhel-CRB    # RHEL 9
     sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm

--- a/plans/features/main.fmf
+++ b/plans/features/main.fmf
@@ -13,9 +13,7 @@ prepare+:
       # have to run as root to do that, and who's running tmt test suite
       # as root?
       #
-      # We need to freeze yq to 3.1.1 so that it's installable on el8 as
-      # newer yq requires tomlkit>=0.11.7 which is python 3.7+ only.
-      - pip3 install --user yq==3.1.1 || pip3 install yq==3.1.1
+      - pip3 install --user yq || pip3 install yq
       - yq --help
 
 adjust+:

--- a/plans/integration/main.fmf
+++ b/plans/integration/main.fmf
@@ -10,6 +10,6 @@ prepare:
     how: install
     package: python3-pip
   - name: Install Requre
-    script: pip3 install "typing-extensions>=3.7.4.3" requre
+    script: pip3 install requre
   - name: Create default nitrate config
     script: "test -e ~/.nitrate || echo -en '[nitrate]\nurl = https://nitrate.server/xmlrpc/\n' | tee ~/.nitrate"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ show_error_codes = true
 # annotations across module boundaries.
 follow_imports = "normal"
 
-python_version = "3.7"
+python_version = "3.9"
 files = ["bin/tmt", "tmt/", "setup.py"]
 
 [[tool.mypy.overrides]]
@@ -27,7 +27,6 @@ module = [
     "nitrate.*",
     "pylero.*",
     "testcloud.*",
-    "importlib_metadata",
     "mrack.*",
 ]
 ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -57,17 +57,6 @@ install_requires = [
     'setuptools',
     ]
 
-# typing_extensions is needed with Python 3.7 and older, types imported
-# from that package (Literal, Protocol, TypedDict, ...) become available
-# from typing since Python 3.8.
-install_requires.append("typing-extensions>=3.7.4.3; python_version < '3.8'")
-
-# dataclasses is needed with Python 3.6
-install_requires.append("dataclasses; python_version < '3.7'")
-
-# entry_points is part of Python 3.9+
-install_requires.append("importlib_metadata; python_version < '3.9'")
-
 extras_require = {
     'docs': [
         'sphinx>=3',
@@ -123,10 +112,10 @@ setup(
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12'
         'Topic :: Utilities',
         ],
     keywords=['metadata', 'testing'],

--- a/tmt.spec
+++ b/tmt.spec
@@ -17,12 +17,6 @@ Source0: https://github.com/teemtee/tmt/releases/download/%{version}/tmt-%{versi
 
 %define workdir_root /var/tmp/tmt
 
-# Hint for shebang fixer, otherwise uses /usr/bin/python3
-# which can be changed by user
-%if 0%{?rhel} == 8
-%global __python3 /usr/bin/python3.6
-%endif
-
 # Main tmt package requires the Python module
 Requires: python%{python3_pkgversion}-%{name} == %{version}-%{release}
 Requires: git-core rsync sshpass
@@ -49,12 +43,6 @@ BuildRequires: python%{python3_pkgversion}-markdown
 BuildRequires: python%{python3_pkgversion}-junit_xml
 BuildRequires: python%{python3_pkgversion}-ruamel-yaml
 BuildRequires: python%{python3_pkgversion}-jinja2
-# Only needed for rhel-8 (it has python3.6)
-%if 0%{?rhel} == 8
-BuildRequires: python%{python3_pkgversion}-typing-extensions
-BuildRequires: python%{python3_pkgversion}-dataclasses
-BuildRequires: python%{python3_pkgversion}-importlib-metadata
-%endif
 # Required for tests
 BuildRequires: rsync
 %{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
@@ -90,17 +78,13 @@ Recommends: qemu-system-s390x-core
 Recommends: qemu-system-x86-core
 %endif
 
-%if 0%{?rhel} >= 9 || 0%{?fedora}
 %package provision-beaker
 Summary: Beaker provisioner for the Test Management Tool
 Requires: tmt = %{version}-%{release}
 Requires: python3-mrack-beaker >= 1.12.1
-%endif
 
-%if 0%{?rhel} >= 9 || 0%{?fedora}
 %description provision-beaker
 Dependencies required to run tests in a Beaker environment.
-%endif
 
 %description provision-virtual
 Dependencies required to run tests in a local virtual machine.
@@ -156,9 +140,7 @@ Requires: tmt-report-html >= %{version}
 Requires: tmt-report-junit >= %{version}
 Requires: tmt-report-polarion >= %{version}
 Requires: tmt-report-reportportal >= %{version}
-%if 0%{?rhel} >= 9 || 0%{?fedora}
 Requires: tmt-provision-beaker >= %{version}
-%endif
 
 %description all
 All extra dependencies of the Test Management Tool. Install this
@@ -182,10 +164,8 @@ install -pm 644 tmt.1* %{buildroot}%{_mandir}/man1
 install -pm 644 bin/complete %{buildroot}/etc/bash_completion.d/tmt
 mkdir -p %{buildroot}%{workdir_root}
 chmod 1777 %{buildroot}%{workdir_root}
-%if 0%{?rhel} >= 9 || 0%{?fedora}
 mkdir -p %{buildroot}/etc/%{name}/
 install -pm 644 %{name}/steps/provision/mrack/mrack* %{buildroot}/etc/%{name}/
-%endif
 
 %check
 %{__python3} -m pytest -vv -m 'not web' --ignore=tests/integration
@@ -218,11 +198,9 @@ install -pm 644 %{name}/steps/provision/mrack/mrack* %{buildroot}/etc/%{name}/
 %files provision-container
 %{python3_sitelib}/%{name}/steps/provision/{,__pycache__/}podman.*
 
-%if 0%{?rhel} >= 9 || 0%{?fedora}
 %files provision-beaker
 %{python3_sitelib}/%{name}/steps/provision/{,__pycache__/}mrack.*
 %config(noreplace) %{_sysconfdir}/%{name}/mrack*
-%endif
 
 %files provision-virtual
 %{python3_sitelib}/%{name}/steps/provision/{,__pycache__/}testcloud.*

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -20,10 +20,12 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Literal,
     Optional,
     Sequence,
     Tuple,
     Type,
+    TypedDict,
     TypeVar,
     Union,
     cast,
@@ -66,11 +68,6 @@ from tmt.utils import (
     normalize_shell_script,
     verdict,
     )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal, TypedDict
-else:
-    from typing_extensions import Literal, TypedDict
 
 if TYPE_CHECKING:
     import tmt.cli

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -347,17 +347,8 @@ def run_tests(context: Context, **kwargs: Any) -> None:
     tmt.base.Test._save_cli_context(context)
 
 
-# FIXME: click 8.0 renamed resultcallback to result_callback. The former
-#        name will be removed in click 8.1. However, click 8.0 will not
-#        be added to F33 and F34. Get rid of this workaround once
-#        all Fedora + EPEL releases have click 8.0 or newer available.
-run_callback = run.result_callback
-if run_callback is None:
-    run_callback = run.resultcallback
-
-
 # TODO: commands is unknown, needs revisit
-@run_callback()
+@run.result_callback()
 @click.pass_context
 def finito(
         click_context: Context,
@@ -1522,13 +1513,7 @@ def clean(context: Context, **kwargs: Any) -> None:
         raise SystemExit(exit_code)
 
 
-# FIXME: Click deprecation, see function finito for more info
-clean_callback = clean.result_callback
-if clean_callback is None:
-    clean_callback = clean.resultcallback
-
-
-@clean_callback()
+@clean.result_callback()
 @click.pass_context
 def perform_clean(
         click_context: Context,

--- a/tmt/export/__init__.py
+++ b/tmt/export/__init__.py
@@ -6,7 +6,6 @@ export of tests, plans or stories.
 """
 
 import re
-import sys
 import traceback
 import types
 import xmlrpc.client
@@ -19,17 +18,13 @@ from typing import (
     Generic,
     List,
     Optional,
+    Protocol,
     Tuple,
     Type,
     TypeVar,
     Union,
     cast,
     )
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
 
 import fmf
 import fmf.utils

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -30,15 +30,9 @@ import logging
 import logging.handlers
 import os
 import sys
-from typing import TYPE_CHECKING, Any, List, Optional, Set, Tuple, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Protocol, Set, Tuple, TypedDict, cast
 
 import click
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol, TypedDict
-else:
-    from typing_extensions import Protocol, TypedDict
-
 
 if TYPE_CHECKING:
     import tmt.utils

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -4,12 +4,8 @@ import importlib
 import os
 import pkgutil
 import sys
+from importlib.metadata import entry_points
 from typing import Any, Dict, Generator, Generic, List, Optional, Tuple, TypeVar
-
-if sys.version_info < (3, 9):
-    from importlib_metadata import entry_points
-else:
-    from importlib.metadata import entry_points
 
 import tmt
 import tmt.utils

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -5,7 +5,6 @@ import collections
 import dataclasses
 import re
 import shutil
-import sys
 import textwrap
 from typing import (
     TYPE_CHECKING,
@@ -18,16 +17,12 @@ from typing import (
     Optional,
     Tuple,
     Type,
+    TypedDict,
     TypeVar,
     Union,
     cast,
     overload,
     )
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
 
 import click
 from click import echo

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -1,8 +1,7 @@
 import dataclasses
 import re
 import shutil
-import sys
-from typing import List, Optional, Tuple, cast
+from typing import List, Literal, Optional, Tuple, cast
 
 import fmf
 import fmf.utils
@@ -16,12 +15,6 @@ import tmt.steps.prepare
 import tmt.utils
 from tmt.steps.provision import Guest, GuestPackageManager
 from tmt.utils import Command, Path, ShellScript, field
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
-
 
 COPR_URL = 'https://copr.fedorainfracloud.org/coprs'
 

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -1,7 +1,6 @@
 import dataclasses
 import datetime
-import sys
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, TypedDict, cast
 
 import requests
 
@@ -12,12 +11,6 @@ import tmt.steps
 import tmt.steps.provision
 import tmt.utils
 from tmt.utils import ProvisionError, cached_property, field, retry_session, updatable_message
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
-
 
 # List of Artemis API versions supported and understood by this plugin.
 # Since API gains support for new features over time, it is important to

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1,10 +1,11 @@
+import asyncio
 import dataclasses
 import datetime
 import logging
 import os
-import sys
 from contextlib import suppress
-from typing import Any, Dict, Optional, Tuple, cast
+from functools import wraps
+from typing import Any, Dict, Optional, Tuple, TypedDict, cast
 
 import tmt
 import tmt.options
@@ -12,14 +13,6 @@ import tmt.steps
 import tmt.steps.provision
 import tmt.utils
 from tmt.utils import ProvisionError, field, updatable_message
-
-if sys.version_info >= (3, 8):
-    from typing import TypedDict
-else:
-    from typing_extensions import TypedDict
-
-import asyncio
-from functools import wraps
 
 mrack = Any
 providers = Any

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -36,6 +36,7 @@ from typing import (
     Generic,
     Iterable,
     List,
+    Literal,
     Optional,
     Pattern,
     Sequence,
@@ -63,11 +64,6 @@ from ruamel.yaml import YAML, scalarstring
 from ruamel.yaml.comments import CommentedMap
 from ruamel.yaml.parser import ParserError
 from ruamel.yaml.representer import Representer
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 import tmt.log
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -98,7 +98,7 @@ class Path(pathlib.PosixPath):
     # implementation considers to not be relative to each other. Therefore, we
     # need to override `is_relative_to()` even for other Python versions, to not
     # depend on `ValueError` raised by the original `relative_to()`.
-    def is_relative_to(self, other: 'Path') -> bool:
+    def is_relative_to(self, other: 'Path') -> bool:  # type: ignore[override]
         # NOTE: the following is not perfect, but it should be enough for
         # what tmt needs to know about its paths.
 
@@ -1700,40 +1700,11 @@ def copytree(
         dirs_exist_ok: bool = False,
         ) -> Path:
     """ Similar to shutil.copytree but with dirs_exist_ok for Python < 3.8 """
-    # No need to reimplement for newer python or if argument is not requested
-    # ignore[call-arg] needed when running type-checks with Python < 3.8
-    if not dirs_exist_ok or sys.version_info >= (3, 8):
-        return cast(
-            Path,
-            shutil.copytree(src=src, dst=dst, symlinks=symlinks,  # type: ignore[call-arg]
-                            dirs_exist_ok=dirs_exist_ok))
-    # Choice was to either copy python implementation and change ONE line
-    # or use rsync (or cp with shell)
-    # We need to copy CONTENT of src into dst
-    # so src has to end with / and dst cannot
-    rsync_src, rsync_dst = str(src), str(dst)
-    if rsync_src[-1] != '/':
-        rsync_src += '/'
-    if rsync_dst[-1] == '/':
-        rsync_dst = rsync_dst[:-1]
-
-    dst.mkdir(parents=True, exist_ok=dirs_exist_ok)
-    command = ["rsync", "-r"]
-    if symlinks:
-        command.append('-l')
-    command.extend([rsync_src, rsync_dst])
-
-    log.debug(f"Calling command '{command}'.")
-    outcome = subprocess.run(
-        command,
-        stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT, universal_newlines=True)
-
-    if outcome.returncode != 0:
-        raise shutil.Error(
-            [f"Unable to copy '{src}' into '{dst}' using rsync.",
-             outcome.returncode, outcome.stdout])
-    return dst
+    # FIXME fix all usages, we don't need this function any more
+    return cast(
+        Path,
+        shutil.copytree(src=src, dst=dst, symlinks=symlinks,
+                        dirs_exist_ok=dirs_exist_ok))
 
 
 def get_full_metadata(fmf_tree_path: Path, node_path: str) -> Any:


### PR DESCRIPTION
First round: Remove epel-8 targets, %if clauses in the spec file, no need to bundle copytree as it will never run and mypy was complaining about 
```
tmt/utils.py:101: error: Signature of "is_relative_to" incompatible with supertype "PurePath"  [override]
tmt/utils.py:101: note:      Superclass:
tmt/utils.py:101: note:          def is_relative_to(self, *other: Union[str, PathLike[str]]) -> bool
tmt/utils.py:101: note:      Subclass:
tmt/utils.py:101: note:          def is_relative_to(self, other: Union[str, Path]) -> bool
```

The #2209 does much more changes and I'm afraid it will take some time until things settle there, so lets' drop python3.6 asap and have easier life with open PR

