### PR TITLE
AVC denials check for tests

### DIFF
--- a/tests/test/check/data/main.fmf
+++ b/tests/test/check/data/main.fmf
@@ -1,4 +1,18 @@
-test: /bin/true
+/dmesg:
+  test: /bin/true
 
-check:
-  - name: dmesg
+  check: dmesg
+
+/avc:
+  check:
+    - avc
+
+  /harmless:
+    test: /bin/true
+
+  /nasty:
+    test: |
+      set -x
+      sudo bash -c "passwd --help &> /root/passwd.log; \
+                    ls -alZ /root/passwd.log; \
+                    rm -f /root/passwd.log" || /bin/true

--- a/tests/test/check/data/plan.fmf
+++ b/tests/test/check/data/plan.fmf
@@ -1,0 +1,5 @@
+execute:
+  how: tmt
+
+discover:
+  how: fmf

--- a/tests/test/check/main.fmf
+++ b/tests/test/check/main.fmf
@@ -1,11 +1,26 @@
 summary: Test test checks
 tier: 2
 
-environment:
-    PROVISION_METHODS: local container
+/dmesg:
+  test: ./test-dmesg.sh
 
-adjust:
-  - when: how == full
-    environment:
-        PROVISION_METHODS: local container virtual
-    tag+: [additional_coverage]
+  environment:
+      PROVISION_METHODS: local container
+
+  adjust:
+    - when: how == full
+      environment:
+          PROVISION_METHODS: local container virtual
+      tag+: [additional_coverage]
+
+/avc:
+  test: ./test-avc.sh
+
+  environment:
+      PROVISION_METHODS: local
+
+  adjust:
+    - when: how == full
+      environment:
+          PROVISION_METHODS: local virtual
+      tag+: [additional_coverage]

--- a/tests/test/check/test-avc.sh
+++ b/tests/test/check/test-avc.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+function assert_check_result () {
+    rlAssertEquals "$1" "avc:$2" "$(yq -r ".[] | .check | .[] | select(.event == \"$3\") | \"\\(.name):\\(.result)\"" $results)"
+}
+
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
+
+        rlRun "results=$run/plan/execute/results.yaml"
+
+        rlRun "pushd data"
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    for method in ${PROVISION_METHODS:-local}; do
+        rlPhaseStartTest "Test harmless AVC check with $method"
+            rlRun "avc_log=$run/plan/execute/data/guest/default-0/avc/harmless-1/tmt-avc-after-test.txt"
+
+            rlRun "tmt -c provision_method=$method run --id $run --scratch -a -vv provision -h $method test -n /avc/harmless"
+
+            rlRun "cat $results"
+            rlRun "cat $avc_log"
+
+            rlAssertExists "$avc_log"
+
+            assert_check_result "avc as an after-test should pass" "pass" "after-test"
+
+            rlAssertGrep "<no matches>" "$avc_log"
+        rlPhaseEnd
+
+        rlPhaseStartTest "Test nasty AVC check with $method"
+            rlRun "tmt -c provision_method=$method run --id $run --scratch -a -vv provision -h $method test -n /avc/nasty"
+
+            rlRun "avc_log=$run/plan/execute/data/guest/default-0/avc/nasty-1/tmt-avc-after-test.txt"
+
+            rlRun "cat $results"
+            rlRun "cat $avc_log"
+
+            rlAssertExists "$avc_log"
+
+            assert_check_result "avc as an after-test should report AVC denials" "fail" "after-test"
+
+            rlAssertGrep "avc:  denied" "$avc_log"
+            rlAssertGrep "path=/root/passwd.log" "$avc_log"
+        rlPhaseEnd
+    done
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+
+        rlRun "rm -rf $run"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/test/check/test-dmesg.sh
+++ b/tests/test/check/test-dmesg.sh
@@ -11,9 +11,9 @@ rlJournalStart
     rlPhaseStartSetup
         rlRun "run=\$(mktemp -d)" 0 "Create run directory"
 
