### PR TITLE
Make the upload to PyPI working again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,11 @@ images:
 wheel:
 	cp -a tmt/__init__.py tmt/__init__.py.backup
 	sed -i $(REPLACE_VERSION) tmt/__init__.py
+	cp -a README.rst README.rst.backup
+	sed '/versionadded::/d' -i README.rst
 	python3 setup.py bdist_wheel
 	mv tmt/__init__.py.backup tmt/__init__.py
+	mv README.rst.backup README.rst
 upload:
 	twine upload dist/*.whl
 

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12'
+        'Programming Language :: Python :: 3.12',
         'Topic :: Utilities',
         ],
     keywords=['metadata', 'testing'],


### PR DESCRIPTION
* Get rid of the `versionadded` during `make wheel` as well.
* Fix the wrong classifier caused by a missing comma.