### PR TITLE
Fix installing package from the command line

### DIFF
--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -32,6 +32,13 @@ rlJournalStart
         fi
     done
 
+    rlPhaseStartTest "Provide package on the command line"
+        rlRun "tmt run -vvvr plan --default \
+            provision --how container \
+            prepare --how install --package tree \
+            finish"
+    rlPhaseEnd
+
     rlPhaseStartTest "Just enable copr"
         rlRun "tmt run -adddvvvr plan --name copr"
     rlPhaseEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -594,7 +594,7 @@ def normalize_require(
     if isinstance(raw_require, (str, dict)):
         return [dependency_factory(raw_require)]
 
-    if isinstance(raw_require, list):
+    if isinstance(raw_require, (list, tuple)):
         return [dependency_factory(require) for require in raw_require]
 
     raise tmt.utils.NormalizationError(


### PR DESCRIPTION
A regression has been introduced in c6f68a1 which caused traceback to be raised when package name for installation was provided on the command line:

    tmt run prepare --how install --package tree

    Field 'PrepareInstallData:package' must be a string, a
    library, a file or a list of their combinations, 'tuple'
    found.

Fix the problem, add test coverage for the scenario.