### PR TITLE
Move check-related code into tmt.checks

### DIFF
--- a/tests/test/check/test.sh
+++ b/tests/test/check/test.sh
@@ -23,6 +23,8 @@ rlJournalStart
         rlPhaseStartTest "Test dmesg check with $method"
             rlRun "tmt run --id $run --scratch -a -vv provision -h $method"
 
+            rlRun "cat $results"
+
             rlAssertExists "$dump_before"
             if [ "$method" = "container" ]; then
                 assert_check_result "dmesg as a before-test should fail with containers" "error" "before-test"

--- a/tmt/checks/__init__.py
+++ b/tmt/checks/__init__.py
@@ -1,18 +1,45 @@
+import dataclasses
 import enum
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, List, Optional, Type
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Type, TypedDict
 
 import tmt.log
 import tmt.steps.provision
 import tmt.utils
 from tmt.plugins import PluginRegistry
+from tmt.utils import cached_property, field
 
 if TYPE_CHECKING:
-    from tmt.base import Check
     from tmt.result import CheckResult
     from tmt.steps.execute import ExecutePlugin
 
 
 CheckPluginClass = Type['CheckPlugin']
+
+_CHECK_PLUGIN_REGISTRY: PluginRegistry[CheckPluginClass] = PluginRegistry()
+
+
+def provides_check(check: str) -> Callable[[CheckPluginClass], CheckPluginClass]:
+    """
+    A decorator for registering test checks.
+
+    Decorate a test check plugin class to register its checks.
+    """
+
+    def _provides_check(check_cls: CheckPluginClass) -> CheckPluginClass:
+        _CHECK_PLUGIN_REGISTRY.register_plugin(
+            plugin_id=check,
+            plugin=check_cls,
+            logger=tmt.log.Logger.get_bootstrap_logger())
+
+        return check_cls
+
+    return _provides_check
+
+
+# A "raw" test check as stored in fmf node data.
+class _RawCheck(TypedDict, total=False):
+    name: str
+    enabled: bool
 
 
 class CheckEvent(enum.Enum):
@@ -29,48 +56,89 @@ class CheckEvent(enum.Enum):
             raise tmt.utils.SpecificationError(f"Invalid test check event '{spec}'.")
 
 
