### PR TITLE
Force tmt-link pre-commit to use fmf 1.3.0 which brings new features

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,4 +61,6 @@ repos:
     hooks:
     - id: tmt-lint
       additional_dependencies:
+        # Make sure we use fmf compatible with tmt in the repo, not the 1.26.0 version.
+        - "fmf>=1.3.0"
         - pint==0.20


### PR DESCRIPTION
Namely case-insesitive context tests - old fmf lacks newly added function parameters, which crashes tmt on the Python level.