### PR TITLE
Framework is not consulted on results provided by tmt-report-result

### DIFF
--- a/stories/features/report-result.fmf
+++ b/stories/features/report-result.fmf
@@ -17,6 +17,10 @@ description: |
     Note, that the only value currently processed by ``tmt`` is
     the test result, other options are silently ignored.
 
+    When ``tmt-report-result`` is called, the return value of the
+    test itself is ignored, and only result saved by
+    ``tmt-report-result`` is consumed by tmt.
+
     __ https://restraint.readthedocs.io/en/latest/commands.html#rstrnt-report-result
 
 example: |

--- a/tests/execute/restraint/report-result/test.sh
+++ b/tests/execute/restraint/report-result/test.sh
@@ -9,18 +9,34 @@ rlJournalStart
     rlPhaseStartTest
         rlRun -s "tmt run -vvv --remove" 1
         rlAssertGrep "pass /report" $rlRun_LOG
+
+        # smoke rstrnt
         rlAssertGrep "pass /smoke/rstrnt-good" $rlRun_LOG
+        rlAssertNotGrep "fail /smoke/rstrnt-good" $rlRun_LOG
         rlAssertGrep "fail /smoke/rstrnt-bad" $rlRun_LOG
+        rlAssertNotGrep "pass /smoke/rstrnt-bad" $rlRun_LOG
         rlAssertGrep "skip /smoke/rstrnt-skip" $rlRun_LOG
+        rlAssertNotGrep "pass /smoke/rstrnt-skip" $rlRun_LOG
         rlAssertGrep "warn /smoke/rstrnt-warn" $rlRun_LOG
-	rlAssertGrep "pass /smoke/rhts-good" $rlRun_LOG
+        rlAssertNotGrep "pass /smoke/rstrnt-warn" $rlRun_LOG
+
+        # smoke rhts
+        rlAssertGrep "pass /smoke/rhts-good" $rlRun_LOG
+        rlAssertNotGrep "fail /smoke/rhts-good" $rlRun_LOG
         rlAssertGrep "fail /smoke/rhts-bad" $rlRun_LOG
+        rlAssertNotGrep "pass /smoke/rhts-bad" $rlRun_LOG
         rlAssertGrep "skip /smoke/rhts-skip" $rlRun_LOG
+        rlAssertNotGrep "pass /smoke/rhts-skip" $rlRun_LOG
         rlAssertGrep "warn /smoke/rhts-warn" $rlRun_LOG
-	rlAssertGrep "pass /multi_reports/rstrnt-good" $rlRun_LOG
+        rlAssertNotGrep "pass /smoke/rhts-warn" $rlRun_LOG
+
+        # multi rstrnt
+        rlAssertGrep "pass /multi_reports/rstrnt-good" $rlRun_LOG
         rlAssertGrep "fail /multi_reports/rstrnt-bad" $rlRun_LOG
         rlAssertGrep "pass /multi_reports/rstrnt-skip" $rlRun_LOG
         rlAssertGrep "warn /multi_reports/rstrnt-warn" $rlRun_LOG
+
+        # multi rhts
         rlAssertGrep "pass /multi_reports/rhts-good" $rlRun_LOG
         rlAssertGrep "fail /multi_reports/rhts-bad" $rlRun_LOG
         rlAssertGrep "pass /multi_reports/rhts-skip" $rlRun_LOG


### PR DESCRIPTION
By a mistake, even after loading results generated by `tmt-report-result` script the test framework was called to provide a test result. This led to a duplication, extra results were generated.

The patch makes `tmt-report-result` results similar to custom results file: if results exist, they are loaded and passed to the execute plugin, and the test framework is not consulted.

Fixes https://github.com/teemtee/tmt/issues/2389

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage