### PR TITLE
Always show the real beaker job id

### DIFF
--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -581,7 +581,7 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
             raise ProvisionError(
                 f"Failed to create, response: '{response}'.")
 
-        self.job_id = response["id"] if not response["system"] else response["system"]
+        self.job_id = response["id"]
         self.info('job id', self.job_id, 'green')
 
         with updatable_message(


### PR DESCRIPTION
Currently it sometimes prints the system name as the job id, like "job id: rdma-perf-00.rdma.lab.eng.rdu2.redhat.com".
As a user, expect it always prints the real beaker job id, like "job id: 8302636", so that we can find out this job from many jobs in beaker quickly.

```
provision
    workdir: /var/tmp/tmt/run-027/rdma/multi-hosts-demo/multi-v7/provision
        Workdir '/var/tmp/tmt/run-027/rdma/multi-hosts-demo/multi-v7/provision/server-1' created.
        how: beaker
        name: server-1
        order: 50
        hardware: hostname: rdma-perf-00.rdma.lab.eng.rdu2.redhat.com

        image: RHEL-9.3.0-20230911.0
        Transformed hardware:
            and:
              - hostname:
                    _op: ==
                    _value: rdma-perf-00.rdma.lab.eng.rdu2.redhat.com
        guest: has been requested

->>>    job id: 8302636

```