### PR TITLE
Make `BasePlugin` generic over step data class

### DIFF
--- a/tests/unit/test_report_junit.py
+++ b/tests/unit/test_report_junit.py
@@ -22,17 +22,11 @@ def report_fix(tmppath: Path, root_logger):
 
     out_file_path = str(tmppath / "out.xml")
 
-    def get(key, default=None):
-        if key == "file":
-            return out_file_path
-        return default
-
     report = ReportJUnit(
         logger=root_logger,
         step=step_mock,
-        data=ReportJUnitData(name='x', how='junit'),
+        data=ReportJUnitData(name='x', how='junit', file=out_file_path),
         workdir=tmppath / 'junit')
-    report.get = get
     report.info = MagicMock()
 
     results = []

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1967,7 +1967,7 @@ class Plan(
     def _lint_step_methods(
             self,
             step: str,
-            plugin_class: Type[tmt.steps.BasePlugin]) -> LinterReturn:
+            plugin_class: tmt.steps.PluginClass) -> LinterReturn:
         """ P003: execute step methods must be known """
 
         phases = self._step_phase_nodes(step)

--- a/tmt/checks/__init__.py
+++ b/tmt/checks/__init__.py
@@ -16,7 +16,7 @@ from tmt.utils import (
 
 if TYPE_CHECKING:
     from tmt.result import CheckResult
-    from tmt.steps.execute import ExecutePlugin
+    from tmt.steps.execute import ExecutePlugin, ExecuteStepDataT
 
 
 CheckPluginClass = Type['CheckPlugin']
@@ -120,7 +120,7 @@ class Check(
             event: CheckEvent,
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
-            plugin: 'tmt.steps.execute.ExecutePlugin',
+            plugin: 'ExecutePlugin[ExecuteStepDataT]',
             environment: Optional[tmt.utils.EnvironmentType] = None,
             logger: tmt.log.Logger) -> List['CheckResult']:
         """
@@ -185,7 +185,7 @@ class CheckPlugin(tmt.utils._CommonBase):
             cls,
             *,
             check: Check,
-            plugin: 'ExecutePlugin',
+            plugin: 'ExecutePlugin[ExecuteStepDataT]',
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,
@@ -197,7 +197,7 @@ class CheckPlugin(tmt.utils._CommonBase):
             cls,
             *,
             check: Check,
-            plugin: 'ExecutePlugin',
+            plugin: 'ExecutePlugin[ExecuteStepDataT]',
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -11,6 +11,7 @@ from tmt.utils import CommandOutput, Path, ShellScript, render_run_exception_str
 
 if TYPE_CHECKING:
     from tmt.base import Test
+    from tmt.steps.execute import ExecutePlugin, ExecuteStepDataT
 
 TEST_POST_AVC_FILENAME = 'tmt-avc-{event}.txt'
 
@@ -20,7 +21,7 @@ class AvcDenials(CheckPlugin):
     @classmethod
     def _save_report(
             cls,
-            plugin: tmt.steps.execute.ExecutePlugin,
+            plugin: 'ExecutePlugin[ExecuteStepDataT]',
             guest: tmt.steps.provision.Guest,
             test: 'Test',
             event: CheckEvent,
@@ -172,7 +173,7 @@ ausearch -i --input-logs -m AVC -m USER_AVC -m SELINUX_ERR -ts $AVC_SINCE
             cls,
             *,
             check: 'Check',
-            plugin: tmt.steps.execute.ExecutePlugin,
+            plugin: 'ExecutePlugin[ExecuteStepDataT]',
             guest: tmt.steps.provision.Guest,
             test: 'Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import tmt.log
 import tmt.steps.execute
@@ -8,6 +8,9 @@ import tmt.utils
 from tmt.checks import Check, CheckEvent, CheckPlugin, provides_check
 from tmt.result import CheckResult, ResultOutcome
 from tmt.utils import Path, render_run_exception_streams
+
+if TYPE_CHECKING:
+    from tmt.steps.execute import ExecutePlugin, ExecuteStepDataT
 
 TEST_POST_DMESG_FILENAME = 'tmt-dmesg-{event}.txt'
 
@@ -40,7 +43,7 @@ class DmesgCheck(CheckPlugin):
     @classmethod
     def _save_dmesg(
             cls,
-            plugin: tmt.steps.execute.ExecutePlugin,
+            plugin: 'ExecutePlugin[ExecuteStepDataT]',
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
             event: CheckEvent,
@@ -81,7 +84,7 @@ class DmesgCheck(CheckPlugin):
             cls,
             *,
             check: 'Check',
-            plugin: tmt.steps.execute.ExecutePlugin,
+            plugin: 'ExecutePlugin[ExecuteStepDataT]',
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,
@@ -95,7 +98,7 @@ class DmesgCheck(CheckPlugin):
             cls,
             *,
             check: 'Check',
-            plugin: tmt.steps.execute.ExecutePlugin,
+            plugin: 'ExecutePlugin[ExecuteStepDataT]',
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,

--- a/tmt/frameworks/__init__.py
+++ b/tmt/frameworks/__init__.py
@@ -7,7 +7,7 @@ import tmt.utils
 
 if TYPE_CHECKING:
     from tmt.base import Test
-    from tmt.steps.execute import ExecutePlugin
+    from tmt.steps.execute import ExecutePlugin, ExecuteStepDataT
     from tmt.steps.provision import Guest
 
 
@@ -47,7 +47,7 @@ class TestFramework:
     @classmethod
     def get_environment_variables(
             cls,
-            parent: 'ExecutePlugin',
+            parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
             logger: tmt.log.Logger) -> tmt.utils.EnvironmentType:
@@ -68,7 +68,7 @@ class TestFramework:
     @classmethod
     def get_test_command(
             cls,
-            parent: 'ExecutePlugin',
+            parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
             logger: tmt.log.Logger) -> tmt.utils.ShellScript:
@@ -89,7 +89,7 @@ class TestFramework:
     @classmethod
     def get_pull_options(
             cls,
-            parent: 'ExecutePlugin',
+            parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
             logger: tmt.log.Logger) -> List[str]:
@@ -109,7 +109,7 @@ class TestFramework:
     @classmethod
     def extract_results(
             cls,
-            parent: 'ExecutePlugin',
+            parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
             logger: tmt.log.Logger) -> List[tmt.result.Result]:

--- a/tmt/frameworks/beakerlib.py
+++ b/tmt/frameworks/beakerlib.py
@@ -12,7 +12,7 @@ from tmt.utils import Path
 
 if TYPE_CHECKING:
     from tmt.base import Test
-    from tmt.steps.execute import ExecutePlugin
+    from tmt.steps.execute import ExecutePlugin, ExecuteStepDataT
     from tmt.steps.provision import Guest
 
 
@@ -21,7 +21,7 @@ class Beakerlib(TestFramework):
     @classmethod
     def get_environment_variables(
             cls,
-            parent: 'ExecutePlugin',
+            parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
             logger: tmt.log.Logger) -> tmt.utils.EnvironmentType:
@@ -34,7 +34,7 @@ class Beakerlib(TestFramework):
     @classmethod
     def get_pull_options(
             cls,
-            parent: 'ExecutePlugin',
+            parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
             logger: tmt.log.Logger) -> List[str]:
@@ -46,7 +46,7 @@ class Beakerlib(TestFramework):
     @classmethod
     def extract_results(
             cls,
-            parent: 'ExecutePlugin',
+            parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
             logger: tmt.log.Logger) -> List[tmt.result.Result]:

--- a/tmt/frameworks/shell.py
+++ b/tmt/frameworks/shell.py
@@ -10,7 +10,7 @@ from tmt.result import ResultOutcome
 
 if TYPE_CHECKING:
     from tmt.base import Test
-    from tmt.steps.execute import ExecutePlugin
+    from tmt.steps.execute import ExecutePlugin, ExecuteStepDataT
     from tmt.steps.provision import Guest
 
 
@@ -19,7 +19,7 @@ class Shell(TestFramework):
     @classmethod
     def get_test_command(
             cls,
-            parent: 'ExecutePlugin',
+            parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
             logger: tmt.log.Logger) -> tmt.utils.ShellScript:
@@ -30,7 +30,7 @@ class Shell(TestFramework):
     @classmethod
     def extract_results(
             cls,
-            parent: 'ExecutePlugin',
+            parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
             logger: tmt.log.Logger) -> List[tmt.result.Result]:

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -166,7 +166,7 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
 
 
 @tmt.steps.provides_method('fmf')
-class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
+class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
     """
     Discover available tests from fmf metadata
 

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -197,7 +197,7 @@ class DiscoverShellData(tmt.steps.discover.DiscoverStepData):
 
 
 @tmt.steps.provides_method('shell')
-class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
+class DiscoverShell(tmt.steps.discover.DiscoverPlugin[DiscoverShellData]):
     """
     Use provided list of shell script tests
 
@@ -310,8 +310,7 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
         dist_git_source = self.get('dist-git-source', False)
 
         # Check and process each defined shell test
-        # FIXME: cast() - https://github.com/teemtee/tmt/issues/1540
-        for data in cast(DiscoverShellData, self.data).tests:
+        for data in self.data.tests:
             # Create data copy (we want to keep original data for save()
             data = copy.deepcopy(data)
             # Extract name, make sure it is present

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -169,7 +169,7 @@ class ExecuteInternalData(tmt.steps.execute.ExecuteStepData):
 
 
 @tmt.steps.provides_method('tmt')
-class ExecuteInternal(tmt.steps.execute.ExecutePlugin):
+class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
     """
     Use the internal tmt executor to execute tests
 

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -11,7 +11,7 @@ import tmt.steps.discover.fmf
 import tmt.steps.execute
 import tmt.steps.provision
 import tmt.utils
-from tmt.steps.discover import DiscoverPlugin
+from tmt.steps.discover import Discover, DiscoverPlugin, DiscoverStepData
 from tmt.steps.discover.fmf import DiscoverFmf, DiscoverFmfStepData, normalize_ref
 from tmt.steps.execute import ExecutePlugin
 from tmt.steps.execute.internal import ExecuteInternal, ExecuteInternalData
@@ -146,7 +146,7 @@ class ExecuteUpgrade(ExecuteInternal):
 
     @property  # type:ignore[override]
     def discover(self) -> Union[
-            'tmt.steps.discover.Discover',
+            Discover,
             DiscoverFmf]:
         """ Return discover plugin instance """
         # If we are in the second phase (upgrade), take tests from our fake
@@ -156,7 +156,7 @@ class ExecuteUpgrade(ExecuteInternal):
         return self.step.plan.discover
 
     @discover.setter
-    def discover(self, plugin: Optional['tmt.steps.discover.DiscoverPlugin']) -> None:
+    def discover(self, plugin: Optional[DiscoverPlugin[DiscoverStepData]]) -> None:
         self._discover = plugin
 
     def go(

--- a/tmt/steps/finish/ansible.py
+++ b/tmt/steps/finish/ansible.py
@@ -5,7 +5,8 @@ from tmt.steps.prepare.ansible import PrepareAnsible
 
 
 @tmt.steps.provides_method('ansible')
-class FinishAnsible(tmt.steps.finish.FinishPlugin, PrepareAnsible):
+class FinishAnsible(
+        tmt.steps.finish.FinishPlugin[tmt.steps.finish.FinishStepData], PrepareAnsible):
     """
     Perform finishing tasks using ansible
 
@@ -31,8 +32,7 @@ class FinishAnsible(tmt.steps.finish.FinishPlugin, PrepareAnsible):
 
     # We are re-using "prepare" step for "finish",
     # and they both have different expectations
-    # FIXME: ignore[assignment]: https://github.com/teemtee/tmt/issues/1540
-    _data_class = tmt.steps.prepare.ansible.PrepareAnsibleData  # type: ignore[assignment]
+    _data_class = tmt.steps.prepare.ansible.PrepareAnsibleData
 
     # FIXME: ignore[assignment]: https://github.com/teemtee/tmt/issues/1540
     # Also, assigning class methods seems to cause trouble to mypy

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -35,7 +35,7 @@ class FinishShellData(tmt.steps.finish.FinishStepData):
 
 
 @tmt.steps.provides_method('shell')
-class FinishShell(tmt.steps.finish.FinishPlugin):
+class FinishShell(tmt.steps.finish.FinishPlugin[FinishShellData]):
     """
     Perform finishing tasks using shell (bash) scripts
 

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -57,7 +57,7 @@ class PrepareAnsibleData(tmt.steps.prepare.PrepareStepData):
 
 
 @tmt.steps.provides_method('ansible')
-class PrepareAnsible(tmt.steps.prepare.PreparePlugin):
+class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
     """
     Prepare guest using ansible
 

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -46,7 +46,7 @@ class InstallBase(tmt.utils.Common):
     def __init__(
             self,
             *,
-            parent: tmt.steps.prepare.PreparePlugin,
+            parent: 'PrepareInstall',
             guest: Guest,
             logger: tmt.log.Logger) -> None:
         """ Initialize installation data """
@@ -54,10 +54,6 @@ class InstallBase(tmt.utils.Common):
         self.guest = guest
 
         # Get package related data from the plugin
-        assert self.parent is not None
-        # FIXME: cast() - https://github.com/teemtee/tmt/issues/1372
-        parent = cast(tmt.steps.prepare.PreparePlugin, self.parent)
-
         self.packages = parent.get("package", [])
         self.directories = cast(List[Path], parent.get("directory", []))
         self.exclude = parent.get("exclude", [])
@@ -191,7 +187,7 @@ class InstallBase(tmt.utils.Common):
     def enable_copr(self) -> None:
         """ Enable requested copr repositories """
         # FIXME: cast() - https://github.com/teemtee/tmt/issues/1372
-        coprs = cast(tmt.steps.prepare.PreparePlugin, self.parent).get('copr')
+        coprs = cast(PrepareInstall, self.parent).get('copr')
         if not coprs:
             return
         # Try to install copr plugin
@@ -219,7 +215,7 @@ class InstallBase(tmt.utils.Common):
         """ Copy packages to the test system """
         assert self.parent is not None
         # FIXME: cast() - https://github.com/teemtee/tmt/issues/1372
-        workdir = cast(tmt.steps.prepare.PreparePlugin, self.parent).step.workdir
+        workdir = cast(PrepareInstall, self.parent).step.workdir
         if not workdir:
             raise tmt.utils.GeneralError('workdir should not be empty')
         self.rpms_directory = workdir / 'rpms'
@@ -524,7 +520,7 @@ class PrepareInstallData(tmt.steps.prepare.PrepareStepData):
 
 
 @tmt.steps.provides_method('install')
-class PrepareInstall(tmt.steps.prepare.PreparePlugin):
+class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
     """
     Install packages on the guest
 

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -35,7 +35,7 @@ class PrepareShellData(tmt.steps.prepare.PrepareStepData):
 
 
 @tmt.steps.provides_method('shell')
-class PrepareShell(tmt.steps.prepare.PreparePlugin):
+class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
     """
     Prepare guest using shell (bash) scripts
 

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -597,7 +597,7 @@ class GuestArtemis(tmt.GuestSsh):
 
 
 @tmt.steps.provides_method('artemis')
-class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin):
+class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin[ProvisionArtemisData]):
     """
     Provision guest using Artemis backend
 

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -38,7 +38,7 @@ class ProvisionConnectData(ConnectGuestData, tmt.steps.provision.ProvisionStepDa
 
 
 @tmt.steps.provides_method('connect')
-class ProvisionConnect(tmt.steps.provision.ProvisionPlugin):
+class ProvisionConnect(tmt.steps.provision.ProvisionPlugin[ProvisionConnectData]):
     """
     Connect to a provisioned guest using ssh
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -129,7 +129,7 @@ class GuestLocal(tmt.Guest):
 
 
 @tmt.steps.provides_method('local')
-class ProvisionLocal(tmt.steps.provision.ProvisionPlugin):
+class ProvisionLocal(tmt.steps.provision.ProvisionPlugin[ProvisionLocalData]):
     """
     Use local host for test execution
 

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -657,7 +657,7 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
 
 
 @tmt.steps.provides_method('beaker')
-class ProvisionBeaker(tmt.steps.provision.ProvisionPlugin):
+class ProvisionBeaker(tmt.steps.provision.ProvisionPlugin[ProvisionBeakerData]):
     """
     Provision guest on Beaker system using mrack
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -297,7 +297,7 @@ class GuestContainer(tmt.Guest):
 
 
 @tmt.steps.provides_method('container')
-class ProvisionPodman(tmt.steps.provision.ProvisionPlugin):
+class ProvisionPodman(tmt.steps.provision.ProvisionPlugin[ProvisionPodmanData]):
     """
     Create a new container using podman
 

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -582,7 +582,7 @@ class GuestTestcloud(tmt.GuestSsh):
 
 
 @tmt.steps.provides_method('virtual.testcloud')
-class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin):
+class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin[ProvisionTestcloudData]):
     """
     Local virtual machine using testcloud
 

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -28,7 +28,7 @@ class ReportDisplayData(tmt.steps.report.ReportStepData):
 
 
 @tmt.steps.provides_method('display')
-class ReportDisplay(tmt.steps.report.ReportPlugin):
+class ReportDisplay(tmt.steps.report.ReportPlugin[ReportDisplayData]):
     """
     Show test results on the terminal
 
@@ -138,10 +138,10 @@ class ReportDisplay(tmt.steps.report.ReportPlugin):
         if not self.verbosity_level:
             return
 
-        if self.get('display-guest') == 'always':
+        if self.data.display_guest == 'always':
             display_guest = True
 
-        elif self.get('display-guest') == 'never':
+        elif self.data.display_guest == 'never':
             display_guest = False
 
         else:

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -39,7 +39,7 @@ class ReportHtmlData(tmt.steps.report.ReportStepData):
 
 
 @tmt.steps.provides_method('html')
-class ReportHtml(tmt.steps.report.ReportPlugin):
+class ReportHtml(tmt.steps.report.ReportPlugin[ReportHtmlData]):
     """
     Format test results into an html report
 
@@ -63,17 +63,17 @@ class ReportHtml(tmt.steps.report.ReportPlugin):
         # Prepare the template
         environment = tmt.utils.default_template_environment()
 
-        if self.get('absolute-paths'):
+        if self.data.absolute_paths:
             environment.filters["linkable_path"] = lambda x: str(Path(x).absolute())
         else:
             # Links used in html should be relative to a workdir
             assert self.workdir is not None  # narrow type
             environment.filters["linkable_path"] = lambda x: str(Path(x).relative_to(self.workdir))
 
-        if self.get('display-guest') == 'always':
+        if self.data.display_guest == 'always':
             display_guest = True
 
-        elif self.get('display-guest') == 'never':
+        elif self.data.display_guest == 'never':
             display_guest = False
 
         else:
@@ -105,7 +105,7 @@ class ReportHtml(tmt.steps.report.ReportPlugin):
         assert self.workdir is not None
         target = self.workdir / filename
         self.info("output", target, color='yellow')
-        if not self.get('open'):
+        if not self.data.open:
             return
 
         # Open target in webbrowser

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -43,7 +43,7 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
 
 
 @tmt.steps.provides_method("reportportal")
-class ReportReportPortal(tmt.steps.report.ReportPlugin):
+class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
     """
     Report test results to a ReportPortal instance via API.
 
@@ -111,21 +111,21 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
 
         super().go()
 
-        server = self.get("url")
+        server = self.data.url
         if not server:
             raise tmt.utils.ReportError("No ReportPortal server url provided.")
         server = server.rstrip("/")
 
-        project = self.get("project")
+        project = self.data.project
         if not project:
             raise tmt.utils.ReportError("No ReportPortal project provided.")
 
-        token = self.get("token")
+        token = self.data.token
         if not token:
             raise tmt.utils.ReportError("No ReportPortal token provided.")
 
         assert self.step.plan.name is not None
-        launch_name = self.get("launch") or self.step.plan.name
+        launch_name = self.data.launch or self.step.plan.name
 
         url = f"{server}/api/{self.DEFAULT_API_VERSION}/{project}"
         headers = {
@@ -133,7 +133,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin):
             "accept": "*/*",
             "Content-Type": "application/json"}
 
-        envar_pattern = self.get("exclude-variables") or "$^"
+        envar_pattern = self.data.exclude_variables
         attributes = [
             {'key': key, 'value': value[0]}
             for key, value in self.step.plan._fmf_context.items()]

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -815,7 +815,7 @@ class _CommonBase:
         # https://github.com/python/mypy/issues/4177
         parent = mro[mro.index(__class__) + 1]  # type: ignore[name-defined]
 
-        if parent is object:
+        if parent in (object, Generic):
             super().__init__()
 
         else:


### PR DESCRIPTION
Plugin classes are now annotated with knowledhe of the exact class of their `data` attribute. This opens door to proper use of `self.data`, replacing `self.get()` for accessing step data, with correct type annotations `get()` cannot deliver.

Fixes https://github.com/teemtee/tmt/issues/1540