### PR TITLE
Add a helper for nonconflicting, multihost-safe filenames

### DIFF
--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -17,6 +17,7 @@ import tmt.steps.execute
 import tmt.utils
 from tmt.base import Test
 from tmt.result import BaseResult, CheckResult, Result, ResultOutcome
+from tmt.steps import safe_filename
 from tmt.steps.execute import SCRIPTS, TEST_OUTPUT_FILENAME, TMT_REBOOT_SCRIPT
 from tmt.steps.provision import Guest
 from tmt.utils import EnvironmentType, Path, ShellScript, Stopwatch, field
@@ -269,7 +270,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         # the same `discover` phase for different guests at the same time, and
         # must keep them isolated. The wrapper script, while being prepared, is
         # a shared global state, and we must prevent race conditions.
-        test_wrapper_filename = f'{TEST_WRAPPER_FILENAME}.{guest.name}'
+        test_wrapper_filename = safe_filename(TEST_WRAPPER_FILENAME, self, guest)
         test_wrapper_filepath = workdir / test_wrapper_filename
 
         logger.debug('test wrapper', test_wrapper_filepath)

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -7,6 +7,7 @@ import tmt
 import tmt.steps
 import tmt.steps.finish
 import tmt.utils
+from tmt.steps import safe_filename
 from tmt.steps.provision import Guest
 from tmt.utils import ShellScript, field
 
@@ -71,7 +72,8 @@ class FinishShell(tmt.steps.finish.FinishPlugin[FinishShellData]):
 
         workdir = self.step.plan.worktree
         assert workdir is not None  # narrow type
-        finish_wrapper_filename = f'{FINISH_WRAPPER_FILENAME}-{self.safe_name}-{guest.safe_name}'
+
+        finish_wrapper_filename = safe_filename(FINISH_WRAPPER_FILENAME, self, guest)
         finish_wrapper_path = workdir / finish_wrapper_filename
 
         logger.debug('finish wrapper', finish_wrapper_path, level=3)

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -8,6 +8,7 @@ import tmt.log
 import tmt.steps
 import tmt.steps.prepare
 import tmt.utils
+from tmt.steps import safe_filename
 from tmt.steps.provision import Guest
 from tmt.utils import ShellScript, field
 
@@ -80,18 +81,15 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             topology = tmt.steps.Topology(self.step.plan.provision.guests())
             topology.guest = tmt.steps.GuestTopology(guest)
 
-            # Since we do not have the test data dir at hand, we must make the topology
-            # filename unique on our own, and include the phase name and guest name.
-            filename_base = f'{tmt.steps.TEST_TOPOLOGY_FILENAME_BASE}-{self.safe_name}-{guest.safe_name}'  # noqa: E501
-
             environment.update(
                 topology.push(
                     dirpath=workdir,
                     guest=guest,
                     logger=logger,
-                    filename_base=filename_base))
+                    filename_base=safe_filename(tmt.steps.TEST_TOPOLOGY_FILENAME_BASE, self, guest)
+                    ))
 
-        prepare_wrapper_filename = f'{PREPARE_WRAPPER_FILENAME}-{self.safe_name}-{guest.safe_name}'
+        prepare_wrapper_filename = safe_filename(PREPARE_WRAPPER_FILENAME, self, guest)
         prepare_wrapper_path = workdir / prepare_wrapper_filename
 
         logger.debug('prepare wrapper', prepare_wrapper_path, level=3)


### PR DESCRIPTION
Since we entered the realms of multihost and parallel executions of phases, we need filenames that, when used by a phase on multiple guests or by one plugin executed multiple times, would allow for now race conditions. We cannot afford a phase overwriting a script wrapper or guest topology.

There are already two places where such files are constructed, two more are in pending pull requests, one is clearly missing, and more will be needed when we start exposing guest facts to guest-setup playbooks. Or to `prepare/feature` plugin.

So, to avoid confusion about how such a file should be called, there's a helper function. If we ever get Pyright, together with a `NewType` we might be able to prevent using non-unique filenames where safe ones are needed.

Patch requires a bit of refactoring of guest topology saving, but nothing serious.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation