### PR TITLE
Hide test/plan/story internal fields from export

### DIFF
--- a/tests/plan/export/test.sh
+++ b/tests/plan/export/test.sh
@@ -2,6 +2,12 @@
 # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
+function assert_internal_fields () {
+    log="$1"
+
+    rlAssertNotGrep " _" $log
+}
+
 rlJournalStart
     rlPhaseStartSetup
         rlRun "pushd data"
@@ -16,7 +22,7 @@ rlJournalStart
         rlAssertGrep "- name: /plan/gate" $rlRun_LOG
         rlAssertGrep "discover:" $rlRun_LOG
         rlAssertGrep "execute:" $rlRun_LOG
-        rlAssertNotGrep " _" $rlRun_LOG
+        assert_internal_fields "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartTest "tmt plan export /plan/basic"
@@ -25,7 +31,7 @@ rlJournalStart
         rlAssertGrep "summary: Just basic keys." $rlRun_LOG
         rlAssertGrep "discover:" $rlRun_LOG
         rlAssertGrep "execute:" $rlRun_LOG
-        rlAssertNotGrep " _" $rlRun_LOG
+        assert_internal_fields "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartTest "tmt plan export /plan/context"
@@ -36,7 +42,7 @@ rlJournalStart
         rlAssertGrep "execute:" $rlRun_LOG
         rlAssertGrep "context:" $rlRun_LOG
         rlAssertGrep "component: dash" $rlRun_LOG
-        rlAssertNotGrep " _" $rlRun_LOG
+        assert_internal_fields "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartTest "tmt plan export /plan/environment"
@@ -47,7 +53,7 @@ rlJournalStart
         rlAssertGrep "execute:" $rlRun_LOG
         rlAssertGrep "environment:" $rlRun_LOG
         rlAssertGrep "RELEASE: f35" $rlRun_LOG
-        rlAssertNotGrep " _" $rlRun_LOG
+        assert_internal_fields "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartTest "tmt plan export /plan/gate"
@@ -60,7 +66,7 @@ rlJournalStart
         rlAssertGrep "- merge-pull-request" $rlRun_LOG
         rlAssertGrep "- add-build-to-update" $rlRun_LOG
         rlAssertGrep "- add-build-to-compose" $rlRun_LOG
-        rlAssertNotGrep " _" $rlRun_LOG
+        assert_internal_fields "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartTest "tmt plan export /plan/with-envvars"

--- a/tests/story/export/test.sh
+++ b/tests/story/export/test.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
+function assert_internal_fields () {
+    log="$1"
+
+    rlAssertNotGrep " _" $log
+}
+
 rlJournalStart
     rlPhaseStartSetup
         rlRun "pushd data"
@@ -11,7 +17,8 @@ rlJournalStart
         rlAssertGrep "name: /mini" $rlRun_LOG
         rlAssertGrep "order: 50" $rlRun_LOG
         rlAssertGrep "story: As a user I want this and that" $rlRun_LOG
-        rlAssertNotGrep " _" $rlRun_LOG
+
+        assert_internal_fields "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartTest "Export to yaml (full story)"
@@ -26,7 +33,7 @@ rlJournalStart
         rlAssertGrep "story: As a user I want this and that" $rlRun_LOG
         rlAssertGrep "title: A Concise Title" $rlRun_LOG
         rlAssertGrep "priority: must have" $rlRun_LOG
-        rlAssertNotGrep " _" $rlRun_LOG
+        assert_internal_fields "$rlRun_LOG"
         rlRun "yq .[].link[] $rlRun_LOG | grep -- 'implemented-by\": \"/some/code.py'"
         rlRun "yq .[].tag[] $rlRun_LOG | grep -- 'foo'"
         rlRun "yq .[].example[] $rlRun_LOG | grep -- 'An inspiring example'"

--- a/tests/test/export/test.sh
+++ b/tests/test/export/test.sh
@@ -2,6 +2,21 @@
 
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
+
+function assert_internal_fields () {
+    log="$1"
+
+    # Make sure internal fields are not exposed
+    rlAssertNotGrep " _" $rlRun_LOG
+    rlAssertNotGrep "serialnumber" $log
+    rlAssertNotGrep "data_path" $log
+    rlAssertNotGrep "returncode" $log
+    rlAssertNotGrep "starttime" $log
+    rlAssertNotGrep "endtime" $log
+    rlAssertNotGrep "real_duration" $log
+}
+
+
 rlJournalStart
     rlPhaseStartSetup
         rlRun "pushd data"
@@ -20,6 +35,8 @@ rlJournalStart
         rlPhaseStartTest "$cmd"
             rlRun -s "$cmd" 0 "Export test"
             rlAssertGrep "name: $tname" $rlRun_LOG
