### PR TITLE
Store fmf `context` in results for each test

### DIFF
--- a/spec/plans/results.fmf
+++ b/spec/plans/results.fmf
@@ -63,6 +63,17 @@ description: |
        # String, path to /data directory storing possible test artifacts
        data-path: path/to/test/data
 
+       # Mapping, stores the actual fmf context defined for this test.
+       # It's a combination of the context provided via command line
+       # and plan's `context` key.
+       context:
+         some-dimension:
+           - its-value
+         another-dimension:
+           - first-value
+           - second-value
+             ...
+
       # Represents results of all test checks executed as driven by test's `check`
       # key. Fields have the same meaning as fields of the "parent" test result, but
       # relate to each check alone.
@@ -157,10 +168,17 @@ description: |
     tell how long it took to produce various custom results, it is still
     able to report the duration of the whole test.
 
+    The same applies to ``context``, tmt will set this key for the
+    original test result in the custom result set to the value known
+    to tmt.
+
     See also the complete `JSON schema`__.
 
     For custom results files in JSON format, the same rules and schema
     apply.
+
+    .. versionchanged:: 1.30
+       fmf context is now saved within results, in the ``context`` key.
 
     __ https://github.com/teemtee/tmt/blob/main/tmt/schemas/results.yaml
 

--- a/tests/execute/result/basic.sh
+++ b/tests/execute/result/basic.sh
@@ -89,6 +89,11 @@ EOF
         rlAssertGrep "00:00:00 errr /test/abort (on default-0) (aborted) [1/1" $rlRun_LOG -F
     rlPhaseEnd
 
+    rlPhaseStartTest "Verify fmf context lands in results"
+        rlRun -s "tmt -c foo=bar run --id ${run} --scratch -a provision --how local test -n '/pass'"
+        rlAssertEquals "Context is stored in result" "$(yq -r ".[] | .context | to_entries[] | \"\\(.key)=\\(.value[])\"" $run/plans/default/execute/results.yaml)" "foo=bar"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r ${run}" 0 "Remove run directory"

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -139,6 +139,14 @@ class Result(BaseResult):
         serialize=lambda fmf_id: fmf_id.to_minimal_spec() if fmf_id is not None else {},
         unserialize=_unserialize_fmf_id
         )
+    context: tmt.utils.FmfContext = field(
+        default_factory=tmt.utils.FmfContext,
+        # ignore[attr-defined]: for reasons unknown, mypy believes the `context`
+        # is an `object` instance. But, when `cast()` is added, mypy complains the
+        # `cast()` is pointless...
+        serialize=lambda context: context.to_spec(),  # type: ignore[attr-defined]
+        unserialize=lambda serialized: tmt.utils.FmfContext(serialized)
+        )
     ids: dict[str, Optional[str]] = field(default_factory=dict)
     guest: ResultGuestData = field(
         default_factory=ResultGuestData,
@@ -215,6 +223,8 @@ class Result(BaseResult):
             guest=guest_data,
             data_path=invocation.data_path('data'))
 
+        if invocation.phase.step.plan is not None:
+            _result.context = invocation.phase.step.plan._fmf_context
         return _result.interpret_result(ResultInterpret(
             invocation.test.result) if invocation.test.result else ResultInterpret.RESPECT)
 

--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -8,6 +8,42 @@ $id: /schemas/common
 $schema: https://json-schema.org/draft-07/schema
 
 definitions:
+  # context dimensions - the defined ones
+  arch:
+    type: string
+    enum:
+      - aarch64
+      - armhfp
+      - i386
+      - ppc64
+      - ppc64le
+      - s390x
+      - x86_64
+
+  distro:
+    type: string
+    patterns:
+      - ^fedora(-[0-9]+)?$
+      - ^centos(-stream)?(-[0-9]+(.[0-9]+)?)?$
+      - ^rhel(-[0-9]+(.[0-9]+)?)?$
+
+  trigger:
+    type: string
+    enum:
+      - build
+      - commit
+      - compose
+      - update
+
+  variant:
+    type: string
+    enum:
+      - Client
+      - Desktop
+      - Server
+      - Workstation
+      - Silverblue
+      - CoreOS
 
   # common definition of an ansible execution method
   ansible:
@@ -40,18 +76,6 @@ definitions:
 
     required:
       - how
-
-  # list of all recognized architectures
-  arch:
-    type: string
-    enum:
-      - aarch64
-      - armhfp
-      - i386
-      - ppc64
-      - ppc64le
-      - s390x
-      - x86_64
 
   # List of all available require types
   # https://tmt.readthedocs.io/en/stable/spec/tests.html#require
@@ -141,6 +165,56 @@ definitions:
         - type: string
         - type: boolean
         - type: number
