### PR TITLE
Extension of the `ReportPortal` plugin using API

### DIFF
--- a/spec/plans/report.fmf
+++ b/spec/plans/report.fmf
@@ -105,18 +105,20 @@ description:
         to detailed test output and other test information.
     description:
         Fill json with test results and other fmf data per each plan,
-        and send it to a Report Portal instance via its API.
+        and send it to a Report Portal instance via its API
+        with token, url and project name given.
     example:
       - |
-        # Set environment variables with the server url and token
-        export TMT_REPORT_REPORTPORTAL_URL=<url-to-RP-instance>
-        export TMT_REPORT_REPORTPORTAL_TOKEN=<token-from-RP-profile>
+        # Set environment variables accoriding to TMT_PLUGIN_REPORT_REPORTPORTAL_${OPTION}
+        export TMT_PLUGIN_REPORT_REPORTPORTAL_URL=${url-to-RP-instance}
+        export TMT_PLUGIN_REPORT_REPORTPORTAL_TOKEN=${token-from-RP-profile}
       - |
         # Enable ReportPortal report from the command line
         tmt run --all report --how reportportal --project=baseosqe
-        tmt run --all report --how reportportal --project=baseosqe --exclude-variables="^(TMT|PACKIT|TESTING_FARM).*"
         tmt run --all report --how reportportal --project=baseosqe --launch=test_plan
         tmt run --all report --how reportportal --project=baseosqe --url=... --token=...
+        tmt run --all report --how reportportal --project=baseosqe --exclude-variables="^(TMT|PACKIT|TESTING_FARM).*"
+        tmt run -a report -h reportportal --merge --launch "Errata" --attributes "errata:123456"
       - |
         # Use ReportPortal as the default report for given plan
         report:

--- a/spec/plans/report.fmf
+++ b/spec/plans/report.fmf
@@ -104,21 +104,47 @@ description:
         web page, filter them via context attributes and get links
         to detailed test output and other test information.
     description:
-        Fill json with test results and other fmf data per each plan,
+        Provide test results and fmf data per each plan,
         and send it to a Report Portal instance via its API
         with token, url and project name given.
     example:
       - |
-        # Set environment variables accoriding to TMT_PLUGIN_REPORT_REPORTPORTAL_${OPTION}
+        # Optionally set environment variables according to TMT_PLUGIN_REPORT_REPORTPORTAL_${OPTION}
         export TMT_PLUGIN_REPORT_REPORTPORTAL_URL=${url-to-RP-instance}
         export TMT_PLUGIN_REPORT_REPORTPORTAL_TOKEN=${token-from-RP-profile}
       - |
-        # Enable ReportPortal report from the command line
+        # Enable ReportPortal report from the command line depending on the use case:
+
+        ## Simple upload with all project, url endpoint and user token passed in command line
+        tmt run --all report --how reportportal --project=baseosqe --url="https://reportportal.xxx.com" --token="abc...789"
+
+        ## Simple upload with url and token exported in environment variable
         tmt run --all report --how reportportal --project=baseosqe
-        tmt run --all report --how reportportal --project=baseosqe --launch=test_plan
-        tmt run --all report --how reportportal --project=baseosqe --url=... --token=...
-        tmt run --all report --how reportportal --project=baseosqe --exclude-variables="^(TMT|PACKIT|TESTING_FARM).*"
-        tmt run -a report -h reportportal --merge --launch "Errata" --attributes "errata:123456"
+
+        ## Upload with project name in fmf data, filtering out parameters (environemnt variables) that tend to be unique and break the history aggregation
+        tmt run --all report --how reportportal --exclude-variables="^(TMT|PACKIT|TESTING_FARM).*"
+
+        ## Upload all plans as suites into one ReportPortal launch
+        tmt run --all report --how reportportal --suite-per-plan --launch=Errata --launch-description="..."
+
+        ## Rerun the launch with suite structure for the test results to be uploaded into the latest launch with the same name as a new 'Retry' tab (mapping based on unique paths)
+        tmt run --all report --how reportportal --suite-per-plan --launch=Errata --launch-rerun
+
+        ## Rerun the tmt run and append the new result logs under the previous one uploaded in ReportPortal (precise mapping)
+        tmt run --id run-012 --all report --how reportportal --again
+
+        ## Additional upload of new suites into given launch with suite structure
+        tmt run --all report --how reportportal --suite-per-plan --upload-to-launch=4321
+
+        ## Additional upload of new tests into given launch with non-suite structure
+        tmt run --all report --how reportportal --launch-per-plan --upload-to-launch=1234
+
+        ## Additional upload of new tests into given suite
+        tmt run --all report --how reportportal --upload-to-suite=123456
+
+        ## Upload Idle tests, then execute it and add result logs into prepared empty tests
+        tmt run discover report --how reportportal --defect-type=Idle
+        tmt run --last --all report --how reportportal --again
       - |
         # Use ReportPortal as the default report for given plan
         report:

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -3194,7 +3194,6 @@ class RunData(SerializableContainer):
     steps: list[str]
     environment: EnvironmentType
     remove: bool
-    rp_uuid: Optional[str]
 
 
 class Run(tmt.utils.Common):
@@ -3232,7 +3231,6 @@ class Run(tmt.utils.Common):
         self._environment_from_workdir: EnvironmentType = {}
         self._environment_from_options: Optional[EnvironmentType] = None
         self.remove = self.opt('remove')
-        self.rp_uuid = self.opt('rp-uuid')
 
     @tmt.utils.cached_property
     def runner(self) -> 'tmt.steps.provision.local.GuestLocal':
