### PR TITLE
Document case-insensitive context dimension values

### DIFF
--- a/spec/context/main.fmf
+++ b/spec/context/main.fmf
@@ -17,11 +17,10 @@ description: |
     context, just make sure the :ref:`/spec/context/dimension`
     name does not conflict with reserved names.
 
-    Some of the context dimensions can be detected (e.g. distro
-    from the provision step config). Each plan can provide its own
-    :ref:`/spec/plans/context` which will override detected
-    values. Finally, the context definition provided directly on
-    the command line overrides detected and defined dimensions.
+    Each plan can also provide its own :ref:`/spec/plans/context`.
+    The context definition provided directly on the command line
+    overrides defined dimensions. All context dimension values are
+    handled in case-insensitive way.
 
     __ https://fmf.readthedocs.io/en/latest/context.html
 


### PR DESCRIPTION
As a follow-up to #2357, let's explicitly document that context dimension values are handled in case-insensitive way. Also remove old mention about the context detection which was never working and it's questionable whether it will ever be possible because of the chicken-and-egg nature of the problem.

Pull Request Checklist

* [x] update the specification