### PR TITLE
Use `format_value()` instead of `pprint()`

### DIFF
--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -2,7 +2,6 @@
 
 import copy
 import os
-import pprint
 import re
 import shlex
 import subprocess
@@ -17,7 +16,7 @@ import tmt.base
 import tmt.export
 import tmt.identifier
 import tmt.utils
-from tmt.utils import ConvertError, GeneralError, Path
+from tmt.utils import ConvertError, GeneralError, Path, format_value
 
 log = fmf.utils.Logging('tmt').logger
 
@@ -321,7 +320,7 @@ def read_datafile(
                 key, value = variable.split('=', maxsplit=1)
                 data['environment'][key] = value
             echo(style('environment:', fg='green'))
-            echo(pprint.pformat(data['environment']))
+            echo(format_value(data['environment']))
 
     def sanitize_name(name: str) -> str:
         """ Raise if package name starts with '-' (negative require) """
@@ -610,8 +609,8 @@ def read(
                 if parent.get(key) == test[key]:
                     test.pop(key)
 
-    log.debug('Common metadata:\n' + pprint.pformat(common_data))
-    log.debug('Individual metadata:\n' + pprint.pformat(individual_data))
+    log.debug('Common metadata:\n' + format_value(common_data))
+    log.debug('Individual metadata:\n' + format_value(individual_data))
     return common_data, individual_data
 
 
@@ -985,7 +984,7 @@ def read_nitrate_case(
             data.pop('environment')
         else:
             echo(style('environment:', fg='green'))
-            echo(pprint.pformat(data['environment']))
+            echo(format_value(data['environment']))
     # Possible multihost tag (detected in Makefile)
     if makefile_data:
         data['tag'].extend(makefile_data.get('tag', []))

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -11,7 +11,6 @@ import io
 import json
 import os
 import pathlib
-import pprint
 import re
 import shlex
 import shutil
@@ -603,7 +602,7 @@ class Command:
             actual_env = os.environ.copy()
             actual_env.update(env)
 
-        logger.debug('environment', pprint.pformat(actual_env), level=4)
+        logger.debug('environment', format_value(actual_env), level=4)
 
         # Set special executable only when shell was requested
         executable = DEFAULT_SHELL if shell else None
@@ -3091,7 +3090,10 @@ def _format_dict(
 
                 # UX: If there is just a single line, put key and value on the
                 # same line.
-                if len(lines) <= 1:
+                if not lines:
+                    yield f'{k_formatted}:'
+
+                elif len(lines) == 1:
                     yield f'{k_formatted}: {lines[0]}'
 
                 # UX: Otherwise, put lines under the key, and indent them.
@@ -4238,7 +4240,7 @@ class StructuredField:
         values = [escape.sub("", value) for value in parts[2::2]]
         for key, value in zip(keys, values):
             self.set(key, value)
-        log.debug(f"Parsed sections:\n{pprint.pformat(self._sections)}")
+        log.debug(f"Parsed sections:\n{format_value(self._sections)}")
 
     def _save_version_zero(self) -> str:
         """ Save version 0 format """


### PR DESCRIPTION
pprint is good when nothing else is available, and tmt does have its own pretty printer, tailored for user readability. Use it instead of standard library to present consistent picture.