### PR TITLE
Fix guest data show() and how it displays hardware requirements

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -424,17 +424,20 @@ class GuestData(tmt.utils.SerializableContainer):
             # TODO: teach GuestFacts to cooperate with show() methods, honor
             # the verbosity at the same time.
             if key == 'facts':
-                return
+                continue
 
             value = getattr(self, key)
 
-            if value is None:
-                return
+            if value == self.default(key):
+                continue
 
             # TODO: it seems tmt.utils.format() needs a key, and logger.info()
             # does not accept already formatted string.
             if isinstance(value, (list, tuple)):
                 printable_value = fmf.utils.listed(value)
+
+            elif isinstance(value, tmt.hardware.Hardware):
+                printable_value = tmt.utils.dict_to_yaml(value.to_spec())
 
             else:
                 printable_value = str(value)

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -656,7 +656,7 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
             ssh_option=self.get('ssh-option')
             )
 
-        data.show(verbose=self.get('verbose'), logger=self._logger)
+        data.show(verbose=self.verbosity_level, logger=self._logger)
 
         self._guest = GuestArtemis(
             logger=self._logger,

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -85,7 +85,7 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
             key=self.get('key')
             )
 
-        data.show(verbose=self.get('verbose'), logger=self._logger)
+        data.show(verbose=self.verbosity_level, logger=self._logger)
 
         if data.password:
             self.debug('Using password authentication.')

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -139,7 +139,7 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
             role=self.get('role')
             )
 
-        data.show(verbose=self.get('verbose'), logger=self._logger)
+        data.show(verbose=self.verbosity_level, logger=self._logger)
 
         if data.hardware and data.hardware.constraint:
             self.warn("The 'local' provision plugin does not support hardware requirements.")

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -671,7 +671,7 @@ class ProvisionBeaker(tmt.steps.provision.ProvisionPlugin):
             provision_tick=self.get('provision-tick'),
             )
 
-        data.show(verbose=self.get('verbose'), logger=self._logger)
+        data.show(verbose=self.verbosity_level, logger=self._logger)
 
         if data.hardware:
             data.hardware.report_support(

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -306,7 +306,7 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
 
         data = PodmanGuestData(**data_from_options)
 
-        data.show(verbose=self.get('verbose'), logger=self._logger)
+        data.show(verbose=self.verbosity_level, logger=self._logger)
 
         if data.hardware and data.hardware.constraint:
             self.warn("The 'container' provision plugin does not support hardware requirements.")

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -662,7 +662,7 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
                     raise tmt.utils.NormalizationError(
                         f'{self.name}:{int_key}', value, 'an integer') from exc
 
-        data.show(verbose=self.get('verbose'), logger=self._logger)
+        data.show(verbose=self.verbosity_level, logger=self._logger)
 
         if data.hardware and data.hardware.constraint:
             self.warn("The 'virtual' provision plugin does not support hardware requirements.")


### PR DESCRIPTION
* there was a bug in `GuestData.show()`, only the first key was shown, thanks to a failed refactoring `return`s did not turn into `continue`s.
* `hardware` field was displayed in a very ugly way, yet `dict_to_yaml` is far from being the perfect choice.
* `get('verbose')` has been replaced with `self.verbosity_level`, rebase missed this change & it sneaked into the final HW requirements patch.