-        rlRun "results=$run/plans/default/execute/results.yaml"
-        rlRun "dump_before=$run/plans/default/execute/data/guest/default-0/default-1/tmt-dmesg-before-test.txt"
-        rlRun "dump_after=$run/plans/default/execute/data/guest/default-0/default-1/tmt-dmesg-after-test.txt"
+        rlRun "results=$run/plan/execute/results.yaml"
+        rlRun "dump_before=$run/plan/execute/data/guest/default-0/dmesg-1/tmt-dmesg-before-test.txt"
+        rlRun "dump_after=$run/plan/execute/data/guest/default-0/dmesg-1/tmt-dmesg-after-test.txt"
 
         rlRun "pushd data"
         rlRun "set -o pipefail"
@@ -21,7 +21,7 @@ rlJournalStart
 
     for method in ${PROVISION_METHODS:-local}; do
         rlPhaseStartTest "Test dmesg check with $method"
-            rlRun "tmt run --id $run --scratch -a -vv provision -h $method"
+            rlRun "tmt run --id $run --scratch -a -vv provision -h $method test -n dmesg"
 
             rlRun "cat $results"
 
@@ -46,7 +46,6 @@ rlJournalStart
 
                 rlLogInfo "$(cat $dump_after)"
             fi
-
         rlPhaseEnd
     done
 

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -1,0 +1,182 @@
+import datetime
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+
+import tmt.log
+import tmt.steps.execute
+import tmt.steps.provision
+import tmt.utils
+from tmt.checks import Check, CheckEvent, CheckPlugin, provides_check
+from tmt.result import CheckResult, ResultOutcome
+from tmt.utils import CommandOutput, Path, ShellScript, render_run_exception_streams
+
+if TYPE_CHECKING:
+    from tmt.base import Test
+
+TEST_POST_AVC_FILENAME = 'tmt-avc-{event}.txt'
+
+
+@provides_check('avc')
+class AvcDenials(CheckPlugin):
+    @classmethod
+    def _save_report(
+            cls,
+            plugin: tmt.steps.execute.ExecutePlugin,
+            guest: tmt.steps.provision.Guest,
+            test: 'Test',
+            event: CheckEvent,
+            logger: tmt.log.Logger) -> Tuple[ResultOutcome, Path]:
+
+        if test.starttime is None:
+            raise tmt.utils.GeneralError(
+                "Test does not have start time recorded, cannot run AVC check.")
+
+        from tmt.steps.execute import ExecutePlugin
+        report_timestamp = ExecutePlugin.format_timestamp(
+            datetime.datetime.now(datetime.timezone.utc))
+
+        assert plugin.step.workdir is not None  # narrow type
+
+        path = plugin.data_path(
+            test,
+            guest,
+            filename=TEST_POST_AVC_FILENAME.format(event=event.value),
+            create=True,
+            full=True)
+
+        def _output_logger(
+                key: str,
+                value: Optional[str] = None,
+                color: Optional[str] = None,
+                shift: int = 2,
+                level: int = 3,
+                topic: Optional[tmt.log.Topic] = None) -> None:
+            logger.verbose(
+                key=key,
+                value=value,
+                color=color,
+                shift=shift,
+                level=level,
+                topic=topic)
+
+        # Collect all report components
+        report: List[str] = [
+            f'# Acquired at {report_timestamp}'
+            ]
+
+        # Flags indicating whether we were able to successfully fetch report components
+        got_sestatus, got_rpm, got_ausearch, got_denials = False, False, False, False
+
+        def _run_script(
+                script: ShellScript,
+                needs_sudo: bool = False) -> Union[
+                    Tuple[CommandOutput, Optional[tmt.utils.RunError]],
+                    Tuple[Optional[CommandOutput], tmt.utils.RunError]
+                ]:
+            if needs_sudo and guest.facts.is_superuser is False:
+                script = ShellScript(f'sudo {script.to_shell_command()}')
+
+            try:
+                output = guest.execute(script, log=_output_logger, silent=True)
+
+                return output, None
+
+            except tmt.utils.RunError as exc:
+                return None, exc
+
+        def _report_success(label: str, output: tmt.utils.CommandOutput) -> List[str]:
+            return [
+                f'# {label}',
+                output.stdout or '',
+                ''
+                ]
+
+        def _report_failure(label: str, exc: tmt.utils.RunError) -> List[str]:
+            return [
+                f'# {label}',
+                "\n".join(render_run_exception_streams(exc.stdout, exc.stderr, verbose=1)),
+                ''
+                ]
+
+        # Get the `sestatus` output.
+        output, exc = _run_script(ShellScript('sestatus'))
+
+        if exc is None:
+            assert output is not None
+
+            got_sestatus = True
+
+            report += _report_success('sestatus', output)
+
+        else:
+            report += _report_failure('sestatus', exc)
+
+        # Record selinux-policy NVR.
+        output, exc = _run_script(ShellScript('rpm -q selinux-policy'))
+
+        if exc is None:
+            assert output is not None
+
+            got_rpm = True
+
+            report += _report_success('rpm -q selinux-policy', output)
+
+        else:
+            report += _report_failure('rpm -q selinux-policy', exc)
+
+        # Finally, run `ausearch`, to list AVC denials from the time the test started.
+        start_timestamp = datetime.datetime.fromisoformat(test.starttime).timestamp()
+
+        script = ShellScript(f"""
+set -x
+export AVC_SINCE=$(LC_ALL=en_US.UTF-8 date "+%m/%d/%Y %H:%M:%S" --date="@{start_timestamp}")
+echo "$AVC_SINCE"
+ausearch -i --input-logs -m AVC -m USER_AVC -m SELINUX_ERR -ts $AVC_SINCE
+""")
+        output, exc = _run_script(script, needs_sudo=True)
+
+        # `ausearch` outcome evaluation is a bit more complicated than the one for a simple
+        # `rpm -q`, because not all non-zero exit codes mean error.
+        if exc is None:
+            assert output is not None
+
+            got_ausearch = True
+            got_denials = True
+
+            report += [
+                '# ausearch',
+                "\n".join(render_run_exception_streams(output.stdout, output.stderr, verbose=1)),
+                ''
+                ]
+
+        else:
+            if exc.returncode == 1 and exc.stderr and '<no matches>' in exc.stderr.strip():
+                got_ausearch = True
+
+            report += _report_failure('ausearch', exc)
+
+        # If we were able to fetch all components successfully, pick the result based on `ausearch`
+        # output.
+        if all([got_sestatus, got_rpm, got_ausearch]):
+            outcome = ResultOutcome.FAIL if got_denials else ResultOutcome.PASS
+
+        # Otherwise, it's an error - we already made all output part of the report.
+        else:
+            outcome = ResultOutcome.ERROR
+
+        plugin.write(path, '\n'.join(report))
+
+        return outcome, path.relative_to(plugin.step.workdir)
+
+    @classmethod
+    def after_test(
+            cls,
+            *,
+            check: 'Check',
+            plugin: tmt.steps.execute.ExecutePlugin,
+            guest: tmt.steps.provision.Guest,
+            test: 'Test',
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> List[CheckResult]:
+        outcome, path = cls._save_report(plugin, guest, test, CheckEvent.AFTER_TEST, logger)
+
+        return [CheckResult(name='avc', result=outcome, log=[path])]

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -259,6 +259,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
 
         # Execute the test, save the output and return code
         starttime = datetime.datetime.now(datetime.timezone.utc)
+        test.starttime = self.format_timestamp(starttime)
 
         try:
             output = guest.execute(
@@ -278,7 +279,12 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             test.returncode = error.returncode
             if test.returncode == tmt.utils.PROCESS_TIMEOUT:
                 logger.debug(f"Test duration '{test.duration}' exceeded.")
+
         endtime = datetime.datetime.now(datetime.timezone.utc)
+        test.endtime = self.format_timestamp(endtime)
+
+        test.real_duration = self.format_duration(endtime - starttime)
+
         self.write(
             self.data_path(test, guest, TEST_OUTPUT_FILENAME, full=True),
             stdout or '', mode='a', level=3)
@@ -291,10 +297,6 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
             environment=environment,
             logger=logger
             )
-
-        test.starttime = self.format_timestamp(starttime)
-        test.endtime = self.format_timestamp(endtime)
-        test.real_duration = self.format_duration(endtime - starttime)
 
         return test_check_results
 


### PR DESCRIPTION
First real post-test check, complementing whatever the test itself did
by checking the system for AVC denials raised during the test runtime.

Follows the design established by Restraint's AVC denial check we all
know and love, and performs the same tasks.