### PR TITLE
Remove irrelevant mention of `rhel-8` in the spec

### DIFF
--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -103,11 +103,6 @@ example: |
 
         __ https://github.com/neoave/mrack
 
-        .. note::
-
-            The beaker provision plugin is not available for
-            ``rhel-8`` or ``centos-stream-8``.
-
         .. versionadded:: 1.22
 
     example:


### PR DESCRIPTION
The whole `tmt` now supports `rhel-9` and higher, no reason for this extra mention here anymore.