### PR TITLE
Render default friendly command for guest execution

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1257,7 +1257,7 @@ class GuestSsh(Guest):
         return self._run_guest_command(
             ssh_command,
             log=log,
-            friendly_command=friendly_command,
+            friendly_command=friendly_command or str(command),
             silent=silent,
             cwd=cwd,
             interactive=interactive,

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -89,7 +89,7 @@ class GuestLocal(tmt.Guest):
             actual_command,
             env=environment,
             log=log,
-            friendly_command=friendly_command,
+            friendly_command=friendly_command or str(command),
             silent=silent,
             cwd=cwd,
             interactive=interactive,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -235,7 +235,7 @@ class GuestContainer(tmt.Guest):
         return self.podman(
             podman_command,
             log=log if log else self._command_verbose_logger,
-            friendly_command=friendly_command,
+            friendly_command=friendly_command or str(command),
             silent=silent,
             interactive=interactive,
             **kwargs)


### PR DESCRIPTION
While it's still possible for a plugin to provide its own friendly command label, the defautl one needs to be rendered on the level of `Guest.execute`. Leaving it for deeper methods, we risk the friendly command to include SSH and environment details, making it too verbose for user-friendly info.