### PR TITLE
Drop special normalization methods

### DIFF
--- a/tests/unit/test_dataclasses.py
+++ b/tests/unit/test_dataclasses.py
@@ -1,6 +1,5 @@
 import dataclasses
 from typing import Any, List, Optional
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -8,7 +7,6 @@ import tmt.log
 import tmt.utils
 from tmt.utils import (
     SerializableContainer,
-    container_field,
     dataclass_normalize_field,
     field,
     )
@@ -56,65 +54,6 @@ def test_field_normalize_callback(root_logger: tmt.log.Logger) -> None:
         dataclass_normalize_field(data, ':foo', 'foo', 'will crash', root_logger)
 
     assert data.foo == 3
-
-
-def test_field_normalize_special_method(root_logger: tmt.log.Logger) -> None:
-    def normalize_foo(cls, key_address: str, raw_value: Any, logger: tmt.log.Logger) -> int:
-        if raw_value is None:
-            return None
-
-        try:
-            return int(raw_value)
-
-        except ValueError as exc:
-            raise tmt.utils.NormalizationError(key_address, raw_value, 'unset or an integer') \
-                from exc
-
-    @dataclasses.dataclass
-    class DummyContainer(SerializableContainer):
-        foo: Optional[int] = field(
-            default=1
-            )
-
-        _normalize_foo = normalize_foo
-
-    # Initialize a data package
-    data = DummyContainer()
-    assert data.foo == 1
-
-    dataclass_normalize_field(data, ':foo', 'foo', None, root_logger)
-    assert data.foo is None
-
-    dataclass_normalize_field(data, ':foo', 'foo', 2, root_logger)
-    assert data.foo == 2
-
-    dataclass_normalize_field(data, ':foo', 'foo', '3', root_logger)
-    assert data.foo == 3
-
-    with pytest.raises(
-            tmt.utils.SpecificationError,
-            match=r"Field ':foo' must be unset or an integer, 'str' found."):
-        dataclass_normalize_field(data, ':foo', 'foo', 'will crash', root_logger)
-
-    assert data.foo == 3
-
-
-def test_normalize_callback_preferred(root_logger: tmt.log.Logger) -> None:
-    @dataclasses.dataclass
-    class DummyContainer(SerializableContainer):
-        foo: Optional[int] = field(default=1)
-
-        _normalize_foo = MagicMock()
-
-    data = DummyContainer()
-    foo_metadata = container_field(data, 'foo')[4]
-
-    foo_metadata.normalize_callback = MagicMock()
-
-    dataclass_normalize_field(data, ':foo', 'foo', 'will crash', root_logger)
-
-    foo_metadata.normalize_callback.assert_called_once_with(':foo', 'will crash', root_logger)
-    data._normalize_foo.assert_not_called()
 
 
 def test_field_custom_serialize():

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -380,6 +380,23 @@ def create_adjust_callback(logger: tmt.log.Logger) -> fmf.base.AdjustCallback:
     return callback
 
 
+def normalize_test_environment(
+        key_address: str,
+        value: Optional[Dict[str, Any]],
+        logger: tmt.log.Logger) -> EnvironmentType:
+    """ Normalize value of tests' ``environment`` key """
+
+    if value is None:
+        return {}
+
+    if isinstance(value, dict):
+        return {
+            name: str(value) for name, value in value.items()
+            }
+
+    raise tmt.utils.NormalizationError(key_address, value, 'unset or a dictionary')
+
+
 # Types describing content accepted by various require-like keys: strings, fmf ids,
 # paths, or lists mixing various types.
 #
@@ -1043,7 +1060,9 @@ class Test(
         default_factory=list,
         normalize=normalize_require,
         exporter=lambda value: [dependency.to_minimal_spec() for dependency in value])
-    environment: tmt.utils.EnvironmentType = field(default_factory=dict)
+    environment: tmt.utils.EnvironmentType = field(
+        default_factory=dict,
+        normalize=normalize_test_environment)
 
     duration: str = DEFAULT_TEST_DURATION_L1
     result: str = 'respect'

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -117,7 +117,10 @@ class TestDescription(
             for recommend in serialized_recommends
             ]
         )
-    environment: tmt.utils.EnvironmentType = field(default_factory=dict)
+    environment: tmt.utils.EnvironmentType = field(
+        default_factory=dict,
+        normalize=tmt.base.normalize_test_environment
+        )
     duration: str = '1h'
     result: str = 'respect'
 


### PR DESCRIPTION
This was a temporary solution, from now on only `field(normalize=...)` is supported.

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
