### PR TITLE
Change the default test pidfile directory to /var/tmp

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -486,9 +486,11 @@ TMT_TEST_PIDFILE, TMT_TEST_PIDFILE_LOCK
     making any changes to the pid file.
 
 TMT_TEST_PIDFILE_ROOT
-    By default, the test pidfile file is stored in the ``$TMT_WORKDIR_ROOT``
+    By default, the test pidfile file is stored in ``/var/tmp``
     directory. If specified, the directory in this variable would be
-    used instead.
+    used instead. The directory permissions should follow the pattern
+    of temporary directory permissions, e.g. ``chmod 1777``, to
+    allow access to users with all privilege levels.
 
 Plugin Variables
 ----------------

--- a/tests/execute/reboot/out-of-session.sh
+++ b/tests/execute/reboot/out-of-session.sh
@@ -41,7 +41,7 @@ rlJournalStart
             # and use it to issue a `tmt-reboot` from outside the direct process tree of the test.
             set -x
 
-            tmt_reboot_command="export TMT_TEST_PIDFILE=/var/tmp/tmt/tmt-test.pid; export TMT_TEST_PIDFILE_LOCK=/var/tmp/tmt/tmt-test.pid.lock; export TMT_DEBUG=1; tmt-reboot"
+            tmt_reboot_command="export TMT_TEST_PIDFILE=/var/tmp/tmt-test.pid; export TMT_TEST_PIDFILE_LOCK=/var/tmp/tmt-test.pid.lock; export TMT_DEBUG=1; tmt-reboot"
 
             if [ "$method" = "container" ]; then
                 podman_exec="$(sed -nr 's/\s*Run command: (podman exec .*) \/bin\/bash.*cd.*/\1/p' tmt.output)"

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -24,19 +24,22 @@ from tmt.utils import EnvironmentType, Path, ShellScript, Stopwatch, field
 TEST_PIDFILE_FILENAME = 'tmt-test.pid'
 TEST_PIDFILE_LOCK_FILENAME = f'{TEST_PIDFILE_FILENAME}.lock'
 
+#: The default directory for storing test pid file.
+TEST_PIDFILE_ROOT = Path('/var/tmp')
+
 
 def effective_pidfile_root() -> Path:
     """
     Find out what the actual pidfile directory is.
 
     If ``TMT_TEST_PIDFILE_ROOT`` variable is set, it is used. Otherwise,
-    the effective workdir root is picked.
+    :py:const:`TEST_PIDFILE_ROOT` is picked.
     """
 
     if 'TMT_TEST_PIDFILE_ROOT' in os.environ:
         return Path(os.environ['TMT_TEST_PIDFILE_ROOT'])
 
-    return tmt.utils.effective_workdir_root()
+    return TEST_PIDFILE_ROOT
 
 
 TEST_WRAPPER_FILENAME = 'tmt-test-wrapper.sh'

--- a/tmt/steps/execute/scripts/tmt-reboot
+++ b/tmt/steps/execute/scripts/tmt-reboot
@@ -6,7 +6,7 @@
 
 [ -n "$TMT_DEBUG" ] && set -x
 
-TMT_TEST_PIDFILE_LOCK="${TMT_TEST_PIDFILE_LOCK:-/var/tmp/tmt/tmt-test.pid}"
+TMT_TEST_PIDFILE_LOCK="${TMT_TEST_PIDFILE_LOCK:-/var/tmp/tmt-test.pid}"
 
 PATH=/sbin:/usr/sbin:$PATH
 

--- a/tmt/steps/execute/scripts/tmt-reboot-core
+++ b/tmt/steps/execute/scripts/tmt-reboot-core
@@ -2,7 +2,7 @@
 
 [ -n "$TMT_DEBUG" ] && set -x
 
-TMT_TEST_PIDFILE="${TMT_TEST_PIDFILE:-/var/tmp/tmt/tmt-test.pid}"
+TMT_TEST_PIDFILE="${TMT_TEST_PIDFILE:-/var/tmp/tmt-test.pid}"
 
 if [ ! -e "$TMT_TEST_PIDFILE" ]; then
     echo "There is no running test to signal the reboot to!"


### PR DESCRIPTION
The original path, `/var/tmp/tmt`, may not always exist or may have unexpected permissions, preventing the pidfile from being created when less privileged account is used to access a guest.

Pull Request Checklist

* [x] implement the feature