### PR TITLE
Fix bug where polarion component is misinterpreted as list

### DIFF
--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -880,8 +880,11 @@ def read_polarion_case(
     # Update component
     if polarion_case.casecomponent:
         current_data['component'] = []
-        for component in polarion_case.casecomponent:
-            current_data['component'].append(str(component))
+        if isinstance(polarion_case.casecomponent, str):
+            current_data['component'].append(str(polarion_case.casecomponent))
+        else:
+            for component in polarion_case.casecomponent:
+                current_data['component'].append(str(component))
         echo(style('component: ', fg='green') + ' '.join(current_data['component']))
 
     # Update tags


### PR DESCRIPTION
Polarion is pretty flexible when it comes to types so for cases where component field is not a list this part of import generated wrong component, e.g. [t,m,t] instead of [tmt].

Type conversion is kept due to types from pylero not being a general string but more complex suds.sax.text.Text.