### PR TITLE
Adjust test coverage for deep beakerlib libraries

### DIFF
--- a/tests/discover/libraries/data/file.sh
+++ b/tests/discover/libraries/data/file.sh
@@ -5,7 +5,7 @@
 rlJournalStart
     rlPhaseStartSetup
         rlAssertRpm "coreutils"
-        rlRun "rlImport test/file"
+        rlRun "rlImport very/deep/file"
         rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
         rlRun "pushd $tmp"
     rlPhaseEnd

--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -50,7 +50,6 @@ rlJournalStart
 
     rlPhaseStartTest "Deep"
         rlRun -s "$tmt file"
-        rlAssertGrep 'the library is stored deep.' $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Strip git suffix"


### PR DESCRIPTION
The symlinks for the deep libraries are no more created as the temporary workaround has been removed in 5c4ee707. Deeply stored libraries are now handled directly by beakerlib.

Relates: #2247