+@dataclasses.dataclass
+class Check(
+        tmt.utils.SpecBasedContainer[_RawCheck, _RawCheck],
+        tmt.utils.SerializableContainer):
+    """
+    Represents a single check from test's ``check`` field.
+
+    Serves as a link between raw fmf/CLI specification and an actual
+    check implementation/plugin.
+    """
+
+    name: str
+    enabled: bool = field(default=True)
+
+    @cached_property
+    def plugin(self) -> 'CheckPluginClass':
+        plugin = _CHECK_PLUGIN_REGISTRY.get_plugin(self.name)
+
+        if plugin is None:
+            raise tmt.utils.GeneralError(
+                f"Test check '{self.name}' was not found in check registry.")
+
+        return plugin
+
+    def go(
+            self,
+            *,
+            event: CheckEvent,
+            guest: tmt.steps.provision.Guest,
+            test: 'tmt.base.Test',
+            plugin: 'tmt.steps.execute.ExecutePlugin',
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> List['CheckResult']:
+        """
+        Run the check.
+
+        :param event: when the check is running - before the test, after the test, etc.
+        :param guest: on this guest the ``test`` will run/was executed.
+        :param test: test to which the check belongs to.
+        :param plugin: an ``execute`` step plugin managing the test execution.
+        :param environment: optional environment to set for the check.
+        :param logger: logger to use for logging.
+        :returns: list of results produced by checks.
+        """
+
+        # TODO: there's "skipped" outcome brewing, we should use it once
+        # it lands
+        if not self.enabled:
+            return []
+
+        if event == CheckEvent.BEFORE_TEST:
+            return self.plugin.before_test(
+                check=self,
+                plugin=plugin,
+                guest=guest,
+                test=test,
+                environment=environment,
+                logger=logger)
+
+        if event == CheckEvent.AFTER_TEST:
+            return self.plugin.after_test(
+                check=self,
+                plugin=plugin,
+                guest=guest,
+                test=test,
+                environment=environment,
+                logger=logger)
+
+        raise tmt.utils.GeneralError(f"Unsupported test check event '{event}'.")
+
+
 class CheckPlugin(tmt.utils._CommonBase):
     """ Base class for plugins providing extra checks before, during and after tests """
-
-    _test_check_plugin_registry: ClassVar[PluginRegistry[CheckPluginClass]]
 
     # Keep this method around, to correctly support Python's method resolution order.
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-    # Cannot use @property as this must remain classmethod
-    @classmethod
-    def get_test_check_plugin_registry(cls) -> PluginRegistry[CheckPluginClass]:
-        """ Return - or initialize - export plugin registry """
-
-        if not hasattr(cls, '_test_check_plugin_registry'):
-            cls._test_check_plugin_registry = PluginRegistry()
-
-        return cls._test_check_plugin_registry
-
-    @classmethod
-    def provides_check(cls, check: str) -> Callable[[CheckPluginClass], CheckPluginClass]:
-        """
-        A decorator for registering test checks.
-
-        Decorate a test check plugin class to register its checks.
-        """
-
-        def _provides_check(check_cls: CheckPluginClass) -> CheckPluginClass:
-            cls.get_test_check_plugin_registry().register_plugin(
-                plugin_id=check,
-                plugin=check_cls,
-                logger=tmt.log.Logger.get_bootstrap_logger())
-
-            return check_cls
-
-        return _provides_check
-
     @classmethod
     def before_test(
             cls,
             *,
-            check: 'Check',
+            check: Check,
             plugin: 'ExecutePlugin',
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
@@ -82,10 +150,62 @@ class CheckPlugin(tmt.utils._CommonBase):
     def after_test(
             cls,
             *,
-            check: 'Check',
+            check: Check,
             plugin: 'ExecutePlugin',
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,
             logger: tmt.log.Logger) -> List['CheckResult']:
         return []
+
+
+def normalize_test_check(
+        key_address: str,
+        raw_test_check: Any,
+        logger: tmt.log.Logger) -> Check:
+    """ Normalize a single test check """
+
+    if isinstance(raw_test_check, str):
+        return Check(name=raw_test_check)
+
+    if isinstance(raw_test_check, dict):
+        try:
+            return Check(**raw_test_check)
+
+        except Exception:
+            raise tmt.utils.NormalizationError(
+                key_address,
+                raw_test_check,
+                'a string or a dictionary')
+
+    raise tmt.utils.NormalizationError(
+        key_address,
+        raw_test_check,
+        'a string or a dictionary')
+
+
+def normalize_checks(
+        key_address: str,
+        raw_checks: Any,
+        logger: tmt.log.Logger) -> List[Check]:
+    """ Normalize (prepare/finish/test) checks """
+
+    if raw_checks is None:
+        return []
+
+    if isinstance(raw_checks, str):
+        return [normalize_test_check(key_address, raw_checks, logger)]
+
+    if isinstance(raw_checks, dict):
+        return [normalize_test_check(key_address, raw_checks, logger)]
+
+    if isinstance(raw_checks, list):
+        return [
+            normalize_test_check(f'{key_address}[{i}]', raw_test_check, logger)
+            for i, raw_test_check in enumerate(raw_checks)
+            ]
+
+    raise tmt.utils.NormalizationError(
+        key_address,
+        raw_checks,
+        'a string, a dictionary, or a list of their combinations')

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -1,22 +1,18 @@
 import datetime
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import tmt.log
 import tmt.steps.execute
 import tmt.steps.provision
 import tmt.utils
-from tmt.checks import CheckEvent, CheckPlugin
+from tmt.checks import Check, CheckEvent, CheckPlugin, provides_check
 from tmt.result import CheckResult, ResultOutcome
 from tmt.utils import Path, render_run_exception_streams
-
-if TYPE_CHECKING:
-    from tmt.base import Check
-
 
 TEST_POST_DMESG_FILENAME = 'tmt-dmesg-{event}.txt'
 
 
-@CheckPlugin.provides_check('dmesg')
+@provides_check('dmesg')
 class DmesgCheck(CheckPlugin):
     @classmethod
     def _fetch_dmesg(


### PR DESCRIPTION
There were some classes and functions in tmt.base that really belong into tmt.checks. The patch just moves stuff around, updating imports and type references.