@@ -3309,8 +3307,7 @@ class Run(tmt.utils.Common):
             plans=[plan.name for plan in self._plans] if self._plans is not None else None,
             steps=list(self._cli_context_object.steps),
             environment=self.environment,
-            remove=self.remove,
-            rp_uuid=self.rp_uuid
+            remove=self.remove
             )
         self.write(Path('run.yaml'), tmt.utils.dict_to_yaml(data.to_serialized()))
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -3194,6 +3194,7 @@ class RunData(SerializableContainer):
     steps: list[str]
     environment: EnvironmentType
     remove: bool
+    rp_uuid: Optional[str]
 
 
 class Run(tmt.utils.Common):
@@ -3231,6 +3232,7 @@ class Run(tmt.utils.Common):
         self._environment_from_workdir: EnvironmentType = {}
         self._environment_from_options: Optional[EnvironmentType] = None
         self.remove = self.opt('remove')
+        self.rp_uuid = self.opt('rp-uuid')
 
     @tmt.utils.cached_property
     def runner(self) -> 'tmt.steps.provision.local.GuestLocal':
@@ -3307,7 +3309,8 @@ class Run(tmt.utils.Common):
             plans=[plan.name for plan in self._plans] if self._plans is not None else None,
             steps=list(self._cli_context_object.steps),
             environment=self.environment,
-            remove=self.remove
+            remove=self.remove,
+            rp_uuid=self.rp_uuid
             )
         self.write(Path('run.yaml'), tmt.utils.dict_to_yaml(data.to_serialized()))
 

--- a/tmt/schemas/report/reportportal.yaml
+++ b/tmt/schemas/report/reportportal.yaml
@@ -34,10 +34,26 @@ properties:
   launch:
     type: string
 
-  attributes:
-    type: array
-    items:
-      type: string
+  launch-description:
+    type: string
+
+  launch-per-plan:
+    type: boolean
+
+  suite-per-plan:
+    type: boolean
+
+  upload-to-launch:
+    type: string
+
+  upload-to-suite:
+    type: string
+
+  launch-rerun:
+    type: boolean
+
+  defect_type:
+    type: string
 
   exclude-variables:
     type: string

--- a/tmt/schemas/report/reportportal.yaml
+++ b/tmt/schemas/report/reportportal.yaml
@@ -34,6 +34,11 @@ properties:
   launch:
     type: string
 
+  attributes:
+    type: array
+    items:
+      type: string
+
   exclude-variables:
     type: string
 

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import requests
 
+import tmt.log
 import tmt.steps.report
 from tmt.result import ResultOutcome
 from tmt.utils import field, yaml_to_dict
@@ -61,8 +62,8 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
         option="--upload-to-suite",
         metavar="LAUNCH_SUITE",
         default=None,
-        help="Pass the suite ID for an additional test upload to an existing launch. "
-             "ID can be found in the suite URL.")
+        help="Pass the suite ID for an additional test upload to a suite "
+             "within an existing launch. ID can be found in the suite URL.")
     launch_rerun: bool = field(
         option="--launch-rerun",
         default=False,
@@ -82,11 +83,17 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
         metavar="PATTERN",
         default="^TMT_.*",
         help="Regular expression for excluding environment variables "
-             "from reporting to ReportPortal ('^TMT_.*' used by default).")
+             "from reporting to ReportPortal ('^TMT_.*' used by default)."
+             "Parameters in ReportPortal get filtered out by the pattern"
+             "to prevent overloading and to preserve the history aggregation"
+             "for ReportPortal item if tmt id is not provided")
+
     launch_url: str = ""
     launch_uuid: str = ""
     suite_uuid: str = ""
-    test_uuids: list[str] = ""
+    test_uuids: dict[int, str] = field(
+        default_factory=dict
+        )
 
 
 @tmt.steps.provides_method("reportportal")
@@ -94,15 +101,22 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
     """
     Report test results to a ReportPortal instance via API.
 
-    Requires a token for authentication, a URL of the ReportPortal
-    instance and the project name. In addition to command line options
-    it's possible to use environment variables in form of
-    ``TMT_PLUGIN_REPORT_REPORTPORTAL_${OPTION}``:
+    For communication with Report Portal API is neccessary to provide
+    following options:
+
+    * token for authentication
+    * URL of the ReportPortal instance
+    * project name
+    * optional API version to override the default one (v1)
+    * optional launch name to override the deafult name based on the tmt
+      plan name
+    
+    In addition to command line options it's possible to use environment
+    variables:
 
     .. code-block:: bash
 
-        export TMT_PLUGIN_REPORT_REPORTPORTAL_URL=...
-        export TMT_PLUGIN_REPORT_REPORTPORTAL_TOKEN=...
+        export TMT_PLUGIN_REPORT_REPORTPORTAL_${MY_OPTION}=${MY_VALUE}
 
     The optional launch name doesn't have to be provided if it is the
     same as the plan name (by default). Assuming the URL and token
@@ -121,14 +135,23 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
         environment:
             ...
 
-    The context and environment sections must be filled in order to
-    report context as attributes and environment variables as parameters
-    in the Item Details. Environment variables can be filtered out by
-    pattern to prevent overloading and to preserve the history
-    aggregation for ReportPortal item if tmt id is not provided. Other
-    reported fmf data are summary, id, web link and contact per test.
+    Where the context and environment sections must be filled with
+    corresponding data in order to report context as attributes
+    (arch, component, distro, trigger, compose, etc.) and
+    environment variables as parameters in the Item Details.
+
+    Other reported fmf data are summary, id, web link and contact per
+    test.
+
+    There are supported two ways of mapping plans into ReportPortal
+
+    * launch-per-plan (default) with reported structure 'launch > test',
+      resulting in one or more launches.
+    * suite-per-plan with reported structure 'launch > suite > test'
+      resulting in one launch only, and one or more suites within.
+      (Recommended to define launch-name and launch-description in
+      addition)
     """
