### PR TITLE
Add a missing blank space

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -254,7 +254,7 @@ def main(
     '--on-plan-error',
     type=click.Choice(['quit', 'continue']),
     default='quit',
-    help='What to do when plan fails to finish. Quit by default, or continue'
+    help='What to do when plan fails to finish. Quit by default, or continue '
          'with the next plan.'
     )
 @environment_options


### PR DESCRIPTION
Without the patch:
With the patch:
$ tmt run --help | grep 'continue'
  --on-plan-error [quit|continue]
                                  by default, or **_continuewith_** the next plan.

With the patch:
$ tmt run --help | grep 'continue'
  --on-plan-error [quit|continue]
                                  by default, or **_continue with_** the next plan.