### PR TITLE
Disable `systemd-resolved` to prevent dns failures

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -13,3 +13,17 @@ adjust:
         how: install
         directory: tmp/RPMS/noarch
     when: how == full
+
+    # Disable systemd-resolved to prevent dns failures
+    # See: https://github.com/teemtee/tmt/issues/2063
+  - prepare+:
+      - name: disable-systemd-resolved
+        how: shell
+        script: |
+            systemctl disable systemd-resolved
+            systemctl mask systemd-resolved
+            rm -f /etc/resolv.conf
+            systemctl restart NetworkManager
+            sleep 3
+            cat /etc/resolv.conf
+    when: initiator == packit and distro == fedora


### PR DESCRIPTION
Prevent random dns failures caused (most probably) by `systemd-resolved`. Using [workaround](https://gitlab.com/testing-farm/infrastructure/-/blob/testing-farm/ansible/tasks/dns.yml?ref_type=heads) from Testing Farm.

Fix #2063.