+
+            assert_internal_fields "$rlRun_LOG"
         rlPhaseEnd
 
         cmd="tmt tests export --how dict $tname"
@@ -27,13 +44,14 @@ rlJournalStart
             rlRun -s "$cmd" 0 "Export test"
             rlAssertGrep "'name': '$tname'" $rlRun_LOG
             rlAssertNotGrep "'_" $rlRun_LOG
+            assert_internal_fields "$rlRun_LOG"
         rlPhaseEnd
 
         cmd="tmt tests export --how yaml $tname"
         rlPhaseStartTest "$cmd"
             rlRun -s "$cmd" 0 "Export test"
             rlAssertGrep "name: $tname" $rlRun_LOG
-            rlAssertNotGrep " _" $rlRun_LOG
+            assert_internal_fields "$rlRun_LOG"
         rlPhaseEnd
     done
 

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -420,7 +420,11 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
 
         return data
 
-    def _export(self, *, keys: Optional[List[str]] = None) -> tmt.export._RawExportedInstance:
+    def _export(
+            self,
+            *,
+            keys: Optional[List[str]] = None,
+            include_internal: bool = False) -> tmt.export._RawExportedInstance:
         # TODO: one day, this should recurse down into each materialized plugin,
         # to give them chance to affect the export of their data.
         return cast(tmt.export._RawExportedInstance, self._raw_data)

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -184,7 +184,7 @@ class Discover(tmt.steps.Step):
                 if test.enabled is not True:
                     continue
 
-                exported_test = test._export()
+                exported_test = test._export(include_internal=True)
                 exported_test['discover_phase'] = phase_name
 
                 raw_test_data.append(exported_test)

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2371,6 +2371,8 @@ class FieldMetadata(Generic[T]):
     Attached to fields defined with :py:func:`field`
     """
 
+    internal: bool = False
+
     #: CLI option parameters, for lazy option creation.
     option_args: Optional['FieldCLIOption'] = None
     option_kwargs: Optional[Dict[str, Any]] = None
@@ -5713,6 +5715,7 @@ def field(
         deprecated: Optional['tmt.options.Deprecated'] = None,
         help: Optional[str] = None,
         show_default: bool = False,
+        internal: bool = False,
         # Input data normalization - not needed, the field is a boolean
         # flag.
         # normalize: Optional[NormalizeCallback[T]] = None
@@ -5739,6 +5742,7 @@ def field(
         deprecated: Optional['tmt.options.Deprecated'] = None,
         help: Optional[str] = None,
         show_default: bool = False,
+        internal: bool = False,
         # Input data normalization
         normalize: Optional[NormalizeCallback[T]] = None,
         # Custom serialization
@@ -5764,6 +5768,7 @@ def field(
         deprecated: Optional['tmt.options.Deprecated'] = None,
         help: Optional[str] = None,
         show_default: bool = False,
+        internal: bool = False,
         # Input data normalization
         normalize: Optional[NormalizeCallback[T]] = None,
         # Custom serialization
@@ -5789,6 +5794,7 @@ def field(
         deprecated: Optional['tmt.options.Deprecated'] = None,
         help: Optional[str] = None,
         show_default: bool = False,
+        internal: bool = False,
         # Input data normalization
         normalize: Optional[NormalizeCallback[T]] = None,
         # Custom serialization
@@ -5832,6 +5838,9 @@ def field(
         ``help`` to :py:func:`click.option`.
     :param show_default: show default value
         Passed directly to :py:func:`click.option`.
+    :param internal: if set, the field is treated as internal-only, and will not
+        appear when showing objects via ``show()`` method, or in export created
+        by :py:meth:`Core._export`.
     :param normalize: a callback for normalizing the input value. Consumed by
         :py:class:`NormalizeKeysMixin`.
     :param serialize: a callback for custom serialization of the field value.
@@ -5845,7 +5854,7 @@ def field(
     if default is dataclasses.MISSING and default_factory is dataclasses.MISSING:
         raise GeneralError("Container field must define one of 'default' or 'default_factory'.")
 
-    metadata: FieldMetadata[T] = FieldMetadata()
+    metadata: FieldMetadata[T] = FieldMetadata(internal=internal)
 
     if option:
         assert is_flag is False or isinstance(default, bool)


### PR DESCRIPTION
Fields - class members of `Test`, `Plan` and `Story` - that are not backed by tmt specification should not be part of the export - by default, that is. We still need them to be saved in `tests.yaml` for tmt to load them when necessary. Marking them as internal, and adding a control parameter to export to expose them when requested.

Fixes https://github.com/teemtee/tmt/issues/2298