### PR TITLE
Multi-string help texts converted to multiline strings

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -179,9 +179,11 @@ environment_options = create_options_decorator(tmt.options.ENVIRONMENT_OPTIONS)
     help="Path to the metadata tree root, '.' used by default.")
 @option(
     '-c', '--context', metavar='DATA', multiple=True,
-    help='Set the fmf context. Use KEY=VAL or KEY=VAL1,VAL2... format '
-         'to define individual dimensions or the @FILE notation to load data '
-         'from provided yaml file. Can be specified multiple times. ')
+    help="""
+         Set the fmf context. Use KEY=VAL or KEY=VAL1,VAL2... format to define individual
+         dimensions or the @FILE notation to load data from provided yaml file. Can be specified
+         multiple times.
+         """)
 @verbosity_options
 @option(
     '--version', is_flag=True,
@@ -253,8 +255,10 @@ def main(
     help='Remove the workdir when test run is finished.')
 @option(
     '-k', '--keep', is_flag=True,
-    help='Keep all files in the run workdir after testing is done '
-         '(skip pruning during the finish step).')
+    help="""
+         Keep all files in the run workdir after testing is done (skip pruning during the finish
+         step).
+         """)
 @option(
     '--scratch', is_flag=True,
     help='Remove the run workdir before executing to start from scratch.')
@@ -282,9 +286,9 @@ def main(
     '--on-plan-error',
     choices=['quit', 'continue'],
     default='quit',
-    help='What to do when plan fails to finish. Quit by default, or continue '
-         'with the next plan.'
-    )
+    help="""
+         What to do when plan fails to finish. Quit by default, or continue with the next plan.
+         """)
 @environment_options
 @verbosity_options
 @force_dry_options
@@ -327,8 +331,9 @@ run.add_command(tmt.steps.Reboot.command())
     help="Use arbitrary Python expression for filtering.")
 @option(
     '--link', 'links', metavar="RELATION:TARGET", multiple=True,
-    help="Filter by linked objects (regular expressions are "
-         "supported for both relation and target).")
+    help="""
+         Filter by linked objects (regular expressions are supported for both relation and target).
+         """)
 @option(
     '--default', is_flag=True,
     help="Use default plans even if others are available.")
