### PR TITLE
Add dynref support to library type dependency

### DIFF
--- a/tests/libraries/dynamic_ref/data/dynamic-ref
+++ b/tests/libraries/dynamic_ref/data/dynamic-ref
@@ -1,0 +1,4 @@
+ref: defaultbranch
+adjust:
+  when: foo is defined
+  ref: otherbranch

--- a/tests/libraries/dynamic_ref/data/lib.sh
+++ b/tests/libraries/dynamic_ref/data/lib.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#   library-prefix = first
+
+firstWorks(){
+  echo yes
+}
+
+firstLibraryLoaded(){
+  return 0
+}

--- a/tests/libraries/dynamic_ref/data/test.sh
+++ b/tests/libraries/dynamic_ref/data/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+set -o pipefail
+
+rlJournalStart
+    rlPhaseStartTest
+        rlRun "rlImport --all"
+        rlRun "firstWorks"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/libraries/dynamic_ref/main.fmf
+++ b/tests/libraries/dynamic_ref/main.fmf
@@ -1,0 +1,6 @@
+summary: Evaluate dynamic ref when fetching a library
+description:
+    Library can be cloned from a dynamically resolved branch.
+require:
+  - git-core
+tier: 4

--- a/tests/libraries/dynamic_ref/test.sh
+++ b/tests/libraries/dynamic_ref/test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+set -o pipefail
+
+rlJournalStart
+    rlPhaseStartSetup "Prepare git repos"
+        testdir=$PWD
+        rlRun "repo1=\$(mktemp -d)"
+        rlRun "repo2=\$(mktemp -d)"
+        # Create test repo
+        rlRun "cp data/test.sh $repo1"
+        cat <<EOF > $repo1/main.fmf
+/first:
+  test: bash test.sh
+  framework: beakerlib
+  require:
+  - name: /dynref
+    type: library
+    url: $repo2
+    ref: "@dynamic-ref"
+EOF
+        rlRun "tmt init $repo1"
+        rlRun "pushd $repo1"
+        rlRun "git config --global init.defaultBranch main"
+        rlRun "git init"
+        rlRun "git config --local user.email me@localhost.localdomain"
+        rlRun "git config --local user.name m e"
+        rlRun "git add -A"
+        rlRun "git commit -m initial"
+        rlRun "popd"
+        # Create library repo
+        rlRun "tmt init $repo2"
+        rlRun "pushd $repo2"
+        rlRun "git init"
+        rlRun "git config --local user.email me@localhost.localdomain"
+        rlRun "git config --local user.name m e"
+        rlRun "cp $testdir/data/dynamic-ref $repo2"
+        rlRun "git add -A"
+        rlRun "git commit -m first"
+        rlRun "git checkout -b otherbranch"
+        rlRun "mkdir dynref"
+        rlRun "cp -r $testdir/data/lib.sh $repo2/dynref"
+        cat <<EOF > $repo2/dynref/main.fmf
+test: bash lib.sh
+framework: beakerlib
+EOF
+        rlRun "git add -A"
+        rlRun "git commit -m second"
+        rlRun "git checkout main"
+        rlRun "popd"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Search for lib in a dynamically resolved branch"
+        rlRun "pushd $repo1"
+        rlRun -s "tmt --context foo=1 run --rm -a -vvv -ddd discover provision -h local"
+        rlAssertGrep "Dynamic 'ref' definition file '.*' detected." $rlRun_LOG -E
+        rlAssertGrep "Dynamic 'ref' resolved as 'otherbranch'." $rlRun_LOG
+        rlAssertGrep "total: 1 test passed" $rlRun_LOG
+        rlRun "popd"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "rm -rf $repo1 $repo2" 0 "Remove temporary directories"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -3753,7 +3753,7 @@ def resolve_dynamic_ref(
         *,
         workdir: Path,
         ref: Optional[str],
-        plan: Plan,
+        plan: Optional[Plan] = None,
         logger: tmt.log.Logger) -> Optional[str]:
     """
     Get the final value for the dynamic reference
@@ -3782,10 +3782,11 @@ def resolve_dynamic_ref(
         raise tmt.utils.FileError(f"Failed to read '{ref_filepath}'.") from error
     # Build a dynamic reference tree, adjust ref based on the context
     reference_tree = fmf.Tree(data=data)
+    if not plan:
+        raise tmt.utils.FileError("Cannot get plan fmf context to evaluate dynamic ref.")
     reference_tree.adjust(fmf.context.Context(**plan._fmf_context))
     # Also temporarily build a plan so that env and context variables are expanded
     Plan(logger=logger, node=reference_tree, run=plan.my_run, skip_validation=True)
     ref = reference_tree.get("ref")
-
-    # RET504: Unnecessary variable assignment before `return` statement. Keeping for readability.
-    return ref  # noqa: RET504
+    logger.debug(f"Dynamic 'ref' resolved as '{ref}'.")
+    return ref


### PR DESCRIPTION
When library is maintained in a repository with dynamic ref it is necessary to copy it from the right branch.
To do so library test dependecies must support dynamic ref.