### PR TITLE
Parallelize the `provision` step

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,24 @@
     Releases
 ======================
 
+tmt-1.31
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`/spec/plans/provision` step is now able to perform
+**provisioning of multiple guests in parallel**. This can
+considerably shorten the time needed for guest provisioning in
+multihost plans. However, whether the parallel provisioning would
+take place depends on what provision plugins were involved,
+because not all plugins are compatible with this feature yet. As
+of now, only :ref:`/spec/plans/provision/artemis`,
+:ref:`/spec/plans/provision/connect`,
+:ref:`/spec/plans/provision/container`,
+:ref:`/spec/plans/provision/local`, and
+:ref:`/spec/plans/provision/virtual` are supported. All other
+plugins would gracefully fall back to the pre-1.31 behavior,
+provisioning in sequence.
+
+
 tmt-1.30
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -27,7 +27,7 @@ rlJournalStart
             rlAssertGrep "interactive" "output"
 
             if [ "$step" = "provision" ]; then
-                rlRun "grep '^    $step$' -A6 output | grep -i interactive"
+                rlRun "grep '^    $step$' -A12 output | grep -i interactive"
             elif [ "$step" = "prepare" ]; then
                 rlRun "grep '^    $step$' -A8 output | grep -i interactive"
             elif [ "$step" = "execute" ]; then

--- a/tests/multihost/complete/test.sh
+++ b/tests/multihost/complete/test.sh
@@ -14,10 +14,10 @@ function check_current_topology () {
 }
 
 function check_shared_topology () {
-    rlAssertEquals "Guest names"        "client-1 client-2 server" "$(yq -r '."guest-names" | join(" ")' $1)"
-    rlAssertEquals "Role names"         "client server"            "$(yq -r '."role-names" | join(" ")' $1)"
-    rlAssertEquals "Client role guests" "client-1 client-2"        "$(yq -r '.roles.client | join(" ")' $1)"
-    rlAssertEquals "Server role guests" "server"                   "$(yq -r '.roles.server | join(" ")' $1)"
+    rlAssertEquals "Guest names"        "client-1 client-2 server" "$(yq -r '."guest-names" | sort | join(" ")' $1)"
+    rlAssertEquals "Role names"         "client server"            "$(yq -r '."role-names" | sort | join(" ")' $1)"
+    rlAssertEquals "Client role guests" "client-1 client-2"        "$(yq -r '.roles.client | sort | join(" ")' $1)"
+    rlAssertEquals "Server role guests" "server"                   "$(yq -r '.roles.server | sort | join(" ")' $1)"
 
     rlAssertEquals "Guest client-1 name"     "client-1"          "$(yq -r '.guests["client-1"].name' $1)"
     rlAssertEquals "Guest client-1 role"     "client"            "$(yq -r '.guests["client-1"].role' $1)"

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -690,6 +690,8 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin[ProvisionArtemisData]
     _data_class = ProvisionArtemisData
     _guest_class = GuestArtemis
 
+    _thread_safe = True
+
     # Guest instance
     _guest = None
 

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -160,6 +160,8 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin[ProvisionConnectData]
     _data_class = ProvisionConnectData
     _guest_class = GuestConnect
 
+    _thread_safe = True
+
     # Guest instance
     _guest = None
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -154,6 +154,8 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin[ProvisionLocalData]):
     _data_class = ProvisionLocalData
     _guest_class = GuestLocal
 
+    _thread_safe = True
+
     # Guest instance
     _guest = None
 

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -680,6 +680,8 @@ class ProvisionBeaker(tmt.steps.provision.ProvisionPlugin[ProvisionBeakerData]):
     _data_class = ProvisionBeakerData
     _guest_class = GuestBeaker
 
+    # _thread_safe = True
+
     # Guest instance
     _guest = None
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -425,6 +425,8 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin[ProvisionPodmanData]):
     _data_class = ProvisionPodmanData
     _guest_class = GuestContainer
 
+    _thread_safe = True
+
     # Guest instance
     _guest = None
 


### PR DESCRIPTION
This change requires refactoring of current queue internals, to better support the third kind of parallelization & queueing. A custom queue task is needed, to run provisioning in parallel, and the step takes care of ordering of provision phases and actions.

Implements https://github.com/teemtee/tmt/issues/2244

Pull Request Checklist

* [x] implement the feature
* [x] include a release note