### PR TITLE
Create a production copr build for each release

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -101,6 +101,25 @@ jobs:
           # builds older than the final release
           - bash -c "hatch version | sed -E 's/\\.[0-9]+\\.dev/.dev/'"
 
+  # Release to copr
+  - job: copr_build
+    trigger: release
+    targets:
+      - fedora-all
+      - epel-9
+    enable_net: False
+    list_on_homepage: True
+    preserve_project: True
+    owner: psss
+    project: tmt
+    actions:
+        create-archive:
+          - hatch run docs:man
+          - hatch build -t sdist
+          - bash -c "ls dist/tmt-*.tar.gz"
+        get-current-version:
+          - hatch version
+
   # Fedora releases
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
Currently only development builds are created in copr. Let's create there a production build upon new releases as well.