### PR TITLE
Put `--help` at the end of the CLI in the step usage

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -370,7 +370,7 @@ class Step(tmt.utils.Common, tmt.export.Exportable['Step']):
         # Give a hint about detailed help
         name = cls.__name__.lower()
         usage += (
-            f"\n\nUse 'tmt run {name} --help --how <method>' to learn more "
+            f"\n\nUse 'tmt run {name} --how <method> --help' to learn more "
             f"about given {name} method and all its supported options.")
         return usage
 


### PR DESCRIPTION
Without the patch:
$ tmt run provision --help | grep "<method>"
  Use 'tmt run provision **_--help_** --how <method>' to learn more about given
The command line with '--help' in the middle did not work.

With the patch:
$ tmt run provision --help | grep "<method>"
  Use 'tmt run provision --how <method> **_--help_**' to learn more about given
The command line with '--help' at the end worked.