### PR TITLE
Wrap `click.Choice` use with `choices` parameter

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -264,23 +264,23 @@ def main(
 @option(
     '-a', '--all', help='Run all steps, customize some.', is_flag=True)
 @option(
-    '-u', '--until', type=click.Choice(tmt.steps.STEPS),
+    '-u', '--until', choices=tmt.steps.STEPS,
     help='Enable given step and all preceding steps.')
 @option(
-    '-s', '--since', type=click.Choice(tmt.steps.STEPS),
+    '-s', '--since', choices=tmt.steps.STEPS,
     help='Enable given step and all following steps.')
 @option(
-    '-A', '--after', type=click.Choice(tmt.steps.STEPS),
+    '-A', '--after', choices=tmt.steps.STEPS,
     help='Enable all steps after the given one.')
 @option(
-    '-B', '--before', type=click.Choice(tmt.steps.STEPS),
+    '-B', '--before', choices=tmt.steps.STEPS,
     help='Enable all steps before the given one.')
 @option(
-    '-S', '--skip', type=click.Choice(tmt.steps.STEPS),
+    '-S', '--skip', choices=tmt.steps.STEPS,
     help='Skip given step(s) during test run execution.', multiple=True)
-@click.option(
+@option(
     '--on-plan-error',
-    type=click.Choice(['quit', 'continue']),
+    choices=['quit', 'continue'],
     default='quit',
     help='What to do when plan fails to finish. Quit by default, or continue '
          'with the next plan.'
@@ -744,12 +744,12 @@ _test_export_default = 'yaml'
 @option(
     '-h', '--how', default=_test_export_default, show_default=True,
     help='Output format.',
-    type=click.Choice(choices=_test_export_formats))
+    choices=_test_export_formats)
 @option(
     '--format', default=_test_export_default, show_default=True,
     help='Output format.',
     deprecated=Deprecated('1.21', hint='use --how instead'),
-    type=click.Choice(choices=_test_export_formats))
+    choices=_test_export_formats)
 @option(
     '--nitrate', is_flag=True,
     help="Export test metadata to Nitrate.",
@@ -1028,12 +1028,12 @@ _plan_export_default = 'yaml'
 @option(
     '-h', '--how', default=_plan_export_default, show_default=True,
     help='Output format.',
-    type=click.Choice(choices=_plan_export_formats))
+    choices=_plan_export_formats)
 @option(
     '--format', default=_plan_export_default, show_default=True,
     help='Output format.',
     deprecated=Deprecated('1.21', hint='use --how instead'),
-    type=click.Choice(choices=_plan_export_formats))
+    choices=_plan_export_formats)
 @option(
     '-d', '--debug', is_flag=True,
     help='Provide as much debugging details as possible.')
@@ -1293,12 +1293,12 @@ _story_export_default = 'yaml'
 @option(
     '-h', '--how', default=_story_export_default, show_default=True,
     help='Output format.',
-    type=click.Choice(choices=_story_export_formats))
+    choices=_story_export_formats)
 @option(
     '--format', default=_story_export_default, show_default=True,
     help='Output format.',
     deprecated=Deprecated('1.21', hint='use --how instead'),
-    type=click.Choice(choices=_story_export_formats))
+    choices=_story_export_formats)
 @option(
     '-d', '--debug', is_flag=True,
     help='Provide as much debugging details as possible.')
@@ -1427,7 +1427,7 @@ def stories_id(
 @click.argument('path', default='.')
 @option(
     '-t', '--template', default='empty',
-    type=click.Choice(['empty', *tmt.templates.INIT_TEMPLATES]),
+    choices=['empty', *tmt.templates.INIT_TEMPLATES],
     help="Use this template to populate the tree.")
 @verbosity_options
 @force_dry_options

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -4,7 +4,7 @@ import contextlib
 import dataclasses
 import re
 import textwrap
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Type, Union
 
 import click
 
@@ -78,6 +78,7 @@ def option(
         prompt: Optional[str] = None,
         envvar: Optional[str] = None,
         # Following parameters are our additions.
+        choices: Optional[Sequence[str]] = None,
         deprecated: Optional[Deprecated] = None) -> ClickOptionDecoratorType:
     """
     Attaches an option to the command.
@@ -86,6 +87,9 @@ def option(
     meaning as those of ``click.option()``, and are passed to ``click.option()``,
     with the exception of ``deprecated`` parameter.
 
+    :param choices: if set, it sets ``type`` of the option to
+        :py:class:`click.Choices`, and limits option values to those
+        listed in ``choices``.
     :param deprecated: if set, it is rendered and appended to ``help``. This
         parameter is **not** passed to :py:func:`click.option`.
     """
@@ -101,6 +105,9 @@ def option(
         else:
             help = deprecated.rendered
 
+    if choices is not None:
+        type = click.Choice(choices)
+
     # Add a metavar listing choices unless an explicit metavar has been provided
     if isinstance(type, click.Choice) and metavar is None:
         metavar = '|'.join(type.choices)
@@ -110,6 +117,7 @@ def option(
     # not accepted by click and the positional parameter.
     kwargs = locals().copy()
     kwargs.pop('param_decls')
+    kwargs.pop('choices')
     kwargs.pop('deprecated')
 
     return click.option(*param_decls, **kwargs)
@@ -128,7 +136,7 @@ VERBOSITY_OPTIONS: List[ClickOptionDecoratorType] = [
         help='Be quiet. Exit code is just enough for me.'),
     option(
         '--log-topic',
-        type=click.Choice([topic.value for topic in tmt.log.Topic]),
+        choices=[topic.value for topic in tmt.log.Topic],
         multiple=True,
         help='If specified, --debug and --verbose would emit logs also for these topics.')
     ]
@@ -284,7 +292,7 @@ LINT_OPTIONS: List[ClickOptionDecoratorType] = [
     option(
         '--outcome-only',
         multiple=True,
-        type=click.Choice(_lint_outcomes),
+        choices=_lint_outcomes,
         help='Display only checks with the given outcome.')
     ]
 

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -1523,7 +1523,7 @@ class Login(Action):
             help='Log in during given phase of selected step(s).')
         @option(
             '-w', '--when', metavar='RESULT', multiple=True,
-            type=click.Choice([m.value for m in ResultOutcome.__members__.values()]),
+            choices=[m.value for m in ResultOutcome.__members__.values()],
             help='Log in if a test finished with given result(s).')
         @option(
             '-c', '--command', metavar='COMMAND',

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2361,10 +2361,10 @@ class FieldMetadata(Generic[T]):
             from tmt.options import option
 
             if isinstance(self.option_choices, (list, tuple)):
-                self.option_kwargs['type'] = click.Choice(self.option_choices)
+                self.option_kwargs['choices'] = self.option_choices
 
             elif callable(self.option_choices):
-                self.option_kwargs['type'] = click.Choice(self.option_choices())
+                self.option_kwargs['choices'] = self.option_choices()
 
             self._option = option(
                 *self.option_args,


### PR DESCRIPTION
Instead of exposing the internals, provide a nice `choices` parameter accepting a list of choices. This decouple the semantics of "having a set of choices" from the CLI-related implementation. It's a bit strange in the CLI area of our code, but this is a general trend, already established by `tmt.utils.field()`, and `option()` should follow the same approach to how field/option choices are specified.