@@ -356,8 +361,9 @@ def run_plans(context: Context, **kwargs: Any) -> None:
     help="Use arbitrary Python expression for filtering.")
 @option(
     '--link', 'links', metavar="RELATION:TARGET", multiple=True,
-    help="Filter by linked objects (regular expressions are "
-         "supported for both relation and target).")
+    help="""
+         Filter by linked objects (regular expressions are supported for both relation and target).
+         """)
 @verbosity_options
 def run_tests(context: Context, **kwargs: Any) -> None:
     """
@@ -626,20 +632,25 @@ def tests_create(
     help='Convert restraint metadata file.')
 @option(
     '--general / --no-general', default=True, is_flag=True,
-    help='Detect components from linked nitrate general plans '
-         '(overrides Makefile/restraint component).')
+    help="""
+         Detect components from linked nitrate general plans (overrides Makefile/restraint
+         component).
+         """)
 @option(
     '--polarion-case-id', multiple=True,
-    help='Polarion Test case ID(s) to import data from. Can be provided multiple times. '
-         'Can provide also test case name like: TEST-123:test_name')
+    help="""
+         Polarion Test case ID(s) to import data from. Can be provided multiple times. Can provide
+         also test case name like: TEST-123:test_name
+         """)
 @option(
     '--link-polarion / --no-link-polarion', default=False, show_default=True, is_flag=True,
     help='Add Polarion link to fmf testcase metadata.')
 @option(
     '--type', 'types', metavar='TYPE', default=['multihost'], multiple=True,
     show_default=True,
-    help="Convert selected types from Makefile into tags. "
-         "Use 'all' to convert all detected types.")
+    help="""
+         Convert selected types from Makefile into tags. Use 'all' to convert all detected types.
+         """)
 @option(
     '--disabled', default=False, is_flag=True,
     help='Import disabled test cases from Nitrate as well.')
@@ -761,35 +772,46 @@ _test_export_default = 'yaml'
     help='Add Polarion link to fmf testcase metadata')
 @option(
     '--bugzilla', is_flag=True,
-    help="Link Nitrate case to Bugzilla specified in the 'link' attribute "
-         "with the relation 'verifies'.")
+    help="""
+         Link Nitrate case to Bugzilla specified in the 'link' attribute with the relation
+         'verifies'.
+         """)
 @option(
     '--ignore-git-validation', is_flag=True,
-    help="Ignore unpublished git changes and export to Nitrate. "
-    "The case might not be able to be scheduled!")
+    help="""
+         Ignore unpublished git changes and export to Nitrate. The case might not be able to be
+         scheduled!
+         """)
 @option(
     '--append-summary / --no-append-summary', default=False, is_flag=True,
-    help="Include test summary in the Nitrate/Polarion test case summary as well. "
-    "By default, only the repository name and test name are used."
-    )
+    help="""
+         Include test summary in the Nitrate/Polarion test case summary as well. By default, only
+         the repository name and test name are used.
+         """)
 @option(
     '--create', is_flag=True,
     help="Create test cases in nitrate if they don't exist.")
 @option(
     '--general / --no-general', default=False, is_flag=True,
-    help="Link Nitrate case to component's General plan. Disabled by default. "
-         "Note that this will unlink any previously connected general plans.")
+    help="""
+         Link Nitrate case to component's General plan. Disabled by default. Note that this will
+         unlink any previously connected general plans.
+         """)
 @option(
     '--link-runs / --no-link-runs', default=False, is_flag=True,
-    help="Link Nitrate case to all open runs of descendant plans of "
-         "General plan. Disabled by default. Implies --general option.")
+    help="""
+         Link Nitrate case to all open runs of descendant plans of General plan. Disabled by
+         default. Implies --general option.
+         """)
 @option(
     '--fmf-id', is_flag=True,
     help='Show fmf identifiers instead of test metadata.')
 @option(
     '--duplicate / --no-duplicate', default=False, show_default=True, is_flag=True,
-    help='Allow or prevent creating duplicates in Nitrate by searching for '
-         'existing test cases with the same fmf identifier.')
+    help="""
+         Allow or prevent creating duplicates in Nitrate by searching for existing test cases with
+         the same fmf identifier.
+         """)
 @option(
     '-n', '--dry', is_flag=True,
     help="Run in dry mode. No changes, please.")
@@ -1466,12 +1488,10 @@ def init(
     help='Run id (name or directory path) to show status of.')
 @option(
     '--abandoned', is_flag=True, default=False,
-    help='List runs which have provision step completed but finish step '
-         'not yet done.')
+    help='List runs which have provision step completed but finish step not yet done.')
 @option(
     '--active', is_flag=True, default=False,
-    help='List runs where at least one of the enabled steps has not '
-         'been finished.')
+    help='List runs where at least one of the enabled steps has not been finished.')
 @option(
     '--finished', is_flag=True, default=False,
     help='List all runs which have all enabled steps completed.')
@@ -1813,8 +1833,10 @@ def setup_completion(shell: str, install: bool) -> None:
 @click.pass_context
 @option(
     '--install', '-i', 'install', is_flag=True,
-    help="Persistently store the script to tmt's configuration directory "
-         "and set it up by modifying '~/.bashrc'.")
+    help="""
+         Persistently store the script to tmt's configuration directory and set it up by modifying
+         '~/.bashrc'.
+         """)
 def completion_bash(context: Context, install: bool, **kwargs: Any) -> None:
     """
     Setup shell completions for bash.
@@ -1826,8 +1848,10 @@ def completion_bash(context: Context, install: bool, **kwargs: Any) -> None:
 @click.pass_context
 @option(
     '--install', '-i', 'install', is_flag=True,
-    help="Persistently store the script to tmt's configuration directory "
-         "and set it up by modifying '~/.zshrc'.")
+    help="""
+         Persistently store the script to tmt's configuration directory and set it up by modifying
+         '~/.zshrc'.
+         """)
 def completion_zsh(context: Context, install: bool, **kwargs: Any) -> None:
     """
     Setup shell completions for zsh.
@@ -1839,8 +1863,7 @@ def completion_zsh(context: Context, install: bool, **kwargs: Any) -> None:
 @click.pass_context
 @option(
     '--install', '-i', 'install', is_flag=True,
-    help="Persistently store the script to "
-         "'~/.config/fish/completions/tmt.fish'.")
+    help="Persistently store the script to '~/.config/fish/completions/tmt.fish'.")
 def completion_fish(context: Context, install: bool, **kwargs: Any) -> None:
     """
     Setup shell completions for fish.

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -164,8 +164,10 @@ WORKDIR_ROOT_OPTIONS: List[ClickOptionDecoratorType] = [
     option(
         '--workdir-root', metavar='PATH', envvar='TMT_WORKDIR_ROOT',
         default=tmt.utils.WORKDIR_ROOT,
-        help=f"Path to root directory containing run workdirs. "
-             f"Defaults to '{tmt.utils.WORKDIR_ROOT}'.")
+        help=f"""
+             Path to root directory containing run workdirs.
+             Defaults to '{tmt.utils.WORKDIR_ROOT}'.
+             """)
     ]
 
 
