### PR TITLE
Make `tmt init` add `.fmf` directory into git index

### DIFF
--- a/tests/init/git/main.fmf
+++ b/tests/init/git/main.fmf
@@ -1,0 +1,4 @@
+summary: Test if tmt automatically adds '.fmf' directory into git.
+description:
+    If 'tmt init ...' is executed in a git repository, '.fmf' directory
+    should be automatically added into git index.

--- a/tests/init/git/test.sh
+++ b/tests/init/git/test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "git init"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Dry"
+        rlRun -s "tmt init -t base --dry"
+        rlAssertGrep "Tree .* would be initialized." "${rlRun_LOG}"
+        rlAssertGrep "Path .* would be added to git index." "${rlRun_LOG}"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Create"
+        rlRun -s "tmt init -t base"
+        rlAssertGrep "Tree .* initialized." "${rlRun_LOG}"
+        rlAssertGrep "Path .* added to git index." "${rlRun_LOG}"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -rf $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2841,6 +2841,21 @@ class Tree(tmt.utils.Common):
                         f"Failed to initialize tree in '{path}': {error}")
                 echo(f"Tree '{tree.root}' initialized.")
 
+        # Add .fmf directory to the git index if possible
+        if tmt.utils.git_root(fmf_root=path, logger=logger):
+            fmf_dir = path / '.fmf'
+            if dry:
+                echo(f"Path '{fmf_dir}' would be added to git index.")
+            else:
+                try:
+                    tmt.utils.git_add(path=fmf_dir, logger=logger)
+                    echo(f"Path '{fmf_dir}' added to git index.")
+                except tmt.utils.GeneralError as error:
+                    message = error.message
+                    if isinstance(error.__cause__, tmt.utils.RunError) and error.__cause__.stderr:
+                        message += " " + " ".join(error.__cause__.stderr.splitlines())
+                    echo(message)
+
         # Populate the tree with example objects if requested
         if template == 'empty':
             choices = listed(tmt.templates.INIT_TEMPLATES, join='or')

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -3271,6 +3271,22 @@ def git_root(*, fmf_root: Path, logger: tmt.log.Logger) -> Optional[Path]:
         return None
 
 
+def git_add(*, path: Path, logger: tmt.log.Logger) -> None:
+    """
+    Add path to the git index.
+
+    :param path: path to add to the git index.
+    :param logger: used for logging.
+    """
+    path = path.resolve()
+
+    try:
+        Command("git", "add", str(path)).run(cwd=path.parent, logger=logger)
+
+    except RunError as error:
+        raise GeneralError(f"Failed to add path '{path}' to git index.") from error
+
+
 def default_branch(
         *,
         repository: Path,


### PR DESCRIPTION
If `tmt init` is executed inside a git repository, tmt will automatically add the .fmf directory to git.

Resolves: #2219 