-    # TODO: Finish the description ^ with the new options
 
     _data_class = ReportReportPortalData
 
@@ -154,6 +177,74 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
         self.debug("Response code from the endpoint", str(response.status_code))
         self.debug("Message from the endpoint", str(response.text))
 
+    def time(self) -> str:
+        return str(int(time() * 1000))
+
+    def get_headers(self) -> dict[str, str]:
+        return {"Authorization": "bearer " + self.token,
+                "accept": "*/*",
+                "Content-Type": "application/json"}
+
+    def get_url(self) -> str:
+        api_version = os.getenv(
+            'TMT_PLUGIN_REPORT_REPORTPORTAL_API_VERSION') or self.DEFAULT_API_VERSION
+        return f"{self.endpoint}/api/{api_version}/{self.project}"
+
+    def construct_launch_attributes(self, suite_per_plan: bool,
+                                    attributes: dict[str, str]) -> dict[str, str]:
+        if not suite_per_plan:
+            return attributes.copy()
+
+        # Get common attributes across the plans
+        merged_plans = [{key: value[0] for key, value in plan._fmf_context.items()}
+                        for plan in self.step.plan.my_run.plans]
+        result_dict = merged_plans[0]
+        for current_plan in merged_plans[1:]:
+            tmp_dict = {}
+            for key, value in current_plan.items():
+                if key in result_dict and result_dict[key] == value:
+                    tmp_dict[key] = value
+            result_dict = tmp_dict
+        return [{'key': key, 'value': value} for key, value in result_dict.items()]
+
+    def get_defect_type_locator(self, session: requests.Session, defect_type: str) -> str:
+        if not defect_type:
+            return "ti001"
+
+        # Get defect type locator via api
+        response = self.get_rp_api(session, "settings")
+        defect_types = yaml_to_dict(response.text).get("subTypes")
+        dt_tmp = [dt['locator'] for dt in defect_types['TO_INVESTIGATE']
+                  if dt['longName'].lower() == defect_type.lower()]
+        dt_locator = dt_tmp[0] if dt_tmp else None
+        if not dt_locator:
+            raise tmt.utils.ReportError(
+                f"Defect type '{defect_type}' is not be defined in the project {self.project}")
+        self.verbose("defect_typ", defect_type, "yellow")
+        return dt_locator
+
+    def get_rp_api(self, session: requests.Session, data_path: str) -> str:
+        response = session.get(url=f"{self.get_url()}/{data_path}",
+                               headers=self.get_headers())
+        self.handle_response(response)
+        return response
+
+    def post_rp_api(self, session: requests.Session, item_path: str, json: dict[str, str]) -> str:
+        response = session.post(
+            url=f"{self.get_url()}/{item_path}",
+            headers=self.get_headers(),
+            json=json)
+        self.handle_response(response)
+        return response
+
+    def put_rp_api(self, session: requests.Session, item_path: str, json: dict[str, str]) -> str:
+        response = session.put(
+            url=f"{self.get_url()}/{item_path}",
+            headers=self.get_headers(),
+            json=json)
+        self.handle_response(response)
+        return response
+
     def go(self) -> None:
         """
         Report test results to the endpoint
@@ -162,51 +253,39 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
         fill it with all parts needed and report the logs.
         """
 
-        # TODO: ? why it did not closed :
-        #           tmt run discover provision -h connect -g 10.0.185.29 -u root
-        #               -p fo0m4nchU  prepare report -h reportportal --suite-per-plan
-        #               --defect-type idle -vvv finish tests -n .
-        #       * test uploading to idle tests
+        # TODO: (to be deleted after review)
         #       * resolve the problem with mypy
-        #       * replace rp_uuid with an universal structure for tmt plugin data
         #       * check the problem with --upload-to-suite functonality
         #       * check the param per plan, and do the matching when uploading (launch_uuid)
-        #       * check the defect_type, idle functionality
         #       * upload documentation (help and spec)
-        #       * add the tests for new features
-        #       * add uploading files
+        #       * add the tests for new features --> another PR
+        #       * add uploading files --> another PR
         #       * edit schemas
-
         #       * check optionality in arguments
         #       * restrict combinations + set warning
         #                   - forbid rerun && launch-per-plan
         #                   - forbid upload-to-suite && launch-per-plan
         #       * try read a launch_uuid at first plan (self.step.plan.report.launch_uuid)
+        #       * rewrite into smarter and neater code (bolean logic for option combinations)
 
         super().go()
 
-        endpoint = self.get("url")
-        if not endpoint:
+        self.endpoint = self.get("url")
+        if not self.endpoint:
             raise tmt.utils.ReportError("No ReportPortal endpoint url provided.")
-        endpoint = endpoint.rstrip("/")
+        self.endpoint = self.endpoint.rstrip("/")
 
-        project = self.get("project")
-        if not project:
+        self.project = self.get("project")
+        if not self.project:
             raise tmt.utils.ReportError("No ReportPortal project provided.")
 
