### PR TITLE
Update the `release` action with `hatch` changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,17 +12,32 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+
+    # Needed for trusted publishing
+    permissions:
+      id-token: write
+
     steps:
-      - uses: actions/checkout@v3
+
+      # Check out the repo
+      - uses: actions/checkout@v4
         if: ${{ github.event_name == 'release' }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           ref: ${{ github.event.inputs.ref }}
-      - name: Create dist
-        run: make wheel
+
+      # Setup python
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      # Build it
+      - name: Build a binary wheel and a source tarball
+        run: |
+            python -m pip install hatch
+            hatch build
+
+      # Publish it
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -410,7 +410,6 @@ TMT_GIT_CREDENTIALS_URL_<suffix>, TMT_GIT_CREDENTIALS_VALUE_<suffix>
 
 __ https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#clone-repository-using-personal-access-token
 __ https://github.blog/2012-09-21-easier-builds-and-deployments-using-git-over-https-and-oauth/
-.. versionadded:: 1.26
 
 Step Variables
 --------------

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -348,9 +348,7 @@ Release a new package to Fedora and EPEL repositories:
 
 * Move the ``fedora`` branch to point to the new release
 * Tag the commit with ``x.y.0``, push tags ``git push --tags``
-* Create a source tarball using the ``make tarball`` command
-* Draft a new `github release`__ based on the tag above
-* Upload tarball to the release attachments and publish it
+* Create a new `github release`__ based on the tag above
 * Check Fedora `pull requests`__, make sure tests pass and merge
 
 Finally, if everything went well:

--- a/tmt.spec
+++ b/tmt.spec
@@ -5,7 +5,7 @@ Summary:        Test Management Tool
 
 License:        MIT
 URL:            https://github.com/teemtee/tmt
-Source:         %{url}/releases/download/%{version}/tmt-%{version}.tar.gz
+Source0:        %{pypi_source tmt}
 
 BuildArch:      noarch
 BuildRequires:  python3-devel


### PR DESCRIPTION
* Use trusted publishing for pushing the package to pypi.
* Update the spec to fetch the source directly from pypi.