### PR TITLE
Build man page during the `release` action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: |
             python -m pip install hatch
+            hatch run docs:man
             hatch build
 
       # Publish it


### PR DESCRIPTION
The man page is needed in the source tarball as that's what `packit` uses during the `propose_downstream` action.