### PR TITLE
Update `where` implementation, docs & test coverage

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -708,8 +708,9 @@ given task (test, preparation script, ansible playbook, etc.) on
 several guests at once. Tasks are assigned to provisioned guests by
 matching the ``where`` key from
 :ref:`discover</spec/plans/discover/where>`,
-:ref:`prepare</spec/plans/prepare/where>` and ``finish`` phases
-with corresponding guests by their
+:ref:`prepare</spec/plans/prepare/where>` and
+:ref:`finish</spec/plans/finish/where>`
+phases with corresponding guests by their
 :ref:`key and role keys</spec/plans/provision/multihost>`.
 Essentially, plan author tells tmt on which guest(s) a test or
 script should run by listing guest name(s) or guest role(s).

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -307,3 +307,8 @@ description: |
                       - test: first client script
                       - test: second client script
                       - test: third client script
+    link:
+      - implemented-by: /tmt/steps
+      - verified-by: /tests/multihost/complete
+      - verified-by: /tests/multihost/web
+      - documented-by: /docs/guide.rst#multihost-testing

--- a/spec/plans/finish.fmf
+++ b/spec/plans/finish.fmf
@@ -53,3 +53,24 @@ example: |
                 - https://foo.bar/rhel7-final-touches.yml
     link:
       - implemented-by: /tmt/steps/finish/ansible.py
+
+/where:
+    summary: Perform finishing tasks on selected guests
+    description: |
+        In the :ref:`/spec/plans/provision/multihost` scenarios it
+        is often necessary to perform different preparation tasks
+        on individual guests. The ``where`` key allows to select
+        guests where the finishing tasks should be applied by
+        providing their ``name`` or the ``role`` they play in the
+        scenario. Use a list to specify multiple names or roles.
+        By default, when the ``where`` key is not defined,
+        finishing tasks are performed on all provisioned guests.
+    example: |
+        # Stop Apache on the server
+        prepare:
+          - how: shell
+            script: systemctl stop httpd
+            where: server
+    link:
+      - implemented-by: /tmt/steps
+      - documented-by: /docs/guide.rst

--- a/spec/plans/prepare.fmf
+++ b/spec/plans/prepare.fmf
@@ -171,3 +171,9 @@ example: |
           - how: ansible
             playbook: common.yaml
             where: [primary, replica]
+    link:
+      - implemented-by: /tmt/steps
+      - verified-by: /tests/multihost/complete
+      - verified-by: /tests/multihost/web
+      - verified-by: /tests/multihost/corner-cases
+      - documented-by: /docs/guide.rst


### PR DESCRIPTION
The `where` key has been implemented already some time ago, update docs accordingly. Also add a new `where` section to the `finish` step specification as well.