### PR TITLE
Adds nice & colorfull help to "make" targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,67 +1,95 @@
+#
+# Notes WRT help: a comment introduced by "##"...
+#   - ... after a target specification will server as its help,
+#   - ... at the beginning of line will serve as a target group separator.
+#
+
 # Prepare variables
 TMP = $(CURDIR)/tmp
 
 # Define special targets
-all: docs packages
+.DEFAULT_GOAL := help
 .PHONY: docs
+
+all: docs packages  ## Generate docs and packages
 
 # Temporary directory, include .fmf to prevent exploring tests there
 tmp:
 	mkdir -p $(TMP)/.fmf
 
-# Run the test suite, optionally with coverage
-test: tmp
+##
+## Run the tests
+##
+test: tmp  ## Run the test suite
 	hatch run test:unit
-smoke: tmp
+
+smoke: tmp  ## Run the smoke-level part of the test suite
 	hatch run test:smoke
-coverage: tmp nitrateconf
+
+coverage: tmp nitrateconf  ## Run the test suite with coverage enabled
 	hatch run test:coverage
+
 nitrateconf:
 	test -e ~/.nitrate || echo -en '[nitrate]\nurl = https://nitrate.server/xmlrpc/\n' | tee ~/.nitrate
 
-# Regenerate test data for integration tests
 # remove selected/all response files in tests/integration/test_data directory
-requre:
+requre:  ## Regenerate test data for integration tests
 	hatch run test:requre
 
-# Build documentation, prepare man page
-docs: clean
+##
+## Documentation
+##
+docs: clean  ## Build documentation
 	hatch run docs:html
-man:
+
+man:  ## Build man page
 	hatch run docs:man
 
-# Packaging and Packit
+##
+## Packaging & Packit
+##
 build: clean man
 	hatch build
 tarball: clean tmp build
 	mkdir -p $(TMP)/SOURCES
 	cp dist/tmt-*.tar.gz $(TMP)/SOURCES
-rpm: tarball ver2spec
+
+rpm: tarball ver2spec  ## Build RPMs
 	# If the build system is missing the required dependencies, use nosrc.rpm to install them
 	rpmbuild --define '_topdir $(TMP)' -bb tmt.spec || echo 'Hint: run `make deps` to install build dependencies'
-srpm: tarball ver2spec
+
+srpm: tarball ver2spec  ## Build SRPM
 	rpmbuild --define '_topdir $(TMP)' -bs tmt.spec
+
 deps: tarball ver2spec
 	rpmbuild --define '_topdir $(TMP)' -br tmt.spec || sudo dnf builddep $(TMP)/SRPMS/tmt-*buildreqs.nosrc.rpm
-packages: rpm srpm
-version:
+
+packages: rpm srpm  ## Build RPM and SRPM packages
+
+version:  ## Build tmt version for packaging purposes
 	hatch version
+
 ver2spec:
 	$(shell sed -E "s/^(Version:[[:space:]]*).*/\1$$(hatch version)/" -i tmt.spec)
 
-# Containers
-images:
+##
+## Containers
+##
+images:  ## Build tmt images for podman/docker
 	podman build -t tmt --squash -f ./containers/Containerfile.mini .
 	podman build -t tmt-all --squash -f ./containers/Containerfile.full .
 
-# Development
-develop:
+##
+## Development
+##
+develop:  ## Install development requirements
 	sudo dnf --setopt=install_weak_deps=False install hatch gcc make git rpm-build python3-nitrate {python3,libvirt,krb5,libpq}-devel jq podman
 
 # Git vim tags and cleanup
 tags:
 	find tmt -name '*.py' | xargs ctags --python-kinds=-i
-clean:
+
+clean:  ## Remove all temporary files, packaging artifacts and docs
 	rm -rf $(TMP) build dist tmt.1
 	rm -rf .cache .mypy_cache .ruff_cache
 	rm -rf docs/{_build,stories,spec}
@@ -72,3 +100,15 @@ clean:
 	rm -f .coverage tags
 	rm -rf examples/convert/{main.fmf,test.md,Manual} Manual
 	rm -f tests/full/repo_copy.tgz
+
+##
+## Help!
+##
+help:: ## Show this help text
+	@gawk -vG=$$(tput setaf 2) -vR=$$(tput sgr0) ' \
+	  match($$0, "^(([^#:]*[^ :]) *:)?([^#]*)##([^#].+|)$$",a) { \
+	    if (a[2] != "") { printf "    make %s%-18s%s %s\n", G, a[2], R, a[4]; next }\
+	    if (a[3] == "") { print a[4]; next }\
+	    printf "\n%-36s %s\n","",a[4]\
+	  }' $(MAKEFILE_LIST)
+	@echo "" # blank line at the end


### PR DESCRIPTION
Let's make the world a better place by adding nice help to our make
targets :)

```
$ make
    make all                 Generate docs and packages

 Run the tests

    make test                Run the test suite
    make smoke               Run the smoke-level part of the test suite
    make coverage            Run the test suite with coverage enabled
    make requre              Regenerate test data for integration tests
```

Plus, patch also changes the default target to be `help` - before
running things that can have plenty of effects, I for one tend to find
out what targets do, hence `make` showing the help & giving me time to
think first, act later feels more useful.