+
+  # https://tmt.readthedocs.io/en/stable/spec/plans.html#context
+  # https://tmt.readthedocs.io/en/stable/spec/context.html#spec-context
+  context:
+    type: object
+
+    additionalProperties:
+      $ref: "#/definitions/one_or_more_strings"
+
+    properties:
+      arch:
+        oneOf:
+          - $ref: "#/definitions/arch"
+
+          - type: array
+            items:
+              $ref: "#/definitions/arch"
+
+      component:
+        $ref: "#/definitions/one_or_more_strings"
+
+      collection:
+        $ref: "#/definitions/one_or_more_strings"
+
+      distro:
+        oneOf:
+          - $ref: "#/definitions/distro"
+
+          - type: array
+            items:
+              $ref: "#/definitions/distro"
+
+      module:
+        $ref: "#/definitions/one_or_more_strings"
+
+      trigger:
+        oneOf:
+          - $ref: "#/definitions/trigger"
+
+          - type: array
+            items:
+              $ref: "#/definitions/trigger"
+
+      variant:
+        oneOf:
+          - $ref: "#/definitions/variant"
+
+          - type: array
+            items:
+              $ref: "#/definitions/variant"
 
   # https://fmf.readthedocs.io/en/stable/concept.html#identifiers
   fmf_id:

--- a/tmt/schemas/plan.yaml
+++ b/tmt/schemas/plan.yaml
@@ -12,32 +12,6 @@ $schema: https://json-schema.org/draft-07/schema
 type: object
 additionalProperties: false
 
-definitions:
-  distro:
-    type: string
-    patterns:
-      - ^fedora(-[0-9]+)?$
-      - ^centos(-stream)?(-[0-9]+(.[0-9]+)?)?$
-      - ^rhel(-[0-9]+(.[0-9]+)?)?$
-
-  trigger:
-    type: string
-    enum:
-      - build
-      - commit
-      - compose
-      - update
-
-  variant:
-    type: string
-    enum:
-      - Client
-      - Desktop
-      - Server
-      - Workstation
-      - Silverblue
-      - CoreOS
-
 properties:
 
   # https://tmt.readthedocs.io/en/stable/spec/core.html#adjust
@@ -47,51 +21,7 @@ properties:
   # https://tmt.readthedocs.io/en/stable/spec/plans.html#context
   # https://tmt.readthedocs.io/en/stable/spec/context.html#spec-context
   context:
-    type: object
-    additionalProperties:
-      $ref: "/schemas/common#/definitions/one_or_more_strings"
-
-    properties:
-      arch:
-        oneOf:
-          - $ref: "/schemas/common#/definitions/arch"
-
-          - type: array
-            items:
-              $ref: "/schemas/common#/definitions/arch"
-
-      component:
-        $ref: "/schemas/common#/definitions/one_or_more_strings"
-
-      collection:
-        $ref: "/schemas/common#/definitions/one_or_more_strings"
-
-      distro:
-        oneOf:
-          - $ref: "#/definitions/distro"
-
-          - type: array
-            items:
-              $ref: "#/definitions/distro"
-
-      module:
-        $ref: "/schemas/common#/definitions/one_or_more_strings"
-
-      trigger:
-        oneOf:
-          - $ref: "#/definitions/trigger"
-
-          - type: array
-            items:
-              $ref: "#/definitions/trigger"
-
-      variant:
-        oneOf:
-          - $ref: "#/definitions/variant"
-
-          - type: array
-            items:
-              $ref: "#/definitions/variant"
+    $ref: "/schemas/common#/definitions/context"
 
   # https://tmt.readthedocs.io/en/stable/spec/core.html#description
   description:

--- a/tmt/schemas/results.yaml
+++ b/tmt/schemas/results.yaml
@@ -39,6 +39,9 @@ items:
     result:
       $ref: "/schemas/common#/definitions/result_outcome"
 
+    context:
+      $ref: "/schemas/common#/definitions/context"
+
     note:
       $ref: "/schemas/common#/definitions/result_note"
 

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -413,12 +413,13 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             # Enforce the correct guest info
             partial_result.guest = ResultGuestData(name=guest.name, role=guest.role)
 
-            # For the result representing the test itself, set the duration
-            # and timestamps to what tmt measured.
+            # For the result representing the test itself, set the important
+            # attributes to reflect the reality.
             if partial_result.name == test.name:
                 partial_result.start_time = invocation.start_time
                 partial_result.end_time = invocation.end_time
                 partial_result.duration = invocation.real_duration
+                partial_result.context = self.step.plan._fmf_context
 
             custom_results.append(partial_result)
 


### PR DESCRIPTION
The actual context is a combination of CLI and plan's context, and it brings additional information on the test configuration that produced a given result.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] update the specification
* [x] adjust plugin docstring
* [x] modify the json schema
* [x] mention the version
* [ ] include a release note
