### PR TITLE
Use dataclass for log record details instead of typed dict

### DIFF
--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -85,7 +85,7 @@ def _assert_log(
     for field_name, expected_value in tests.items():
         if field_name.startswith('details_'):
             field_name = field_name.replace('details_', '')
-            def field_getter(record, name): return record.details.get(name, None)
+            def field_getter(record, name): return getattr(record.details, name, None)
 
         else:
             def field_getter(record, name): return getattr(record, name)

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -8,6 +8,7 @@ import pytest
 from tmt.log import (
     DebugLevelFilter,
     Logger,
+    LogRecordDetails,
     QuietnessFilter,
     Topic,
     TopicFilter,
@@ -137,10 +138,10 @@ def test_verbosity_filter(
 
     assert filter.filter(logging.makeLogRecord({
         'levelno': logging.INFO,
-        'details': {
-            'logger_verbosity_level': logger_verbosity,
-            'message_verbosity_level': message_verbosity
-            }
+        'details': LogRecordDetails(
+            key='dummy key',
+            logger_verbosity_level=logger_verbosity,
+            message_verbosity_level=message_verbosity)
         })) == filter_outcome
 
 
@@ -183,10 +184,10 @@ def test_debug_filter(
 
     assert filter.filter(logging.makeLogRecord({
         'levelno': logging.DEBUG,
-        'details': {
-            'logger_debug_level': logger_debug,
-            'message_debug_level': message_debug
-            }
+        'details': LogRecordDetails(
+            key='dummy key',
+            logger_debug_level=logger_debug,
+            message_debug_level=message_debug)
         })) == filter_outcome
 
 
@@ -351,8 +352,8 @@ def test_topic_filter(
 
     assert filter.filter(logging.makeLogRecord({
         'levelno': logging.INFO,
-        'details': {
-            'logger_topics': logger_topics,
-            'message_topic': message_topic
-            }
+        'details': LogRecordDetails(
+            key='dummy key',
+            logger_topics=logger_topics,
+            message_topic=message_topic)
         })) == filter_outcome


### PR DESCRIPTION
As reported by Pyright, the dictionary has some issues a data class does not suffer from, especially a data class can provide default values. This makes use of the "keys" cleaner, without the need for `get()`.