### PR TITLE
Refactor data container helpers to allow transparent handling of multiword keys

### DIFF
--- a/tests/unit/test_dataclasses.py
+++ b/tests/unit/test_dataclasses.py
@@ -8,8 +8,7 @@ import tmt.log
 import tmt.utils
 from tmt.utils import (
     SerializableContainer,
-    dataclass_field_by_name,
-    dataclass_field_metadata,
+    container_field,
     dataclass_normalize_field,
     field,
     )
@@ -108,7 +107,7 @@ def test_normalize_callback_preferred(root_logger: tmt.log.Logger) -> None:
         _normalize_foo = MagicMock()
 
     data = DummyContainer()
-    foo_metadata = dataclass_field_metadata(dataclass_field_by_name(data, 'foo'))
+    foo_metadata = container_field(data, 'foo')[4]
 
     foo_metadata.normalize_callback = MagicMock()
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -16,7 +16,6 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
-    Generator,
     Iterable,
     Iterator,
     List,
@@ -1823,7 +1822,7 @@ class Plan(
     def _iter_steps(self,
                     enabled_only: bool = True,
                     skip: Optional[List[str]] = None
-                    ) -> Generator[Tuple[str, tmt.steps.Step], None, None]:
+                    ) -> Iterator[Tuple[str, tmt.steps.Step]]:
         """
         Iterate over steps.
 
@@ -1842,7 +1841,7 @@ class Plan(
 
     def steps(self,
               enabled_only: bool = True,
-              skip: Optional[List[str]] = None) -> Generator[tmt.steps.Step, None, None]:
+              skip: Optional[List[str]] = None) -> Iterator[tmt.steps.Step]:
         """
         Iterate over steps.
 
@@ -1855,7 +1854,7 @@ class Plan(
 
     def step_names(self,
                    enabled_only: bool = True,
-                   skip: Optional[List[str]] = None) -> Generator[str, None, None]:
+                   skip: Optional[List[str]] = None) -> Iterator[str]:
         """
         Iterate over step names.
 

--- a/tmt/checks/__init__.py
+++ b/tmt/checks/__init__.py
@@ -6,7 +6,13 @@ import tmt.log
 import tmt.steps.provision
 import tmt.utils
 from tmt.plugins import PluginRegistry
-from tmt.utils import cached_property, field
+from tmt.utils import (
+    NormalizeKeysMixin,
+    SerializableContainer,
+    SpecBasedContainer,
+    cached_property,
+    field,
+    )
 
 if TYPE_CHECKING:
     from tmt.result import CheckResult
@@ -74,9 +80,9 @@ class CheckEvent(enum.Enum):
 
 @dataclasses.dataclass
 class Check(
-        tmt.utils.SpecBasedContainer[_RawCheck, _RawCheck],
-        tmt.utils.SerializableContainer,
-        tmt.utils.NormalizeKeysMixin):
+        SpecBasedContainer[_RawCheck, _RawCheck],
+        SerializableContainer,
+        NormalizeKeysMixin):
     """
     Represents a single check from test's ``check`` field.
 

--- a/tmt/export/nitrate.py
+++ b/tmt/export/nitrate.py
@@ -4,7 +4,17 @@ import re
 import types
 from contextlib import suppress
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+    )
 
 import fmf.context
 from click import echo, style
@@ -66,7 +76,7 @@ def import_nitrate() -> Nitrate:
         raise ConvertError(error)
 
 
