### PR TITLE
Use `renku` as the default theme for building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,8 @@ from typing import List, Optional, Tuple
 import tmt.utils
 
 _POSSIBLE_THEMES: List[Tuple[Optional[str], str]] = [
+    # Use renku as the default theme
+    ('renku_sphinx_theme', 'renku'),
     # Fall back to sphinx_rtd_theme if available
     ('sphinx_rtd_theme', 'sphinx_rtd_theme'),
     # The default theme
@@ -182,14 +184,6 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = HTML_THEME
-
-# 1.3.1 sphinx READTHEDOCS build compat
-# SEE:
-# https://github.com/shabda/pysaml2/commit/d55bfeebe
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if on_rtd:  # only import and set the theme if we're building docs locally
-    html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ all = [
     ]
 # Needed for readthedocs and man page build. Not being packaged in rpm.
 docs = [
-    "sphinx_rtd_theme>=1.2.2", # The theme pulls a specific sphinx version
+    "renku-sphinx-theme==0.3.0",
     "readthedocs-sphinx-ext",
     "docutils>=0.18.1",
     "fmf>=1.3.0",
@@ -155,7 +155,6 @@ python = ["3.9", "3.11"]
 
 [tool.hatch.envs.docs]
 dependencies = ["tmt[docs]"]
-detached = true
 
 [tool.hatch.envs.docs.scripts]
 html = "make -C {root}/docs html"


### PR DESCRIPTION
Let's try a fresh look for our online documentation!

Pull Request Checklist

* [x] implement the feature
