### PR TITLE
Convert test execution internals to use "invocation" bundle

### DIFF
--- a/tmt/checks/__init__.py
+++ b/tmt/checks/__init__.py
@@ -125,9 +125,7 @@ class Check(
         Run the check.
 
         :param event: when the check is running - before the test, after the test, etc.
-        :param guest: on this guest the ``test`` will run/was executed.
-        :param test: test to which the check belongs to.
-        :param plugin: an ``execute`` step plugin managing the test execution.
+        :param invocation: test invocation to which the check belongs to.
         :param environment: optional environment to set for the check.
         :param logger: logger to use for logging.
         :returns: list of results produced by checks.

--- a/tmt/checks/__init__.py
+++ b/tmt/checks/__init__.py
@@ -16,7 +16,7 @@ from tmt.utils import (
 
 if TYPE_CHECKING:
     from tmt.result import CheckResult
-    from tmt.steps.execute import ExecutePlugin, ExecuteStepDataT
+    from tmt.steps.execute import TestInvocation
 
 
 CheckPluginClass = type['CheckPlugin']
@@ -118,9 +118,7 @@ class Check(
             self,
             *,
             event: CheckEvent,
-            guest: tmt.steps.provision.Guest,
-            test: 'tmt.base.Test',
-            plugin: 'ExecutePlugin[ExecuteStepDataT]',
+            invocation: 'TestInvocation',
             environment: Optional[tmt.utils.EnvironmentType] = None,
             logger: tmt.log.Logger) -> list['CheckResult']:
         """
@@ -143,18 +141,14 @@ class Check(
         if event == CheckEvent.BEFORE_TEST:
             return self.plugin.before_test(
                 check=self,
-                plugin=plugin,
-                guest=guest,
-                test=test,
+                invocation=invocation,
                 environment=environment,
                 logger=logger)
 
         if event == CheckEvent.AFTER_TEST:
             return self.plugin.after_test(
                 check=self,
-                plugin=plugin,
-                guest=guest,
-                test=test,
+                invocation=invocation,
                 environment=environment,
                 logger=logger)
 
@@ -185,9 +179,7 @@ class CheckPlugin(tmt.utils._CommonBase):
             cls,
             *,
             check: Check,
-            plugin: 'ExecutePlugin[ExecuteStepDataT]',
-            guest: tmt.steps.provision.Guest,
-            test: 'tmt.base.Test',
+            invocation: 'TestInvocation',
             environment: Optional[tmt.utils.EnvironmentType] = None,
             logger: tmt.log.Logger) -> list['CheckResult']:
         return []
@@ -197,9 +189,7 @@ class CheckPlugin(tmt.utils._CommonBase):
             cls,
             *,
             check: Check,
-            plugin: 'ExecutePlugin[ExecuteStepDataT]',
-            guest: tmt.steps.provision.Guest,
-            test: 'tmt.base.Test',
+            invocation: 'TestInvocation',
             environment: Optional[tmt.utils.EnvironmentType] = None,
             logger: tmt.log.Logger) -> list['CheckResult']:
         return []

--- a/tmt/frameworks/__init__.py
+++ b/tmt/frameworks/__init__.py
@@ -50,9 +50,7 @@ class TestFramework:
         """
         Provide additional environment variables for the test.
 
-        :param parent: ``execute`` plugin managing the test.
-        :param test: a test that would be executed.
-        :param guest: a guest on which the test would run.
+        :param invocation: test invocation to which the check belongs to.
         :param logger: to use for logging.
         :returns: environment variables to expose for the test. Variables
             would be added on top of any variables the plugin, test or plan
@@ -69,9 +67,7 @@ class TestFramework:
         """
         Provide a test command.
 
-        :param parent: ``execute`` plugin managing the test.
-        :param test: a test that would be executed.
-        :param guest: a guest on which the test would run.
+        :param invocation: test invocation to which the check belongs to.
         :param logger: to use for logging.
         :returns: a command to use to run the test.
         """
@@ -88,9 +84,7 @@ class TestFramework:
         """
         Provide additional options for pulling test data directory.
 
-        :param parent: ``execute`` plugin managing the test.
-        :param test: a test that would be executed.
-        :param guest: a guest on which the test would run.
+        :param invocation: test invocation to which the check belongs to.
         :param logger: to use for logging.
         :returns: additional options for the ``rsync`` tmt would use to pull
             the test data directory from the guest.
@@ -106,9 +100,7 @@ class TestFramework:
         """
         Extract test results.
 
-        :param parent: ``execute`` plugin managing the test.
-        :param test: a test that would be executed.
-        :param guest: a guest on which the test would run.
+        :param invocation: test invocation to which the check belongs to.
         :param logger: to use for logging.
         :returns: list of results produced by the given test.
         """

--- a/tmt/frameworks/__init__.py
+++ b/tmt/frameworks/__init__.py
@@ -6,9 +6,7 @@ import tmt.result
 import tmt.utils
 
 if TYPE_CHECKING:
-    from tmt.base import Test
-    from tmt.steps.execute import ExecutePlugin, ExecuteStepDataT
-    from tmt.steps.provision import Guest
+    from tmt.steps.execute import TestInvocation
 
 
 TestFrameworkClass = type['TestFramework']
@@ -47,9 +45,7 @@ class TestFramework:
     @classmethod
     def get_environment_variables(
             cls,
-            parent: 'ExecutePlugin[ExecuteStepDataT]',
-            test: 'Test',
-            guest: 'Guest',
+            invocation: 'TestInvocation',
             logger: tmt.log.Logger) -> tmt.utils.EnvironmentType:
         """
         Provide additional environment variables for the test.
@@ -68,9 +64,7 @@ class TestFramework:
     @classmethod
     def get_test_command(
             cls,
-            parent: 'ExecutePlugin[ExecuteStepDataT]',
-            test: 'Test',
-            guest: 'Guest',
+            invocation: 'TestInvocation',
             logger: tmt.log.Logger) -> tmt.utils.ShellScript:
         """
         Provide a test command.
@@ -82,16 +76,14 @@ class TestFramework:
         :returns: a command to use to run the test.
         """
 
-        assert test.test is not None  # narrow type
+        assert invocation.test.test is not None  # narrow type
 
-        return test.test
+        return invocation.test.test
 
     @classmethod
     def get_pull_options(
             cls,
-            parent: 'ExecutePlugin[ExecuteStepDataT]',
-            test: 'Test',
-            guest: 'Guest',
+            invocation: 'TestInvocation',
             logger: tmt.log.Logger) -> list[str]:
         """
         Provide additional options for pulling test data directory.
@@ -109,9 +101,7 @@ class TestFramework:
     @classmethod
     def extract_results(
             cls,
-            parent: 'ExecutePlugin[ExecuteStepDataT]',
-            test: 'Test',
-            guest: 'Guest',
+            invocation: 'TestInvocation',
             logger: tmt.log.Logger) -> list[tmt.result.Result]:
         """
         Extract test results.

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -153,7 +153,7 @@ class TestInvocation:
             full: bool = False,
             create: bool = False) -> Path:
         """
-        Prepare full/relative test data directory/file path
+        Prepare full/relative test data directory/file path.
 
         Construct test data directory path for given test, create it
         if requested and return the full or relative path to it (if

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -250,7 +250,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
 
         test, guest = invocation.test, invocation.guest
 
-        logger.debug(f"Execute '{invocation.test.name}' as a '{invocation.test.framework}' test.")
+        logger.debug(f"Execute '{test.name}' as a '{test.framework}' test.")
 
         test_check_results: list[CheckResult] = []
 


### PR DESCRIPTION
Execute plugins pass around test and guest as components of a test invocation. But, there is no data structure or its instance that would allow code to add more data to this invocation description, which seems to be necessary for implementation of some checks. So, motivated by this, the patch refactors code to use `TestInvocation` dataclass, bundling together plugin, guest, and test: as a by-product, we get fewer parameters being passed around. Invocation package is created once, and then passed around. There is no chance a call forgets to pass a guest where it's needed. Simpler method signatures, and it's clear what's required to run a test.

And for the original goal, this allows for check to store per-invocation data: for the watchdog check (https://github.com/teemtee/tmt/issues/1523) we will need a way for the check (running in its own thread) to notify the main thread (running the test) that the guest has been marked as dead and/or has been forcefully rebooted. Data like this cannot be added to `Test` or `Guest` instances because those are shared - with the `TestInvocation`, the check will be given this object, and would be able to store whatever data it needs.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation