### PR TITLE
Beaker plugin is negating Beaker operators by default

### DIFF
--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -77,7 +77,7 @@ def operator_to_beaker_op(operator: tmt.hardware.Operator, value: str) -> Tuple[
     """
 
     if operator in OPERATOR_SIGN_TO_OPERATOR:
-        return OPERATOR_SIGN_TO_OPERATOR[operator], value, True
+        return OPERATOR_SIGN_TO_OPERATOR[operator], value, False
 
     # MATCH has special handling - convert the pattern to a wildcard form -
     # and that may be weird :/


### PR DESCRIPTION
And that's a bug, a nasty bug. Every operator would end up being wrapped with a `<not/>` element.

Fixes https://github.com/teemtee/tmt/issues/2322