### PR TITLE
Add -e/--environment/--environment-files to plan show/export

### DIFF
--- a/tests/plan/export/data/plan.fmf
+++ b/tests/plan/export/data/plan.fmf
@@ -31,3 +31,8 @@ execute:
         import:
             url: https://github.com/teemtee/tmt
             name: /plans/features/basic
+
+/with-envvars:
+    prepare:
+      how: shell
+      script: "$ENV_SCRIPT"

--- a/tests/plan/export/test.sh
+++ b/tests/plan/export/test.sh
@@ -63,6 +63,14 @@ rlJournalStart
         rlAssertNotGrep " _" $rlRun_LOG
     rlPhaseEnd
 
+    rlPhaseStartTest "tmt plan export /plan/with-envvars"
+        rlRun -s "tmt plan export /plan/with-envvars" 0 "Show plan"
+        rlAssertEquals "prepare script shall be an envvar" "$(yq -r '.[] | .prepare | .[] | .script' $rlRun_LOG)" "\$ENV_SCRIPT"
+
+        rlRun -s "tmt plan export -e ENV_SCRIPT=dummy-script /plan/with-envvars" 0 "Export plan"
+        rlAssertEquals "prepare script shall be an replaced" "$(yq -r '.[] | .prepare | .[] | .script' $rlRun_LOG)" "dummy-script"
+    rlPhaseEnd
+
     rlPhaseStartTest "Invalid format"
         rlRun -s "tmt plan export --how weird" 2
 

--- a/tests/plan/show/data/plans/envvars.fmf
+++ b/tests/plan/show/data/plans/envvars.fmf
@@ -1,0 +1,2 @@
+execute:
+    script: "$ENV_SCRIPT"

--- a/tests/plan/show/test.sh
+++ b/tests/plan/show/test.sh
@@ -176,6 +176,14 @@ rlJournalStart
         rlAssertGrep "enabled false" $rlRun_LOG
     rlPhaseEnd
 
+    rlPhaseStartTest "Show and honor envvars"
+        rlRun -s "tmt plan show /plans/envvars" 0 "Show plan"
+        rlAssertEquals "script shall be an envvar" "$(grep ' script ' $rlRun_LOG | awk '{print $2}')" "\$ENV_SCRIPT"
+
+        rlRun -s "tmt plan show -e ENV_SCRIPT=dummy-script /plans/envvars" 0 "Export plan"
+        rlAssertEquals "script shall be an replaced" "$(grep ' script ' $rlRun_LOG | awk '{print $2}')" "dummy-script"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm $output"

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -138,6 +138,7 @@ fmf_source_options = create_options_decorator(tmt.options.FMF_SOURCE_OPTIONS)
 story_flags_filter_options = create_options_decorator(tmt.options.STORY_FLAGS_FILTER_OPTIONS)
 remote_plan_options = create_options_decorator(tmt.options.REMOTE_PLAN_OPTIONS)
 lint_options = create_options_decorator(tmt.options.LINT_OPTIONS)
+environment_options = create_options_decorator(tmt.options.ENVIRONMENT_OPTIONS)
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -249,14 +250,6 @@ def main(
 @option(
     '-S', '--skip', type=click.Choice(tmt.steps.STEPS),
     help='Skip given step(s) during test run execution.', multiple=True)
-@option(
-    '-e', '--environment', metavar='KEY=VALUE|@FILE', multiple=True,
-    help='Set environment variable. Can be specified multiple times. The '
-         '"@" prefix marks a file to load (yaml or dotenv formats supported).')
-@option(
-    '--environment-file', metavar='FILE|URL', multiple=True,
-    help='Set environment variables from file or url (yaml or dotenv formats '
-         'are supported). Can be specified multiple times.')
 @click.option(
     '--on-plan-error',
     type=click.Choice(['quit', 'continue']),
@@ -264,6 +257,7 @@ def main(
     help='What to do when plan fails to finish. Quit by default, or continue'
          'with the next plan.'
     )
+@environment_options
 @verbosity_options
 @force_dry_options
 def run(context: Context, id_: Optional[str], **kwargs: Any) -> None:
@@ -874,6 +868,7 @@ def plans_ls(context: Context, **kwargs: Any) -> None:
 @plans.command(name='show')
 @click.pass_context
 @filter_options
+@environment_options
 @verbosity_options
 @remote_plan_options
 def plans_show(context: Context, **kwargs: Any) -> None:
@@ -997,6 +992,7 @@ _plan_export_default = 'yaml'
     '--template', metavar='PATH',
     help="Path to a template to use for rendering the export. Used with '--how=template' only."
     )
+@environment_options
 def plans_export(
         context: Context,
         how: str,

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -289,6 +289,22 @@ LINT_OPTIONS: List[ClickOptionDecoratorType] = [
     ]
 
 
+ENVIRONMENT_OPTIONS: List[ClickOptionDecoratorType] = [
+    option(
+        '-e', '--environment',
+        metavar='KEY=VALUE|@FILE',
+        multiple=True,
+        help='Set environment variable. Can be specified multiple times. The '
+             '"@" prefix marks a file to load (yaml or dotenv formats supported).'),
+    option(
+        '--environment-file',
+        metavar='FILE|URL',
+        multiple=True,
+        help='Set environment variables from file or url (yaml or dotenv formats '
+             'are supported). Can be specified multiple times.')
+    ]
+
+
 def create_options_decorator(options: List[ClickOptionDecoratorType]) -> Callable[[FC], FC]:
     def common_decorator(fn: FC) -> FC:
         for option in reversed(options):


### PR DESCRIPTION
Only `tmt run` was allowed to accept environment options. That's fine until one wishes to run `tmt plan export` and expects various environment variables, used e.g. in `hardware` or `arch` keys, to be replaced.

Usualy, not really a problem, plan export simply emits what's been loaded from fmf, which is exactly what it should emit, but here comes Testing Farm: `plan export` is used for exposing `hardware` which then can be passed down to Artemis for provisioning.

Therefore the patch adds the same set of options to `plan show` and `plan export`, for those who would like to see how evaluated envvars affected the plan.