### PR TITLE
Reconcile HW requirements with virtual's own options

### DIFF
--- a/tests/provision/virtual.testcloud/test.sh
+++ b/tests/provision/virtual.testcloud/test.sh
@@ -16,16 +16,40 @@ rlJournalStart
 
     rlPhaseStartTest "All options used in plan"
         rlRun "cp $SRC_PLAN ."
+
         if ! rlRun "tmt run -i $run --scratch"; then
             rlRun "cat $run/log.txt" 0 "Dump log.txt"
+        else
+            rlAssertGrep "memory: 2048 megabyte" "$run/log.txt"
+            rlAssertGrep "disk: 10 gigabyte" "$run/log.txt"
+            rlAssertGrep "effective hardware: variant #1: memory: == 2048 megabyte" "$run/log.txt"
+            rlAssertGrep "effective hardware: variant #1: disk.size: == 10 gigabyte" "$run/log.txt"
+            rlAssertGrep "memory: set to '2048 megabyte' because of 'memory: == 2048 megabyte'" "$run/log.txt"
+            rlAssertGrep "disk\\[0\\].size: set to '10 gigabyte' because of 'disk.size: == 10 gigabyte'" "$run/log.txt"
+            rlAssertGrep "final domain memory: 2048000" "$run/log.txt"
+            rlAssertGrep "final domain disk size: 10" "$run/log.txt"
         fi
     rlPhaseEnd
 
     rlPhaseStartTest "All options used in plan from cmdline"
         rlRun "cp $SRC_PLAN ."
+
         if ! rlRun "tmt run -i $run --scratch --all \
-        provision -h virtual.testcloud --image fedora --disk 10 --memory 2048 --connection system"; then
+                            provision -h virtual.testcloud \
+                                      --image fedora \
+                                      --disk 11 \
+                                      --memory 2049 \
+                                      --connection system" ; then
             rlRun "cat $run/log.txt" 0 "Dump log.txt"
+        else
+            rlAssertGrep "memory: 2049 megabyte" "$run/log.txt"
+            rlAssertGrep "disk: 11 gigabyte" "$run/log.txt"
+            rlAssertGrep "effective hardware: variant #1: memory: == 2049 megabyte" "$run/log.txt"
+            rlAssertGrep "effective hardware: variant #1: disk.size: == 11 gigabyte" "$run/log.txt"
+            rlAssertGrep "memory: set to '2049 megabyte' because of 'memory: == 2049 megabyte'" "$run/log.txt"
+            rlAssertGrep "disk\\[0\\].size: set to '11 gigabyte' because of 'disk.size: == 11 gigabyte'" "$run/log.txt"
+            rlAssertGrep "final domain memory: 2049000" "$run/log.txt"
+            rlAssertGrep "final domain disk size: 11" "$run/log.txt"
         fi
     rlPhaseEnd
 


### PR DESCRIPTION
TL;DR: `virtual` switches to HW requirements, gets support for `memory` and `disk.size`, and its own options know how to play along.

Testcloud-backed `virtual` plugin has its own options for HW tweaks of provisioned VMs. The patch tries to make them play nicely with HW requirements:

* HW requirements become the primary source for memory and disk size;
* plugin keys/options still exist, and if specified, they override plans' `hardware` key - warnings are shown in such case.