-        token = self.get("token")
-        if not token:
+        self.token = self.get("token")
+        if not self.token:
             raise tmt.utils.ReportError("No ReportPortal token provided.")
 
-        url = f"{endpoint}/api/{self.DEFAULT_API_VERSION}/{project}"
-        headers = {
-            "Authorization": "bearer " + token,
-            "accept": "*/*",
-            "Content-Type": "application/json"}
+        launch_time = self.time()
 
-        launch_time = str(int(time() * 1000))
-
-        # to support idle tests
+        # Supporting idle tests
         executed = False
         if len(self.step.plan.execute.results()) > 0:
             launch_time = self.step.plan.execute.results()[0].start_time
@@ -214,12 +293,6 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
 
         # Create launch, suites (if "--suite_per_plan") and tests;
         # or report to existing launch/suite if its id is given
-        launch_uuid = self.get("launch_uuid") or self.step.plan.my_run.rp_uuid
-        suite_uuid = self.get("suite_uuid")
-
-        launch_id = self.get("upload_to_launch")
-        suite_id = self.get("upload_to_suite")
-
         suite_per_plan = self.get("suite_per_plan")
         launch_per_plan = self.get("launch_per_plan")
         if not launch_per_plan and not suite_per_plan:
@@ -229,11 +302,23 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
                 "The options '--launch-per-plan' and "
                 "'--suite-per-plan' are mutually exclusive. Choose one of them only.")
 
-        create_launch = not (launch_uuid or launch_id or suite_uuid or suite_id)
-        create_suite = suite_per_plan and not (suite_uuid or suite_id)
+        suite_id = self.get("upload_to_suite")
+        launch_id = self.get("upload_to_launch")
 
-        launch_url = ""
+        suite_uuid = self.get("suite_uuid")
+        launch_uuid = self.get("launch_uuid")
+        additional_upload = suite_id or launch_id or launch_uuid
+        is_the_first_plan = self.step.plan == self.step.plan.my_run.plans[0]
+        if not launch_uuid and suite_per_plan and not is_the_first_plan:
+            launch_uuid = self.step.plan.my_run.plans[0].report.data[0].launch_uuid
+
+        create_test = not self.data.test_uuids
+        create_suite = suite_per_plan and not (suite_uuid or suite_id)
+        create_launch = not (launch_uuid or launch_id or suite_uuid or suite_id)
+
         launch_name = self.get("launch") or self.step.plan.name
+        suite_name = ""
+        launch_url = ""
 
         launch_rerun = self.get("launch_rerun")
         envar_pattern = self.get("exclude-variables") or "$^"
@@ -243,121 +328,83 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
             {'key': key, 'value': value[0]}
             for key, value in self.step.plan._fmf_context.items()]
 
-        if suite_per_plan:
-            # Get common attributes from all plans
-            merged_plans = [{key: value[0] for key, value in plan._fmf_context.items()}
-                            for plan in self.step.plan.my_run.plans]
-            result_dict = merged_plans[0]
-            for current_plan in merged_plans[1:]:
-                tmp_dict = {}
-                for key, value in current_plan.items():
-                    if key in result_dict and result_dict[key] == value:
-                        tmp_dict[key] = value
-                result_dict = tmp_dict
-            launch_attributes = [
-                {'key': key, 'value': value}
-                for key, value in result_dict.items()]
-        else:
-            launch_attributes = attributes.copy()
+        launch_attributes = self.construct_launch_attributes(suite_per_plan, attributes)
 
         launch_description = self.get("launch_description") or self.step.plan.summary
 
         # Communication with RP instance
         with tmt.utils.retry_session() as session:
 
-            # Get defect type locator
-            dt_locator = None
-            if defect_type:
-                response = session.get(url=f"{url}/settings", headers=headers)
-                self.handle_response(response)
-                defect_types = yaml_to_dict(response.text).get("subTypes")
-                dt_tmp = [dt['locator'] for dt in defect_types['TO_INVESTIGATE']
-                          if dt['longName'].lower() == defect_type.lower()]
-                dt_locator = dt_tmp[0] if dt_tmp else None
-                if not dt_locator:
-                    raise tmt.utils.ReportError(
-                        f"Defect type '{defect_type}' is not be defined in the project {project}")
-                self.verbose("defect_typ", defect_type, "yellow")
-
             if create_launch:
 
                 # Create a launch
                 self.info("launch", launch_name, color="cyan")
-                response = session.post(
-                    url=f"{url}/launch",
-                    headers=headers,
-                    json={"name": launch_name,
-                          "description": launch_description,
-                          "attributes": launch_attributes,
-                          "startTime": launch_time,
-                          "rerun": launch_rerun})
-                self.handle_response(response)
+                response = self.post_rp_api(session, "launch",
+                                            json={"name": launch_name,
+                                                  "description": launch_description,
+                                                  "attributes": launch_attributes,
+                                                  "startTime": launch_time,
+                                                  "rerun": launch_rerun})
                 launch_uuid = yaml_to_dict(response.text).get("id")
-                if suite_per_plan:
-                    self.step.plan.my_run.rp_uuid = launch_uuid
 
             else:
                 # Get the launch_uuid or info to log
-
                 if suite_id:
-                    response = session.get(
-                        url=f"{url}/item/{suite_id}",
-                        headers=headers)
-                    self.handle_response(response)
+                    response = self.get_rp_api(session, f"item/{suite_id}")
                     suite_uuid = yaml_to_dict(response.text).get("uuid")
