### PR TITLE
Add page `Releases` to highlight important changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,3 +7,4 @@ Pull Request Checklist
 * [ ] adjust plugin docstring
 * [ ] modify the json schema
 * [ ] mention the version
+* [ ] include a release note

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -277,15 +277,16 @@ irrelevant for your change.
     * [ ] implement the feature
     * [ ] write the documentation
     * [ ] extend the test coverage
-
     * [ ] update the specification
     * [ ] adjust plugin docstring
     * [ ] modify the json schema
     * [ ] mention the version
+    * [ ] include a release note
 
-The version should be mentioned in the specification when a new
-essential feature is added so that users can easily check whether
-given functionality is already available in their package:
+The version should be mentioned in the specification and a release
+note should be included when a new essential feature is added or
+an important change is introduced so that users can easily check
+whether given functionality is already available in their package:
 
 .. code-block:: rst
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,3 +35,4 @@ Table of Contents
     Contribute <contribute>
     Classes <classes>
     Plugins <plugins>
+    Releases <releases>

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -1,0 +1,31 @@
+.. _releases:
+
+======================
+    Releases
+======================
+
+
+tmt-1.28
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The new :ref:`/stories/cli/multiple phases/update-missing` option
+can be used to update step phase fields only when not set in the
+``fmf`` files. In this way it's possible to easily fill the gaps
+in the plans, for example provide the default distro image.
+
+The :ref:`/spec/plans/report/html` report plugin now shows
+provided :ref:`/spec/plans/context` and link to the test ``data``
+directory so that additional logs can be easily checked.
+
+The **avc** :ref:`/spec/tests/check` allows to detect avc denials
+which appear during the test execution.
+
+A new ``skip`` custom result outcome has been added to the
+:ref:`/spec/plans/results` specification.
+
+All context :ref:`/spec/context/dimension` values are now handled
+in a case insensitive way.
+
+See the `full changelog`__ for more details.
+
+__ https://github.com/teemtee/tmt/releases/tag/1.28.0


### PR DESCRIPTION
When creating a new `tmt` release it's not easy to pick the most important changes which are included in the release. What about adding a short note about the interesting changes already during the pull request when everything is still fresh in the memory?

Pull Request Checklist

* [x] write the documentation