-def _nitrate_find_fmf_testcases(test: 'tmt.Test') -> Generator[Any, None, None]:
+def _nitrate_find_fmf_testcases(test: 'tmt.Test') -> Iterator[Any]:
     """
     Find all Nitrate test cases with the same fmf identifier
 

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -52,6 +52,7 @@ import pint
 
 import tmt.log
 import tmt.utils
+from tmt.utils import SpecBasedContainer
 
 if TYPE_CHECKING:
     from pint import Quantity
@@ -323,7 +324,7 @@ class ParseError(tmt.utils.MetadataError):
 #
 
 @dataclasses.dataclass(repr=False)
-class BaseConstraint(tmt.utils.SpecBasedContainer[Spec, Spec]):
+class BaseConstraint(SpecBasedContainer[Spec, Spec]):
     """
     Base class for all classes representing one or more constraints.
     """
@@ -1166,7 +1167,7 @@ def parse_hw_requirements(spec: Spec) -> BaseConstraint:
 
 
 @dataclasses.dataclass
-class Hardware(tmt.utils.SpecBasedContainer[Spec, Spec]):
+class Hardware(SpecBasedContainer[Spec, Spec]):
     constraint: Optional[BaseConstraint]
     spec: Spec
 

--- a/tmt/lint.py
+++ b/tmt/lint.py
@@ -73,9 +73,9 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Generator,
     Generic,
     Iterable,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -134,7 +134,7 @@ _OUTCOME_TO_COLOR = {
 #: Info on how a linter decided: linter itself, its outcome & the message.
 LinterRuling = Tuple['Linter', LinterOutcome, LinterOutcome, str]
 #: A return value type of a single linter.
-LinterReturn = Generator[Tuple[LinterOutcome, str], None, None]
+LinterReturn = Iterator[Tuple[LinterOutcome, str]]
 #: A linter itself, a callable method.
 LinterCallback = Callable[['Lintable'], LinterReturn]
 
@@ -344,7 +344,7 @@ class Lintable(Generic[LintableT]):
 
 def filter_allowed_checks(
         rulings: Iterable[LinterRuling],
-        outcomes: Optional[List[LinterOutcome]] = None) -> Generator[LinterRuling, None, None]:
+        outcomes: Optional[List[LinterOutcome]] = None) -> Iterator[LinterRuling]:
     """
     Filter only rulings whose outcomes are allowed.
 
