### PR TITLE
Include the `fmf` root in the tarball as well

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ include = [
     "/tmt.spec",
     "/tmt.1",
     "/completions",
+    "/.fmf",
     ]
 
 [tool.hatch.envs.default]

--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -174,7 +174,7 @@ execute:
         discover:
             how: fmf
             dist-git-source: true
-            dist-git-init: false
+            dist-git-init: true
             test: tests/prepare/install$
 
     /exclude:

--- a/tests/discover/distgit.sh
+++ b/tests/discover/distgit.sh
@@ -313,7 +313,7 @@ done
     rlPhaseStartTest "Run directly from the DistGit (Fedora) [cli]"
         rlRun 'pushd tmt'
         rlRun -s 'tmt run --remove plans --default \
-            discover -v --how fmf --dist-git-source \
+            discover -v --how fmf --dist-git-source --dist-git-init \
             tests --name tests/prepare/install$'
         rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
         rlAssertGrep "/tests/prepare/install" $rlRun_LOG -F
@@ -330,7 +330,7 @@ done
 
     rlPhaseStartTest "URL is path to a local distgit repo"
         rlRun -s 'tmt run --remove plans --default \
-            discover --how fmf --dist-git-source --dist-git-type fedora --url $CLONED_TMT \
+            discover --how fmf --dist-git-source --dist-git-init --dist-git-type fedora --url $CLONED_TMT \
             --dist-git-merge tests --name tests/prepare/install$'
         rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
     rlPhaseEnd


### PR DESCRIPTION
It was there before and `/tests/discover/distgit` started to fail when the changes were merged to Fedora rawhide branch. Include the root in `pyproject` and adjust the test to perform `--dist-git-init` as well.