### PR TITLE
Add `skip` as a supported custom result outcome

### DIFF
--- a/spec/plans/results.fmf
+++ b/spec/plans/results.fmf
@@ -27,7 +27,7 @@ description: |
          path: /
 
        # String, outcome of the test execution.
-       result: "pass"|"fail"|"info"|"warn"|"error"
+       result: "pass"|"fail"|"info"|"warn"|"error"|"skip"
 
        # String, optional comment to report with the result.
        note: "Things were great."
@@ -68,7 +68,7 @@ description: |
       # relate to each check alone.
       check:
           # String, outcome of the test execution.
-        - result: "pass"|"fail"|"info"|"warn"|"error"
+        - result: "pass"|"fail"|"info"|"warn"|"error"|"skip"
 
           # String, optional comment to report with the result.
           note: "Things were great."
@@ -102,10 +102,10 @@ description: |
 
     info
         Test finished but only produced an informational
-        message. Represents a soft pass, used for skipped
-        tests and for tests with the :ref:`/spec/tests/result`
-        attribute set to ``ignore``. Automation must treat
-        this as a passed test.
+        message. Represents a soft pass, used for tests
+        with the :ref:`/spec/tests/result` attribute set
+        to ``info``. Automation must treat this as a
+        passed test.
 
     warn
         A problem appeared during test execution which does
@@ -121,6 +121,11 @@ description: |
 
     fail
         Test execution successfully finished and failed.
+
+    skip
+        Test was discovered but not executed. Can be used when
+        a single process produces multiple results but not all
+        tests were run.
 
     The ``name`` and ``result`` keys are required. Also, ``name``, ``result``,
     and ``event`` keys are required for entries under ``check`` key. Custom

--- a/tests/execute/restraint/report-result/test.sh
+++ b/tests/execute/restraint/report-result/test.sh
@@ -11,7 +11,7 @@ rlJournalStart
         rlAssertGrep "pass /report" $rlRun_LOG
         rlAssertGrep "pass /smoke/good" $rlRun_LOG
         rlAssertGrep "fail /smoke/bad" $rlRun_LOG
-        rlAssertGrep "info /smoke/skip" $rlRun_LOG
+        rlAssertGrep "skip /smoke/skip" $rlRun_LOG
         rlAssertGrep "warn /smoke/warn" $rlRun_LOG
     rlPhaseEnd
 

--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -16,10 +16,11 @@ rlJournalStart
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 1 "Test provides 'results.yaml' file by itself"
         rlAssertGrep "00:11:22 pass /test/custom-results/test/passing" $rlRun_LOG
         rlAssertGrep "00:22:33 fail /test/custom-results/test/failing" $rlRun_LOG
+        rlAssertGrep "00:00:00 skip /test/custom-results/test/skipped" $rlRun_LOG
         # The duration of the main result is replaced with the duration measured by tmt for the whole test.
         rlAssertGrep "00:00:00 pass /test/custom-results (on default-0) \[1/1\]" $rlRun_LOG
         rlAssertGrep "00:55:44 pass /test/custom-results/without-leading-slash.*name should start with '/'" $rlRun_LOG
-        rlAssertGrep "total: 3 tests passed and 1 test failed" $rlRun_LOG
+        rlAssertGrep "total: 3 tests passed, 1 test failed and 1 test skipped" $rlRun_LOG
 
         rlAssertExists "$(sed -n 's/ *pass_log: \(.\+\)/\1/p' $rlRun_LOG)"
         rlAssertExists "$(sed -n 's/ *fail_log: \(.\+\)/\1/p' $rlRun_LOG)"

--- a/tests/execute/result/custom/results.yaml
+++ b/tests/execute/result/custom/results.yaml
@@ -51,3 +51,8 @@
   guest:
     name: client-1
     role: clients
+
+- name: /test/skipped
+  result: skip
+  duration: 00:00:00
+  serialnumber: 5

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -24,6 +24,7 @@ class ResultOutcome(enum.Enum):
     INFO = 'info'
     WARN = 'warn'
     ERROR = 'error'
+    SKIP = 'skip'
 
     @classmethod
     def from_spec(cls, spec: str) -> 'ResultOutcome':
@@ -42,6 +43,7 @@ class ResultInterpret(enum.Enum):
     INFO = 'info'
     WARN = 'warn'
     ERROR = 'error'
+    SKIP = 'skip'
 
     # Special interpret values
     RESPECT = 'respect'
@@ -58,7 +60,9 @@ RESULT_OUTCOME_COLORS: Dict[ResultOutcome, str] = {
     ResultOutcome.FAIL: 'red',
     ResultOutcome.INFO: 'blue',
     ResultOutcome.WARN: 'yellow',
-    ResultOutcome.ERROR: 'magenta'
+    ResultOutcome.ERROR: 'magenta',
+    # TODO (happz) make sure the color is visible for all terminals
+    ResultOutcome.SKIP: 'bright_black',
     }
 
 
@@ -279,6 +283,9 @@ class Result(BaseResult):
         if stats.get(ResultOutcome.FAIL):
             failed = ' ' + click.style('failed', fg='red')
             comments.append(fmf.utils.listed(stats[ResultOutcome.FAIL], 'test') + failed)
+        if stats.get(ResultOutcome.SKIP):
+            skipped = ' ' + click.style('skipped', fg='bright_black')
+            comments.append(fmf.utils.listed(stats[ResultOutcome.SKIP], 'test') + skipped)
         if stats.get(ResultOutcome.INFO):
             count, comment = fmf.utils.listed(stats[ResultOutcome.INFO], 'info').split()
             comments.append(count + ' ' + click.style(comment, fg='blue'))

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -581,8 +581,17 @@ class Execute(tmt.steps.Step):
 
     def summary(self) -> None:
         """ Give a concise summary of the execution """
-        tests = fmf.utils.listed(self.results(), 'test')
-        self.info('summary', f'{tests} executed', 'green', shift=1)
+        executed_tests = [r for r in self.results() if r.result != ResultOutcome.SKIP]
+        skipped_tests = [r for r in self.results() if r.result == ResultOutcome.SKIP]
+
+        message = [
+            fmf.utils.listed(executed_tests, 'test') + ' executed'
+            ]
+
+        if skipped_tests:
+            message.append(fmf.utils.listed(skipped_tests, 'test') + ' skipped')
+
+        self.info('summary', ', '.join(message), 'green', shift=1)
 
     def go(self) -> None:
         """ Execute tests """


### PR DESCRIPTION
As we discussed with @lukaszachy probably a month ago the purpose of this is to explicitly state that a test was not executed.
The use case is when a single tmt test produces multiple results but some of them were not executed because the implementation decided so. It should be visible to the user that such a test exists and that there is not a bug in the implementation which caused the test to be missing.
It is still an open question how such cases should be displayed in Fedora's CI.