### PR TITLE
Remove the `.dev0` suffix from the spec `Version`

### DIFF
--- a/tmt.spec
+++ b/tmt.spec
@@ -1,5 +1,5 @@
 Name:           tmt
-Version:        1.28.0.dev0
+Version:        1.28.0
 Release:        %autorelease
 Summary:        Test Management Tool
 


### PR DESCRIPTION
The extra suffix breaks the `propose_downstream` action and it seems that it's not needed as it's overwritten by the `ver2spec` target anyway.

Example failure: https://github.com/teemtee/tmt/runs/17580696508