### PR TITLE
Refactor parameters of `Plan._iter_steps()`

### DIFF
--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -3986,7 +3986,7 @@ def load_run(run: 'tmt.base.Run') -> Tuple[bool, Optional[Exception]]:
     except GeneralError as error:
         return False, error
     for plan in run.plans:
-        for step in plan.steps(disabled=True):
+        for step in plan.steps(enabled_only=False):
             step.load()
     return True, None
 


### PR DESCRIPTION
I always found `disabled=True` puzzling. Is it going to return disabled steps only? Or include disabled steps? Especially when `enabled` was always `True`.

Patch drops `enabled` and `disabled`, replacing them with `enabled_only` parameter. If set to `False`, disabled steps would be listed as well as enabled ones.