-                    self.info("suite_id", suite_id, color="red")
+                    # self.info("suite_id", suite_id, color="yellow")
+                    suite_name = yaml_to_dict(response.text).get("name")
                     launch_id = yaml_to_dict(response.text).get("launchId")
-                    self.info("launch_id", launch_id, color="red")
 
                 if launch_id:
-                    response = session.get(
-                        url=f"{url}/launch/{launch_id}",
-                        headers=headers)
-                    self.handle_response(response)
+                    response = self.get_rp_api(session, f"launch/{launch_id}")
                     launch_uuid = yaml_to_dict(response.text).get("uuid")
 
-                elif launch_uuid:
-                    response = session.get(
-                        url=f"{url}/launch/uuid/{launch_uuid}",
-                        headers=headers)
-                    self.handle_response(response)
-                    launch_id = yaml_to_dict(response.text).get("id")
+            if launch_uuid and not launch_id:
+                response = self.get_rp_api(session, f"launch/uuid/{launch_uuid}")
+                launch_id = yaml_to_dict(response.text).get("id")
 
+            # Print the launch info
+            if not create_launch:
                 launch_name = yaml_to_dict(response.text).get("name")
-                self.verbose("launch", launch_name, color="yellow")
-                launch_url = f"{endpoint}/ui/#{project}/launches/all/{launch_id}"
+                self.verbose("launch", launch_name, color="green")
+                self.verbose("id", launch_id, "yellow", shift=1)
 
             assert launch_uuid is not None
             self.verbose("uuid", launch_uuid, "yellow", shift=1)
             self.data.launch_uuid = launch_uuid
 
+            launch_url = f"{self.endpoint}/ui/#{self.project}/launches/all/{launch_id}"
+
             if create_suite:
                 # Create a suite
                 suite_name = self.step.plan.name
                 self.info("suite", suite_name, color="cyan")
-                response = session.post(
-                    url=f"{url}/item",
-                    headers=headers,
-                    json={
-                        "name": suite_name,
-                        "description": self.step.plan.summary,
-                        "attributes": attributes,
-                        "startTime": launch_time,
-                        "launchUuid": launch_uuid,
-                        "type": "suite"})
-                self.handle_response(response)
+                response = self.post_rp_api(session, "item",
+                                            json={"name": suite_name,
+                                                  "description": self.step.plan.summary,
+                                                  "attributes": attributes,
+                                                  "startTime": launch_time,
+                                                  "launchUuid": launch_uuid,
+                                                  "type": "suite"})
                 suite_uuid = yaml_to_dict(response.text).get("id")
                 assert suite_uuid is not None
+
+            elif suite_name:
+                self.info("suite", suite_name, color="green")
+                self.verbose("id", suite_id, "yellow", shift=1)
+
+            if suite_uuid:
                 self.verbose("uuid", suite_uuid, "yellow", shift=1)
+                self.data.suite_uuid = suite_uuid
 
             # For each test
             for test in self.step.plan.discover.tests():
-                test_time = str(int(time() * 1000))
+                test_time = self.time()
                 if executed:
                     result = next((result for result in self.step.plan.execute.results()
                                    if test.serial_number == result.serial_number), None)
                     test_time = result.start_time
-
                 # TODO: for happz, connect Test to Result if possible
                 #       (but now it is probably too hackish to be fixed)
 
@@ -369,25 +416,27 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
                     for key, value in test.environment.items()
                     if not re.search(envar_pattern, key)]
 
-                # Create a test item
-                self.info("test", test.name, color="cyan")
-                response = session.post(
-                    url=f"{url}/item{f'/{suite_uuid}' if suite_uuid else ''}",
-                    headers=headers,
-                    json={
-                        "name": test.name,
-                        "description": test.summary,
-                        "attributes": item_attributes,
-                        "parameters": env_vars,
-                        "codeRef": test.web_link() or None,
-                        "launchUuid": launch_uuid,
-                        "type": "step",
-                        "testCaseId": test.id or None,
-                        "startTime": test_time})
-                self.handle_response(response)
-                item_uuid = yaml_to_dict(response.text).get("id")
-                assert item_uuid is not None
-                self.verbose("uuid", item_uuid, "yellow", shift=1)
+                if create_test:
+                    # Create a test item
+                    self.info("test", test.name, color="cyan")
+                    response = self.post_rp_api(session,
+                                                f"item{f'/{suite_uuid}' if {suite_uuid} else ''}",
+                                                json={
+                                                    "name": test.name,
+                                                    "description": test.summary,
+                                                    "attributes": item_attributes,
+                                                    "parameters": env_vars,
+                                                    "codeRef": test.web_link() or None,
+                                                    "launchUuid": launch_uuid,
+                                                    "type": "step",
+                                                    "testCaseId": test.id or None,
+                                                    "startTime": test_time})
+                    item_uuid = yaml_to_dict(response.text).get("id")
+                    assert item_uuid is not None
+                    self.verbose("uuid", item_uuid, "yellow", shift=1)
+                    self.data.test_uuids[test.serial_number] = item_uuid
+                else:
+                    item_uuid = self.data.test_uuids[test.serial_number]
 
                 # to supoort idle tests
                 status = "SKIPPED"
@@ -403,69 +452,65 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
                         status = self.TMT_TO_RP_RESULT_STATUS[result.result]
 
                         # Upload log
