### PR TITLE
Correctly update environment from the importing plan

### DIFF
--- a/tests/plan/import/modify.sh
+++ b/tests/plan/import/modify.sh
@@ -17,12 +17,14 @@ rlJournalStart
     rlPhaseStartTest "Show importing plan (modify imported plan)"
         rlRun -s "tmt plan show ${importing}"
         rlAssertGrep 'test "foobar" == "foobar"' $rlRun_LOG
+        rlAssertGrep 'environment VARIABLE: foobar' $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Run plan ${importing}"
-        rlRun -s "tmt run -vv plan --name ${importing}" 0 "Run plan ${importing}"
+        rlRun -s "tmt run -dddvv plan --name ${importing}" 0 "Run plan ${importing}"
         rlAssertGrep 'cmd: test "foobar" == "foobar"' $rlRun_LOG
         rlAssertGrep "summary: 1 test passed" $rlRun_LOG
+        rlAssertGrep "VARIABLE: foobar" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1678,6 +1678,9 @@ class Plan(
         if self.my_run:
             combined = self._plan_environment.copy()
             combined.update(self._environment)
+            # Include environment of the importing plan
+            if self._original_plan is not None:
+                combined.update(self._original_plan.environment)
             # Command line variables take precedence
             combined.update(self.my_run.environment)
             # Include path to the plan data directory


### PR DESCRIPTION
The environment from the importing plan was ignored.       
                                                                         
As agreed, let's make the `environment` a cached property and inherit       
the importing plan environment automatically.                                            
                                                                                           
Resolves #2446

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