@@ -363,7 +363,7 @@ def filter_allowed_checks(
         yield (linter, actual_outcome, eventual_outcome, message)
 
 
-def format_rulings(rulings: Iterable[LinterRuling]) -> Generator[str, None, None]:
+def format_rulings(rulings: Iterable[LinterRuling]) -> Iterator[str]:
     """
     Format rulings for printing or logging.
 

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -5,7 +5,7 @@ import os
 import pkgutil
 import sys
 from importlib.metadata import entry_points
-from typing import Any, Dict, Generator, Generic, List, Optional, Tuple, TypeVar
+from typing import Any, Dict, Generic, Iterator, List, Optional, Tuple, TypeVar
 
 import tmt
 import tmt.utils
@@ -24,7 +24,7 @@ ALREADY_EXPLORED = False
 _TMT_ROOT = Path(tmt.__file__).resolve().parent
 
 
-def discover(path: Path) -> Generator[str, None, None]:
+def discover(path: Path) -> Iterator[str]:
     """ Discover available plugins for given paths """
     for _, name, package in pkgutil.iter_modules([str(path)]):
         if not package:
@@ -292,8 +292,8 @@ class PluginRegistry(Generic[RegisterableT]):
 
         return self._plugins.get(plugin_id, None)
 
-    def iter_plugin_ids(self) -> Generator[str, None, None]:
+    def iter_plugin_ids(self) -> Iterator[str]:
         yield from self._plugins.keys()
 
-    def iter_plugins(self) -> Generator[RegisterableT, None, None]:
+    def iter_plugins(self) -> Iterator[RegisterableT]:
         yield from self._plugins.values()

--- a/tmt/queue.py
+++ b/tmt/queue.py
@@ -1,6 +1,6 @@
 import dataclasses
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from typing import TYPE_CHECKING, Dict, Generator, Generic, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Dict, Generic, Iterator, List, Optional, TypeVar
 
 import fmf.utils
 
@@ -65,7 +65,7 @@ class _Task:
     def guest_ids(self) -> List[str]:
         return [guest.multihost_name for guest in self.guests]
 
-    def go(self) -> Generator[TaskOutcome['Self'], None, None]:
+    def go(self) -> Iterator[TaskOutcome['Self']]:
         """ Perform the task """
 
         raise NotImplementedError
@@ -87,7 +87,7 @@ class GuestlessTask(_Task):
     def run(self, logger: Logger) -> None:
         raise NotImplementedError
 
-    def go(self) -> Generator[TaskOutcome['Self'], None, None]:
+    def go(self) -> Iterator[TaskOutcome['Self']]:
         try:
             self.run(self.logger)
 
@@ -149,7 +149,7 @@ class Task(_Task):
 
         return loggers
 
-    def go(self) -> Generator[TaskOutcome['Self'], None, None]:
+    def go(self) -> Iterator[TaskOutcome['Self']]:
         multiple_guests = len(self.guests) > 1
 
         new_loggers = self.prepare_loggers(self.logger)
@@ -240,7 +240,7 @@ class Queue(List[TaskT]):
             f'{task.name} on {fmf.utils.listed(task.guest_ids)}',
             color='cyan')
 
-    def run(self) -> Generator[TaskOutcome[TaskT], None, None]:
+    def run(self) -> Iterator[TaskOutcome[TaskT]]:
         """
         Start crunching the queued phases.
 

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -8,7 +8,7 @@ import fmf
 
 import tmt.utils
 from tmt.checks import CheckEvent
-from tmt.utils import Path, field
+from tmt.utils import Path, SerializableContainer, field
 
 if TYPE_CHECKING:
     import tmt.base
@@ -67,7 +67,7 @@ RESULT_OUTCOME_COLORS: Dict[ResultOutcome, str] = {
 
 
 @dataclasses.dataclass
-class ResultGuestData(tmt.utils.SerializableContainer):
+class ResultGuestData(SerializableContainer):
     """ Describes what tmt knows about a guest the result was produced on """
 
     name: str = f'{tmt.utils.DEFAULT_NAME}-0'
@@ -83,7 +83,7 @@ def _unserialize_fmf_id(serialized: 'tmt.base._RawFmfId') -> 'tmt.base.FmfId':
 
 
 @dataclasses.dataclass
-class BaseResult(tmt.utils.SerializableContainer):
+class BaseResult(SerializableContainer):
     """ Describes what tmt knows about a result """
 
     name: str

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -14,8 +14,8 @@ from typing import (
     Callable,
     DefaultDict,
     Dict,
-    Generator,
     Iterable,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -155,7 +155,7 @@ class DefaultNameGenerator:
     def restart(self) -> None:
         """ Reset the generator and start from the beginning again """
 
-        def _generator() -> Generator[str, None, None]:
+        def _generator() -> Iterator[str]:
             for i in itertools.count(start=0):
                 name = f'{DEFAULT_NAME}-{i}'
 
@@ -598,7 +598,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
             keys representing CLI options.
             """
 
-            def _iter_options() -> Generator[Tuple[str, Any], None, None]:
+            def _iter_options() -> Iterator[Tuple[str, Any]]:
                 for name, value in options.items():
                     if name in ('update', 'update_missing', 'insert'):
                         continue
@@ -1966,7 +1966,7 @@ class QueuedPhase(GuestlessTask, Task):
             guest=guest,
             logger=logger)
 
-    def go(self) -> Generator[TaskOutcome['Self'], None, None]:
+    def go(self) -> Iterator[TaskOutcome['Self']]:
         # Based on the phase, pick the proper parent class' go()
         if isinstance(self.phase, Action):
             yield from GuestlessTask.go(self)

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Type, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Type, cast
 
 import click
 from fmf.utils import listed
@@ -343,11 +343,11 @@ class Discover(tmt.steps.Step):
             *,
             phase_name: Optional[str] = None,
             enabled: Optional[bool] = None) -> List['tmt.Test']:
-        def _iter_all_tests() -> Generator['tmt.Test', None, None]:
+        def _iter_all_tests() -> Iterator['tmt.Test']:
             for phase_tests in self._tests.values():
                 yield from phase_tests
 
-        def _iter_phase_tests() -> Generator['tmt.Test', None, None]:
+        def _iter_phase_tests() -> Iterator['tmt.Test']:
             assert phase_name is not None
 
             yield from self._tests[phase_name]

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -17,12 +17,12 @@ import tmt.utils
 from tmt.options import option
 from tmt.plugins import PluginRegistry
 from tmt.steps import Action
-from tmt.utils import Command, GeneralError, Path, flatten
+from tmt.utils import Command, GeneralError, Path, field, flatten
 
 
 @dataclasses.dataclass
 class DiscoverStepData(tmt.steps.WhereableStepData, tmt.steps.StepData):
-    dist_git_source: bool = tmt.utils.field(
+    dist_git_source: bool = field(
         default=False,
         option='--dist-git-source',
         is_flag=True,
@@ -30,7 +30,7 @@ class DiscoverStepData(tmt.steps.WhereableStepData, tmt.steps.StepData):
         )
 
     # TODO: use enum!
-    dist_git_type: Optional[str] = tmt.utils.field(
+    dist_git_type: Optional[str] = field(
         default=None,
         option='--dist-git-type',
         choices=tmt.utils.get_distgit_handler_names,

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -12,16 +12,16 @@ import tmt.log
 import tmt.steps
 import tmt.steps.discover
 import tmt.utils
-from tmt.utils import Command, Path, ShellScript, field
+from tmt.utils import Command, Path, SerializableContainer, ShellScript, SpecBasedContainer, field
 
 T = TypeVar('T', bound='TestDescription')
 
 
 @dataclasses.dataclass
 class TestDescription(
-        tmt.utils.SpecBasedContainer[Dict[str, Any], Dict[str, Any]],
+        SpecBasedContainer[Dict[str, Any], Dict[str, Any]],
         tmt.utils.NormalizeKeysMixin,
-        tmt.utils.SerializableContainer):
+        SerializableContainer):
     """
     Keys necessary to describe a shell-based test.
 
@@ -165,19 +165,19 @@ class DiscoverShellData(tmt.steps.discover.DiscoverStepData):
             ]
         )
 
-    url: Optional[str] = tmt.utils.field(
+    url: Optional[str] = field(
         option="--url",
         metavar='REPOSITORY',
         default=None,
         help="URL of the git repository with tests to be fetched.")
 
-    ref: Optional[str] = tmt.utils.field(
+    ref: Optional[str] = field(
         option="--ref",
         metavar='REVISION',
         default=None,
         help="Branch, tag or commit specifying the git revision.")
 
-    keep_git_metadata: Optional[bool] = tmt.utils.field(
+    keep_git_metadata: Optional[bool] = field(
         option="--keep-git-metadata",
         is_flag=True,
         default=False,

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -8,12 +8,12 @@ import tmt.steps
 import tmt.steps.finish
 import tmt.utils
 from tmt.steps.provision import Guest
-from tmt.utils import ShellScript
+from tmt.utils import ShellScript, field
 
 
 @dataclasses.dataclass
 class FinishShellData(tmt.steps.finish.FinishStepData):
-    script: List[ShellScript] = tmt.utils.field(
+    script: List[ShellScript] = field(
         default_factory=list,
         option=('-s', '--script'),
         multiple=True,

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -40,7 +40,15 @@ import tmt.utils
 from tmt.options import option
 from tmt.plugins import PluginRegistry
 from tmt.steps import Action
-from tmt.utils import Command, Path, ShellScript, cached_property, field, key_to_option
+from tmt.utils import (
+    Command,
+    Path,
+    SerializableContainer,
+    ShellScript,
+    cached_property,
+    field,
+    key_to_option,
+    )
 
 if TYPE_CHECKING:
     import tmt.base
@@ -88,7 +96,7 @@ T = TypeVar('T')
 
 
 @dataclasses.dataclass
-class GuestFacts(tmt.utils.SerializableContainer):
+class GuestFacts(SerializableContainer):
     """
     Contains interesting facts about the guest.
 
@@ -372,7 +380,7 @@ GuestDataT = TypeVar('GuestDataT', bound='GuestData')
 
 
 @dataclasses.dataclass
-class GuestData(tmt.utils.SerializableContainer):
+class GuestData(SerializableContainer):
     """
     Keys necessary to describe, create, save and restore a guest.
 
@@ -1767,7 +1775,7 @@ class Provision(tmt.steps.Step):
             raw_guest_data = tmt.utils.yaml_to_dict(self.read(Path('guests.yaml')))
 
             self._guest_data = {
-                name: tmt.utils.SerializableContainer.unserialize(guest_data, self._logger)
+                name: SerializableContainer.unserialize(guest_data, self._logger)
                 for name, guest_data in raw_guest_data.items()
                 }
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -16,7 +16,7 @@ from typing import (
     Any,
     DefaultDict,
     Dict,
-    Generator,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -183,7 +183,7 @@ class GuestFacts(SerializableContainer):
         if not output or not output.stdout:
             return content
 
-        def _iter_pairs() -> Generator[Tuple[str, str], None, None]:
+        def _iter_pairs() -> Iterator[Tuple[str, str]]:
             assert output  # narrow type in a closure
             assert output.stdout  # narrow type in a closure
 
@@ -418,7 +418,7 @@ class GuestData(SerializableContainer):
     # TODO: find out whether this could live in DataContainer. It probably could,
     # but there are containers not backed by options... Maybe a mixin then?
     @classmethod
-    def options(cls) -> Generator[Tuple[str, str], None, None]:
+    def options(cls) -> Iterator[Tuple[str, str]]:
         """
         Iterate over option names.
 


### PR DESCRIPTION
…iword keys

No functional changes visible outside, but part of internal key/value/items processing have been refactored. This should allow transparent handling of multiword keys during export and serialization, where `foo_bar` key needs to be transofrmed into `foo-bar` "option".

Related to https://github.com/teemtee/tmt/issues/2054