-                        response = session.post(
-                            url=f"{url}/log/entry",
-                            headers=headers,
-                            json={
-                                "message": log,
-                                "itemUuid": item_uuid,
-                                "launchUuid": launch_uuid,
-                                "level": level,
-                                "time": result.end_time})
-                        self.handle_response(response)
+                        response = self.post_rp_api(session, "log/entry",
+                                                    json={"message": log,
+                                                          "itemUuid": item_uuid,
+                                                          "launchUuid": launch_uuid,
+                                                          "level": level,
+                                                          "time": result.end_time})
 
                         # Write out failures
                         if index == 0 and status == "FAILED":
                             message = result.failures(log)
-                            response = session.post(
-                                url=f"{url}/log/entry",
-                                headers=headers,
-                                json={
-                                    "message": message,
-                                    "itemUuid": item_uuid,
-                                    "launchUuid": launch_uuid,
-                                    "level": "ERROR",
-                                    "time": result.end_time})
-                            self.handle_response(response)
+                            response = self.post_rp_api(session, "log/entry",
+                                                        json={"message": message,
+                                                              "itemUuid": item_uuid,
+                                                              "launchUuid": launch_uuid,
+                                                              "level": "ERROR",
+                                                              "time": result.end_time})
 
                     # TODO: Add tmt files as attachments
 
                     test_time = result.end_time
 
                 # Finish the test item
-                response = session.put(
-                    url=f"{url}/item/{item_uuid}",
-                    headers=headers,
+                # # response = self.put_rp_api(session, f"item/{item_uuid}",
+                # #     json={"launchUuid": launch_uuid,
+                # #           "endTime": test_time,
+                # #           "status": "PASSED"})
+                response = self.put_rp_api(
+                    session,
+                    f"item/{item_uuid}",
                     json={
                         "launchUuid": launch_uuid,
                         "endTime": test_time,
                         "status": status,
-                        "issue": {"issueType": dt_locator or "ti001"}})
+                        "issue": {
+                            "issueType": self.get_defect_type_locator(
+                                session,
+                                defect_type)}})
                 self.handle_response(response)
                 launch_time = test_time
 
+                # TODO: resolve problem with reporting original defect type (idle)
+                #       after additional report of results
+                #       - temporary solution idea:
+                #               if again_additional_tests and status failed,
+                #               get test_id, report passed and then again failed
+
             if create_suite:
                 # Finish the test suite
-                response = session.put(
-                    url=f"{url}/item/{suite_uuid}",
-                    headers=headers,
-                    json={
-                        "launchUuid": launch_uuid,
-                        "endTime": launch_time})
-                self.handle_response(response)
+                response = self.put_rp_api(session, f"item/{suite_uuid}",
+                                           json={"launchUuid": launch_uuid,
+                                                 "endTime": launch_time})
 
             is_the_last_plan = self.step.plan == self.step.plan.my_run.plans[-1]
-            additional_upload = self.get("upload_to_launch") is not None \
-                or self.get("upload_to_suite") is not None
 
             if ((launch_per_plan or (suite_per_plan and is_the_last_plan))
                     and not additional_upload):
                 # Finish the launch
-                response = session.put(
-                    url=f"{url}/launch/{launch_uuid}/finish",
-                    headers=headers,
-                    json={"endTime": launch_time})
-                self.handle_response(response)
+                response = self.put_rp_api(session, f"launch/{launch_uuid}/finish",
+                                           json={"endTime": launch_time})
                 launch_url = yaml_to_dict(response.text).get("link")
 
             assert launch_url is not None

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -1,7 +1,7 @@
 import dataclasses
 import os
 import re
-from typing import Optional
+from typing import List, Optional
 
 import requests
 
@@ -15,12 +15,12 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
     url: Optional[str] = field(
         option="--url",
         metavar="URL",
-        default=os.environ.get("TMT_REPORT_REPORTPORTAL_URL"),
+        default=None,
         help="The URL of the ReportPortal instance where the data should be sent to.")
     token: Optional[str] = field(
         option="--token",
         metavar="TOKEN",
-        default=os.environ.get("TMT_REPORT_REPORTPORTAL_TOKEN"),
+        default=None,
         help="The token to use for upload to the ReportPortal instance (from the user profile).")
     project: Optional[str] = field(
         option="--project",
@@ -36,27 +36,46 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
         option="--exclude-variables",
         metavar="PATTERN",
         default="^TMT_.*",
-        help="""
-             Regular expression for excluding environment variables from reporting to ReportPortal
-             ('^TMT_.*' used by default).
-             """)
+        help="Regular expression for excluding environment variables "
+             "from reporting to ReportPortal ('^TMT_.*' used by default).")
+    attributes: List[str] = field(
+        default_factory=list,
+        multiple=True,
+        normalize=tmt.utils.normalize_string_list,
+        option="--attributes",
+        metavar="KEY:VALUE",
+        help="Additional attributes to be reported to ReportPortal,"
+             "especially launch attributes for merge option.")
+    merge: bool = field(
+        option="--merge",
+        default=False,
+        is_flag=True,
+        help="Report suite per plan and merge them into one launch.")
+    uuid: Optional[str] = field(
+        option="--uuid",
+        metavar="LAUNCH_UUID",
+        default=None,
+        help="The launch uuid for additional merging to an existing launch.")
+    launch_url: str = ""
+    launch_uuid: str = ""
 
 
 @tmt.steps.provides_method("reportportal")
