### PR TITLE
Try several times to build the `become` container

### DIFF
--- a/tests/provision/become/test.sh
+++ b/tests/provision/become/test.sh
@@ -11,9 +11,10 @@ rlJournalStart
             # https://github.com/teemtee/tmt/issues/2063
             for attempt in {1..5}; do
                 if podman build -t become-container-test:latest . ; then
+                    rlPass "Container image built successfully."
                     break
                 else
-                    echo "Attempt $attempt unsuccessful."
+                    rlLog "Attempt $attempt unsuccessful."
                     [[ $attempt == 5 ]] && rlDie "Unable to prepare the image"
                     sleep 5
                 fi

--- a/tests/provision/become/test.sh
+++ b/tests/provision/become/test.sh
@@ -7,7 +7,17 @@ rlJournalStart
     if [[ "$PROVISION_METHODS" =~ container ]]; then
         rlPhaseStartSetup
             rlRun "pushd data"
-            rlRun "podman build -t become-container-test:latest ."
+            # Try several times to build the container
+            # https://github.com/teemtee/tmt/issues/2063
+            for attempt in {1..5}; do
+                if rlRun "podman build -t become-container-test:latest ."; then
+                    break
+                else
+                    echo "Attempt $attempt unsuccessful."
+                    [[ $attempt == 5 ]] && rlDie "Unable to prepare the image"
+                    sleep 5
+                fi
+            done
         rlPhaseEnd
 
         rlPhaseStartTest "Container, test with become=true"

--- a/tests/provision/become/test.sh
+++ b/tests/provision/become/test.sh
@@ -10,7 +10,7 @@ rlJournalStart
             # Try several times to build the container
             # https://github.com/teemtee/tmt/issues/2063
             for attempt in {1..5}; do
-                if rlRun "podman build -t become-container-test:latest ."; then
+                if podman build -t become-container-test:latest . ; then
                     break
                 else
                     echo "Attempt $attempt unsuccessful."

--- a/tests/provision/become/test.sh
+++ b/tests/provision/become/test.sh
@@ -9,16 +9,8 @@ rlJournalStart
             rlRun "pushd data"
             # Try several times to build the container
             # https://github.com/teemtee/tmt/issues/2063
-            for attempt in {1..5}; do
-                if podman build -t become-container-test:latest . ; then
-                    rlPass "Container image built successfully."
-                    break
-                else
-                    rlLog "Attempt $attempt unsuccessful."
-                    [[ $attempt == 5 ]] && rlDie "Unable to prepare the image"
-                    sleep 5
-                fi
-            done
+            build="podman build -t become-container-test:latest ."
+            rlRun "rlWaitForCmd '$build' -m 5 -d 5" || rlDie "Unable to prepare the image"
         rlPhaseEnd
 
         rlPhaseStartTest "Container, test with become=true"


### PR DESCRIPTION
Seems this is the only point where the podman tests are still failing with the random network errors tracked in #2063. Let's give several attempts to build the container to reduce the failures.

Pull Request Checklist

* [x] extend the test coverage