### PR TITLE
Replace Generator type annotation with Iterator

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -16,7 +16,6 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
-    Generator,
     Iterable,
     Iterator,
     List,
@@ -1823,7 +1822,7 @@ class Plan(
     def _iter_steps(self,
                     enabled_only: bool = True,
                     skip: Optional[List[str]] = None
-                    ) -> Generator[Tuple[str, tmt.steps.Step], None, None]:
+                    ) -> Iterator[Tuple[str, tmt.steps.Step]]:
         """
         Iterate over steps.
 
@@ -1842,7 +1841,7 @@ class Plan(
 
     def steps(self,
               enabled_only: bool = True,
-              skip: Optional[List[str]] = None) -> Generator[tmt.steps.Step, None, None]:
+              skip: Optional[List[str]] = None) -> Iterator[tmt.steps.Step]:
         """
         Iterate over steps.
 
@@ -1855,7 +1854,7 @@ class Plan(
 
     def step_names(self,
                    enabled_only: bool = True,
-                   skip: Optional[List[str]] = None) -> Generator[str, None, None]:
+                   skip: Optional[List[str]] = None) -> Iterator[str]:
         """
         Iterate over step names.
 

--- a/tmt/export/nitrate.py
+++ b/tmt/export/nitrate.py
@@ -4,7 +4,17 @@ import re
 import types
 from contextlib import suppress
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+    )
 
 import fmf.context
 from click import echo, style
@@ -66,7 +76,7 @@ def import_nitrate() -> Nitrate:
         raise ConvertError(error)
 
 
-def _nitrate_find_fmf_testcases(test: 'tmt.Test') -> Generator[Any, None, None]:
+def _nitrate_find_fmf_testcases(test: 'tmt.Test') -> Iterator[Any]:
     """
     Find all Nitrate test cases with the same fmf identifier
 

--- a/tmt/lint.py
+++ b/tmt/lint.py
@@ -73,9 +73,9 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Generator,
     Generic,
     Iterable,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -134,7 +134,7 @@ _OUTCOME_TO_COLOR = {
 #: Info on how a linter decided: linter itself, its outcome & the message.
 LinterRuling = Tuple['Linter', LinterOutcome, LinterOutcome, str]
 #: A return value type of a single linter.
-LinterReturn = Generator[Tuple[LinterOutcome, str], None, None]
+LinterReturn = Iterator[Tuple[LinterOutcome, str]]
 #: A linter itself, a callable method.
 LinterCallback = Callable[['Lintable'], LinterReturn]
 
@@ -344,7 +344,7 @@ class Lintable(Generic[LintableT]):
 
 def filter_allowed_checks(
         rulings: Iterable[LinterRuling],
-        outcomes: Optional[List[LinterOutcome]] = None) -> Generator[LinterRuling, None, None]:
+        outcomes: Optional[List[LinterOutcome]] = None) -> Iterator[LinterRuling]:
     """
     Filter only rulings whose outcomes are allowed.
 
@@ -363,7 +363,7 @@ def filter_allowed_checks(
         yield (linter, actual_outcome, eventual_outcome, message)
 
 
-def format_rulings(rulings: Iterable[LinterRuling]) -> Generator[str, None, None]:
+def format_rulings(rulings: Iterable[LinterRuling]) -> Iterator[str]:
     """
     Format rulings for printing or logging.
 

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -5,7 +5,7 @@ import os
 import pkgutil
 import sys
 from importlib.metadata import entry_points
-from typing import Any, Dict, Generator, Generic, List, Optional, Tuple, TypeVar
+from typing import Any, Dict, Generic, Iterator, List, Optional, Tuple, TypeVar
 
 import tmt
 import tmt.utils
@@ -24,7 +24,7 @@ ALREADY_EXPLORED = False
 _TMT_ROOT = Path(tmt.__file__).resolve().parent
 
 
-def discover(path: Path) -> Generator[str, None, None]:
+def discover(path: Path) -> Iterator[str]:
     """ Discover available plugins for given paths """
     for _, name, package in pkgutil.iter_modules([str(path)]):
         if not package:
@@ -292,8 +292,8 @@ class PluginRegistry(Generic[RegisterableT]):
 
         return self._plugins.get(plugin_id, None)
 
-    def iter_plugin_ids(self) -> Generator[str, None, None]:
+    def iter_plugin_ids(self) -> Iterator[str]:
         yield from self._plugins.keys()
 
-    def iter_plugins(self) -> Generator[RegisterableT, None, None]:
+    def iter_plugins(self) -> Iterator[RegisterableT]:
         yield from self._plugins.values()