@@ -186,8 +188,10 @@ FILTER_OPTIONS: List[ClickOptionDecoratorType] = [
         help="Show only disabled tests, plans or stories."),
     option(
         '--link', 'links', metavar="RELATION:TARGET", multiple=True,
-        help="Filter by linked objects (regular expressions are "
-             "supported for both relation and target)."),
+        help="""
+             Filter by linked objects (regular expressions are supported for both relation and
+             target).
+             """),
     option(
         '-x', '--exclude', 'exclude', metavar='[REGEXP]', multiple=True,
         help="Exclude a regular expression from search result."),
@@ -211,8 +215,10 @@ FILTER_OPTIONS_LONG: List[ClickOptionDecoratorType] = [
         help="Show only disabled tests, plans or stories."),
     option(
         '--link', 'links', metavar="RELATION:TARGET", multiple=True,
-        help="Filter by linked objects (regular expressions are "
-             "supported for both relation and target)."),
+        help="""
+             Filter by linked objects (regular expressions are supported for both relation and
+             target).
+             """),
     option(
         '--exclude', 'exclude', metavar='[REGEXP]', multiple=True,
         help="Exclude a regular expression from search result."),
@@ -302,14 +308,18 @@ ENVIRONMENT_OPTIONS: List[ClickOptionDecoratorType] = [
         '-e', '--environment',
         metavar='KEY=VALUE|@FILE',
         multiple=True,
-        help='Set environment variable. Can be specified multiple times. The '
-             '"@" prefix marks a file to load (yaml or dotenv formats supported).'),
+        help="""
+             Set environment variable. Can be specified multiple times. The "@" prefix marks a file
+             to load (yaml or dotenv formats supported).
+             """),
     option(
         '--environment-file',
         metavar='FILE|URL',
         multiple=True,
-        help='Set environment variables from file or url (yaml or dotenv formats '
-             'are supported). Can be specified multiple times.')
+        help="""
+             Set environment variables from file or url (yaml or dotenv formats are supported). Can
+             be specified multiple times.
+             """)
     ]
 
 

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -65,8 +65,10 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
         option='--link',
         metavar="RELATION:TARGET",
         multiple=True,
-        help="Filter by linked objects (regular expressions are "
-        "supported for both relation and target).")
+        help="""
+             Filter by linked objects (regular expressions are supported for both relation and
+             target).
+             """)
     filter: List[str] = field(
         default_factory=list,
         option=('-F', '--filter'),
@@ -97,22 +99,27 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
         default=cast(Optional[str], None),
         option='--modified-ref',
         metavar='REVISION',
-        help='Branch, tag or commit specifying the reference git '
-        'revision (if not provided, the default branch is used).')
+        help="""
+            Branch, tag or commit specifying the reference git revision (if not provided, the
+            default branch is used).
+            """)
 
     # Dist git integration
     dist_git_init: bool = field(
         default=False,
         option='--dist-git-init',
         is_flag=True,
-        help='Initialize fmf root inside extracted sources '
-        '(at dist-git-extract or top directory).')
+        help="""
+             Initialize fmf root inside extracted sources (at dist-git-extract or top directory).
+             """)
     dist_git_remove_fmf_root: bool = field(
         default=False,
         option='--dist-git-remove-fmf-root',
         is_flag=True,
-        help='Remove fmf root from extracted source (top one or selected by copy-path, '
-        'happens before dist-git-extract.')
+        help="""
+             Remove fmf root from extracted source (top one or selected by copy-path, happens
+             before dist-git-extract.
+             """)
     dist_git_merge: bool = field(
         default=False,
         option='--dist-git-merge',
@@ -121,17 +128,20 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
     dist_git_extract: Optional[str] = field(
         default=cast(Optional[str], None),
         option='--dist-git-extract',
-        help='What to copy from extracted sources, globbing is supported. '
-        'Defaults to the top fmf root if it is present, otherwise top '
-        'directory (shortcut "/").')
+        help="""
+             What to copy from extracted sources, globbing is supported. Defaults to the top fmf
+             root if it is present, otherwise top directory (shortcut "/").
+             """)
 
     # Special options
     sync_repo: bool = field(
         default=False,
         option='--sync-repo',
         is_flag=True,
-        help='Force the sync of the whole git repo. By default, the '
-        'repo is copied only if the used options require it.')
+        help="""
+             Force the sync of the whole git repo. By default, the repo is copied only if the used
+             options require it.
+             """)
     fmf_id: bool = field(
         default=False,
         option='--fmf-id',

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1035,9 +1035,10 @@ class GuestSshData(GuestData):
         option='--ssh-option',
         metavar="OPTION",
         multiple=True,
-        help="Specify an additional SSH option. "
-        "Value is passed to SSH's -o option, see ssh_config(5) for "
-        "supported options. Can be specified multiple times.",
+        help="""
+             Specify an additional SSH option. Value is passed to SSH's -o option, see
+             ssh_config(5) for supported options. Can be specified multiple times.
+             """,
         normalize=tmt.utils.normalize_string_list)
 
 

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -187,44 +187,56 @@ class ArtemisGuestData(tmt.steps.provision.GuestSshData):
         default=DEFAULT_PROVISION_TIMEOUT,
         option='--provision-timeout',
         metavar='SECONDS',
