### PR TITLE
Copr repo with a group owner requires quotes

### DIFF
--- a/spec/plans/prepare.fmf
+++ b/spec/plans/prepare.fmf
@@ -138,6 +138,8 @@ example: |
         # Enable copr repository, skip missing packages
         prepare:
             how: install
+            # Repository with a group owner (@ prefixed) requires quotes, e.g.
+            # copr: "@osci/rpminspect"
             copr: psss/tmt
             package: tmt-all
             missing: skip


### PR DESCRIPTION
I almost started filling an issue until I realized that the

```
Invalid yaml syntax: Failed to parse '/*/plans/*.fmf'.
while scanning for the next token
found character that cannot start any token
  in "<unicode string>", line x, column y
```

really means a mistake on my side and I need to enclose the group-owned copr repo in quotes because of the `@` which copr prefixes the groups with.

Feel free to close if you think that's obvious and doesn't need any explicit notes.