### PR TITLE
Move the copr repository to the `teemtee` group

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,11 +20,8 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-        fedora-all: {}
-        epel-9: {}
-        fedora-39:
-            additional_repos:
-              - https://download.copr.fedorainfracloud.org/results/frantisekz/testcloud-wip/fedora-39-x86_64/
+      - fedora-all
+      - epel-9
     enable_net: False
     actions:
         create-archive:
@@ -88,7 +85,7 @@ jobs:
     enable_net: False
     list_on_homepage: True
     preserve_project: True
-    owner: psss
+    owner: "@teemtee"
     project: tmt
     release_suffix: "{PACKIT_PROJECT_BRANCH}"
     actions:
@@ -110,7 +107,7 @@ jobs:
     enable_net: False
     list_on_homepage: True
     preserve_project: True
-    owner: psss
+    owner: "@teemtee"
     project: tmt
     actions:
         create-archive:

--- a/README.rst
+++ b/README.rst
@@ -254,7 +254,7 @@ Then you can install either everything or only those you need::
 Impatient to try the fresh features as soon as possible? Install
 the latest greatest version from the ``copr`` repository::
 
-    sudo dnf copr enable psss/tmt
+    sudo dnf copr enable @teemtee/tmt
     sudo dnf install tmt
 
 Not sure, just want to try out how it works? Experiment safely and
@@ -551,7 +551,7 @@ Releases:
 https://github.com/teemtee/tmt/releases
 
 Copr:
-http://copr.fedoraproject.org/coprs/psss/tmt
+https://copr.fedorainfracloud.org/coprs/g/teemtee/tmt/
 
 PIP:
 https://pypi.org/project/tmt/


### PR DESCRIPTION
Also remove the temporary workaround for a fresh `testcloud`.