### PR TITLE
Remove TBD of `initiator` context for Packit

### DIFF
--- a/spec/context/initiator.fmf
+++ b/spec/context/initiator.fmf
@@ -14,7 +14,6 @@ description: |
 
     packit
         For jobs initiated by the Packit service.
-        To be implemented.
 
     fedora-ci
         Testing in the Fedora CI pipeline.


### PR DESCRIPTION
Implemented in packit/packit-service#2176

<!-- review notes -->

Should be deployed next week, I guess you might wanna keep it open by then?