### PR TITLE
Hide command event debug logs behind a log topic

### DIFF
--- a/tests/execute/duration/test.sh
+++ b/tests/execute/duration/test.sh
@@ -10,17 +10,17 @@ rlJournalStart
     for execute_method in tmt; do
         for provision_method in ${PROVISION_METHODS:-local container}; do
             rlPhaseStartTest "Test provision $provision_method, execute $execute_method, short tests"
-                rlRun -s "tmt run --scratch -vfi $tmp -a provision -h $provision_method execute -h $execute_method test --name short" 0
+                rlRun -s "tmt --log-topic=command-events run --scratch -vfi $tmp -a provision -h $provision_method execute -h $execute_method test --name short" 0
 
                 rlRun "grep 'duration \"5\" exceeded' $tmp/log.txt" 1
             rlPhaseEnd
 
             rlPhaseStartTest "Test provision $provision_method, execute $execute_method, long tests"
-                rlRun -s "tmt run --scratch -vfi $tmp -a provision -h $provision_method execute -h $execute_method test --name long 2>&1" 2
+                rlRun -s "tmt --log-topic=command-events run --scratch -vfi $tmp -a provision -h $provision_method execute -h $execute_method test --name long 2>&1" 2
                 rlAssertNotGrep "00:02:.. errr /test/long/beakerlib (timeout)" $rlRun_LOG
                 rlAssertNotGrep "00:02:.. errr /test/long/shell (timeout)" $rlRun_LOG
 
-                rlRun -s "tmt run --last report -fvvvv 2>&1" 2
+                rlRun -s "tmt --log-topic=command-events run --last report -fvvvv 2>&1" 2
                 rlAssertGrep "Maximum test time '5s' exceeded." $rlRun_LOG
                 rlAssertGrep "Adjust the test 'duration' attribute" $rlRun_LOG
                 rlAssertGrep "spec/tests.html#duration" $rlRun_LOG

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -51,6 +51,7 @@ DEFAULT_DEBUG_LEVEL = 0
 class Topic(enum.Enum):
     KEY_NORMALIZATION = 'key-normalization'
     CLI_INVOCATIONS = 'cli-invocations'
+    COMMAND_EVENTS = 'command-events'
 
 
 DEFAULT_TOPICS: Set[Topic] = set()

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -662,7 +662,11 @@ class Command:
             return f'{time.monotonic() - start_timestamp:.4}'
 
         def log_event(msg: str) -> None:
-            logger.debug('Command event', f'{_event_timestamp()} {msg}', level=4)
+            logger.debug(
+                'Command event',
+                f'{_event_timestamp()} {msg}',
+                level=4,
+                topic=tmt.log.Topic.COMMAND_EVENTS)
 
         try:
             process.wait(timeout=timeout)


### PR DESCRIPTION
These were useful when timeouts did not work as expected, but they are not needed in general, therefore hiding them behind a log topic to make the log less noisy.