### PR TITLE
Ensure the imported plan's `enabled` key is respected

### DIFF
--- a/spec/plans/import.fmf
+++ b/spec/plans/import.fmf
@@ -30,9 +30,15 @@ description: |
     Plan steps must not be defined in the remote plan reference.
     Inheriting or overriding remote plan config with local plan
     steps might be possible in the future but currently is not
-    supported. The only way how to modify imported plan is via
-    environment variables. Variables defined in the plan override
-    any variables defined in the remote plan.
+    supported. The imported plan can be modified in only two ways.
+    First way is via environment variables. Variables defined
+    in the plan override any variables defined in the remote plan.
+
+    The imported plan can also be altered using the ``enabled`` key.
+    If the local plan is enabled, it will follow the status of the
+    remote plan – whether it's enabled or disabled. If the local
+    plan is disabled, the remote plan will also be disabled.
+    Adjust rules are respected during this process.
 
     .. versionadded:: 1.19
 

--- a/tests/plan/import/basic.sh
+++ b/tests/plan/import/basic.sh
@@ -9,7 +9,7 @@ rlJournalStart
     rlPhaseStartTest "Explore Plans"
         rlRun -s "tmt plan"
         rlAssertNotGrep "warn" $rlRun_LOG
-        rlAssertGrep "Found 6 plans" $rlRun_LOG
+        rlAssertGrep "Found 9 plans" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Show Plans (deep)"
@@ -17,7 +17,7 @@ rlJournalStart
         rlAssertGrep "/plans/minimal" $rlRun_LOG
         rlAssertNotGrep "summary Just url and name" $rlRun_LOG
         rlAssertGrep "summary Metadata used by tmt itself are valid" $rlRun_LOG
-        rlAssertNotGrep "import" $rlRun_LOG
+        rlAssertNotGrep "\<import\>" $rlRun_LOG
         rlAssertNotGrep "ref 1.16.0" $rlRun_LOG
         rlAssertNotGrep "warn" $rlRun_LOG
     rlPhaseEnd
@@ -27,7 +27,7 @@ rlJournalStart
         rlAssertGrep "/plans/minimal" $rlRun_LOG
         rlAssertGrep "summary Just url and name" $rlRun_LOG
         rlAssertNotGrep "summary Metadata used by tmt itself are valid" $rlRun_LOG
-        rlAssertNotGrep "import" $rlRun_LOG
+        rlAssertNotGrep "\<import\>" $rlRun_LOG
         rlAssertNotGrep "ref 1.16.0" $rlRun_LOG
         rlAssertNotGrep "warn" $rlRun_LOG
     rlPhaseEnd
@@ -37,7 +37,7 @@ rlJournalStart
         rlAssertGrep "/plans/minimal" $rlRun_LOG
         rlAssertNotGrep "summary Just url and name" $rlRun_LOG
         rlAssertGrep "summary Metadata used by tmt itself are valid" $rlRun_LOG
-        rlAssertGrep "import" $rlRun_LOG
+        rlAssertGrep "\<import\>" $rlRun_LOG
         rlAssertGrep "url https://github.com/teemtee/tmt" $rlRun_LOG
         rlAssertGrep "path /tests/run/worktree/data/prepare" $rlRun_LOG
         rlAssertGrep "name /plan" $rlRun_LOG
@@ -50,7 +50,7 @@ rlJournalStart
         rlAssertGrep "/plans/minimal" $rlRun_LOG
         rlAssertGrep "summary Just url and name" $rlRun_LOG
         rlAssertNotGrep "summary Metadata used by tmt itself are valid" $rlRun_LOG
-        rlAssertGrep "import" $rlRun_LOG
+        rlAssertGrep "\<import\>" $rlRun_LOG
         rlAssertGrep "url https://github.com/teemtee/tmt" $rlRun_LOG
         rlAssertGrep "path /tests/run/worktree/data/prepare" $rlRun_LOG
         rlAssertGrep "name /plan" $rlRun_LOG
@@ -58,17 +58,38 @@ rlJournalStart
         rlAssertNotGrep "warn" $rlRun_LOG
     rlPhaseEnd
 
+    rlPhaseStartTest "Show only enabled plans"
+        rlRun -s "tmt plan show --enabled"
+        rlAssertGrep "/plans/imported/enabled" $rlRun_LOG
+        rlAssertGrep "enabled true" $rlRun_LOG
+        rlAssertNotGrep "/plans/imported/disabled" $rlRun_LOG
+        rlAssertNotGrep "/plans/disabled" $rlRun_LOG
+        rlAssertNotGrep "enabled false" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Show only disabled plans"
+        rlRun -s "tmt plan show --disabled"
+        rlAssertGrep "/plans/imported/disabled" $rlRun_LOG
+        rlAssertGrep "/plans/disabled" $rlRun_LOG
+        rlAssertGrep "enabled false" $rlRun_LOG
+        rlAssertNotGrep "/plans/imported/enabled" $rlRun_LOG
+        rlAssertNotGrep "enabled true" $rlRun_LOG
+    rlPhaseEnd
+
     rlPhaseStartTest "Discover Tests"
         # Exclude /plans/dynamic-ref as dynamic ref cannot be evaluated in dry mode
-        rlRun -s "tmt run discover -v plan -n '/plans/[^d]'"
+        rlRun -s "tmt run --remove discover -v plan -n '/plans/(?!dynamic-ref)'"
         rlAssertGrep "/plans/full/fmf" $rlRun_LOG
