### PR TITLE
Use the latest `sphinx-rtd-theme` for docs building

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ install_requires.append("importlib_metadata; python_version < '3.9'")
 extras_require = {
     'docs': [
         'sphinx>=3',
-        'sphinx_rtd_theme'],
+        'sphinx-rtd-theme==1.3.0rc1'],
     'tests': [
         'flake8',
         'pytest',


### PR DESCRIPTION
Currently docs building is broken because of https://github.com/readthedocs/sphinx_rtd_theme/issues/1463. Let's use the latest available to fix docs building now.