-        help='How long to wait for provisioning to complete, '
-        f'{DEFAULT_PROVISION_TIMEOUT} seconds by default.',
+        help=f"""
+             How long to wait for provisioning to complete,
+             {DEFAULT_PROVISION_TIMEOUT} seconds by default.
+             """,
         normalize=tmt.utils.normalize_int)
     provision_tick: int = field(
         default=DEFAULT_PROVISION_TICK,
         option='--provision-tick',
         metavar='SECONDS',
-        help=f'How often check Artemis API for provisioning status, '
-        f'{DEFAULT_PROVISION_TICK} seconds by default.',
+        help=f"""
+             How often check Artemis API for provisioning status,
+             {DEFAULT_PROVISION_TICK} seconds by default.
+             """,
         normalize=tmt.utils.normalize_int)
     api_timeout: int = field(
         default=DEFAULT_API_TIMEOUT,
         option='--api-timeout',
         metavar='SECONDS',
-        help=f'How long to wait for API operations to complete, '
-        f'{DEFAULT_API_TIMEOUT} seconds by default.',
+        help=f"""
+             How long to wait for API operations to complete,
+             {DEFAULT_API_TIMEOUT} seconds by default.
+             """,
         normalize=tmt.utils.normalize_int)
     api_retries: int = field(
         default=DEFAULT_API_RETRIES,
         option='--api-retries',
         metavar='COUNT',
-        help=f'How many attempts to use when talking to API, '
-        f'{DEFAULT_API_RETRIES} by default.',
+        help=f"""
+             How many attempts to use when talking to API,
+             {DEFAULT_API_RETRIES} by default.
+             """,
         normalize=tmt.utils.normalize_int)
     api_retry_backoff_factor: int = field(
         default=DEFAULT_RETRY_BACKOFF_FACTOR,
         option='--api-retry-backoff-factor',
         metavar='COUNT',
-        help=f'A factor for exponential API retry backoff, '
-        f'{DEFAULT_RETRY_BACKOFF_FACTOR} by default.',
+        help=f"""
+             A factor for exponential API retry backoff,
+            {DEFAULT_RETRY_BACKOFF_FACTOR} by default.
+            """,
         normalize=tmt.utils.normalize_int)
     # Artemis core already contains default values
     watchdog_dispatch_delay: Optional[int] = field(
         default=cast(Optional[int], None),
         option='--watchdog-dispatch-delay',
         metavar='SECONDS',
-        help='How long (seconds) before the guest "is-alive" watchdog is dispatched. '
-        'The dispatch timer starts once the guest is successfully provisioned.',
+        help="""
+             How long (seconds) before the guest "is-alive" watchdog is dispatched. The dispatch
+             timer starts once the guest is successfully provisioned.
+             """,
         normalize=tmt.utils.normalize_optional_int)
     watchdog_period_delay: Optional[int] = field(
         default=cast(Optional[int], None),

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -380,15 +380,19 @@ class BeakerGuestData(tmt.steps.provision.GuestSshData):
         default=DEFAULT_PROVISION_TIMEOUT,
         option='--provision-timeout',
         metavar='SECONDS',
-        help=f'How long to wait for provisioning to complete, '
-        f'{DEFAULT_PROVISION_TIMEOUT} seconds by default.',
+        help="""
+             How long to wait for provisioning to complete,
+             {DEFAULT_PROVISION_TIMEOUT} seconds by default.
+             """,
         normalize=tmt.utils.normalize_int)
     provision_tick: int = field(
         default=DEFAULT_PROVISION_TICK,
         option='--provision-tick',
         metavar='SECONDS',
-        help=f'How often check Beaker for provisioning status, '
-        f'{DEFAULT_PROVISION_TICK} seconds by default.',
+        help=f"""
+             How often check Beaker for provisioning status,
+             {DEFAULT_PROVISION_TICK} seconds by default.
+             """,
         normalize=tmt.utils.normalize_int)
 
 

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -179,8 +179,10 @@ class TestcloudGuestData(tmt.steps.provision.GuestSshData):
         default=DEFAULT_IMAGE,
         option=('-i', '--image'),
         metavar='IMAGE',
