### PR TITLE
Properly normalize the test `path` key

### DIFF
--- a/tests/core/path/data/weird.fmf
+++ b/tests/core/path/data/weird.fmf
@@ -1,0 +1,3 @@
+summary: Invalid path should raise an error
+test: 'true'
+path: 0

--- a/tests/core/path/test.py
+++ b/tests/core/path/test.py
@@ -1,3 +1,5 @@
+import pytest
+
 import tmt
 import tmt.log
 from tmt.utils import Path
@@ -23,3 +25,8 @@ def test_virtual():
     for virtual in tree.tests(names=['/virtual']):
         assert 'Virtual test' in virtual.summary
         assert virtual.path.resolve() == Path('/virtual')
+
+
+def test_weird():
+    with pytest.raises(tmt.utils.NormalizationError):
+        assert tree.tests(names=['/weird'])[0] is not None

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1047,8 +1047,7 @@ class Test(
         exporter=lambda value: str(value) if isinstance(value, ShellScript) else None)
     path: Optional[Path] = field(
         default=None,
-        normalize=lambda key_address, raw_value, logger:
-            None if raw_value is None else Path(raw_value),
+        normalize=tmt.utils.normalize_path,
         exporter=lambda value: str(value) if isinstance(value, Path) else None)
     framework: str = "shell"
     manual: bool = False

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -5562,6 +5562,24 @@ def normalize_string_list(
     return [value] if isinstance(value, str) else value
 
 
+def normalize_path(
+        key_address: str,
+        value: Any,
+        logger: tmt.log.Logger) -> Optional[Path]:
+    """ Normalize content of the test `path` key """
+
+    if value is None:
+        return None
+
+    if isinstance(value, Path):
+        return value
+
+    if isinstance(value, str):
+        return Path(value)
+
+    raise tmt.utils.NormalizationError(key_address, value, 'a string')
+
+
 def normalize_path_list(
         key_address: str,
         value: Union[None, str, List[str]],


### PR DESCRIPTION
When an `int` was provided as the test `path` key, test discovery would result into an ugly traceback. Fix the problem by properly normalizing the `path` key an give a reasonable error message.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage