### PR TITLE
Allow Path instance to be used when constructing commands

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1698,7 +1698,7 @@ class Plan(
 
         # Sync metadata root to the worktree
         self.debug(f"Sync the worktree to '{self.worktree}'.", level=2)
-        self.run(Command("rsync", "-ar", "--exclude", ".git", f"{tree_root}/", str(self.worktree)))
+        self.run(Command("rsync", "-ar", "--exclude", ".git", f"{tree_root}/", self.worktree))
 
     def _initialize_data_directory(self) -> None:
         """

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -401,7 +401,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin):
             self.info('ref', ref, 'green')
             self.debug(f"Checkout ref '{ref}'.")
             self.run(
-                Command('git', 'checkout', '-f', str(ref)),
+                Command('git', 'checkout', '-f', ref),
                 cwd=self.testdir)
 
         # Show current commit hash if inside a git repository

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -283,7 +283,7 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin):
         if ref:
             self.info('ref', ref, 'green')
             self.debug(f"Checkout ref '{ref}'.")
-            self.run(Command('git', 'checkout', '-f', str(ref)), cwd=testdir)
+            self.run(Command('git', 'checkout', '-f', ref), cwd=testdir)
 
         # Remove .git so that it's not copied to the SUT
         # if 'keep-git-metadata' option is not specified

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -178,7 +178,7 @@ class GuestFacts(SerializableContainer):
 
         content: Dict[str, str] = {}
 
-        output = self._execute(guest, Command('cat', str(filepath)))
+        output = self._execute(guest, Command('cat', filepath))
 
         if not output or not output.stdout:
             return content
@@ -1132,7 +1132,7 @@ class GuestSsh(Guest):
 
     def _ssh_options(self) -> Command:
         """ Return common ssh options (list or joined) """
-        options = [
+        options: tmt.utils.RawCommand = [
             '-oForwardX11=no',
             '-oStrictHostKeyChecking=no',
             '-oUserKnownHostsFile=/dev/null',
@@ -1148,7 +1148,7 @@ class GuestSsh(Guest):
             options.append(f'-p{self.port}')
         if self.key:
             for key in self.key:
-                options.extend(['-i', str(key)])
+                options.extend(['-i', key])
         if self.password:
             options.extend(['-oPasswordAuthentication=yes'])
 
@@ -1218,7 +1218,7 @@ class GuestSsh(Guest):
         ansible_command += Command(
             '--ssh-common-args', self._ssh_options().to_element(),
             '-i', f'{self._ssh_guest()},',
-            str(playbook))
+            playbook)
 
         # FIXME: cast() - https://github.com/teemtee/tmt/issues/1372
         parent = cast(Provision, self.parent)
@@ -1360,7 +1360,7 @@ class GuestSsh(Guest):
                 *cmd,
                 *options,
                 "-e", self._ssh_command().to_element(),
-                str(source),
+                source,
                 f"{self._ssh_guest()}:{destination}"
                 ), silent=True)
 
@@ -1426,7 +1426,7 @@ class GuestSsh(Guest):
                 *options,
                 "-e", self._ssh_command().to_element(),
                 f"{self._ssh_guest()}:{source}",
-                str(destination)
+                destination
                 ), silent=True)
 
         # Try to pull twice, check for rsync after the first failure

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -60,7 +60,7 @@ class GuestLocal(tmt.Guest):
                 *self._ansible_extra_args(extra_args),
                 '-c', 'local',
                 '-i', 'localhost,',
-                str(playbook)),
+                playbook),
             env=self._prepare_environment(),
             friendly_command=friendly_command,
             log=log,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -1,7 +1,7 @@
 import dataclasses
 import os
 from shlex import quote
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, cast
 
 import tmt
 import tmt.base
@@ -170,12 +170,12 @@ class GuestContainer(tmt.Guest):
         if os.geteuid() != 0:
             podman_command += ['podman', 'unshare']
 
-        podman_command += [
+        podman_command += cast(tmt.utils.RawCommand, [
             'ansible-playbook',
             *self._ansible_verbosity(),
             *self._ansible_extra_args(extra_args),
-            '-c', 'podman', '-i', f'{self.container},', str(playbook)
-            ]
+            '-c', 'podman', '-i', f'{self.container},', playbook
+            ])
 
         return self._run_guest_command(
             podman_command,
@@ -266,12 +266,12 @@ class GuestContainer(tmt.Guest):
         # Relabel workdir to container_file_t if SELinux supported
         if tmt.utils.is_selinux_supported():
             self._run_guest_command(Command(
-                "chcon", "--recursive", "--type=container_file_t", str(self.parent.plan.workdir)
+                "chcon", "--recursive", "--type=container_file_t", self.parent.plan.workdir
                 ), shell=False, silent=True)
         # In case explicit destination is given, use `podman cp` to copy data
         # to the container
         if source and destination:
-            self.podman(Command("cp", str(source), f"{self.container}:{destination}"))
+            self.podman(Command("cp", source, f"{self.container}:{destination}"))
 
     def pull(
             self,

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -348,14 +348,14 @@ class GuestTestcloud(tmt.GuestSsh):
         # Use existing key
         if self.key:
             self.debug("Extract public key from the provided private one.")
-            command = Command("ssh-keygen", "-f", str(self.key[0]), "-y")
+            command = Command("ssh-keygen", "-f", self.key[0], "-y")
             public_key = self._run_guest_command(command, silent=True).stdout
         # Generate new ssh key pair
         else:
             self.debug('Generating an ssh key.')
             key_name = f"id_{key_type if key_type is not None else 'rsa'}"
             self.key = [self.workdir / key_name]
-            command = Command("ssh-keygen", "-f", str(self.key[0]), "-N", "")
+            command = Command("ssh-keygen", "-f", self.key[0], "-N", "")
             if key_type is not None:
                 command += Command("-t", key_type)
             self._run_guest_command(command, silent=True)


### PR DESCRIPTION
A `Path` instance is easy to convert into a string, there is no need for escaping or sanitizing when it comes to `Command`. By allowing `Path` instances to be used directly, we can drop several `str(some_path)` calls in code.