### PR TITLE
Add `--update-missing` to update phase fields only when not set by fmf

### DIFF
--- a/tests/core/phases/data/plans.fmf
+++ b/tests/core/phases/data/plans.fmf
@@ -16,6 +16,7 @@ execute:
 /with-multiple-reports:
   report:
     - how: html
+      display-guest: always
     - how: html
 
 /with-order:


### PR DESCRIPTION
Similar to `--update`, `--update-missing-only` sets phase fields via the command line. Unlike `--update`, values are modified only when fmf did not set them.