--- a/tmt/queue.py
+++ b/tmt/queue.py
@@ -1,6 +1,6 @@
 import dataclasses
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from typing import TYPE_CHECKING, Dict, Generator, Generic, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Dict, Generic, Iterator, List, Optional, TypeVar
 
 import fmf.utils
 
@@ -65,7 +65,7 @@ class _Task:
     def guest_ids(self) -> List[str]:
         return [guest.multihost_name for guest in self.guests]
 
-    def go(self) -> Generator[TaskOutcome['Self'], None, None]:
+    def go(self) -> Iterator[TaskOutcome['Self']]:
         """ Perform the task """
 
         raise NotImplementedError
@@ -87,7 +87,7 @@ class GuestlessTask(_Task):
     def run(self, logger: Logger) -> None:
         raise NotImplementedError
 
-    def go(self) -> Generator[TaskOutcome['Self'], None, None]:
+    def go(self) -> Iterator[TaskOutcome['Self']]:
         try:
             self.run(self.logger)
 
@@ -149,7 +149,7 @@ class Task(_Task):
 
         return loggers
 
-    def go(self) -> Generator[TaskOutcome['Self'], None, None]:
+    def go(self) -> Iterator[TaskOutcome['Self']]:
         multiple_guests = len(self.guests) > 1
 
         new_loggers = self.prepare_loggers(self.logger)
@@ -240,7 +240,7 @@ class Queue(List[TaskT]):
             f'{task.name} on {fmf.utils.listed(task.guest_ids)}',
             color='cyan')
 
-    def run(self) -> Generator[TaskOutcome[TaskT], None, None]:
+    def run(self) -> Iterator[TaskOutcome[TaskT]]:
         """
         Start crunching the queued phases.
 

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -14,8 +14,8 @@ from typing import (
     Callable,
     DefaultDict,
     Dict,
-    Generator,
     Iterable,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -155,7 +155,7 @@ class DefaultNameGenerator:
     def restart(self) -> None:
         """ Reset the generator and start from the beginning again """
 
-        def _generator() -> Generator[str, None, None]:
+        def _generator() -> Iterator[str]:
             for i in itertools.count(start=0):
                 name = f'{DEFAULT_NAME}-{i}'
 
@@ -598,7 +598,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
             keys representing CLI options.
             """
 
-            def _iter_options() -> Generator[Tuple[str, Any], None, None]:
+            def _iter_options() -> Iterator[Tuple[str, Any]]:
                 for name, value in options.items():
                     if name in ('update', 'update_missing', 'insert'):
                         continue
@@ -1966,7 +1966,7 @@ class QueuedPhase(GuestlessTask, Task):
             guest=guest,
             logger=logger)
 
-    def go(self) -> Generator[TaskOutcome['Self'], None, None]:
+    def go(self) -> Iterator[TaskOutcome['Self']]:
         # Based on the phase, pick the proper parent class' go()
         if isinstance(self.phase, Action):
             yield from GuestlessTask.go(self)

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import TYPE_CHECKING, Any, Dict, Generator, List, Optional, Type, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Type, cast
 
 import click
 from fmf.utils import listed
@@ -343,11 +343,11 @@ class Discover(tmt.steps.Step):
             *,
             phase_name: Optional[str] = None,
             enabled: Optional[bool] = None) -> List['tmt.Test']:
-        def _iter_all_tests() -> Generator['tmt.Test', None, None]:
+        def _iter_all_tests() -> Iterator['tmt.Test']:
             for phase_tests in self._tests.values():
                 yield from phase_tests
 
-        def _iter_phase_tests() -> Generator['tmt.Test', None, None]:
+        def _iter_phase_tests() -> Iterator['tmt.Test']:
             assert phase_name is not None
 
             yield from self._tests[phase_name]

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -16,7 +16,7 @@ from typing import (
     Any,
     DefaultDict,
     Dict,
-    Generator,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -183,7 +183,7 @@ class GuestFacts(SerializableContainer):
         if not output or not output.stdout:
             return content
 
-        def _iter_pairs() -> Generator[Tuple[str, str], None, None]:
+        def _iter_pairs() -> Iterator[Tuple[str, str]]:
             assert output  # narrow type in a closure
             assert output.stdout  # narrow type in a closure
 
@@ -418,7 +418,7 @@ class GuestData(SerializableContainer):
     # TODO: find out whether this could live in DataContainer. It probably could,
     # but there are containers not backed by options... Maybe a mixin then?
     @classmethod
-    def options(cls) -> Generator[Tuple[str, str], None, None]:
+    def options(cls) -> Iterator[Tuple[str, str]]:
         """
         Iterate over option names.
 


### PR DESCRIPTION
We need very little from our generators, and `Iterator` is simpler annotation.