### PR TITLE
Disable `dist-git-init` in the `distgit` test

### DIFF
--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -174,7 +174,7 @@ execute:
         discover:
             how: fmf
             dist-git-source: true
-            dist-git-init: true
+            dist-git-init: false
             test: tests/prepare/install$
 
     /exclude:

--- a/tests/discover/distgit.sh
+++ b/tests/discover/distgit.sh
@@ -310,7 +310,7 @@ done
     rlPhaseStartTest "Run directly from the DistGit (Fedora) [cli]"
         rlRun 'pushd tmt'
         rlRun -s 'tmt run --remove plans --default \
-            discover -v --how fmf --dist-git-source --dist-git-init \
+            discover -v --how fmf --dist-git-source \
             tests --name tests/prepare/install$'
         rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
         rlAssertGrep "/tests/prepare/install" $rlRun_LOG -F
@@ -327,7 +327,7 @@ done
 
     rlPhaseStartTest "URL is path to a local distgit repo"
         rlRun -s 'tmt run --remove plans --default \
-            discover --how fmf --dist-git-source --dist-git-init --dist-git-type fedora --url $CLONED_TMT \
+            discover --how fmf --dist-git-source --dist-git-type fedora --url $CLONED_TMT \
             --dist-git-merge tests --name tests/prepare/install$'
         rlAssertGrep "summary: 1 test selected" $rlRun_LOG -F
     rlPhaseEnd


### PR DESCRIPTION
Now that the `fmf` root is back in the source tarball the time has come to remove the explicit `dist-git-init` from the test, 'cause otherwise the nested `fmf` root hides all available tests.

Related to #2399.

Pull Request Checklist

* [x] fix the test coverage