-        rlAssertGrep "/plans/full/tmt" $rlRun_LOG
         rlAssertGrep "/tests/basic/ls" $rlRun_LOG
         rlAssertGrep "/tests/basic/show" $rlRun_LOG
         rlAssertGrep "/plans/minimal" $rlRun_LOG
         rlAssertGrep "/lint/tests" $rlRun_LOG
         rlAssertGrep "/lint/plans" $rlRun_LOG
         rlAssertNotGrep "/default/plan" $rlRun_LOG
+        # Disabled plans should not be discovered
+        rlAssertNotGrep "/plans/full/tmt" $rlRun_LOG
+        rlAssertNotGrep "/plans/disabled" $rlRun_LOG
+        rlAssertNotGrep "/plans/imported/disabled" $rlRun_LOG
         # logging import plan details in verbose mode
         rlAssertGrep "import url: https://github.com/teemtee/tmt" $rlRun_LOG
         rlAssertGrep "import ref: 1.16.0" $rlRun_LOG
@@ -77,7 +98,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Discover dynamic-ref plan in detail"
-        rlRun -s "tmt -c branch=fedora run -dddvvv discover plan -n dynamic-ref"
+        rlRun -s "tmt -c branch=fedora run -dddvvv --remove discover plan -n dynamic-ref"
         rlAssertGrep "Dynamic 'ref' definition file.*detected" $rlRun_LOG -E
         rlAssertGrep "Run command: git checkout fedora" $rlRun_LOG
         rlAssertGrep "Found 1 plan" $rlRun_LOG
@@ -95,11 +116,27 @@ rlJournalStart
         rlAssertGrep "enabled true" $rlRun_LOG
     rlPhaseEnd
 
+    rlPhaseStartTest "Make sure local plan can disable imported plan"
+        rlRun -s "tmt run --remove discover -v plan -n '/plans/disabled'" 2 "Expect error"
+        rlAssertNotGrep "/plans/disabled" $rlRun_LOG
+    rlPhaseEnd
+
     rlPhaseStartTest "Run Tests"
-        rlRun -s "tmt run --verbose --dry plan --name /plans/minimal" 0 "Run tests (dry mode)"
-        rlRun -s "tmt run --verbose       plan --name /plans/minimal" 0 "Run tests"
+        rlRun -s "tmt run -v --remove --dry plan --name /plans/minimal" 0 "Run tests (dry mode)"
+        rlRun -s "tmt run -v --remove       plan --name /plans/minimal" 0 "Run tests"
         rlAssertGrep "pass /lint/plans" $rlRun_LOG
         rlAssertGrep "pass /lint/tests" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Disabled plans should not be executed"
+        rlRun -s "tmt run -v --remove plan --name /plans/full/tmt" 2 "Expect error"
+        rlRun -s "tmt run -v --remove plan --name /plans/disabled" 2 "Expect error"
+        rlRun -s "tmt run -v --remove plan --name /plans/imported/disabled" 2 "Expect error"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Imported plan's adjust should be respected"
+        rlRun -s "tmt run --remove --dry plan --name /plans/full/tmt" 2 "Expect error (dry mode)"
+        rlRun -s "tmt -c how=full run -r --dry plan -n /plans/full/tmt" 0 "Run plan (dry mode)"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/plan/import/data/plans.fmf
+++ b/tests/plan/import/data/plans.fmf
@@ -45,3 +45,27 @@
             ref: "@tests/discover/data/dynamic-ref.fmf"
             path: /tests/discover/data
             name: /plans/smoke
+
+/imported/enabled:
+    summary: Imported plan should be enabled by default
+    plan:
+        import:
+            url: https://github.com/teemtee/tmt
+            name: /plans/sanity/lint
+    enabled: true
+
+/imported/disabled:
+    summary: Imported plan should be disabled by default
+    plan:
+        import:
+            url: https://github.com/teemtee/tmt
+            name: /plans/provision
+    enabled: true
+
+/disabled:
+    summary: Imported plan will be disabled by local plan
+    plan:
+        import:
+            url: https://github.com/teemtee/tmt
+            name: /plans/sanity/lint
+    enabled: false

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2377,6 +2377,10 @@ class Plan(
         # action.
         node.adjust(fmf.context.Context(**self._fmf_context), case_sensitive=False)
 
+        # If the local plan is disabled, disable the imported plan as well
+        if not self.enabled:
+            node.data['enabled'] = False
+
         # Override the plan name with the local one to ensure unique names
         node.name = self.name
         # Create the plan object, save links between both plans
@@ -2947,12 +2951,12 @@ class Tree(tmt.utils.Common):
                     sources=sources),
                 ]]
 
-        plans = self._filters_conditions(
+        if not Plan._opt('shallow'):
+            plans = [plan.import_plan() or plan for plan in plans]
+
+        return self._filters_conditions(
             sorted(plans, key=lambda plan: plan.order),
             filters, conditions, links, excludes)
-        if Plan._opt('shallow'):
-            return plans
-        return [plan.import_plan() or plan for plan in plans]
 
     def stories(
             self,


### PR DESCRIPTION
Imported plan's `enabled` key is now respected by tmt. Context and adjust rules are taken into account as well. This should also work for `tmt plans show --enabled|--disabled` filters.

Fixes #2297