### PR TITLE
Add a new `cpu` property `stepping` to hardware

### DIFF
--- a/spec/hardware/cpu.fmf
+++ b/spec/hardware/cpu.fmf
@@ -16,14 +16,14 @@ example:
         # The total number of logical CPUs.
         processors: 8
 
-        # CPU model name. Usually reported as such by /proc/cpuinfo or lscpu.
-        model-name: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
-        # CPU model number.
-        model: 142
         # CPU family name.
         family-name: Comet Lake
         # CPU family number.
         family: 6
+        # CPU model name. Usually reported as such by /proc/cpuinfo or lscpu.
+        model-name: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+        # CPU model number.
+        model: 142
         # CPU stepping.
         stepping: 10
 

--- a/spec/hardware/cpu.fmf
+++ b/spec/hardware/cpu.fmf
@@ -24,6 +24,8 @@ example:
         family-name: Comet Lake
         # CPU family number.
         family: 6
+        # CPU stepping.
+        stepping: 10
 
         # CPU flag(s) as reported with /proc/cpuinfo
         # Field applies an implicit "and" to listed flags

--- a/tmt/schemas/provision/hardware.yaml
+++ b/tmt/schemas/provision/hardware.yaml
@@ -82,6 +82,10 @@ definitions:
           - type: integer
       model-name:
         type: string
+      stepping:
+        anyOf:
+          - type: string
+          - type: integer
       flag:
         type: array
         items:


### PR DESCRIPTION
This PR adds a new cpu property: stepping.
It also updates cpu properties order in the documentation to align
with widely used notation for cpus: family-model-stepping, ex 6-142-10
