### PR TITLE
Fix beakerlib libraries with specific path

### DIFF
--- a/tests/libraries/layered_fmf/data/main.fmf
+++ b/tests/libraries/layered_fmf/data/main.fmf
@@ -1,0 +1,6 @@
+summary: test for library with layered fmf
+test: ./test.sh
+require:
+  - path: PATH
+    name: /first/test
+    type: library

--- a/tests/libraries/layered_fmf/data/test.sh
+++ b/tests/libraries/layered_fmf/data/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+set -o pipefail
+
+rlJournalStart
+    rlPhaseStartTest
+        rlRun "rlImport --all"
+        rlRun "first"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/libraries/layered_fmf/main.fmf
+++ b/tests/libraries/layered_fmf/main.fmf
@@ -1,0 +1,4 @@
+summary: Test that library can have layered fmf
+require:
+- git-core
+tier: 4

--- a/tests/libraries/layered_fmf/test.sh
+++ b/tests/libraries/layered_fmf/test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+set -o pipefail
+
+rlJournalStart
+    rlPhaseStartSetup "Prepare library and test"
+        rlRun "libdir=\$(mktemp -d)"
+        rlRun "cp -r lib/* $libdir"
+        rlRun "tmt init $libdir"
+
+        rlRun "testdir=\$(mktemp -d)"
+        rlRun "cp -r data/* $testdir"
+        rlRun "pushd $testdir"
+        rlRun "tmt init"
+        rlRun "git init"
+        rlRun "git config --local user.email me@localhost.localdomain"
+        rlRun "git config --local user.name m e"
+        rlRun "git add -A"
+        rlRun "git commit -m initial"
+        rlRun "sed 's|PATH|$libdir|' -i main.fmf"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test layered library fmf"
+        rlRun -s "tmt run --rm -a -vvv -ddd provision -h local"
+        rlAssertGrep "1 tests passed" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -rf $libdir $testdir" 0 "Remove temporary directories"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -290,8 +290,15 @@ class BeakerLib(Library):
                     library_path: Path = clone_dir / str(self.fmf_node_path).strip('/')
                     local_library_path: Path = directory / str(self.fmf_node_path).strip('/')
                     if not library_path.exists():
-                        self.parent.debug(f"Failed to find library {self} at {self.url}")
-                        raise LibraryError
+                        tree = fmf.Tree(str(clone_dir)).find(self.name)
+                        if tree:
+                            full_lib_path = tree.data.get('path')
+                            if full_lib_path:
+                                library_path = clone_dir / full_lib_path.strip('/')
+                                local_library_path = directory / full_lib_path.strip('/')
+                        if not library_path.exists():
+                            self.parent.debug(f"Failed to find library {self} at {self.url}")
+                            raise LibraryError
                     self.parent.debug(f"Library {self} is copied into {directory}")
                     tmt.utils.copytree(library_path, local_library_path, dirs_exist_ok=True)
 


### PR DESCRIPTION
When libraries are defined with fmf files in layered/child directory and then have path argument they wouldn't clone correctly after pruning or would miss any dependencies if wrong name/path argument was provided (like the one to the parent directory).

Example library/test:
├── metadata
├── plans
│   └── plan.fmf
├── PURPOSE
├── lib.sh
├── runtest.sh
└── tests
    └── test.fmf
