### PR TITLE
Add hardware schema for GPU

### DIFF
--- a/spec/hardware/gpu.fmf
+++ b/spec/hardware/gpu.fmf
@@ -1,0 +1,14 @@
+summary:
+    Choose system according to the available graphics processing unit (gpu)
+example:
+  - |
+    # GPU-related stuff grouped together.
+    gpu:
+        # GPU device name name.
+        device-name: G86 [Quadro NVS 290]
+        # GPU vendor name.
+        vendor-name: NVIDIA Corporation
+
+# NOTE: not yet supported
+# link:
+#   - implemented-by: /tmt/steps/provision/artemis.py

--- a/tests/unit/test_hardware.py
+++ b/tests/unit/test_hardware.py
@@ -109,6 +109,8 @@ def test_parse_maximal_constraint() -> None:
         disk:
             - size: 40 GiB
             - size: 120 GiB
+        gpu:
+            device-name: G86 [Quadro NVS 290]
         hostname: "~ .*.foo.redhat.com"
         memory: 8 GiB
         network:

--- a/tmt/schemas/provision/hardware.yaml
+++ b/tmt/schemas/provision/hardware.yaml
@@ -154,6 +154,23 @@ definitions:
     items:
       "$ref": "#/definitions/disk"
 
+  # HW requirements: single `gpu` item
+  gpu:
+    type: object
+
+    properties:
+      device-name:
+        type: string
+
+      vendor-name:
+        type: string
+
+    additionalProperties: false
+
+    # enforce at least one property - we don't care which one, but we don't want
+    # empty `gpu`.
+    minProperties: 1
+
   hostname:
     type: string
 
@@ -272,6 +289,9 @@ definitions:
 
       disk:
         "$ref": "#/definitions/disks"
+
+      gpu:
+        "$ref": "#/definitions/gpu"
 
       hostname:
         "$ref": "#/definitions/hostname"


### PR DESCRIPTION
To be able to select machines according to the graphics card introduce the `gpu` key under `hardware`.

According to discussion, use for now only `product` and `vendor` names to be available for filtering, those can be easily detected using the command:

```
lshw -C display
```

Resolves #2154

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] update the specification
* [x] modify the json schema
