### PR TITLE
Full `pip install` expected to fail on `Rawhide`

### DIFF
--- a/plans/install/pip.fmf
+++ b/plans/install/pip.fmf
@@ -11,29 +11,11 @@ execute:
 /mini:
     summary+: " (mini)"
     discover:
-        tests:
-          - name: /install
-            test: /tmp/venv/bin/pip install .
-            require:
-              - gcc
-              - python3
-              - python3-devel
-          - name: /help
-            test: /tmp/venv/bin/tmt --help
+        how: fmf
+        test: /tests/pip/install/mini
 
 /full:
     summary+: " (full)"
     discover:
-        tests:
-          - name: /install
-            test: /tmp/venv/bin/pip install .[all]
-            require:
-              - gcc
-              - python3
-              - python3-devel
-              - libvirt-devel
-              - krb5-devel
-              - libpq-devel
-              - redhat-rpm-config
-          - name: /help
-            test: /tmp/venv/bin/tmt run --help
+        how: fmf
+        test: /tests/pip/install/full

--- a/tests/pip/install.fmf
+++ b/tests/pip/install.fmf
@@ -1,0 +1,28 @@
+path: "/"
+framework: shell
+require:
+    - gcc
+    - python3
+    - python3-devel
+tier: null
+
+/mini:
+    summary: Ensure the minimal pip install works
+    test: |
+        /tmp/venv/bin/pip install .
+        /tmp/venv/bin/tmt --help
+
+/full:
+    summary: Ensure the full pip install works
+    require+:
+        - libvirt-devel
+        - krb5-devel
+        - libpq-devel
+        - redhat-rpm-config
+    test: |
+        /tmp/venv/bin/pip install .[all]
+        /tmp/venv/bin/tmt --help
+    adjust:
+        result: xfail
+        when: distro == fedora-rawhide
+        because: https://github.com/aio-libs/aiohttp/issues/7229


### PR DESCRIPTION
Because of aio-libs/aiohttp/issues/7229 the full pip install test is expected to fail on `rawhide` until the issue is fixed. Move test code from the plan to a real test to enable the adjust rule.