### PR TITLE
Fix README and man page command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,9 +82,9 @@ Run all or selected steps for each plan::
 
 List tests, show details, check against the specification::
 
-    tmt test ls
-    tmt test show
-    tmt test lint
+    tmt tests ls
+    tmt tests show
+    tmt tests lint
 
 Create a new test, import test metadata from other formats::
 
@@ -93,22 +93,22 @@ Create a new test, import test metadata from other formats::
 
 List plans, show details, check against the specification::
 
-    tmt plan ls
-    tmt plan show
-    tmt plan lint
+    tmt plans ls
+    tmt plans show
+    tmt plans lint
 
 List stories, check details, show coverage status::
 
-    tmt story ls
-    tmt story show
-    tmt story coverage
+    tmt stories ls
+    tmt stories show
+    tmt stories coverage
 
 Many commands support regular expression filtering and other
 specific options::
 
-    tmt story ls cli
-    tmt story show create
-    tmt story coverage --implemented
+    tmt stories ls cli
+    tmt stories show create
+    tmt stories coverage --implemented
 
 Check help message of individual commands for the full list of
 available options.
@@ -145,8 +145,8 @@ finish
     Perform the finishing tasks and clean up provisioned guests.
 
 
-Test
-----
+Tests
+-----
 
 Manage tests (L1 metadata). Check available tests, inspect their
 metadata, gather old metadata from various sources and stored them
@@ -164,8 +164,8 @@ import
     Convert old test metadata into the new fmf format.
 
 
-Plan
-----
+Plans
+-----
 
 Manage test plans (L2 metadata). Search for available plans.
 Explore detailed test step configuration.
@@ -178,8 +178,8 @@ lint
     Check plans against the L2 metadata specification.
 
 
-Story
------
+Stories
+-------
 
 Manage user stories. Check available user stories. Explore
 coverage (test, implementation, documentation).

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -268,9 +268,9 @@ An example story can look like this:
         As a user I want to see more detailed information for
         particular command.
     example:
-      - tmt test show -v
-      - tmt test show -vvv
-      - tmt test show --verbose
+      - tmt tests show -v
+      - tmt tests show -vvv
+      - tmt tests show --verbose
 
 In order to start experimenting with the complete set of examples
 covering all metadata levels, use the ``full`` template which
@@ -365,8 +365,8 @@ create a new plan with templates:
 
 .. code-block:: shell
 
-    tmt plans create --template mini /plans/smoke
-    tmt plans create --t full /plans/features
+    tmt plan create --template mini /plans/smoke
+    tmt plan create --t full /plans/features
 
 When creating many plans, for example when migrating the whole
 test coverage from a different tooling, it might be handy to
@@ -443,7 +443,7 @@ see ``tmt lint --help``.
     tmt lint --list-checks
 
     # All checks tmt has for tests
-    tmt test lint --list-checks
+    tmt tests lint --list-checks
 
 You should run ``tmt lint`` before pushing changes, ideally even
 before you commit your changes. You can set up `pre-commit`__ to


### PR DESCRIPTION
As I understand the most right command name for tests and plans are ```tests``` and ```plans```.
In the command line is this:
```
tmt --help
...
  tests    Manage tests (L1 metadata).
  plans    Manage test plans (L2 metadata).
...
```

In doc is ```test``` and ```plan```.
I looked to history and there was rewrite from ```def test()``` to ```def tests()```
Both versions are working.
I deduced that the short version is old and we need to fix it.

btw: I don't know what about commands in examples/scripts. When we need backward compatibility we need to use short names.