### PR TITLE
Update and polish `hardware` requirement docs

### DIFF
--- a/docs/story.rst.j2
+++ b/docs/story.rst.j2
@@ -55,6 +55,30 @@
 {% endmacro %}
 
 {#
+    Emit a link leading to tmt's plugin.
+
+    :param link: tmt.base.Link instance.
+#}
+{% macro emit_tmt_plugin_link(link) %}
+{% set matched = link.target | match('^/tmt/steps/([a-z_]+/[a-z_]+)\\.py$') %}
+{#
+    A couple of plugins where the file name does not match the "how" name
+    used commonly in fmf files/on command line.
+#}
+{% set plugin_name = matched.group(1) %}
+{% if plugin_name == "execute/internal" %}
+    {% set plugin_name = "execute/tmt" %}
+{% elif plugin_name == "provision/mrack" %}
+    {% set plugin_name = "provision/beaker" %}
+{% elif plugin_name == "provision/podman" %}
+    {% set plugin_name = "provision/container" %}
+{% elif plugin_name == "provision/testcloud" %}
+    {% set plugin_name = "provision/virtual" %}
+{% endif %}
+{{ _emit_remote_link(link, plugin_name, "https://github.com/teemtee/tmt/tree/main/" + link.target) }}
+{% endmacro %}
+
+{#
     Emit a link leading to an object in tmt's upstream repository - a test,
     story, source file.
 
@@ -165,7 +189,7 @@
 
 {# Links pointing to step plugins #}
 {% elif link.target | match('^/tmt/steps/([a-z_]+/[a-z_]+)\\.py$') %}
-{{ emit_tmt_repo_link(link, '/tmt/steps/([a-z_]+/[a-z_]+)\\.py') }}
+{{ emit_tmt_plugin_link(link) }}
 
 {# Links pointing to other tmt code #}
 {% elif link.target.startswith('/tmt') %}

--- a/spec/hardware/arch.fmf
+++ b/spec/hardware/arch.fmf
@@ -1,9 +1,18 @@
-summary:
-    Select the desired architecture
+summary: |
+    Select or provision a guest with a given CPU architecture.
+
+description: |
+    .. code-block::
+
+       # String, any of well-known short architecture names.
+       arch: "aarch64"|"i386"|"ppc64"|"ppc64le"|"s390x"|"x86_64"|...
+
 example:
   - |
-    # Architecture (any of well-known short architecture names,
-    # for example aarch64, i386, ppc64, ppc64le, s390x, x86_64)
+    # Require a good old x86_64 box
     arch: x86_64
+
 link:
   - implemented-by: /tmt/steps/provision/artemis.py
+  - implemented-by: /tmt/steps/provision/mrack.py
+  - implemented-by: /tmt/steps/provision/testcloud.py

--- a/spec/hardware/boot.fmf
+++ b/spec/hardware/boot.fmf
@@ -1,14 +1,23 @@
-summary:
-    Features related to machine boot
+summary: |
+    Select or provision a guest with requested boot properties.
+
+description: |
+    .. code-block::
+
+       boot:
+         # String, a boot method the guest must boot with.
+         method: "bios"|"uefi"
+
 example:
   - |
-    # Guest with BIOS
-    boot:
-        method: bios
-
-  - |
-    # Guest with UEFI
+    # Require a guest with a UEFI boot method.
     boot:
         method: uefi
+
+  - |
+    # Require a guest without a legacy BIOS.
+    boot:
+        method: "!= bios"
+
 link:
   - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/hardware/compatible.fmf
+++ b/spec/hardware/compatible.fmf
@@ -1,10 +1,19 @@
-summary:
-    Select guest based on given compatibility
-description:
-    Pick only guests compatible with given operating system
-    distribution. See the context :ref:`/spec/context/dimension`
-    definitions for the list of supported values of the ``distro``
-    key. Must be a list of strings.
+summary: |
+    Select or provision a guest compatible with given areas.
+
+description: |
+    .. code-block::
+
+       compatible:
+         # List of strings, any of distro names.
+         distro:
+           - distro1
+           - distro2
+             ...
+
+    See the context :ref:`/spec/context/dimension` definitions for
+    the list of supported values of the ``distro`` items.
+
 example:
   - |
     # Select a guest compatible with both rhel-8 and rhel-9

--- a/spec/hardware/cpu.fmf
+++ b/spec/hardware/cpu.fmf
@@ -1,39 +1,81 @@
-summary:
-    Choose system according to the processor features
+summary: |
+    Select or provision a guest with given CPU properties.
+
+description: |
+    .. code-block::
+
+       cpu:
+           # Integer or string, number of CPU sockets in the system.
+          sockets: 1|">= 1"
+
+          # Integer or string, number of CPU cores in the system.
+          cores: 4|">= 4"
+
+          # Integer or string, number of CPU threads in the system.
+          threads: 8|">= 8"
+
+          # Integer or string, number of CPU cores per socket.
+          cores-per-socket: 4|">= 4"
+
+          # Integer or string, number of CPU threads per core.
+          threads-per-core: 2|">= 2"
+
+          # Integer or string, total number of logical CPUs.
+          processors: 8|">= 8"
+
+          # String, CPU family name.
+          family-name: Comet Lake
+
+          # Integer or string, CPU family.
+          family: 6|">= 6"
+
+          # String, CPU model name.
+          model-name: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
+
+          # Integer or string, CPU model.
+          model: 142|">= 142"
+
+          # Integer or string, CPU stepping.
+          stepping: 10|">= 10"
+
+          # List of strings, CPU flags as reported
+          # Field applies an implicit "and" to listed flags, all items of the
+          # list must match.
+          # Items may contain a nested operator, "=" and "!=" are only two allowed.
+          flag:
+            - flag1
+            - flag2
+            - "= flag3"
+            - "!= flag4"
+              ...
+
+    See e.g. https://virtual-dba.com/blog/sockets-cores-and-threads/ for the
+    socket, core and thread distinction.
+
+    See e.g. https://en.wikichip.org/wiki/WikiChip for information on family,
+    model, stepping and corresponding names. ``/proc/cpuinfo`` and ``lscpu``
+    are also useful resources.
+
 example:
   - |
-    # Processor-related stuff grouped together
+    # Request a rather stronger guest.
     cpu:
-        # The total number of various CPU components in the system.
-        sockets: 1
-        cores: 4
-        threads: 8
+        processors: ">= 16"
 
-        # Ther number of various CPU components per their parent.
-        cores-per-socket: 4
-        threads-per-core: 2
+  - |
+    # Request a CPU of a specific model set.
+    cpu:
+        model-name: "~ Intel(R) Core(TM) i7-.+"
 
-        # The total number of logical CPUs.
-        processors: 8
-
-        # CPU family name.
-        family-name: Comet Lake
-        # CPU family number.
-        family: 6
-        # CPU model name. Usually reported as such by /proc/cpuinfo or lscpu.
-        model-name: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
-        # CPU model number.
-        model: 142
-        # CPU stepping.
-        stepping: 10
-
-        # CPU flag(s) as reported with /proc/cpuinfo
-        # Field applies an implicit "and" to listed flags
-        # Supported operators: "=" and "!="
+  - |
+    # Request a CPU with AVX support
+    cpu:
         flag:
           - avx
           - avx2
-          - "!= smep"
+
 link:
   - implemented-by: /tmt/steps/provision/artemis.py
     note: "``cpu.flag`` not supported yet"
+  - implemented-by: /tmt/steps/provision/mrack.py
+    note: "``cpu.processors`` and ``cpu.model`` only"

--- a/spec/hardware/device.fmf
+++ b/spec/hardware/device.fmf
@@ -1,16 +1,36 @@
-summary:
-    Select system with given device
-description:
-    Use the ``device-name`` to provide the device name as a string,
-    ``device`` to select a system with a specified device PCI ID,
-    ``driver`` key to specify the kernel module name
-    ``vendor-name`` to provide the vendor name as a string,
-    ``vendor`` to select a system with the vendor's unique identifier
+summary: |
+    Select or provision a guest with a given device.
+
+description: |
+    This is a generalization of various device-like requirements like ``gpu``
+    or ``network``. It provides a generic way for requesting devices for
+    which tmt defines no special HW requirements. The specialized requirements
+    are recommended, as they express the desired guest properties in a more
+    explicit way.
+
+    .. code-block::
+
+       device:
+           # String, a network device name.
+           device-name: "A Generic Ethernet Card"
+
+           # Number or string, a network device ID.
+           device: 1234|"> 1234"
+
+           # String, a name of the device vendor.
+           vendor-name: "A Well-Known Device Manufacturer"
+
+           # Number or string, an ID of the device vendor.
+           vendor: 1234|"> 1234"
+
+           # String, name of the kernel driver module for the device.
+           driver: noveau
+
+    .. versionadded:: 1.29
+
 example:
   - |
+    # Request a guest with a Thunderbolt controller
     device:
-        device-name: C51 [GeForce 6150 LE]
-        device: 0241
-        driver: nouveau
-        vendor-name: NVIDIA
-        vendor: 10de
+        device-name: "~ Intel Corporation .* Thunderbolt 3"
+        driver: thundebolt

--- a/spec/hardware/disk.fmf
+++ b/spec/hardware/disk.fmf
@@ -1,8 +1,18 @@
-summary:
-    Choose the disk size
+summary: |
+    Select or provision a guest with a given disk storage.
+
+description: |
+    .. code-block::
+
+       # A list of dictionaries, each describing one disk storage.
+       disk:
+           # Number or string, the amount of storage requested.
+           # Bytes are assumed when no unit is specified.
+         - size: 1234|">= 512 GiB"
+
 example:
   - |
-    # Disk group used to allow possible future extensions
+    # Require a disk big enough for testing
     disk:
       - size: 500 GB
 
@@ -11,5 +21,9 @@ example:
     disk:
       - size: '>= 2 GB'
       - size: '>= 20 GB'
+
 link:
   - implemented-by: /tmt/steps/provision/artemis.py
+  - implemented-by: /tmt/steps/provision/mrack.py
+  - implemented-by: /tmt/steps/provision/testcloud.py
+    note: "``=``, ``>=`` and ``<=`` operators only"

--- a/spec/hardware/gpu.fmf
+++ b/spec/hardware/gpu.fmf
@@ -1,13 +1,41 @@
-summary:
-    Choose system according to the available graphics processing unit (gpu)
+summary: |
+    Select or provision a guest with a given GPU properties.
+
+description: |
+    .. code-block::
+
+       gpu:
+           # String, a network device name.
+           device-name: "A Generic Graphics Card"
+
+           # Number or string, a network device ID.
+           device: 1234|"> 1234"
+
+           # String, a name of the device vendor.
+           vendor-name: "A Well-Known GPU Manufacturer"
+
+           # Number or string, an ID of the device vendor.
+           vendor: 1234|"> 1234"
+
+           # String, name of the kernel driver module for the device.
+           driver: a_generic_vga_driver
+
+    .. versionadded:: 1.29
+
 example:
   - |
-    # GPU-related stuff grouped together.
+    # Request a guest with particular GPU
     gpu:
-        # GPU device name name.
-        device-name: G86 [Quadro NVS 290]
-        # GPU vendor name.
-        vendor-name: NVIDIA Corporation
+        # By the device name...
+        device-name: C51 [GeForce 6150 LE]
+        # ... or by its ID.
+        device: 0241
+        driver: nouveau
+
+  - |
+    # Request a guest with any NVIDIA GPU
+    gpu:
+        vendor-name: NVIDIA
 
 # NOTE: not yet supported
 # link:

--- a/spec/hardware/hostname.fmf
+++ b/spec/hardware/hostname.fmf
@@ -1,5 +1,12 @@
-summary:
-    Select specific guest by its hostname
+summary: |
+    Select a guest with a specific hostname.
+
+description: |
+    .. code-block::
+
+       # String, the hostname requested.
+       hostname: foo.bar.com
+
 example:
   - |
     # Choose machine with given hostname
@@ -12,5 +19,7 @@ example:
   - |
     # Hostname not matching a regular expression
     hostname: "!~ kvm-01.*"
+
 link:
   - implemented-by: /tmt/steps/provision/artemis.py
+  - implemented-by: /tmt/steps/provision/mrack.py

--- a/spec/hardware/main.fmf
+++ b/spec/hardware/main.fmf
@@ -1,4 +1,4 @@
-story:
+story: |
     As a tester I want to specify detailed hardware requirements
     for the guest on which the tests will be executed.
 
@@ -58,10 +58,6 @@ description: |
     the string. Any leading or trailing white space from the
     search string is removed.
 
-    Please note, that the full extent of regular expressions might
-    not be supported across all provision implementations. The
-    ``.*`` notation, however, should be supported everywhere:
-
     .. code-block:: yaml
 
         # Search for processors using a cpu model name
@@ -70,6 +66,12 @@ description: |
 
         # Select guests with a non-matching hostname
         hostname: "!~ kvm-01.*"
+
+    .. note::
+
+       The full extent of regular expressions might not be supported
+       across all provision implementations. However, the "any
+       character" pattern, ``.*``, should be supported everywhere.
 
     Logic operators
     ---------------
@@ -136,6 +138,21 @@ description: |
     expression operators (``~`` and ``!~``) while IDs can be used
     very reasonably with other comparison operators like ``>=``.
 
+    Device and vendor IDs
+    ---------------------
+
+    Besides the names, provisioning infrastructures may support
+    searching for devices by device and/or vendor ID. The ID
+    namespace would be determined by the guest architecture, the
+    buses and other specifications the guest HW is built from.
+
+    For example, probably the most common namespace would be the
+    `PCI ID Repository <https://pci-ids.ucw.cz/>`_, collecting IDs
+    and names of PCI devices, easy to encounter in both bare-metal
+    and virtualized x86_64 guests. However, this ID database is not
+    the only one in existence, and guest architecture may allow
+    for additional device and vendor ID schemas.
+
     Notes
     -----
 
@@ -164,6 +181,9 @@ description: |
         plugin can support the ``cpu.family`` requirement, but it
         is hard-locked to the CPU of one's own machine.
 
+        When facing impossible requirements, plugins will emit a
+        warning reporting this situation to the user, but in general,
+        plugins will try to continue provisioning the guest.
 
 example:
   - |

--- a/spec/hardware/memory.fmf
+++ b/spec/hardware/memory.fmf
@@ -1,11 +1,24 @@
-summary:
-    Select the desired amount of memory
+summary: |
+    Select or provision a guest with the desired amount of memory.
+
+description: |
+    .. code-block::
+
+       # Number or string, the amount of memory requested.
+       # Bytes are assumed when no unit is specified.
+       memory: 1234|"2 GiB"
+
 example:
   - |
     # Require an exact amount of memory
     memory: 8 GB
+
   - |
     # Pick a guest with at least 8 GB
     memory: ">= 8 GB"
+
 link:
   - implemented-by: /tmt/steps/provision/artemis.py
+  - implemented-by: /tmt/steps/provision/mrack.py
+  - implemented-by: /tmt/steps/provision/testcloud.py
+    note: "``=``, ``>=`` and ``<=`` operators only"

--- a/spec/hardware/network.fmf
+++ b/spec/hardware/network.fmf
@@ -1,5 +1,32 @@
-summary:
-    Select guests with given network devices
+summary: |
+    Select or provision a guest with given network devices.
+
+description: |
+    .. code-block::
+
+       # A list of dictionaries, each describing one network device.
+       network:
+           # String, a network device type.
+         - type: "eth"|"bridge"|"ipip"|...
+
+           # String, a network device name.
+           device-name: "A Generic Ethernet Card"
+
+           # Number or string, a network device ID.
+           device: 1234|"> 1234"
+
+           # String, a name of the device vendor.
+           vendor-name: "A Well-Known Device Manufacturer"
+
+           # Number or string, an ID of the device vendor.
+           vendor: 1234|"> 1234"
+
+           # String, name of the kernel driver module for the device.
+           driver: a_generic_nic_driver
+
+    .. versionchanged:: 1.29
+       Added missing ``device`` and ``vendor`` into specification.
+
 example:
   - |
     # Select by vendor and device name
@@ -7,6 +34,7 @@ example:
       - type: eth
         vendor-name: ~ ^Broadcom
         device-name: ~ ^NetXtreme II BCM
+
 link:
   - implemented-by: /tmt/steps/provision/artemis.py
-    note: "``network.type`` only"
+    note: "``network.type`` only, ``network.type: eth`` only"

--- a/spec/hardware/system.fmf
+++ b/spec/hardware/system.fmf
@@ -1,17 +1,33 @@
-summary:
-    Select machine with given system attributes
+summary: |
+    Select or provision a guest with given system properties.
+
+description: |
+    .. code-block::
+
+       system:
+           # Number or string, an ID of the device vendor.
+           vendor: 1234|"> 1234"
+
+           # String, a name of the device vendor.
+           vendor-name: "A Well-Known Device Manufacturer"
+
+           # Integer or string, system model ID.
+           model: 1234|"> 1234"
+
+           # String, system model name.
+           model-name: ProLiant DL385 Gen10
+
+           # Integer or string, required number of NUMA nodes.
+           numa-nodes: 2|">= 2"
+
 example:
   - |
+    # Select any system by a given vendor
     system:
-        # System vendor by ID...
-        vendor: 0x03E8
-        # ... or by its name.
         vendor-name: "~ HPE"
 
-        # System model by ID...
-        model: 79
-        # ... or by its name.
-        model-name: ProLiant DL385 Gen10
-
-        # Required number of NUMA nodes.
-        numa-nodes: '>= 2'
+  - |
+    # Select any HPE system with enough NUMA nodes.
+    system:
+        vendor-name: "~ HPE"
+        numa-nodes: ">= 4"

--- a/spec/hardware/tpm.fmf
+++ b/spec/hardware/tpm.fmf
@@ -1,11 +1,18 @@
-summary:
-    Require the `Trusted Platform Module` features
-description:
-    Use the ``version`` key to select the desired ``tpm`` version,
-    its value must be a ``string``.
+summary: |
+    Select or provision a guest with the `Trusted Platform Module`.
+
+description: |
+    .. code-block::
+
+       tpm:
+           # String, TPM version requested.
+           version: "x.y"
+
 example:
   - |
+    # Require a presence of TPM of a specific version.
     tpm:
         version: "2.0"
+
 link:
   - implemented-by: /tmt/steps/provision/artemis.py

--- a/spec/hardware/virtualization.fmf
+++ b/spec/hardware/virtualization.fmf
@@ -1,19 +1,36 @@
-summary:
-    Features related to virtualization
-description:
-    This section allows to select guests which are virtualized or
-    support virtualization. Use the ``hypervisor`` key to select
-    specific implementation, for example ``hyperv``, ``kvm``,
-    ``nitro``, ``powerkvm``, ``powervm``, ``vmware`` or ``xen``.
+summary: |
+    Select or provision a guest with requested virtualization properties.
+
+description: |
+    .. code-block::
+
+       virtualization:
+           # String, any of well-known hypervisor names.
+           hypervisor: "hyperv"|"powerkvm"|"kvm"|"xen"|"nitro"|...
+
+           # Boolean, whether the guest itself is virtualized or not.
+           is-virtualized: true|false
+
+           # Boolean, whether the guest supports hardware-assisted
+           # virtualization.
+           is-supported: true|false
+
 example:
   - |
     # Require a guest which supports virtualization
     virtualization:
         is-supported: true
+
   - |
-    # Ask for a virtualized guest using kvm hypervisor
+    # Require a bare-metal guest
+    virtualization:
+        is-virtualized: false
+
+  - |
+    # Ask for a virtualized guest on top of a kvm hypervisor
     virtualization:
         is-virtualized: true
         hypervisor: kvm
+
 link:
   - implemented-by: /tmt/steps/provision/artemis.py

--- a/tmt/schemas/provision/hardware.yaml
+++ b/tmt/schemas/provision/hardware.yaml
@@ -162,7 +162,20 @@ definitions:
       device-name:
         type: string
 
+      device:
+        anyOf:
+          - type: string
+          - type: integer
+
       vendor-name:
+        type: string
+
+      vendor:
+        anyOf:
+          - type: string
+          - type: integer
+
+      driver:
         type: string
 
     additionalProperties: false
@@ -187,10 +200,23 @@ definitions:
       device-name:
         type: string
 
-      type:
-        type: string
+      device:
+        anyOf:
+          - type: string
+          - type: integer
 
       vendor-name:
+        type: string
+
+      vendor:
+        anyOf:
+          - type: string
+          - type: integer
+
+      driver:
+        type: string
+
+      type:
         type: string
 
     additionalProperties: false


### PR DESCRIPTION
Unifying the format of HW requirement documentation:

* short `summary`,
* `description` with a `code-block` describing format and purpose of all keys - following the same approach established when documenting `results.yaml`,
* several `examples`,
* and `links` to all plugins supporting the requirement, with added notes listing caveats.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] update the specification
* [x] modify the json schema
* [x] mention the version
