### PR TITLE
Extend sufficiently the full test suite duration

### DIFF
--- a/tests/full/test.fmf
+++ b/tests/full/test.fmf
@@ -34,7 +34,7 @@ require:
 recommend:
 - guestfs-tools
 - python3-docutils
-duration: 4h
+duration: 12h
 extra-hardware: |
   keyvalue=HVM=1
   hostrequire=memory >= 6144


### PR DESCRIPTION
Sometimes the full test suite can take a longer time, especially when slower machines are involved. Extend the `duration` with a sufficient reserve.