### PR TITLE
Fix creation of guest data from plugin options

### DIFF
--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -11,7 +11,13 @@ import tmt.options
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
-from tmt.utils import ProvisionError, cached_property, field, retry_session, updatable_message
+from tmt.utils import (
+    ProvisionError,
+    cached_property,
+    field,
+    retry_session,
+    updatable_message,
+    )
 
 # List of Artemis API versions supported and understood by this plugin.
 # Since API gains support for new features over time, it is important to
@@ -645,28 +651,8 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
         except ValueError:
             raise ProvisionError('Cannot parse user-data.')
 
-        data = ArtemisGuestData(
-            api_url=self.get('api-url'),
-            api_version=api_version,
-            arch=self.get('arch'),
-            image=self.get('image'),
-            hardware=self.get('hardware'),
-            kickstart=self.get('kickstart'),
-            log_type=self.get('log_type'),
-            pool=self.get('pool'),
-            priority_group=self.get('priority-group'),
-            keyname=self.get('keyname'),
-            user_data=user_data,
-            user=self.get('user'),
-            provision_timeout=self.get('provision-timeout'),
-            provision_tick=self.get('provision-tick'),
-            api_timeout=self.get('api-timeout'),
-            api_retries=self.get('api-retries'),
-            api_retry_backoff_factor=self.get('api-retry-backoff-factor'),
-            watchdog_dispatch_delay=self.get('watchdog-dispatch-delay'),
-            watchdog_period_delay=self.get('watchdog-period-delay'),
-            ssh_option=self.get('ssh-option')
-            )
+        data = ArtemisGuestData.from_plugin(self)
+        data.user_data = user_data
 
         data.show(verbose=self.verbosity_level, logger=self._logger)
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -157,10 +157,8 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
         super().go()
 
         # Create a GuestLocal instance
-        data = tmt.steps.provision.GuestData(
-            guest='localhost',
-            role=self.get('role')
-            )
+        data = tmt.steps.provision.GuestData.from_plugin(self)
+        data.guest = 'localhost'
 
         data.show(verbose=self.verbosity_level, logger=self._logger)
 

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -696,14 +696,7 @@ class ProvisionBeaker(tmt.steps.provision.ProvisionPlugin):
 
         super().go()
 
-        data = BeakerGuestData(
-            arch=self.get('arch'),
-            image=self.get('image'),
-            hardware=self.get('hardware'),
-            user=self.get('user'),
-            provision_timeout=self.get('provision-timeout'),
-            provision_tick=self.get('provision-tick'),
-            )
+        data = BeakerGuestData.from_plugin(self)
 
         data.show(verbose=self.verbosity_level, logger=self._logger)
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -331,14 +331,7 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
         super().go()
 
         # Prepare data for the guest instance
-        data_from_options = {
-            key: self.get(key)
-            # SIM118: Use `{key} in {dict}` instead of `{key} in {dict}.keys()`.
-            # "Type[PodmanGuestData]" has no attribute "__iter__" (not iterable)
-            for key in PodmanGuestData.keys()  # noqa: SIM118
-            }
-
-        data = PodmanGuestData(**data_from_options)
+        data = PodmanGuestData.from_plugin(self)
 
         data.show(verbose=self.verbosity_level, logger=self._logger)
 

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -647,12 +647,7 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
             raise SystemExit(0)
 
         # Give info about provided data
-        data = TestcloudGuestData(**{
-            key: self.get(key)
-            # SIM118: Use `{key} in {dict}` instead of `{key} in {dict}.keys()`.
-            # "Type[TestcloudGuestData]" has no attribute "__iter__" (not iterable)
-            for key in TestcloudGuestData.keys()  # noqa: SIM118
-            })
+        data = TestcloudGuestData.from_plugin(self)
 
         # Once plan schema is enforced this won't be necessary
         # click enforces int for cmdline and schema validation


### PR DESCRIPTION
This was often done by plenty of `self.get(...)` calls, some plugins did iterate over container keys, but there were gaps:

* `self.get()` accepts options, `keys()` yield key names, that's `-` vs `_` conflict,
* one can easily forget to add `get()` call for a newly added or inherited field,
* iteration is the way to go, but we can have a helper for that, no need for plugins to copy & paste the dict comprehension.

Fixes https://github.com/teemtee/tmt/issues/2352