### PR TITLE
Extract beakerlib phase name to a failure log

### DIFF
--- a/tmt/result.py
+++ b/tmt/result.py
@@ -299,14 +299,39 @@ class Result(BaseResult):
             return ''
         filtered = ''
 
-        # Filter beakerlib style logs, reverse the log string by lines, search for each FAIL
-        # and every associated line, then reverse the picked lines back into correct order
-        for m in re.findall(
-                fr'(^.*\[\s*{msg_type}\s*\][\S\s]*?)(?:^::\s+\[[0-9: ]+|:{{80}})',
-                '\n'.join(log.split('\n')[::-1]), re.MULTILINE):
-            filtered += m.strip() + '\n'
-        if filtered:
-            return '\n'.join(filtered.strip().split('\n')[::-1])
+        # Filter beakerlib style logs in the following way:
+        # 1. Reverse the log string by lines
+        # 2. Search for each FAIL and extract every associated line.
+        # 3. For failed phases also extract phase name so the log is easier to understand
+        # 4. Reverse extracted lines back into correct order.
+        if re.search(':: \\[   FAIL   \\] ::', log):  # dumb check for a beakerlib log
+            copy_line = False
+            copy_phase_name = False
+            failure_log = []
+            # we will be processing log lines in a reversed order
+            iterator = iter(reversed(log.split("\n")))
+            for line in iterator:
+                # found FAIL enables log extraction
+                if re.search(':: \\[   FAIL   \\] ::', line):
+                    copy_line = True
+                    copy_phase_name = True
+                # BEGIN of rlRun block or previous command or beginning of a test section
+                # disables extraction
+                elif re.search('(:: \\[.{10}\\] ::|[:]{80})', line):
+                    copy_line = False
+                # extract line from the log
+                if copy_line:
+                    failure_log.append(line)
+                # Add beakerlib phase name to a failure log, in order to properly match the phase
+                # name we need to do this in two steps.
+                if copy_phase_name and re.search('[:]{80}', line):
+                    # read the next line containing phase name
+                    line = next(iterator)
+                    failure_log.append(f'\n{line}')
+                    copy_phase_name = False
+            # reverse extracted lines to restore previous order
+            failure_log.reverse()
+            return '\n'.join(failure_log).strip()
 
         # Check for other failures and errors when not using beakerlib
         for m in re.findall(


### PR DESCRIPTION
When there are failures across multiple test phases it is difficult to pair single failure to the respective test phase. This change adds phase names to a failure log so it is easier to read.