-        help='Select image to be used. Provide a short name, '
-        'full path to a local file or a complete url.')
+        help="""
+             Select image to be used. Provide a short name, full path to a local file
+             or a complete url.
+             """)
     memory: int = field(
         default=DEFAULT_MEMORY,
         option=('-m', '--memory'),

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -14,9 +14,10 @@ class ReportDisplayData(tmt.steps.report.ReportStepData):
         option='--display-guest',
         metavar='auto|always|never',
         choices=['auto', 'always', 'never'],
-        help="When to display full guest name in report:"
-             " when more than a single guest was involved (default), always, or never."
-        )
+        help="""
+             When to display full guest name in report: when more than a single guest was involved
+             (default), always, or never.
+             """)
 
 
 @tmt.steps.provides_method('display')

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -34,9 +34,10 @@ class ReportHtmlData(tmt.steps.report.ReportStepData):
         option='--display-guest',
         metavar='auto|always|never',
         choices=['auto', 'always', 'never'],
-        help="When to display full guest name in report:"
-             " when more than a single guest was involved (default), always, or never."
-        )
+        help="""
+             When to display full guest name in report: when more than a single guest was involved
+             (default), always, or never.
+             """)
 
 
 @tmt.steps.provides_method('html')

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -37,27 +37,30 @@ class ReportPolarionData(tmt.steps.report.ReportStepData):
         default=None,
         option='--project-id',
         metavar='ID',