-class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
+class ReportReportPortal(tmt.steps.report.ReportPlugin):
     """
     Report test results to a ReportPortal instance via API.
 
-    Requires a ``token`` for authentication, a URL of the ReportPortal
-    instance and the ``project`` name. In addition to command line options
-    it's possible to use environment variables to set the URL and token:
+    Requires a token for authentication, a URL of the ReportPortal
+    instance and the project name. In addition to command line options
+    it's possible to use environment variables in form of
+    ``TMT_PLUGIN_REPORT_REPORTPORTAL_${OPTION}``:
 
     .. code-block:: bash
 
-        export TMT_REPORT_REPORTPORTAL_URL=...
-        export TMT_REPORT_REPORTPORTAL_TOKEN=...
+        export TMT_PLUGIN_REPORT_REPORTPORTAL_URL=...
+        export TMT_PLUGIN_REPORT_REPORTPORTAL_TOKEN=...
 
-    The optional ``launch`` name doesn't have to be provided if it is the
+    The optional launch name doesn't have to be provided if it is the
     same as the plan name (by default). Assuming the URL and token
     are provided by the environment variables, the plan config can look
     like this:
@@ -95,19 +114,19 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
 
     def handle_response(self, response: requests.Response) -> None:
         """
-        Check the server response and raise an exception if needed.
+        Check the endpoint response and raise an exception if needed.
         """
 
         if not response.ok:
             raise tmt.utils.ReportError(
                 f"Received non-ok status code from ReportPortal: {response.text}")
 
-        self.debug("Response code from the server", response.status_code)
-        self.debug("Message from the server", response.text)
+        self.debug("Response code from the endpoint", str(response.status_code))
+        self.debug("Message from the endpoint", str(response.text))
 
     def go(self) -> None:
         """
-        Report test results to the server
+        Report test results to the endpoint
 
         Create a ReportPortal launch and its test items,
         fill it with all parts needed and report the logs.
@@ -115,56 +134,110 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
 
         super().go()
 
-        server = self.data.url
-        if not server:
-            raise tmt.utils.ReportError("No ReportPortal server url provided.")
-        server = server.rstrip("/")
+        endpoint = self.get("url", os.getenv('TMT_PLUGIN_REPORT_REPORTPORTAL_URL'))
+        if not endpoint:
+            raise tmt.utils.ReportError("No ReportPortal endpoint url provided.")
+        endpoint = endpoint.rstrip("/")
 
-        project = self.data.project
+        project = self.get("project", os.getenv('TMT_PLUGIN_REPORT_REPORTPORTAL_PROJECT'))
         if not project:
             raise tmt.utils.ReportError("No ReportPortal project provided.")
 
-        token = self.data.token
+        token = self.get("token", os.getenv('TMT_PLUGIN_REPORT_REPORTPORTAL_TOKEN'))
         if not token:
             raise tmt.utils.ReportError("No ReportPortal token provided.")
 
-        assert self.step.plan.name is not None
-        launch_name = self.data.launch or self.step.plan.name
-
-        url = f"{server}/api/{self.DEFAULT_API_VERSION}/{project}"
+        url = f"{endpoint}/api/{self.DEFAULT_API_VERSION}/{project}"
         headers = {
             "Authorization": "bearer " + token,
             "accept": "*/*",
             "Content-Type": "application/json"}
 
-        envar_pattern = self.data.exclude_variables
+        launch_time = self.step.plan.execute.results()[0].starttime
+        merge_bool = self.get("merge")
+        rerun_bool = False
+        create_launch = True
+        launch_uuid = ""
+        suite_uuid = ""
+        launch_url = ""
+        launch_name = ""
+
+        envar_pattern = self.get("exclude-variables") or "$^"
+        extra_attributes = self.get("attributes")
+        launch_attributes = [
+            {'key': attribute.split(':', 2)[0], 'value': attribute.split(':', 2)[1]}
+            for attribute in extra_attributes] or []
+
         attributes = [
             {'key': key, 'value': value[0]}
             for key, value in self.step.plan._fmf_context.items()]
-        launch_time = self.step.plan.execute.results()[0].start_time
+        for attr in launch_attributes:
+            if attr not in attributes:
+                attributes.append(attr)
 
         # Communication with RP instance
         with tmt.utils.retry_session() as session:
 
-            # Create a launch
-            self.info("launch", launch_name, color="cyan")
-            response = session.post(
-                url=f"{url}/launch",
-                headers=headers,
-                json={
-                    "name": launch_name,
-                    "description": self.step.plan.summary,
-                    "attributes": attributes,
-                    "startTime": launch_time})
-            self.handle_response(response)
-            launch_uuid = yaml_to_dict(response.text).get("id")
-            assert launch_uuid is not None
+            stored_launch_uuid = self.get("uuid") or self.step.plan.my_run.rp_uuid
+            if merge_bool and stored_launch_uuid:
+                create_launch = False
+                launch_uuid = stored_launch_uuid
+                response = session.get(
+                    url=f"{url}/launch/uuid/{launch_uuid}",
+                    headers=headers)
+                self.handle_response(response)
+                launch_name = yaml_to_dict(response.text).get("name")
+                self.verbose("launch", launch_name, color="yellow")
+                launch_id = yaml_to_dict(response.text).get("id")
+                launch_url = f"{endpoint}/ui/#{project}/launches/all/{launch_id}"
+            else:
+                # create_launch = True
+                launch_name = self.get("launch", os.getenv(
+                    'TMT_PLUGIN_REPORT_REPORTPORTAL_LAUNCH')) or self.step.plan.name
+
+                # Create a launch
+                self.info("launch", launch_name, color="cyan")
+                response = session.post(
+                    url=f"{url}/launch",
+                    headers=headers,
+                    json={
+                        "name": launch_name,
+                        "description": "" if merge_bool else self.step.plan.summary,
+                        "attributes": launch_attributes if merge_bool else attributes,
+                        "startTime": launch_time,
+                        "rerun": rerun_bool})
+                self.handle_response(response)
+                launch_uuid = yaml_to_dict(response.text).get("id")
+                assert launch_uuid is not None
+                if merge_bool:
+                    self.step.plan.my_run.rp_uuid = launch_uuid
+
             self.verbose("uuid", launch_uuid, "yellow", shift=1)
