### PR TITLE
Extend the expected `pip install` fail to `f-39`

### DIFF
--- a/tests/pip/install.fmf
+++ b/tests/pip/install.fmf
@@ -24,5 +24,5 @@ tier: null
         /tmp/venv/bin/tmt --help
     adjust:
         result: xfail
-        when: distro == fedora-rawhide
+        when: distro >= fedora-39
         because: https://github.com/aio-libs/aiohttp/issues/7229


### PR DESCRIPTION
Fedora was branched, so now the expected failure appears on `fedora-39` as well.