-        help=(
-            'Use specific Polarion project ID, '
-            'also uses environment variable TMT_PLUGIN_REPORT_POLARION_PROJECT_ID.')
+        help="""
+             Use specific Polarion project ID,
+             also uses environment variable TMT_PLUGIN_REPORT_POLARION_PROJECT_ID.
+             """
         )
 
     title: Optional[str] = field(
         default=None,
         option='--title',
         metavar='TITLE',
-        help=(
-            'Use specific test run title, '
-            'also uses environment variable TMT_PLUGIN_REPORT_POLARION_TITLE.')
+        help="""
+             Use specific test run title,
+             also uses environment variable TMT_PLUGIN_REPORT_POLARION_TITLE.
+             """
         )
 
     template: Optional[str] = field(
         default=None,
         option='--template',
         metavar='TEMPLATE',
-        help=(
-            'Use specific test run template, '
-            'also uses environment variable TMT_PLUGIN_REPORT_POLARION_TEMPLATE.')
+        help="""
+             Use specific test run template,
+             also uses environment variable TMT_PLUGIN_REPORT_POLARION_TEMPLATE.
+             """
         )
 
     use_facts: bool = field(
@@ -72,81 +75,90 @@ class ReportPolarionData(tmt.steps.report.ReportStepData):
         default=None,
         option='--planned-in',
         metavar='PLANNEDIN',
-        help=(
-            'Select a specific release to mark this test run with, '
-            'also uses environment variable TMT_PLUGIN_REPORT_POLARION_PLANNED_IN.')
+        help="""
+             Select a specific release to mark this test run with,
+             also uses environment variable TMT_PLUGIN_REPORT_POLARION_PLANNED_IN.
+             """
         )
 
     assignee: Optional[str] = field(
         default=None,
         option='--assignee',
         metavar='ASSIGNEE',
-        help=(
-            'Who is responsible for this test run, '
-            'also uses environment variable TMT_PLUGIN_REPORT_POLARION_ASSIGNEE.')
+        help="""
+             Who is responsible for this test run,
+             also uses environment variable TMT_PLUGIN_REPORT_POLARION_ASSIGNEE.
+             """
         )
 
     pool_team: Optional[str] = field(
         default=None,
         option='--pool-team',
         metavar='POOLTEAM',
-        help=(
-            'Which subsystem is this test run relevant for, '
-            'also uses environment variable TMT_PLUGIN_REPORT_POLARION_POOL_TEAM')
+        help="""
+             Which subsystem is this test run relevant for,
+             also uses environment variable TMT_PLUGIN_REPORT_POLARION_POOL_TEAM.
+             """
         )
 
     arch: Optional[str] = field(
         default=None,
         option='--arch',
         metavar='ARCH',
-        help=(
-            'Which architecture was this run executed on, '
-            'also uses environment variable TMT_PLUGIN_REPORT_POLARION_ARCH.')
+        help="""
+             Which architecture was this run executed on,
+             also uses environment variable TMT_PLUGIN_REPORT_POLARION_ARCH.
+             """
         )
 
     platform: Optional[str] = field(
         default=None,
         option='--platform',
         metavar='PLATFORM',
-        help=(
-            'Which platform was this run executed on, '
-            'also uses environment variable TMT_PLUGIN_REPORT_POLARION_PLATFORM.')
+        help="""
+             Which platform was this run executed on,
+             also uses environment variable TMT_PLUGIN_REPORT_POLARION_PLATFORM.
+             """
         )
 
     build: Optional[str] = field(
         default=None,
         option='--build',
         metavar='BUILD',
-        help=(
-            'Which build was this run executed on, '
-            'also uses environment variable TMT_PLUGIN_REPORT_POLARION_BUILD.')
+        help="""
+             Which build was this run executed on,
+             also uses environment variable TMT_PLUGIN_REPORT_POLARION_BUILD.
+             """
         )
 
     sample_image: Optional[str] = field(
         default=None,
         option='--sample-image',
         metavar='SAMPLEIMAGE',
-        help=(
-            'Which sample image was this run executed on, '
-            'also uses environment variable TMT_PLUGIN_REPORT_POLARION_SAMPLE_IMAGE.')
+        help="""
+             Which sample image was this run executed on,
+             also uses environment variable TMT_PLUGIN_REPORT_POLARION_SAMPLE_IMAGE.
+             """
         )
 
     logs: Optional[str] = field(
         default=None,
         option='--logs',
         metavar='LOGLOCATION',
-        help=(
-            'Location of the logs for this test run, '
-            'also uses environment variable TMT_PLUGIN_REPORT_POLARION_LOGS.')
+        help="""
+             Location of the logs for this test run,
+             also uses environment variable TMT_PLUGIN_REPORT_POLARION_LOGS.
+             """
         )
 
     compose_id: Optional[str] = field(
         default=None,
         option='--compose-id',
         metavar='COMPOSEID',
-        help=(
-            'Compose ID of image used for this run, '
-            'also uses environment variable TMT_PLUGIN_REPORT_POLARION_COMPOSE_ID.')
+        help="""
+             Compose ID of image used for this run,
+             also uses environment variable TMT_PLUGIN_REPORT_POLARION_COMPOSE_ID.
+             """
         )
 
 

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -36,8 +36,10 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
         option="--exclude-variables",
         metavar="PATTERN",
         default="^TMT_.*",
-        help="Regular expression for excluding environment variables "
-             "from reporting to ReportPortal ('^TMT_.*' used by default).")
+        help="""
+             Regular expression for excluding environment variables from reporting to ReportPortal
+             ('^TMT_.*' used by default).
+             """)
 
 
 @tmt.steps.provides_method("reportportal")


### PR DESCRIPTION
There is a clear distinction: multi-string help texts often involve a trailing or leading whitespace, e.g. a hard space at the end of the first string, to materialize inside the help text once both strings are joined into a single one.

Since this is prone to mistakes, one can easily forget to include a space and produce a visual "typo" in a command help text, and since our `option()` and `field()` helpers support mutliline strings, all multi-string help texts were converted to multiline ones. Involved parties will take care of dedenting a string & reflowing it to fit the help window.

The output should remain unchanged, more or less.