### PR TITLE
Display test check results in `display` report output

### DIFF
--- a/tmt/result.py
+++ b/tmt/result.py
@@ -94,6 +94,21 @@ class BaseResult(tmt.utils.SerializableContainer):
         serialize=lambda logs: [str(log) for log in logs],
         unserialize=lambda value: [Path(log) for log in value])
 
+    def show(self) -> str:
+        """ Return a nicely colored result with test name (and note) """
+
+        result = 'errr' if self.result == ResultOutcome.ERROR else self.result.value
+
+        components: List[str] = [
+            click.style(result, fg=RESULT_OUTCOME_COLORS[self.result]),
+            self.name
+            ]
+
+        if self.note:
+            components.append(f'({self.note})')
+
+        return ' '.join(components)
+
 
 @dataclasses.dataclass
 class CheckResult(BaseResult):

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -3,8 +3,15 @@ import dataclasses
 import tmt
 import tmt.steps
 import tmt.steps.report
+from tmt.result import BaseResult, CheckResult, Result
 from tmt.steps.execute import TEST_OUTPUT_FILENAME
-from tmt.utils import field
+from tmt.utils import Path, field
+
+# How much test and test check info should be shifted to the right in the output.
+# We want tests to be shifted by one extra level, with their checks shifted by
+# yet another level.
+TEST_SHIFT = 1
+CHECK_SHIFT = 2
 
 
 @dataclasses.dataclass
@@ -32,25 +39,97 @@ class ReportDisplay(tmt.steps.report.ReportPlugin):
     _data_class = ReportDisplayData
 
     def details(self, result: tmt.Result, verbosity: int, display_guest: bool) -> None:
-        """ Print result details based on the verbose mode """
-        # -v prints just result + name
-        # -vv prints path to logs
-        # -vvv prints also test output
-        self.verbose(result.show(display_guest=display_guest), shift=1)
-        if verbosity == 1:
-            return
-        # -vv and more follows
-        # TODO: are we sure it cannot be None?
-        assert self.step.plan.execute.workdir is not None
-        for log_file in result.log:
-            log_name = log_file.name
-            full_path = self.step.plan.execute.workdir / log_file
-            # List path to logs (-vv and more)
-            self.verbose(log_name, full_path, color='yellow', shift=2)
-            # Show the whole test output (-vvv and more)
-            if verbosity > 2 and log_name == TEST_OUTPUT_FILENAME:
+        """
+        Print result details.
+
+        :param result: a test result to display.
+        :param verbosity: how verbose should the report be. Generally equal to
+            number of  ``--verbose``/``-v`` options given on command line.
+            For ``1``, display only test name and its result, ``2`` will add
+            log paths, and ``3`` or more would show the test output as well.
+        :param display_guest: if set, guest multihost name would be part of the
+            report.
+        """
+
+        def _display_log_info(log: Path, shift: int) -> None:
+            """ Display info about a single result log """
+
+            # TODO: are we sure it cannot be None?
+            assert self.step.plan.execute.workdir is not None
+
+            self.verbose(
+                log.name,
+                self.step.plan.execute.workdir / log,
+                color='yellow',
+                shift=shift)
+
+        def _display_log_content(log: Path, shift: int) -> None:
+            """ Display content of a single result log """
+
+            # TODO: are we sure it cannot be None?
+            assert self.step.plan.execute.workdir is not None
+
+            self.verbose(
+                'content',
+                self.read(self.step.plan.execute.workdir / log),
+                color='yellow',
+                shift=shift)
+
+        def display_outcome(result: BaseResult) -> None:
+            """ Display a single result outcome """
+
+            if isinstance(result, CheckResult):
                 self.verbose(
-                    'content', self.read(full_path), color='yellow', shift=2)
+                    f'{result.show()} ({result.event.value} check)',
+                    shift=CHECK_SHIFT)
+
+            elif isinstance(result, Result):
+                self.verbose(result.show(display_guest=display_guest), shift=TEST_SHIFT)
+
+        def display_log_info(result: BaseResult) -> None:
+            """ Display info about result logs """
+
+            # TODO: are we sure it cannot be None?
+            assert self.step.plan.execute.workdir is not None
+
+            shift = (TEST_SHIFT + 1) if isinstance(result, Result) else (CHECK_SHIFT + 1)
+
+            for log in result.log:
+                _display_log_info(log, shift)
+
+        def display_log_content(result: BaseResult) -> None:
+            """ Display content of interesting result logs """
+
+            # TODO: are we sure it cannot be None?
+            assert self.step.plan.execute.workdir is not None
+
+            shift = (TEST_SHIFT + 1) if isinstance(result, Result) else (CHECK_SHIFT + 1)
+
+            for log in result.log:
+                _display_log_info(log, shift)
+
+                if log.name == TEST_OUTPUT_FILENAME:
+                    _display_log_content(log, shift)
+
+        # Always show the result outcome
+        display_outcome(result)
+
+        # With verbosity increased to `-vvv` or more, display content of the main test log
+        if verbosity > 2:
+            display_log_content(result)
+
+        # With verbosity increased to `-vv`, display the list of logs
+        elif verbosity > 1:
+            display_log_info(result)
+
+        for check_result in result.check:
+            display_outcome(check_result)
+
+            if verbosity > 2:
+                display_log_content(check_result)
+
+            elif verbosity > 1:
+                display_log_info(check_result)
 
     def go(self) -> None:
         """ Discover available tests """


### PR DESCRIPTION
```
    report
        how: display
            pass /avc/nasty
                fail avc (after-test check)

```

```
    report
        how: display
            pass /avc/nasty
                output.txt: /tmp/tmp.TUxXDJjmC6/plan/execute/data/guest/default-0/avc/nasty-1/output.txt
                fail avc (after-test check)
                    tmt-avc-after-test.txt: /tmp/tmp.TUxXDJjmC6/plan/execute/data/guest/default-0/avc/nasty-1/tmt-avc-after-test.txt
```

```
    report
        how: display
        order: 50
            pass /avc/nasty
                output.txt: /tmp/tmp.TUxXDJjmC6/plan/execute/data/guest/default-0/avc/nasty-1/output.txt
                content:
                    ++ sudo bash -c 'passwd --help &> /root/passwd.log;               ls -alZ /root/passwd.log;               rm -f /root/passwd.log'
                    -rw-r--r--. 1 root root unconfined_u:object_r:admin_home_t:s0 0 Sep 27 14:37 /root/passwd.log
                fail avc (after-test check)
                    tmt-avc-after-test.txt: /tmp/tmp.TUxXDJjmC6/plan/execute/data/guest/default-0/avc/nasty-1/tmt-avc-after-test.txt
```