+            self.data.launch_uuid = launch_uuid
+
+            if merge_bool:
+                # Create a suite
+                suite_name = self.step.plan.name
+                self.info("suite", suite_name, color="cyan")
+                response = session.post(
+                    url=f"{url}/item",
+                    headers=headers,
+                    json={
+                        "name": suite_name,
+                        "description": self.step.plan.summary,
+                        "attributes": attributes,
+                        "startTime": launch_time,
+                        "launchUuid": launch_uuid,
+                        "type": "suite"})
+                self.handle_response(response)
+                suite_uuid = yaml_to_dict(response.text).get("id")
+                assert suite_uuid is not None
+                self.verbose("uuid", suite_uuid, "yellow", shift=1)
 
             # For each test
             for result in self.step.plan.execute.results():
-                test = next(test for test in self.step.plan.discover.tests()
-                            if test.serial_number == result.serial_number)
+                test = [test for test in self.step.plan.discover.tests()
+                        if test.serialnumber == result.serialnumber][0]
                 # TODO: for happz, connect Test to Result if possible
 
                 item_attributes = attributes.copy()
@@ -178,7 +251,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
                 # Create a test item
                 self.info("test", result.name, color="cyan")
                 response = session.post(
-                    url=f"{url}/item",
+                    url=f"{url}/item{f'/{suite_uuid}' if merge_bool else ''}",
                     headers=headers,
                     json={
                         "name": result.name,
@@ -189,7 +262,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
                         "launchUuid": launch_uuid,
                         "type": "step",
                         "testCaseId": test.id or None,
-                        "startTime": result.start_time})
+                        "startTime": result.starttime})
                 self.handle_response(response)
                 item_uuid = yaml_to_dict(response.text).get("id")
                 assert item_uuid is not None
@@ -228,7 +301,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
                                 "itemUuid": item_uuid,
                                 "launchUuid": launch_uuid,
                                 "level": "ERROR",
-                                "time": result.end_time})
+                                "time": result.endtime})
                         self.handle_response(response)
 
                 # Finish the test item
@@ -237,16 +310,29 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
                     headers=headers,
                     json={
                         "launchUuid": launch_uuid,
-                        "endTime": result.end_time,
+                        "endTime": result.endtime,
                         "status": status})
                 self.handle_response(response)
-                launch_time = result.end_time
+                launch_time = result.endtime
 
-            # Finish the launch
-            response = session.put(
-                url=f"{url}/launch/{launch_uuid}/finish",
-                headers=headers,
-                json={"endTime": launch_time})
-            self.handle_response(response)
-            link = yaml_to_dict(response.text).get("link")
-            self.info("url", link, "magenta")
+            if merge_bool:
+                # Finish the test suite
+                response = session.put(
+                    url=f"{url}/item/{suite_uuid}",
+                    headers=headers,
+                    json={
+                        "launchUuid": launch_uuid,
+                        "endTime": launch_time})
+                self.handle_response(response)
+
+            if create_launch:
+                # Finish the launch
+                response = session.put(
+                    url=f"{url}/launch/{launch_uuid}/finish",
+                    headers=headers,
+                    json={"endTime": launch_time})
+                self.handle_response(response)
+                launch_url = yaml_to_dict(response.text).get("link")
+
+            self.info("url", launch_url, "magenta")
+            self.data.launch_url = launch_url


### PR DESCRIPTION
**PR should cover following use cases:**

1.|  Create one launch for all plans and create suite per each plan
2.|  Additionaly upload new suite/tests to a an existing launch
3.|  Prepare launch with empty (idle) tests and additionally report their results (within the same run id)
4.|  Rerun and upload new version into new `Retry` item within the last launch based on mapping via names.
5.|  Upload files
6.|  Enable using v2

**New implemented options:**

* option `--launch-per-plan` for creating a new launch per each plan (default)
* option `--suite-per-plan` for mapping a suite per each plan, all enclosed in one launch (launch uuid is stored in run of the first plan)
* option `--launch-description` for providing unified launch description, intended mainly for suite-per-plan mapping
* option `--upload-to-launch LAUNCH_ID`  to append new plans to an existing launch
* option `--upload-to-suite SUITE_ID` to append new tests to an existing suite within launch
* option `--launch-rerun` for reruns with 'Retry' item in RP, name-based mapping, only for suite-per-plan structure.
* option `--defect-type` for passing the defect type to failing tests, enables report idle tests to be additionally updated. 


**Additional work behind that:**

* rewritten environment variables to the uniform form TMT_PLUGIN_REPORT_REPORTPORTAL_${option}
* enabled to report without results
* get launch attributes from all common ones in plans (suite-per-plan)
* storing uuids per each launch/suite followed by reusing them (update based on identifiers)
* analyzed option combinations
* version v2

**Yet todo:**

* uploading to suites
* check stored identifiers
* restrict problematic option combinations
* resolve problems with mypy
* and lot of small debugging
* schemas, documentation
* tests (for new PR)
* uploading files (for new PR)