### PR TITLE
Adjust imported plan to let its adjust rules make changes

### DIFF
--- a/tests/plan/import/basic.sh
+++ b/tests/plan/import/basic.sh
@@ -98,7 +98,9 @@ rlJournalStart
     rlPhaseStartTest "Run Tests"
         # Exclude /plans/dynamic-ref as dynamic ref cannot be evaluated in dry mode
         rlRun -s "tmt run --verbose --dry plan -n '/plans/[^d]'" 0 "Run tests (dry mode)"
-        rlRun -s "tmt run --verbose" 0 "Run tests"
+        # TODO: skip full/tmt plan, because of https://github.com/teemtee/tmt/issues/2297
+        # all its tests would be executed even though the plan is not enabled.
+        rlRun -s "tmt run --verbose       plan -n '/plans/(?!full/tmt)'" 0 "Run tests"
         rlAssertGrep "pass /tests/basic/ls" $rlRun_LOG
         rlAssertGrep "pass /lint/tests" $rlRun_LOG
     rlPhaseEnd

--- a/tests/plan/import/basic.sh
+++ b/tests/plan/import/basic.sh
@@ -9,7 +9,7 @@ rlJournalStart
     rlPhaseStartTest "Explore Plans"
         rlRun -s "tmt plan"
         rlAssertNotGrep "warn" $rlRun_LOG
-        rlAssertGrep "Found 5 plans" $rlRun_LOG
+        rlAssertGrep "Found 6 plans" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Show Plans (deep)"

--- a/tests/plan/import/basic.sh
+++ b/tests/plan/import/basic.sh
@@ -61,7 +61,8 @@ rlJournalStart
     rlPhaseStartTest "Discover Tests"
         # Exclude /plans/dynamic-ref as dynamic ref cannot be evaluated in dry mode
         rlRun -s "tmt run discover -v plan -n '/plans/[^d]'"
-        rlAssertGrep "/plans/full" $rlRun_LOG
+        rlAssertGrep "/plans/full/fmf" $rlRun_LOG
+        rlAssertGrep "/plans/full/tmt" $rlRun_LOG
         rlAssertGrep "/tests/basic/ls" $rlRun_LOG
         rlAssertGrep "/tests/basic/show" $rlRun_LOG
         rlAssertGrep "/plans/minimal" $rlRun_LOG
@@ -84,6 +85,14 @@ rlJournalStart
         rlAssertGrep "import ref: fedora" $rlRun_LOG
         rlAssertGrep "import path: /tests/discover/data" $rlRun_LOG
         rlAssertGrep "import name: /plans/smoke" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Make sure context is applied to plan itself"
+        rlRun -s "tmt plan show -vvvv /plans/full/tmt"
+        rlAssertGrep "enabled false" $rlRun_LOG
+
+        rlRun -s "tmt -c how=full plan show -vvvv /plans/full/tmt"
+        rlAssertGrep "enabled true" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Run Tests"

--- a/tests/plan/import/data/plans.fmf
+++ b/tests/plan/import/data/plans.fmf
@@ -21,12 +21,19 @@
             import+:
                 path: tests/run/worktree/data/prepare
 
-/full:
+/full/fmf:
     summary: Full plan with test scripts
     plan:
         import:
             url: https://github.com/teemtee/fmf
             name: /plans/features
+
+/full/tmt:
+    summary: Full plan with test scripts
+    plan:
+        import:
+            url: https://github.com/teemtee/tmt
+            name: /plans/provision
 
 /dynamic-ref:
     summary: Git URL and dynamic ref

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2195,6 +2195,11 @@ class Plan(
             raise tmt.utils.DiscoverError(
                 f"Failed to find plan '{plan_id.name}' "
                 f"at 'url: {plan_id.url}, 'ref: {plan_id.ref}'.")
+
+        # Adjust the imported tree, to let any `adjust` rules defined in it take
+        # action.
+        node.adjust(fmf.context.Context(**self._fmf_context))
+
         # Override the plan name with the local one to ensure unique names
         node.name = self.name
         # Create the plan object, save links between both plans


### PR DESCRIPTION
When importing a (remote) plan, its adjust rules were ignored. They may add new phases, modify environment of the plan, and should be honored and take place. Otherwise, for tests to run in the environment they expect, importing party would have to include those rules in the importing plan.