### PR TITLE
Add Python 3.12 to the test matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ template = "dev"
 description = "Run scripts with multiple Python versions"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.11"]
+python = ["3.9", "3.11", "3.12"]
 
 [tool.hatch.envs.docs]
 dependencies = ["tmt[docs]"]


### PR DESCRIPTION
Require pre-release aiohttp which is required to setup hatch environments.
Currently released version doesn't support py3.12 yet.

Pull Request Checklist
- none applicable

