### PR TITLE
Enable `pyupgrade` check, use `python>=3.9` syntax

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,11 +14,11 @@
 import importlib
 import os
 import sys
-from typing import List, Optional, Tuple
+from typing import Optional
 
 import tmt.utils
 
-_POSSIBLE_THEMES: List[Tuple[Optional[str], str]] = [
+_POSSIBLE_THEMES: list[tuple[Optional[str], str]] = [
     # Use renku as the default theme
     ('renku_sphinx_theme', 'renku'),
     # Fall back to sphinx_rtd_theme if available

--- a/docs/scripts/generate-lint-checks.py
+++ b/docs/scripts/generate-lint-checks.py
@@ -2,7 +2,6 @@
 
 import sys
 import textwrap
-from typing import List
 
 from tmt.base import Plan, Story, Test
 from tmt.lint import Linter
@@ -15,7 +14,7 @@ Generate docs for all known lint checks.
 """).strip()
 
 
-def _sort_linters(linters: List[Linter]) -> List[Linter]:
+def _sort_linters(linters: list[Linter]) -> list[Linter]:
     """ Sort a list of linters by their ID """
     return sorted(linters, key=lambda x: x.id)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,7 @@ select = [
     "W",  # pycodestyle
     "I",  # isort
     "N",  # pep8-naming
+    "UP",  # pyupgrade
     "B",  # flake8-bugbear
     "C4",  # flake8-comprehensions
     "YTT",  # flake8-2020

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,5 @@
-from typing import IO, Any, Mapping, Optional, Sequence, Union
+from collections.abc import Mapping, Sequence
+from typing import IO, Any, Optional, Union
 
 import click.core
 import click.testing

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import operator
 import re
-from typing import Any, Callable, Iterable, List, Tuple
+from typing import Any, Callable, Iterable
 
 import _pytest.logging
 import pytest
@@ -80,7 +80,7 @@ def _assert_log(
     # field name, a callable accepting two parameters, and the given (expected) value. With these,
     # we can reduce the matching into functions calls without worrying what functions we work with.
 
-    operators: List[Tuple[Callable[[Any], Any], str, Callable[[Any, Any], bool], Any]] = []
+    operators: list[tuple[Callable[[Any], Any], str, Callable[[Any, Any], bool], Any]] = []
 
     for field_name, expected_value in tests.items():
         if field_name.startswith('details_'):

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,7 +1,8 @@
 import logging
 import operator
 import re
-from typing import Any, Callable, Iterable
+from collections.abc import Iterable
+from typing import Any, Callable
 
 import _pytest.logging
 import pytest

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import sys
 import tempfile
-from typing import Tuple
 
 import _pytest.monkeypatch
 import pytest
@@ -139,7 +138,7 @@ class DecideColorizationTestcase:
 
     # Name of the testcase and expected outcome of decide_colorization()
     name: str
-    expected: Tuple[bool, bool]
+    expected: tuple[bool, bool]
 
     # Testcase environment setup to perform before calling decide_colorization()
     set_no_color_option: bool = False

--- a/tests/unit/test_dataclasses.py
+++ b/tests/unit/test_dataclasses.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import pytest
 
@@ -59,7 +59,7 @@ def test_field_normalize_callback(root_logger: tmt.log.Logger) -> None:
 def test_field_custom_serialize():
     @dataclasses.dataclass
     class DummyContainer(SerializableContainer):
-        foo: List[str] = field(
+        foo: list[str] = field(
             default_factory=list,
             serialize=lambda foo: ['serialized-into'],
             unserialize=lambda serialized_foo: ['unserialized-from']

--- a/tests/unit/test_hardware.py
+++ b/tests/unit/test_hardware.py
@@ -1,5 +1,5 @@
 import textwrap
-from typing import Any, Tuple
+from typing import Any
 
 import pytest
 
@@ -36,7 +36,7 @@ _constraint_value_pattern_inputs = [
         for input, expected in _constraint_value_pattern_inputs
         ]
     )
-def test_constraint_value_pattern(value: str, expected: Tuple[Any, Any]) -> None:
+def test_constraint_value_pattern(value: str, expected: tuple[Any, Any]) -> None:
     match = tmt.hardware.CONSTRAINT_VALUE_PATTERN.match(value)
 
     assert match is not None
@@ -58,7 +58,7 @@ _constraint_name_pattern_input = [
         for input, expected in _constraint_name_pattern_input
         ]
     )
-def test_constraint_name_pattern(value: str, expected: Tuple[Any, Any]) -> None:
+def test_constraint_name_pattern(value: str, expected: tuple[Any, Any]) -> None:
     match = tmt.hardware.CONSTRAINT_NAME_PATTERN.match(value)
 
     assert match is not None
@@ -80,7 +80,7 @@ _constraint_components_pattern_input = [
         for input, expected in _constraint_components_pattern_input
         ]
     )
-def test_constraint_components_pattern(value: str, expected: Tuple[Any, Any]) -> None:
+def test_constraint_components_pattern(value: str, expected: tuple[Any, Any]) -> None:
     match = tmt.hardware.CONSTRAINT_COMPONENTS_PATTERN.match(value)
 
     assert match is not None

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, Set
+from typing import Optional
 
 import _pytest.capture
 import _pytest.logging
@@ -26,7 +26,7 @@ def _exercise_logger(
         capsys: _pytest.capture.CaptureFixture[str],
         logger: Logger,
         indent_by: str = '',
-        labels: Optional[List[str]] = None,
+        labels: Optional[list[str]] = None,
         reset: bool = True) -> None:
     labels = labels or []
 
@@ -361,7 +361,7 @@ def test_indent(key, value, color, level, labels, labels_padding, expected):
         )
     )
 def test_topic_filter(
-        logger_topics: Set[Topic],
+        logger_topics: set[Topic],
         message_topic: Optional[Topic],
         filter_outcome: bool) -> None:
     filter = TopicFilter()

--- a/tests/unit/test_report_junit.py
+++ b/tests/unit/test_report_junit.py
@@ -72,9 +72,9 @@ def _compare_xml_node(tree_path: list[str], expected: xml.dom.Node, actual: xml.
     for (expected_name, expected_value), (actual_name, actual_value) in zip(
             expected_attributes, actual_attributes):
         assert expected_name == actual_name, f"Attribute mismatch at {tree_path_joined}: " \
-                                             f"expected {expected_name}=\"{expected_value}\""
+            f"expected {expected_name}=\"{expected_value}\""
         assert expected_value == actual_value, f"Attribute mismatch at {tree_path_joined}: " \
-                                               f"found {actual_name}=\"{actual_value}\""
+            f"found {actual_name}=\"{actual_value}\""
 
     # Hooray, attributes match. Dig deeper, how about children?
     # To compare children, use this very function to compare each child with

--- a/tests/unit/test_report_junit.py
+++ b/tests/unit/test_report_junit.py
@@ -1,6 +1,5 @@
 import xml.dom
 import xml.dom.minidom
-from typing import List
 from unittest.mock import MagicMock, PropertyMock
 
 import pytest
@@ -42,7 +41,7 @@ def report_fix(tmppath: Path, root_logger):
 # .toprettyxml() methods. But that has been observed as not fully deterministic
 # with Python 3.6, changing order or attributes from time to time. Therefore
 # taking the longer, more verbose approach.
-def _compare_xml_node(tree_path: List[str], expected: xml.dom.Node, actual: xml.dom.Node) -> None:
+def _compare_xml_node(tree_path: list[str], expected: xml.dom.Node, actual: xml.dom.Node) -> None:
     """ Assert two XML nodes have the same content """
 
     # All of this would be doable in a much, much simpler, condensed manner,
@@ -85,7 +84,7 @@ def _compare_xml_node(tree_path: List[str], expected: xml.dom.Node, actual: xml.
     # XML, they are not important - in this case, they are spawned by indentation of
     # elements in the expected XML string, and they do not affect the semantics of those
     # nodes.
-    def _valid_children(node: xml.dom.Node) -> List[xml.dom.Node]:
+    def _valid_children(node: xml.dom.Node) -> list[xml.dom.Node]:
         return [
             child for child in node.childNodes
             if child.nodeType != xml.dom.Node.TEXT_NODE or child.data.strip()

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -7,7 +7,7 @@ import time
 import unittest
 import unittest.mock
 from datetime import timedelta
-from typing import Any, List, Optional, Tuple
+from typing import Any, Optional
 
 import fmf
 import pytest
@@ -69,7 +69,7 @@ def local_git_repo(tmppath: Path) -> Path:
 
 
 @pytest.fixture()
-def origin_and_local_git_repo(local_git_repo: Path) -> Tuple[Path, Path]:
+def origin_and_local_git_repo(local_git_repo: Path) -> tuple[Path, Path]:
     top_dir = local_git_repo.parent
     fork_dir = top_dir / 'fork'
     run(ShellScript(f'git clone {local_git_repo} {fork_dir}').to_shell_command(),
@@ -82,7 +82,7 @@ def origin_and_local_git_repo(local_git_repo: Path) -> Tuple[Path, Path]:
 
 
 @pytest.fixture()
-def nested_file(tmppath: Path) -> Tuple[Path, Path, Path]:
+def nested_file(tmppath: Path) -> tuple[Path, Path, Path]:
     top_dir = tmppath / 'top_dir'
     top_dir.mkdir()
     sub_dir = top_dir / 'sub_dir'
@@ -747,7 +747,7 @@ class TestValidateGitStatus:
                              [False, True], ids=["without path", "with path"])
     def test_all_good(
             cls,
-            origin_and_local_git_repo: Tuple[Path, Path],
+            origin_and_local_git_repo: tuple[Path, Path],
             use_path: bool,
             root_logger):
         # No need to modify origin, ignoring it
@@ -823,7 +823,7 @@ class TestValidateGitStatus:
                              [False, True], ids=["without path", "with path"])
     def test_local_changes(
             cls,
-            origin_and_local_git_repo: Tuple[Path, Path],
+            origin_and_local_git_repo: tuple[Path, Path],
             use_path,
             root_logger):
         origin, mine = origin_and_local_git_repo
@@ -854,7 +854,7 @@ class TestValidateGitStatus:
             False, "Uncommitted changes in " + ('fmf_root/' if use_path else '') + "main.fmf")
 
     @classmethod
-    def test_not_pushed(cls, origin_and_local_git_repo: Tuple[Path, Path], root_logger):
+    def test_not_pushed(cls, origin_and_local_git_repo: tuple[Path, Path], root_logger):
         # No need for original repo (it is required just to have remote in
         # local clone)
         mine = origin_and_local_git_repo[1]
@@ -879,7 +879,7 @@ class TestGitAdd:
     @classmethod
     def test_not_in_repository(
             cls,
-            nested_file: Tuple[Path, Path, Path],
+            nested_file: tuple[Path, Path, Path],
             root_logger):
         top_dir, sub_dir, file = nested_file
 
@@ -889,7 +889,7 @@ class TestGitAdd:
     @classmethod
     def test_in_repository(
             cls,
-            nested_file: Tuple[Path, Path, Path],
+            nested_file: tuple[Path, Path, Path],
             root_logger):
         top_dir, sub_dir, file = nested_file
         run(ShellScript('git init').to_shell_command(), cwd=top_dir)
@@ -1082,7 +1082,7 @@ def test_common_base_inheritance(root_logger):
         'duplicates'
         )
     )
-def test_uniq(values: List[Any], expected: List[Any]) -> None:
+def test_uniq(values: list[Any], expected: list[Any]) -> None:
     assert tmt.utils.uniq(values) == expected
 
 
@@ -1099,7 +1099,7 @@ def test_uniq(values: List[Any], expected: List[Any]) -> None:
         'duplicates'
         )
     )
-def test_duplicates(values: List[Any], expected: List[Any]) -> None:
+def test_duplicates(values: list[Any], expected: list[Any]) -> None:
     assert list(tmt.utils.duplicates(values)) == expected
 
 
@@ -1118,7 +1118,7 @@ def test_duplicates(values: List[Any], expected: List[Any]) -> None:
         'unique-enabled'
         )
     )
-def test_flatten(lists: List[List[Any]], unique: bool, expected: List[Any]) -> None:
+def test_flatten(lists: list[list[Any]], unique: bool, expected: list[Any]) -> None:
     assert tmt.utils.flatten(lists, unique=unique) == expected
 
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -444,7 +444,7 @@ class DependencyFmfId(
     # and fixing that would result in a big patch. To allow use of dependencies
     # in sets, provide __hash__ & fix the rest later.
     def __hash__(self) -> int:
-        return hash((getattr(self, key) for key in self.VALID_KEYS))
+        return hash(getattr(self, key) for key in self.VALID_KEYS)
 
     # ignore[override]: expected, we do want to return more specific
     # type than the one declared in superclass.

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -16,15 +16,11 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Dict,
     Iterable,
     Iterator,
-    List,
     Literal,
     Optional,
     Sequence,
-    Tuple,
-    Type,
     TypedDict,
     TypeVar,
     Union,
@@ -142,10 +138,10 @@ class FmfId(
         tmt.export.Exportable['FmfId']):
 
     # The list of valid fmf id keys
-    VALID_KEYS: ClassVar[List[str]] = ['url', 'ref', 'path', 'name']
+    VALID_KEYS: ClassVar[list[str]] = ['url', 'ref', 'path', 'name']
 
     #: Keys that are present, might be set, but shall not be exported.
-    NONEXPORTABLE_KEYS: ClassVar[List[str]] = ['fmf_root', 'git_root', 'default_branch']
+    NONEXPORTABLE_KEYS: ClassVar[list[str]] = ['fmf_root', 'git_root', 'default_branch']
 
     # Save context of the ID for later - there are places where it matters,
     # e.g. to not display `ref` under some conditions.
@@ -223,7 +219,7 @@ class FmfId(
 
         return fmf_id
 
-    def validate(self) -> Tuple[bool, str]:
+    def validate(self) -> tuple[bool, str]:
         """
         Validate fmf id and return a human readable error
 
@@ -245,7 +241,7 @@ class FmfId(
             fmf.base.Tree.node(node_data)
         except fmf.utils.GeneralError as error:
             # Map fmf errors to more user friendly alternatives
-            error_map: List[Tuple[str, str]] = [
+            error_map: list[tuple[str, str]] = [
                 ('git clone', f"repo '{self.url}' cannot be cloned"),
                 ('git checkout', f"git ref '{self.ref}' is invalid"),
                 ('directory path', f"path '{self.path}' is invalid"),
@@ -264,7 +260,7 @@ class FmfId(
     def _export(
             self,
             *,
-            keys: Optional[List[str]] = None
+            keys: Optional[list[str]] = None
             ) -> tmt.export._RawExportedInstance:
 
         spec = self.to_minimal_spec()
@@ -306,7 +302,7 @@ _RawLinkRelationName = Literal[
 _RawLinkTarget = Union[str, _RawFmfId]
 
 # Basic "relation-aware" link - essentialy a mapping with one key/value pair.
-_RawLinkRelation = Dict[_RawLinkRelationName, _RawLinkTarget]
+_RawLinkRelation = dict[_RawLinkRelationName, _RawLinkTarget]
 
 # A single link can be represented as a string or FMF ID (meaning only target is specified),
 # or a "relation-aware" link aka mapping defined above.
@@ -320,7 +316,7 @@ _RawLink = Union[
 # link forms may be used together.
 _RawLinks = Union[
     _RawLink,
-    List[_RawLink]
+    list[_RawLink]
     ]
 
 
@@ -382,7 +378,7 @@ def create_adjust_callback(logger: tmt.log.Logger) -> fmf.base.AdjustCallback:
 
 def normalize_test_environment(
         key_address: str,
-        value: Optional[Dict[str, Any]],
+        value: Optional[dict[str, Any]],
         logger: tmt.log.Logger) -> EnvironmentType:
     """ Normalize value of tests' ``environment`` key """
 
@@ -436,7 +432,7 @@ class DependencyFmfId(
     several extra keys.
     """
 
-    VALID_KEYS: ClassVar[List[str]] = [*FmfId.VALID_KEYS, 'destination', 'nick', 'type']
+    VALID_KEYS: ClassVar[list[str]] = [*FmfId.VALID_KEYS, 'destination', 'nick', 'type']
 
     destination: Optional[Path] = None
     nick: Optional[str] = None
@@ -508,7 +504,7 @@ class DependencyFmfId(
 
 class _RawDependencyFile(TypedDict):
     type: Optional[str]
-    pattern: Optional[List[str]]
+    pattern: Optional[list[str]]
 
 
 @dataclasses.dataclass
@@ -516,10 +512,10 @@ class DependencyFile(
         SpecBasedContainer[_RawDependencyFile, _RawDependencyFile],
         SerializableContainer,
         tmt.export.Exportable['DependencyFile']):
-    VALID_KEYS: ClassVar[List[str]] = ['type', 'pattern']
+    VALID_KEYS: ClassVar[list[str]] = ['type', 'pattern']
 
     type: str = 'file'
-    pattern: List[str] = field(
+    pattern: list[str] = field(
         default_factory=list,
         normalize=tmt.utils.normalize_string_list)
 
@@ -565,7 +561,7 @@ class DependencyFile(
         return dependency
 
     @staticmethod
-    def validate() -> Tuple[bool, str]:
+    def validate() -> tuple[bool, str]:
         """
         Validate file dependency and return a human readable error
 
@@ -579,7 +575,7 @@ class DependencyFile(
 
 
 _RawDependencyItem = Union[str, _RawDependencyFmfId, _RawDependencyFile]
-_RawDependency = Union[_RawDependencyItem, List[_RawDependencyItem]]
+_RawDependency = Union[_RawDependencyItem, list[_RawDependencyItem]]
 
 Dependency = Union[DependencySimple, DependencyFmfId, DependencyFile]
 
@@ -600,7 +596,7 @@ def dependency_factory(raw_dependency: Optional[_RawDependencyItem]) -> Dependen
 def normalize_require(
         key_address: str,
         raw_require: Optional[_RawDependency],
-        logger: tmt.log.Logger) -> List[Dependency]:
+        logger: tmt.log.Logger) -> list[Dependency]:
     """
     Normalize content of ``require`` key.
 
@@ -626,9 +622,9 @@ def normalize_require(
 
 
 def assert_simple_dependencies(
-        dependencies: List[Dependency],
+        dependencies: list[Dependency],
         error_message: str,
-        logger: tmt.log.Logger) -> List[DependencySimple]:
+        logger: tmt.log.Logger) -> list[DependencySimple]:
     """
     Make sure the list of dependencies consists of simple ones.
 
@@ -645,7 +641,7 @@ def assert_simple_dependencies(
         ))
 
     if not non_simple_dependencies:
-        return cast(List[DependencySimple], dependencies)
+        return cast(list[DependencySimple], dependencies)
 
     for dependency in non_simple_dependencies:
         logger.fail(f'Invalid requirement: {dependency}')
@@ -686,14 +682,14 @@ class Core(
         normalize=_normalize_link,
         exporter=lambda value: value.to_spec() if value is not None else [])
     id: Optional[str] = None
-    tag: List[str] = field(
+    tag: list[str] = field(
         default_factory=list,
         normalize=tmt.utils.normalize_string_list)
     tier: Optional[str] = field(
         default=None,
         normalize=lambda key_address, raw_value, logger:
             None if raw_value is None else str(raw_value))
-    adjust: Optional[List[_RawAdjustRule]] = field(
+    adjust: Optional[list[_RawAdjustRule]] = field(
         default_factory=list,
         normalize=lambda key_address, raw_value, logger: [] if raw_value is None
         else ([raw_value] if not isinstance(raw_value, list) else raw_value))
@@ -743,7 +739,7 @@ class Core(
         return self.name
 
     @classmethod
-    def from_tree(cls: Type[T], tree: 'tmt.Tree') -> List[T]:
+    def from_tree(cls: type[T], tree: 'tmt.Tree') -> list[T]:
         """
         Gather list of instances of this class in a given tree.
 
@@ -754,7 +750,7 @@ class Core(
         :param tree: tree to search for objects.
         """
 
-        return cast(List[T], getattr(tree, f'{cls.__name__.lower()}s')())
+        return cast(list[T], getattr(tree, f'{cls.__name__.lower()}s')())
 
     def _update_metadata(self) -> None:
         """ Update the _metadata attribute """
@@ -773,7 +769,7 @@ class Core(
 
     def _fmf_id(self) -> None:
         """ Show fmf identifier """
-        echo(tmt.utils.format('fmf-id', cast(Dict[str, Any],
+        echo(tmt.utils.format('fmf-id', cast(dict[str, Any],
              self.fmf_id.to_minimal_spec()), key_color='magenta'))
 
     # TODO: cached_property candidates
@@ -806,7 +802,7 @@ class Core(
             logger=self._logger)
 
     @cached_property
-    def fmf_sources(self) -> List[Path]:
+    def fmf_sources(self) -> list[Path]:
         return [Path(source) for source in self.node.sources]
 
     def web_link(self) -> Optional[str]:
@@ -864,13 +860,13 @@ class Core(
     def _export(
             self,
             *,
-            keys: Optional[List[str]] = None,
+            keys: Optional[list[str]] = None,
             include_internal: bool = False) -> tmt.export._RawExportedInstance:
         if keys is None:
             keys = self._keys()
 
         # Always include node name, add requested keys, ignore adjust
-        data: Dict[str, Any] = {'name': self.name}
+        data: dict[str, Any] = {'name': self.name}
         for key in keys:
             # TODO: provide more mature solution for https://github.com/teemtee/tmt/issues/1688
             # Until that, do not export fields that start with an underscore, to avoid leaking
@@ -903,7 +899,7 @@ class Core(
 
         return data
 
-    def _lint_keys(self, additional_keys: List[str]) -> List[str]:
+    def _lint_keys(self, additional_keys: list[str]) -> list[str]:
         """ Return list of invalid keys used, empty when all good """
         known_keys = additional_keys + self._keys()
         return [key for key in self.node.get() if key not in known_keys]
@@ -1029,11 +1025,11 @@ class Test(
     """ Test object (L1 Metadata) """
 
     # Basic test information
-    contact: List[str] = field(
+    contact: list[str] = field(
         default_factory=list,
         normalize=tmt.utils.normalize_string_list
         )
-    component: List[str] = field(
+    component: list[str] = field(
         default_factory=list,
         normalize=tmt.utils.normalize_string_list
         )
@@ -1051,11 +1047,11 @@ class Test(
         exporter=lambda value: str(value) if isinstance(value, Path) else None)
     framework: str = "shell"
     manual: bool = False
-    require: List[Dependency] = field(
+    require: list[Dependency] = field(
         default_factory=list,
         normalize=normalize_require,
         exporter=lambda value: [dependency.to_minimal_spec() for dependency in value])
-    recommend: List[Dependency] = field(
+    recommend: list[Dependency] = field(
         default_factory=list,
         normalize=normalize_require,
         exporter=lambda value: [dependency.to_minimal_spec() for dependency in value])
@@ -1066,9 +1062,9 @@ class Test(
     duration: str = DEFAULT_TEST_DURATION_L1
     result: str = 'respect'
 
-    where: List[str] = field(default_factory=list)
+    where: list[str] = field(default_factory=list)
 
-    check: List[Check] = field(
+    check: list[Check] = field(
         default_factory=list,
         normalize=tmt.checks.normalize_checks,
         serialize=lambda checks: [check.to_spec() for check in checks],
@@ -1124,7 +1120,7 @@ class Test(
     def from_dict(
             cls,
             *,
-            mapping: Dict[str, Any],
+            mapping: dict[str, Any],
             name: str,
             skip_validation: bool = False,
             raise_on_validation_error: bool = False,
@@ -1243,7 +1239,7 @@ class Test(
         except KeyError:
             raise tmt.utils.GeneralError(f"Invalid template '{template}'.")
         # Append link with appropriate relation
-        links = Links(data=list(cast(List[_RawLink], Test._opt('link', []))))
+        links = Links(data=list(cast(list[_RawLink], Test._opt('link', []))))
         if links:  # Output 'links' if and only if it is not empty
             content += dict_to_yaml({
                 'link': links.to_spec()
@@ -1299,13 +1295,13 @@ class Test(
             if key in ('require', 'recommend') and value:
                 echo(tmt.utils.format(
                     key,
-                    [dependency.to_minimal_spec() for dependency in cast(List[Dependency], value)]
+                    [dependency.to_minimal_spec() for dependency in cast(list[Dependency], value)]
                     ))
                 continue
             if key == 'check' and value:
                 echo(tmt.utils.format(
                     key,
-                    [check.to_spec() for check in cast(List[Check], value)]
+                    [check.to_spec() for check in cast(list[Check], value)]
                     ))
                 continue
             if value not in [None, [], {}]:
@@ -1517,7 +1513,7 @@ class Plan(
         # ignore[attr-defined]: for some reason, mypy cannot infer `value` is an `FmfContext`
         # instance.
         exporter=lambda value: value.to_spec())  # type: ignore[attr-defined]
-    gate: List[str] = field(
+    gate: list[str] = field(
         default_factory=list,
         normalize=tmt.utils.normalize_string_list)
 
@@ -1624,7 +1620,7 @@ class Plan(
 
         self._update_metadata()
 
-    def _expand_node_data(self, data: T, fmf_context: Dict[str, str]) -> T:
+    def _expand_node_data(self, data: T, fmf_context: dict[str, str]) -> T:
         """ Recursively expand variables in node data """
         if isinstance(data, str):
             # Expand environment and context variables. This is a bit
@@ -1873,8 +1869,8 @@ class Plan(
 
     def _iter_steps(self,
                     enabled_only: bool = True,
-                    skip: Optional[List[str]] = None
-                    ) -> Iterator[Tuple[str, tmt.steps.Step]]:
+                    skip: Optional[list[str]] = None
+                    ) -> Iterator[tuple[str, tmt.steps.Step]]:
         """
         Iterate over steps.
 
@@ -1893,7 +1889,7 @@ class Plan(
 
     def steps(self,
               enabled_only: bool = True,
-              skip: Optional[List[str]] = None) -> Iterator[tmt.steps.Step]:
+              skip: Optional[list[str]] = None) -> Iterator[tmt.steps.Step]:
         """
         Iterate over steps.
 
@@ -1906,7 +1902,7 @@ class Plan(
 
     def step_names(self,
                    enabled_only: bool = True,
-                   skip: Optional[List[str]] = None) -> Iterator[str]:
+                   skip: Optional[list[str]] = None) -> Iterator[str]:
         """
         Iterate over step names.
 
@@ -1995,7 +1991,7 @@ class Plan(
 
         yield LinterOutcome.PASS, 'execute step defined with "how"'
 
-    def _step_phase_nodes(self, step: str) -> List[Dict[str, Any]]:
+    def _step_phase_nodes(self, step: str) -> list[dict[str, Any]]:
         """ List raw fmf nodes for the given step """
 
         _phases = self.node.get(step)
@@ -2006,7 +2002,7 @@ class Plan(
         if isinstance(_phases, dict):
             return [_phases]
 
-        return cast(List[Dict[str, Any]], _phases)
+        return cast(list[dict[str, Any]], _phases)
 
     def _lint_step_methods(
             self,
@@ -2053,7 +2049,7 @@ class Plan(
     def lint_fmf_remote_ids_valid(self) -> LinterReturn:
         """ P005: remote fmf ids must be valid """
 
-        fmf_ids: List[Tuple[FmfId, Dict[str, Any]]] = []
+        fmf_ids: list[tuple[FmfId, dict[str, Any]]] = []
 
         for phase in self._step_phase_nodes('discover'):
             if phase.get('how') != 'fmf':
@@ -2102,8 +2098,8 @@ class Plan(
     def lint_phases_have_guests(self) -> LinterReturn:
         """ P007: step phases require existing guests and roles """
 
-        guest_names: List[str] = []
-        guest_roles: List[str] = []
+        guest_names: list[str] = []
+        guest_roles: list[str] = []
 
         for i, phase in enumerate(self._step_phase_nodes('provision')):
             guest_name = cast(Optional[str], phase.get('name'))
@@ -2242,7 +2238,7 @@ class Plan(
     def _export(
             self,
             *,
-            keys: Optional[List[str]] = None,
+            keys: Optional[list[str]] = None,
             include_internal: bool = False) -> tmt.export._RawExportedInstance:
         data = super()._export(keys=keys, include_internal=include_internal)
 
@@ -2403,7 +2399,7 @@ class Story(
         tmt.lint.Lintable['Story']):
     """ User story object """
 
-    example: List[str] = field(
+    example: list[str] = field(
         default_factory=list,
         normalize=tmt.utils.normalize_string_list)
     # TODO: `story` is mandatory, but it's defined after attributes with default
@@ -2452,26 +2448,26 @@ class Story(
 
     # Override the parent implementation - it would try to call `Tree.storys()`...
     @classmethod
-    def from_tree(cls, tree: 'tmt.Tree') -> List['Story']:
+    def from_tree(cls, tree: 'tmt.Tree') -> list['Story']:
         return tree.stories()
 
     @property
-    def documented(self) -> List['Link']:
+    def documented(self) -> list['Link']:
         """ Return links to relevant documentation """
         return self.link.get('documented-by') if self.link else []
 
     @property
-    def verified(self) -> List['Link']:
+    def verified(self) -> list['Link']:
         """ Return links to relevant test coverage """
         return self.link.get('verified-by') if self.link else []
 
     @property
-    def implemented(self) -> List['Link']:
+    def implemented(self) -> list['Link']:
         """ Return links to relevant source code """
         return self.link.get('implemented-by') if self.link else []
 
     @property
-    def status(self) -> List[str]:
+    def status(self) -> list[str]:
         """ Aggregate story status from implemented-, verified- and documented-by links """
         status = []
 
@@ -2582,7 +2578,7 @@ class Story(
         if self.verbosity_level:
             self._show_additional_keys()
 
-    def coverage(self, code: bool, test: bool, docs: bool) -> Tuple[bool, bool, bool]:
+    def coverage(self, code: bool, test: bool, docs: bool) -> tuple[bool, bool, bool]:
         """ Show story coverage """
         if code:
             code = bool(self.implemented)
@@ -2684,10 +2680,10 @@ class Tree(tmt.utils.Common):
     def _filters_conditions(
             self,
             nodes: Sequence[CoreT],
-            filters: List[str],
-            conditions: List[str],
-            links: List['LinkNeedle'],
-            excludes: List[str]) -> List[CoreT]:
+            filters: list[str],
+            conditions: list[str],
+            links: list['LinkNeedle'],
+            excludes: list[str]) -> list[CoreT]:
         """ Apply filters and conditions, return pruned nodes """
         result = []
         for node in nodes:
@@ -2732,7 +2728,7 @@ class Tree(tmt.utils.Common):
             result.append(node)
         return result
 
-    def sanitize_cli_names(self, names: List[str]) -> List[str]:
+    def sanitize_cli_names(self, names: list[str]) -> list[str]:
         """ Sanitize CLI names in case name includes control character """
         for name in names:
             if not name.isprintable():
@@ -2773,14 +2769,14 @@ class Tree(tmt.utils.Common):
     def tests(
             self,
             logger: Optional[tmt.log.Logger] = None,
-            keys: Optional[List[str]] = None,
-            names: Optional[List[str]] = None,
-            filters: Optional[List[str]] = None,
-            conditions: Optional[List[str]] = None,
+            keys: Optional[list[str]] = None,
+            names: Optional[list[str]] = None,
+            filters: Optional[list[str]] = None,
+            conditions: Optional[list[str]] = None,
             unique: bool = True,
-            links: Optional[List['LinkNeedle']] = None,
-            excludes: Optional[List[str]] = None
-            ) -> List[Test]:
+            links: Optional[list['LinkNeedle']] = None,
+            excludes: Optional[list[str]] = None
+            ) -> list[Test]:
         """ Search available tests """
         # Handle defaults, apply possible command line options
         logger = logger or self._logger
@@ -2791,16 +2787,16 @@ class Tree(tmt.utils.Common):
         # FIXME: cast() - typeless "dispatcher" method
         links = (links or []) + [
             LinkNeedle.from_spec(value)
-            for value in cast(List[str], Test._opt('links', []))
+            for value in cast(list[str], Test._opt('links', []))
             ]
         excludes = (excludes or []) + list(Test._opt('exclude', []))
         # Used in: tmt run test --name NAME, tmt test ls NAME...
-        cmd_line_names: List[str] = list(Test._opt('names', []))
+        cmd_line_names: list[str] = list(Test._opt('names', []))
 
         # Sanitize test names to make sure no name includes control character
         cmd_line_names = self.sanitize_cli_names(cmd_line_names)
 
-        def name_filter(nodes: Iterable[fmf.Tree]) -> List[fmf.Tree]:
+        def name_filter(nodes: Iterable[fmf.Tree]) -> list[fmf.Tree]:
             """ Filter nodes based on names provided on the command line """
             if not cmd_line_names:
                 return list(nodes)
@@ -2854,14 +2850,14 @@ class Tree(tmt.utils.Common):
     def plans(
             self,
             logger: Optional[tmt.log.Logger] = None,
-            keys: Optional[List[str]] = None,
-            names: Optional[List[str]] = None,
-            filters: Optional[List[str]] = None,
-            conditions: Optional[List[str]] = None,
+            keys: Optional[list[str]] = None,
+            names: Optional[list[str]] = None,
+            filters: Optional[list[str]] = None,
+            conditions: Optional[list[str]] = None,
             run: Optional['Run'] = None,
-            links: Optional[List['LinkNeedle']] = None,
-            excludes: Optional[List[str]] = None
-            ) -> List[Plan]:
+            links: Optional[list['LinkNeedle']] = None,
+            excludes: Optional[list[str]] = None
+            ) -> list[Plan]:
         """ Search available plans """
         # Handle defaults, apply possible command line options
         logger = logger or (run._logger if run is not None else self._logger)
@@ -2873,7 +2869,7 @@ class Tree(tmt.utils.Common):
         # FIXME: cast() - typeless "dispatcher" method
         links = (links or []) + [
             LinkNeedle.from_spec(value)
-            for value in cast(List[str], Plan._opt('links', []))
+            for value in cast(list[str], Plan._opt('links', []))
             ]
         excludes = (excludes or []) + list(Plan._opt('exclude', []))
 
@@ -2925,14 +2921,14 @@ class Tree(tmt.utils.Common):
     def stories(
             self,
             logger: Optional[tmt.log.Logger] = None,
-            keys: Optional[List[str]] = None,
-            names: Optional[List[str]] = None,
-            filters: Optional[List[str]] = None,
-            conditions: Optional[List[str]] = None,
+            keys: Optional[list[str]] = None,
+            names: Optional[list[str]] = None,
+            filters: Optional[list[str]] = None,
+            conditions: Optional[list[str]] = None,
             whole: bool = False,
-            links: Optional[List['LinkNeedle']] = None,
-            excludes: Optional[List[str]] = None
-            ) -> List[Story]:
+            links: Optional[list['LinkNeedle']] = None,
+            excludes: Optional[list[str]] = None
+            ) -> list[Story]:
         """ Search available stories """
         # Handle defaults, apply possible command line options
         logger = logger or self._logger
@@ -2943,7 +2939,7 @@ class Tree(tmt.utils.Common):
         # FIXME: cast() - typeless "dispatcher" method
         links = (links or []) + [
             LinkNeedle.from_spec(value)
-            for value in cast(List[str], Story._opt('links', []))
+            for value in cast(list[str], Story._opt('links', []))
             ]
         excludes = (excludes or []) + list(Story._opt('exclude', []))
 
@@ -3089,10 +3085,10 @@ class Tree(tmt.utils.Common):
 @dataclasses.dataclass
 class RunData(SerializableContainer):
     root: Optional[str]
-    plans: Optional[List[str]]
+    plans: Optional[list[str]]
     # TODO: this needs resolution - _context_object.steps is List[Step],
     # but stores as a List[str] in run.yaml...
-    steps: List[str]
+    steps: list[str]
     environment: EnvironmentType
     remove: bool
 
@@ -3127,7 +3123,7 @@ class Run(tmt.utils.Common):
         super().__init__(cli_invocation=cli_invocation, logger=logger)
         self._workdir_path: WorkdirArgumentType = id_ or True
         self._tree = tree
-        self._plans: Optional[List[Plan]] = None
+        self._plans: Optional[list[Plan]] = None
         self._environment_from_workdir: EnvironmentType = {}
         self._environment_from_options: Optional[EnvironmentType] = None
         self.remove = self.opt('remove')
@@ -3293,7 +3289,7 @@ class Run(tmt.utils.Common):
         self.debug(f"Remove workdir when finished: {self.remove}", level=3)
 
     @property
-    def plans(self) -> List[Plan]:
+    def plans(self) -> list[Plan]:
         """ Test plans for execution """
         if self._plans is None:
             assert self.tree is not None  # narrow type
@@ -3410,7 +3406,7 @@ class Run(tmt.utils.Common):
                     tmt.steps.prepare.Prepare,
                     tmt.steps.execute.Execute,
                     tmt.steps.finish.Finish):
-                klass = cast(Type[tmt.steps.Step], _klass)
+                klass = cast(type[tmt.steps.Step], _klass)
 
                 cli_invocation = klass.cli_invocation
 
@@ -3459,7 +3455,7 @@ class Run(tmt.utils.Common):
         self.save()
 
         # Iterate over plans
-        crashed_plans: List[Tuple[Plan, Exception]] = []
+        crashed_plans: list[tuple[Plan, Exception]] = []
 
         for plan in self.plans:
             try:
@@ -3953,7 +3949,7 @@ class Link(SpecBasedContainer[Any, _RawLinkRelation]):
         return spec
 
 
-class Links(SpecBasedContainer[Any, List[_RawLinkRelation]]):
+class Links(SpecBasedContainer[Any, list[_RawLinkRelation]]):
     """
     Collection of links in tests, plans and stories.
 
@@ -3963,7 +3959,7 @@ class Links(SpecBasedContainer[Any, List[_RawLinkRelation]]):
     """
 
     # The list of all supported link relations
-    _relations: List[_RawLinkRelationName] = [
+    _relations: list[_RawLinkRelationName] = [
         'verifies', 'verified-by',
         'implements', 'implemented-by',
         'documents', 'documented-by',
@@ -3973,7 +3969,7 @@ class Links(SpecBasedContainer[Any, List[_RawLinkRelation]]):
         'relates', 'test-script',
         ]
 
-    _links: List[Link]
+    _links: list[Link]
 
     def __init__(self, *, data: Optional[_RawLinks] = None):
         """ Create a collection from raw link data """
@@ -3995,7 +3991,7 @@ class Links(SpecBasedContainer[Any, List[_RawLinkRelation]]):
         # Ensure that each link is in the canonical form
         self._links = [Link.from_spec(spec) for spec in specs]
 
-    def to_spec(self) -> List[_RawLinkRelation]:
+    def to_spec(self) -> list[_RawLinkRelation]:
         """
         Convert to a form suitable for saving in a specification file
 
@@ -4015,7 +4011,7 @@ class Links(SpecBasedContainer[Any, List[_RawLinkRelation]]):
             for link in self._links
             ]
 
-    def get(self, relation: Optional[_RawLinkRelationName] = None) -> List[Link]:
+    def get(self, relation: Optional[_RawLinkRelationName] = None) -> list[Link]:
         """ Get links with given relation, all by default """
         return [
             link for link in self._links

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -11,16 +11,14 @@ import shutil
 import sys
 import tempfile
 import time
+from collections.abc import Iterable, Iterator, Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
-    Iterable,
-    Iterator,
     Literal,
     Optional,
-    Sequence,
     TypedDict,
     TypeVar,
     Union,

--- a/tmt/checks/__init__.py
+++ b/tmt/checks/__init__.py
@@ -1,6 +1,6 @@
 import dataclasses
 import enum
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypedDict, cast
 
 import tmt.log
 import tmt.steps.provision
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from tmt.steps.execute import ExecutePlugin, ExecuteStepDataT
 
 
-CheckPluginClass = Type['CheckPlugin']
+CheckPluginClass = type['CheckPlugin']
 
 _CHECK_PLUGIN_REGISTRY: PluginRegistry[CheckPluginClass] = PluginRegistry()
 
@@ -104,7 +104,7 @@ class Check(
             raw_data: _RawCheck,
             logger: tmt.log.Logger) -> 'Check':
         data = cls(name=raw_data['name'])
-        data._load_keys(cast(Dict[str, Any], raw_data), cls.__name__, logger)
+        data._load_keys(cast(dict[str, Any], raw_data), cls.__name__, logger)
 
         return data
 
@@ -122,7 +122,7 @@ class Check(
             test: 'tmt.base.Test',
             plugin: 'ExecutePlugin[ExecuteStepDataT]',
             environment: Optional[tmt.utils.EnvironmentType] = None,
-            logger: tmt.log.Logger) -> List['CheckResult']:
+            logger: tmt.log.Logger) -> list['CheckResult']:
         """
         Run the check.
 
@@ -164,7 +164,7 @@ class Check(
 class CheckPlugin(tmt.utils._CommonBase):
     """ Base class for plugins providing extra checks before, during and after tests """
 
-    _check_class: Type[Check] = Check
+    _check_class: type[Check] = Check
 
     # Keep this method around, to correctly support Python's method resolution order.
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -189,7 +189,7 @@ class CheckPlugin(tmt.utils._CommonBase):
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,
-            logger: tmt.log.Logger) -> List['CheckResult']:
+            logger: tmt.log.Logger) -> list['CheckResult']:
         return []
 
     @classmethod
@@ -201,7 +201,7 @@ class CheckPlugin(tmt.utils._CommonBase):
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,
-            logger: tmt.log.Logger) -> List['CheckResult']:
+            logger: tmt.log.Logger) -> list['CheckResult']:
         return []
 
 
@@ -238,7 +238,7 @@ def normalize_test_check(
 def normalize_checks(
         key_address: str,
         raw_checks: Any,
-        logger: tmt.log.Logger) -> List[Check]:
+        logger: tmt.log.Logger) -> list[Check]:
     """ Normalize (prepare/finish/test) checks """
 
     if raw_checks is None:

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import tmt.log
 import tmt.steps.execute
@@ -25,7 +25,7 @@ class AvcDenials(CheckPlugin):
             guest: tmt.steps.provision.Guest,
             test: 'Test',
             event: CheckEvent,
-            logger: tmt.log.Logger) -> Tuple[ResultOutcome, Path]:
+            logger: tmt.log.Logger) -> tuple[ResultOutcome, Path]:
 
         if test.start_time is None:
             raise tmt.utils.GeneralError(
@@ -60,7 +60,7 @@ class AvcDenials(CheckPlugin):
                 topic=topic)
 
         # Collect all report components
-        report: List[str] = [
+        report: list[str] = [
             f'# Acquired at {report_timestamp}'
             ]
 
@@ -70,8 +70,8 @@ class AvcDenials(CheckPlugin):
         def _run_script(
                 script: ShellScript,
                 needs_sudo: bool = False) -> Union[
-                    Tuple[CommandOutput, Optional[tmt.utils.RunError]],
-                    Tuple[Optional[CommandOutput], tmt.utils.RunError]
+                    tuple[CommandOutput, Optional[tmt.utils.RunError]],
+                    tuple[Optional[CommandOutput], tmt.utils.RunError]
                 ]:
             if needs_sudo and guest.facts.is_superuser is False:
                 script = ShellScript(f'sudo {script.to_shell_command()}')
@@ -84,14 +84,14 @@ class AvcDenials(CheckPlugin):
             except tmt.utils.RunError as exc:
                 return None, exc
 
-        def _report_success(label: str, output: tmt.utils.CommandOutput) -> List[str]:
+        def _report_success(label: str, output: tmt.utils.CommandOutput) -> list[str]:
             return [
                 f'# {label}',
                 output.stdout or '',
                 ''
                 ]
 
-        def _report_failure(label: str, exc: tmt.utils.RunError) -> List[str]:
+        def _report_failure(label: str, exc: tmt.utils.RunError) -> list[str]:
             return [
                 f'# {label}',
                 "\n".join(render_run_exception_streams(exc.stdout, exc.stderr, verbose=1)),
@@ -177,7 +177,7 @@ ausearch -i --input-logs -m AVC -m USER_AVC -m SELINUX_ERR -ts $AVC_SINCE
             guest: tmt.steps.provision.Guest,
             test: 'Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,
-            logger: tmt.log.Logger) -> List[CheckResult]:
+            logger: tmt.log.Logger) -> list[CheckResult]:
         outcome, path = cls._save_report(plugin, guest, test, CheckEvent.AFTER_TEST, logger)
 
         return [CheckResult(name='avc', result=outcome, log=[path])]

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, Optional
 
 import tmt.log
 import tmt.steps.execute
@@ -47,7 +47,7 @@ class DmesgCheck(CheckPlugin):
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
             event: CheckEvent,
-            logger: tmt.log.Logger) -> Tuple[ResultOutcome, Path]:
+            logger: tmt.log.Logger) -> tuple[ResultOutcome, Path]:
 
         from tmt.steps.execute import ExecutePlugin
 
@@ -88,7 +88,7 @@ class DmesgCheck(CheckPlugin):
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,
-            logger: tmt.log.Logger) -> List[CheckResult]:
+            logger: tmt.log.Logger) -> list[CheckResult]:
         outcome, path = cls._save_dmesg(plugin, guest, test, CheckEvent.BEFORE_TEST, logger)
 
         return [CheckResult(name='dmesg', result=outcome, log=[path])]
@@ -102,7 +102,7 @@ class DmesgCheck(CheckPlugin):
             guest: tmt.steps.provision.Guest,
             test: 'tmt.base.Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,
-            logger: tmt.log.Logger) -> List[CheckResult]:
+            logger: tmt.log.Logger) -> list[CheckResult]:
         outcome, path = cls._save_dmesg(plugin, guest, test, CheckEvent.AFTER_TEST, logger)
 
         return [CheckResult(name='dmesg', result=outcome, log=[path])]

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 """ Command line interface for the Test Management Tool """
 

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -6,7 +6,7 @@ import collections
 import dataclasses
 import subprocess
 import sys
-from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List, Optional, Set, Tuple, Type, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import click
 import fmf
@@ -58,10 +58,10 @@ class ContextObject:
     common: tmt.utils.Common
     fmf_context: tmt.utils.FmfContext
     tree: tmt.Tree
-    steps: Set[str] = dataclasses.field(default_factory=set)
+    steps: set[str] = dataclasses.field(default_factory=set)
     clean: Optional[tmt.Clean] = None
     clean_logger: Optional[tmt.log.Logger] = None
-    clean_partials: DefaultDict[str, List[tmt.base.CleanCallback]] = dataclasses.field(
+    clean_partials: collections.defaultdict[str, list[tmt.base.CleanCallback]] = dataclasses.field(
         default_factory=lambda: collections.defaultdict(list))
     run: Optional[tmt.Run] = None
 
@@ -100,14 +100,14 @@ class CliInvocation:
     """
 
     context: Optional[Context]
-    options: Dict[str, Any]
+    options: dict[str, Any]
 
     @classmethod
     def from_context(cls, context: Context) -> 'CliInvocation':
         return CliInvocation(context=context, options=context.params)
 
     @cached_property
-    def option_sources(self) -> Dict[str, click.core.ParameterSource]:
+    def option_sources(self) -> dict[str, click.core.ParameterSource]:
         if not self.context:
             return {}
 
@@ -123,7 +123,7 @@ class CustomGroup(click.Group):
 
     # ignore[override]: expected, we want to use more specific `Context`
     # type than the one declared in superclass.
-    def list_commands(self, context: Context) -> List[str]:  # type: ignore[override]
+    def list_commands(self, context: Context) -> list[str]:  # type: ignore[override]
         """ Prevent alphabetical sorting """
         return list(self.commands.keys())
 
@@ -199,7 +199,7 @@ environment_options = create_options_decorator(tmt.options.ENVIRONMENT_OPTIONS)
 def main(
         click_contex: Context,
         root: str,
-        context: List[str],
+        context: list[str],
         no_color: bool,
         force_color: bool,
         **kwargs: Any) -> None:
@@ -395,12 +395,12 @@ def finito(
 
 def _lint_class(
         context: Context,
-        klass: Union[Type[tmt.base.Test], Type[tmt.base.Plan], Type[tmt.base.Story]],
+        klass: Union[type[tmt.base.Test], type[tmt.base.Plan], type[tmt.base.Story]],
         failed_only: bool,
-        enable_checks: List[str],
-        disable_checks: List[str],
-        enforce_checks: List[str],
-        outcomes: List[tmt.lint.LinterOutcome],
+        enable_checks: list[str],
+        disable_checks: list[str],
+        enforce_checks: list[str],
+        outcomes: list[tmt.lint.LinterOutcome],
         **kwargs: Any) -> int:
     """ Lint a single class of objects """
 
@@ -447,13 +447,13 @@ def _lint_class(
 
 def do_lint(
         context: Context,
-        klasses: List[Union[Type[tmt.base.Test], Type[tmt.base.Plan], Type[tmt.base.Story]]],
+        klasses: list[Union[type[tmt.base.Test], type[tmt.base.Plan], type[tmt.base.Story]]],
         list_checks: bool,
         failed_only: bool,
-        enable_checks: List[str],
-        disable_checks: List[str],
-        enforce_checks: List[str],
-        outcomes: List[tmt.lint.LinterOutcome],
+        enable_checks: list[str],
+        disable_checks: list[str],
+        enforce_checks: list[str],
+        outcomes: list[tmt.lint.LinterOutcome],
         **kwargs: Any) -> int:
     """ Core of all ``lint`` commands """
 
@@ -552,10 +552,10 @@ def tests_lint(
         context: Context,
         list_checks: bool,
         failed_only: bool,
-        enable_checks: List[str],
-        disable_checks: List[str],
-        enforce_checks: List[str],
-        outcome_only: Tuple[str, ...],
+        enable_checks: list[str],
+        disable_checks: list[str],
+        enforce_checks: list[str],
+        outcome_only: tuple[str, ...],
         **kwargs: Any) -> None:
     """
     Check tests against the L1 metadata specification.
@@ -673,14 +673,14 @@ def tests_create(
 @force_dry_options
 def tests_import(
         context: Context,
-        paths: List[str],
+        paths: list[str],
         makefile: bool,
         restraint: bool,
         general: bool,
-        types: List[str],
+        types: list[str],
         nitrate: bool,
         polarion: bool,
-        polarion_case_id: List[str],
+        polarion_case_id: list[str],
         link_polarion: bool,
         purpose: bool,
         disabled: bool,
@@ -970,10 +970,10 @@ def plans_lint(
         context: Context,
         list_checks: bool,
         failed_only: bool,
-        enable_checks: List[str],
-        disable_checks: List[str],
-        enforce_checks: List[str],
-        outcome_only: Tuple[str, ...],
+        enable_checks: list[str],
+        disable_checks: list[str],
+        enforce_checks: list[str],
+        outcome_only: tuple[str, ...],
         **kwargs: Any) -> None:
     """
     Check plans against the L2 metadata specification.
@@ -1384,10 +1384,10 @@ def stories_lint(
         context: Context,
         list_checks: bool,
         failed_only: bool,
-        enable_checks: List[str],
-        disable_checks: List[str],
-        enforce_checks: List[str],
-        outcome_only: Tuple[str, ...],
+        enable_checks: list[str],
+        disable_checks: list[str],
+        enforce_checks: list[str],
+        outcome_only: tuple[str, ...],
         **kwargs: Any) -> None:
     """
     Check stories against the L3 metadata specification.
@@ -1747,11 +1747,11 @@ def clean_images(context: Context, **kwargs: Any) -> None:
 def lint(
         context: Context,
         list_checks: bool,
-        enable_checks: List[str],
-        disable_checks: List[str],
-        enforce_checks: List[str],
+        enable_checks: list[str],
+        disable_checks: list[str],
+        enforce_checks: list[str],
         failed_only: bool,
-        outcome_only: Tuple[str, ...],
+        outcome_only: tuple[str, ...],
         **kwargs: Any) -> None:
     """
     Check all the present metadata against the specification.

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -6,7 +6,7 @@ import re
 import shlex
 import subprocess
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 from uuid import UUID, uuid4
 
 import fmf.utils
@@ -21,7 +21,7 @@ from tmt.utils import ConvertError, GeneralError, Path, format_value
 log = fmf.utils.Logging('tmt').logger
 
 # It is not possible to use TypedDict here, because all keys are unknown
-NitrateDataType = Dict[str, Any]
+NitrateDataType = dict[str, Any]
 
 if TYPE_CHECKING:
     from nitrate import TestCase
@@ -117,7 +117,7 @@ def read_manual(
     os.chdir(old_cwd)
 
 
-def read_manual_data(testcase: 'TestCase') -> Dict[str, str]:
+def read_manual_data(testcase: 'TestCase') -> dict[str, str]:
     """ Read test data from manual fields """
     md_content = {}
     md_content['setup'] = html_to_markdown(testcase.setup)
@@ -142,7 +142,7 @@ def html_to_markdown(html: str) -> str:
     return markdown
 
 
-def write_markdown(path: Path, content: Dict[str, str]) -> None:
+def write_markdown(path: Path, content: dict[str, str]) -> None:
     """ Write gathered metadata in the markdown format """
     to_print = ""
     if content['setup']:
@@ -190,9 +190,9 @@ def read_datafile(
         path: Path,
         filename: str,
         datafile: str,
-        types: List[str],
+        types: list[str],
         testinfo: Optional[str] = None
-        ) -> Tuple[str, NitrateDataType]:
+        ) -> tuple[str, NitrateDataType]:
     """
     Read data values from supplied Makefile or metadata file.
     Returns task name and a dictionary of the collected values.
@@ -372,7 +372,7 @@ def read_datafile(
     return beaker_task, data
 
 
-ReadOutputType = Tuple[NitrateDataType, List[NitrateDataType]]
+ReadOutputType = tuple[NitrateDataType, list[NitrateDataType]]
 
 
 def read(
@@ -381,11 +381,11 @@ def read(
         restraint: bool,
         nitrate: bool,
         polarion: bool,
-        polarion_case_id: List[str],
+        polarion_case_id: list[str],
         link_polarion: bool,
         purpose: bool,
         disabled: bool,
-        types: List[str],
+        types: list[str],
         general: bool
         ) -> ReadOutputType:
     """
@@ -511,7 +511,7 @@ def read(
             read_datafile(path, filename, datafile, types, testinfo)
 
         # Warn if makefile has extra lines in run target
-        def target_content_run() -> List[str]:
+        def target_content_run() -> list[str]:
             """ Extract lines from the run content """
             newline_stub = '_XXX_NEWLINE_0x734'
             datafile_test = datafile
@@ -529,7 +529,7 @@ def read(
             return [line.strip('\t') for line in target.splitlines()]
 
         # Warn if makefile has extra lines in build target
-        def target_content_build() -> List[str]:
+        def target_content_build() -> list[str]:
             """ Extract lines from the build content """
             regexp = r'^build:.*\n((?:\t[^\n]*\n?)*)'
             search_result = re.search(regexp, datafile, re.M)
@@ -616,7 +616,7 @@ def read(
 
 def filter_common_data(
         common_data: NitrateDataType,
-        individual_data: List[NitrateDataType]) -> None:
+        individual_data: list[NitrateDataType]) -> None:
     """ Filter common data out from individual data """
     common_candidates = copy.copy(individual_data[0])
     histogram = {}
@@ -763,10 +763,10 @@ def read_tier(tag: str, data: NitrateDataType) -> None:
 
 def read_polarion(
         common_data: NitrateDataType,
-        individual_data: List[NitrateDataType],
-        polarion_case_id: List[str],
+        individual_data: list[NitrateDataType],
+        polarion_case_id: list[str],
         link_polarion: bool,
-        filenames: List[str]) -> None:
+        filenames: list[str]) -> None:
     """ Read data from Polarion """
     if not polarion_case_id:
         read_polarion_case(common_data, None, link_polarion)
@@ -802,7 +802,7 @@ def read_polarion(
 
 
 def read_polarion_case(
-        data: Union[NitrateDataType, List[NitrateDataType]],
+        data: Union[NitrateDataType, list[NitrateDataType]],
         polarion_case_id: Optional[str],
         link_polarion: bool) -> None:
     """ Read data of specific case from Polarion """
@@ -920,7 +920,7 @@ def read_polarion_case(
     current_data['filename'] = f'{file_name}.fmf'
 
 
-RelevancyType = Union[str, List[str]]
+RelevancyType = Union[str, list[str]]
 
 
 def extract_relevancy(
@@ -1129,7 +1129,7 @@ def write(path: Path, data: NitrateDataType, quiet: bool = False) -> None:
 
 
 def relevancy_to_adjust(
-        relevancy: RelevancyType) -> List[NitrateDataType]:
+        relevancy: RelevancyType) -> list[NitrateDataType]:
     """
     Convert the old test case relevancy into adjust rules
 

--- a/tmt/export/__init__.py
+++ b/tmt/export/__init__.py
@@ -14,13 +14,9 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Dict,
     Generic,
-    List,
     Optional,
     Protocol,
-    Tuple,
-    Type,
     TypeVar,
     Union,
     cast,
@@ -58,16 +54,16 @@ RE_BUGZILLA_URL = r'bugzilla.redhat.com/show_bug.cgi\?id=(\d+)'
 
 # ignore[type-arg]: bound type vars cannot be generic, and it would create a loop anyway.
 ExportableT = TypeVar('ExportableT', bound='Exportable')  # type: ignore[type-arg]
-ExportClass = Type['ExportPlugin']
+ExportClass = type['ExportPlugin']
 
-_RawExportedInstance = Dict[str, Any]
-_RawExportedCollection = List[_RawExportedInstance]
+_RawExportedInstance = dict[str, Any]
+_RawExportedCollection = list[_RawExportedInstance]
 _RawExported = Union[_RawExportedInstance, _RawExportedCollection]
 
 
 # Protocols describing export methods.
 class Exporter(Protocol):
-    def __call__(self, collection: List[ExportableT], keys: Optional[List[str]] = None) -> str:
+    def __call__(self, collection: list[ExportableT], keys: Optional[list[str]] = None) -> str:
         pass
 
 
@@ -136,7 +132,7 @@ class Exportable(Generic[ExportableT], tmt.utils._CommonBase):
         return cast(Exporter, getattr(
             exporter_class, f'export_{cls.__name__.lower()}_collection'))
 
-    def _export(self, *, keys: Optional[List[str]] = None) -> _RawExportedInstance:
+    def _export(self, *, keys: Optional[list[str]] = None) -> _RawExportedInstance:
         """
         Export instance as "raw" dictionary.
 
@@ -146,7 +142,7 @@ class Exportable(Generic[ExportableT], tmt.utils._CommonBase):
 
         raise NotImplementedError
 
-    def export(self, *, format: str, keys: Optional[List[str]] = None, **kwargs: Any) -> str:
+    def export(self, *, format: str, keys: Optional[list[str]] = None, **kwargs: Any) -> str:
         """ Export this instance in a given format """
 
         return self.export_collection(
@@ -161,11 +157,11 @@ class Exportable(Generic[ExportableT], tmt.utils._CommonBase):
 
     @classmethod
     def export_collection(
-            cls: Type[ExportableT],
+            cls: type[ExportableT],
             *,
-            collection: List[ExportableT],
+            collection: list[ExportableT],
             format: str,
-            keys: Optional[List[str]] = None,
+            keys: Optional[list[str]] = None,
             **kwargs: Any) -> str:
         """ Export collection of instances in a given format """
 
@@ -183,30 +179,30 @@ class ExportPlugin:
     """ Base class for plugins providing metadata export functionality """
 
     @classmethod
-    def export_fmfid_collection(cls, fmf_ids: List['tmt.base.FmfId'], **kwargs: Any) -> str:
+    def export_fmfid_collection(cls, fmf_ids: list['tmt.base.FmfId'], **kwargs: Any) -> str:
         """ Export collection of fmf ids """
         raise NotImplementedError
 
     @classmethod
     def export_test_collection(cls,
-                               tests: List['tmt.base.Test'],
-                               keys: Optional[List[str]] = None,
+                               tests: list['tmt.base.Test'],
+                               keys: Optional[list[str]] = None,
                                **kwargs: Any) -> str:
         """ Export collection of tests """
         raise NotImplementedError
 
     @classmethod
     def export_plan_collection(cls,
-                               plans: List['tmt.base.Plan'],
-                               keys: Optional[List[str]] = None,
+                               plans: list['tmt.base.Plan'],
+                               keys: Optional[list[str]] = None,
                                **kwargs: Any) -> str:
         """ Export collection of plans """
         raise NotImplementedError
 
     @classmethod
     def export_story_collection(cls,
-                                stories: List['tmt.base.Story'],
-                                keys: Optional[List[str]] = None,
+                                stories: list['tmt.base.Story'],
+                                keys: Optional[list[str]] = None,
                                 **kwargs: Any) -> str:
         """ Export collection of stories """
         raise NotImplementedError
@@ -245,12 +241,12 @@ class TrivialExporter(ExportPlugin):
 
     @classmethod
     def export_fmfid_collection(cls,
-                                fmf_ids: List['tmt.base.FmfId'],
-                                keys: Optional[List[str]] = None,
+                                fmf_ids: list['tmt.base.FmfId'],
+                                keys: Optional[list[str]] = None,
                                 **kwargs: Any) -> str:
         # Special case: fmf id export shall not display `ref` if it is equal
         # to the default branch.
-        exported_fmf_ids: List[tmt.base._RawFmfId] = []
+        exported_fmf_ids: list[tmt.base._RawFmfId] = []
 
         for fmf_id in fmf_ids:
             exported = fmf_id._export(keys=keys)
@@ -260,26 +256,26 @@ class TrivialExporter(ExportPlugin):
 
             exported_fmf_ids.append(cast(tmt.base._RawFmfId, exported))
 
-        return cls._export(cast(List[_RawExportedInstance], exported_fmf_ids))
+        return cls._export(cast(list[_RawExportedInstance], exported_fmf_ids))
 
     @classmethod
     def export_test_collection(cls,
-                               tests: List['tmt.base.Test'],
-                               keys: Optional[List[str]] = None,
+                               tests: list['tmt.base.Test'],
+                               keys: Optional[list[str]] = None,
                                **kwargs: Any) -> str:
         return cls._export([test._export(keys=keys) for test in tests])
 
     @classmethod
     def export_plan_collection(cls,
-                               plans: List['tmt.base.Plan'],
-                               keys: Optional[List[str]] = None,
+                               plans: list['tmt.base.Plan'],
+                               keys: Optional[list[str]] = None,
                                **kwargs: Any) -> str:
         return cls._export([plan._export(keys=keys) for plan in plans])
 
     @classmethod
     def export_story_collection(cls,
-                                stories: List['tmt.base.Story'],
-                                keys: Optional[List[str]] = None,
+                                stories: list['tmt.base.Story'],
+                                keys: Optional[list[str]] = None,
                                 **kwargs: Any) -> str:
         return cls._export([story._export(keys=keys) for story in stories])
 
@@ -305,7 +301,7 @@ def get_bz_instance() -> BugzillaInstance:
     return bz_instance
 
 
-def bz_set_coverage(bug_ids: List[int], case_id: str, tracker_id: int) -> None:
+def bz_set_coverage(bug_ids: list[int], case_id: str, tracker_id: int) -> None:
     """ Set coverage in Bugzilla """
     bz_instance = get_bz_instance()
 
@@ -364,7 +360,7 @@ def bz_set_coverage(bug_ids: List[int], case_id: str, tracker_id: int) -> None:
         " ".join([f"BZ#{bz_id}" for bz_id in bug_ids])), fg='magenta'))
 
 
-def check_md_file_respects_spec(md_path: Path) -> List[str]:
+def check_md_file_respects_spec(md_path: Path) -> list[str]:
     """
     Check that the file respects manual test specification
 
@@ -423,9 +419,9 @@ def check_md_file_respects_spec(md_path: Path) -> List[str]:
                                'section "{}"'
 
     def required_section_exists(
-            section: List[str],
+            section: list[str],
             section_name: str,
-            prefix: Union[str, Tuple[str, ...]]) -> int:
+            prefix: Union[str, tuple[str, ...]]) -> int:
         res = list(filter(
             lambda t: t.startswith(prefix), section))
         if not res:

--- a/tmt/export/nitrate.py
+++ b/tmt/export/nitrate.py
@@ -2,12 +2,12 @@ import email.utils
 import os
 import re
 import types
+from collections.abc import Iterator
 from contextlib import suppress
 from functools import cache
 from typing import (
     TYPE_CHECKING,
     Any,
-    Iterator,
     Optional,
     Union,
     cast,

--- a/tmt/export/nitrate.py
+++ b/tmt/export/nitrate.py
@@ -3,7 +3,7 @@ import os
 import re
 import types
 from contextlib import suppress
-from functools import lru_cache
+from functools import cache
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -335,7 +335,7 @@ def prepare_extra_summary(test: 'tmt.Test', append_summary: bool) -> str:
 
 
 # avoid multiple searching for general plans (it is expensive)
-@lru_cache(maxsize=None)
+@cache
 def find_general_plan(component: str) -> NitrateTestPlan:
     """ Return single General Test Plan or raise an error """
     assert nitrate

--- a/tmt/export/nitrate.py
+++ b/tmt/export/nitrate.py
@@ -7,11 +7,8 @@ from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Any,
-    Dict,
     Iterator,
-    List,
     Optional,
-    Tuple,
     Union,
     cast,
     )
@@ -48,9 +45,9 @@ NitrateTestCase = Any
 
 DEFAULT_PRODUCT: Any = None
 
-SectionsReturnType = Tuple[str, str, str, str]
-HeadingsType = List[List[Union[int, str]]]
-SectionsHeadingsType = Dict[str, HeadingsType]
+SectionsReturnType = tuple[str, str, str, str]
+HeadingsType = list[list[Union[int, str]]]
+SectionsHeadingsType = dict[str, HeadingsType]
 
 # TODO: why this exists?
 log = fmf.utils.Logging('tmt').logger
@@ -152,7 +149,7 @@ def convert_manual_to_nitrate(test_md: Path) -> SectionsReturnType:
                 sections_headings[key] = result
                 break
 
-    def concatenate_headings_content(headings: Tuple[str, ...]) -> HeadingsType:
+    def concatenate_headings_content(headings: tuple[str, ...]) -> HeadingsType:
         content = []
         for v in headings:
             content += sections_headings[v]
@@ -343,7 +340,7 @@ def find_general_plan(component: str) -> NitrateTestPlan:
     """ Return single General Test Plan or raise an error """
     assert nitrate
     # At first find by linked components
-    found: List[NitrateTestPlan] = nitrate.TestPlan.search(
+    found: list[NitrateTestPlan] = nitrate.TestPlan.search(
         type__name="General",
         is_active=True,
         component__name=f"{component}")
@@ -657,8 +654,8 @@ def export_to_nitrate(test: 'tmt.Test') -> None:
 class NitrateExporter(tmt.export.ExportPlugin):
     @classmethod
     def export_test_collection(cls,
-                               tests: List[tmt.base.Test],
-                               keys: Optional[List[str]] = None,
+                               tests: list[tmt.base.Test],
+                               keys: Optional[list[str]] = None,
                                **kwargs: Any) -> str:
         for test in tests:
             export_to_nitrate(test)

--- a/tmt/export/nitrate.py
+++ b/tmt/export/nitrate.py
@@ -642,8 +642,8 @@ def export_to_nitrate(test: 'tmt.Test') -> None:
     # Update nitrate test case
     if not dry_mode:
         nitrate_case.update()
-        echo(style("Test case '{}' successfully exported to nitrate.".format(
-            nitrate_case.identifier), fg='magenta'))
+        echo(style(f"Test case '{nitrate_case.identifier}' successfully exported to nitrate.",
+                   fg='magenta'))
 
     # Optionally link Bugzilla to Nitrate case
     if link_bugzilla and verifies_bug_ids and not dry_mode:

--- a/tmt/export/polarion.py
+++ b/tmt/export/polarion.py
@@ -1,7 +1,7 @@
 import email.utils
 import re
 import traceback
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Optional
 
 import fmf.utils
 from click import echo, style
@@ -44,8 +44,8 @@ def import_polarion() -> None:
 
 
 def get_polarion_ids(
-        query_result: List[Any],
-        preferred_project: Optional[str] = None) -> Tuple[str, Optional[str]]:
+        query_result: list[Any],
+        preferred_project: Optional[str] = None) -> tuple[str, Optional[str]]:
     """ Return case and project ids from query results """
     if not query_result:
         return 'None', None
@@ -70,9 +70,9 @@ def get_polarion_ids(
 
 
 def find_polarion_case_ids(
-        data: Dict[str, Optional[str]],
+        data: dict[str, Optional[str]],
         preferred_project: Optional[str] = None,
-        polarion_case_id: Optional[str] = None) -> Tuple[str, Optional[str]]:
+        polarion_case_id: Optional[str] = None) -> tuple[str, Optional[str]]:
     """ Find IDs for Polarion case from data dictionary """
     assert PolarionWorkItem
 
@@ -113,7 +113,7 @@ def find_polarion_case_ids(
 
 
 def get_polarion_case(
-        data: Dict[str, Optional[str]],
+        data: dict[str, Optional[str]],
         preferred_project: Optional[str] = None,
         polarion_case_id: Optional[str] = None) -> Optional[PolarionTestCase]:
     """ Get Polarion case through couple different methods """
@@ -360,8 +360,8 @@ def export_to_polarion(test: tmt.base.Test) -> None:
 class PolarionExporter(tmt.export.ExportPlugin):
     @classmethod
     def export_test_collection(cls,
-                               tests: List[tmt.base.Test],
-                               keys: Optional[List[str]] = None,
+                               tests: list[tmt.base.Test],
+                               keys: Optional[list[str]] = None,
                                **kwargs: Any) -> str:
         for test in tests:
             export_to_polarion(test)

--- a/tmt/export/rst.py
+++ b/tmt/export/rst.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import tmt.base
 import tmt.export
@@ -12,7 +12,7 @@ class RestructuredExporter(tmt.export.ExportPlugin):
     @classmethod
     def export_story(cls,
                      story: tmt.base.Story,
-                     keys: Optional[List[str]] = None,
+                     keys: Optional[list[str]] = None,
                      template: Optional[Path] = None,
                      include_title: bool = True) -> str:
         return tmt.export.template.TemplateExporter.render_template(
@@ -24,8 +24,8 @@ class RestructuredExporter(tmt.export.ExportPlugin):
 
     @classmethod
     def export_story_collection(cls,
-                                stories: List[tmt.base.Story],
-                                keys: Optional[List[str]] = None,
+                                stories: list[tmt.base.Story],
+                                keys: Optional[list[str]] = None,
                                 template: Optional[Path] = None,
                                 include_title: bool = True,
                                 **kwargs: Any) -> str:

--- a/tmt/export/template.py
+++ b/tmt/export/template.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 import tmt.base
 import tmt.export
@@ -17,7 +17,7 @@ class TemplateExporter(tmt.export.ExportPlugin):
             *,
             template_filepath: Optional[Path] = None,
             default_template_filename: str,
-            keys: Optional[List[str]] = None,
+            keys: Optional[list[str]] = None,
             **variables: Any
             ) -> str:
         return tmt.utils.render_template_file(
@@ -28,8 +28,8 @@ class TemplateExporter(tmt.export.ExportPlugin):
 
     @classmethod
     def export_fmfid_collection(cls,
-                                fmf_ids: List[tmt.base.FmfId],
-                                keys: Optional[List[str]] = None,
+                                fmf_ids: list[tmt.base.FmfId],
+                                keys: Optional[list[str]] = None,
                                 template: Optional[Path] = None,
                                 **kwargs: Any) -> str:
         return '\n\n'.join([
@@ -43,8 +43,8 @@ class TemplateExporter(tmt.export.ExportPlugin):
 
     @classmethod
     def export_test_collection(cls,
-                               tests: List[tmt.base.Test],
-                               keys: Optional[List[str]] = None,
+                               tests: list[tmt.base.Test],
+                               keys: Optional[list[str]] = None,
                                template: Optional[Path] = None,
                                **kwargs: Any) -> str:
         return '\n\n'.join([
@@ -58,8 +58,8 @@ class TemplateExporter(tmt.export.ExportPlugin):
 
     @classmethod
     def export_plan_collection(cls,
-                               plans: List[tmt.base.Plan],
-                               keys: Optional[List[str]] = None,
+                               plans: list[tmt.base.Plan],
+                               keys: Optional[list[str]] = None,
                                template: Optional[Path] = None,
                                **kwargs: Any) -> str:
         return '\n\n'.join([
@@ -73,8 +73,8 @@ class TemplateExporter(tmt.export.ExportPlugin):
 
     @classmethod
     def export_story_collection(cls,
-                                stories: List[tmt.base.Story],
-                                keys: Optional[List[str]] = None,
+                                stories: list[tmt.base.Story],
+                                keys: Optional[list[str]] = None,
                                 template: Optional[Path] = None,
                                 include_title: bool = True,
                                 **kwargs: Any) -> str:

--- a/tmt/frameworks/__init__.py
+++ b/tmt/frameworks/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Callable, List, Type
+from typing import TYPE_CHECKING, Callable
 
 import tmt.log
 import tmt.plugins
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from tmt.steps.provision import Guest
 
 
-TestFrameworkClass = Type['TestFramework']
+TestFrameworkClass = type['TestFramework']
 
 
 _FRAMEWORK_PLUGIN_REGISTRY: tmt.plugins.PluginRegistry[TestFrameworkClass] = \
@@ -92,7 +92,7 @@ class TestFramework:
             parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
-            logger: tmt.log.Logger) -> List[str]:
+            logger: tmt.log.Logger) -> list[str]:
         """
         Provide additional options for pulling test data directory.
 
@@ -112,7 +112,7 @@ class TestFramework:
             parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
-            logger: tmt.log.Logger) -> List[tmt.result.Result]:
+            logger: tmt.log.Logger) -> list[tmt.result.Result]:
         """
         Extract test results.
 

--- a/tmt/frameworks/beakerlib.py
+++ b/tmt/frameworks/beakerlib.py
@@ -1,5 +1,5 @@
 import re
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Optional
 
 import tmt.base
 import tmt.log
@@ -37,7 +37,7 @@ class Beakerlib(TestFramework):
             parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
-            logger: tmt.log.Logger) -> List[str]:
+            logger: tmt.log.Logger) -> list[str]:
         return [
             '--exclude',
             str(parent.data_path(test, guest, "backup*", full=True))
@@ -49,11 +49,11 @@ class Beakerlib(TestFramework):
             parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
-            logger: tmt.log.Logger) -> List[tmt.result.Result]:
+            logger: tmt.log.Logger) -> list[tmt.result.Result]:
         """ Check result of a beakerlib test """
         # Initialize data, prepare log paths
         note: Optional[str] = None
-        log: List[Path] = []
+        log: list[Path] = []
         for filename in [tmt.steps.execute.TEST_OUTPUT_FILENAME, 'journal.txt']:
             if parent.data_path(test, guest, filename, full=True).is_file():
                 log.append(parent.data_path(test, guest, filename))

--- a/tmt/frameworks/shell.py
+++ b/tmt/frameworks/shell.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 import tmt.base
 import tmt.log
@@ -33,7 +33,7 @@ class Shell(TestFramework):
             parent: 'ExecutePlugin[ExecuteStepDataT]',
             test: 'Test',
             guest: 'Guest',
-            logger: tmt.log.Logger) -> List[tmt.result.Result]:
+            logger: tmt.log.Logger) -> list[tmt.result.Result]:
         """ Check result of a shell test """
         assert test.return_code is not None
         note = None

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -33,12 +33,11 @@ import itertools
 import operator
 import re
 import sys
+from collections.abc import Iterable, Iterator
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Iterable,
-    Iterator,
     NamedTuple,
     Optional,
     TypeVar,

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -37,13 +37,10 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     Iterable,
     Iterator,
-    List,
     NamedTuple,
     Optional,
-    Type,
     TypeVar,
     Union,
     )
@@ -246,7 +243,7 @@ def not_match(text: str, pattern: str) -> bool:
     return re.match(pattern, text) is None
 
 
-def not_contains(haystack: List[str], needle: str) -> bool:
+def not_contains(haystack: list[str], needle: str) -> bool:
     """
     Find out whether an item is in the given list.
 
@@ -279,7 +276,7 @@ OPERATOR_SIGN_TO_OPERATOR = {
     }
 
 
-OPERATOR_TO_HANDLER: Dict[Operator, OperatorHandlerType] = {
+OPERATOR_TO_HANDLER: dict[Operator, OperatorHandlerType] = {
     Operator.EQ: operator.eq,
     Operator.NEQ: operator.ne,
     Operator.GT: operator.gt,
@@ -353,8 +350,8 @@ class BaseConstraint(SpecBasedContainer[Spec, Spec]):
 
     def variants(
             self,
-            members: Optional[List['Constraint']] = None
-            ) -> Iterator[List['Constraint']]:
+            members: Optional[list['Constraint']] = None
+            ) -> Iterator[list['Constraint']]:
         """
         Generate all distinct variants of constraints covered by this one.
 
@@ -369,7 +366,7 @@ class BaseConstraint(SpecBasedContainer[Spec, Spec]):
 
         raise NotImplementedError
 
-    def variant(self) -> List['Constraint']:
+    def variant(self) -> list['Constraint']:
         """
         Pick one of the available variants of this contraints.
 
@@ -397,7 +394,7 @@ class CompoundConstraint(BaseConstraint):
     def __init__(
             self,
             reducer: ReducerType = any,
-            constraints: Optional[List[BaseConstraint]] = None
+            constraints: Optional[list[BaseConstraint]] = None
             ) -> None:
         """
         Construct a compound constraint, constraint imposed to more than one dimension.
@@ -441,8 +438,8 @@ class CompoundConstraint(BaseConstraint):
 
     def variants(
             self,
-            members: Optional[List['Constraint']] = None
-            ) -> Iterator[List['Constraint']]:
+            members: Optional[list['Constraint']] = None
+            ) -> Iterator[list['Constraint']]:
         """
         Generate all distinct variants of constraints covered by this one.
 
@@ -494,7 +491,7 @@ class Constraint(BaseConstraint):
 
     @classmethod
     def from_specification(
-            cls: Type[T],
+            cls: type[T],
             name: str,
             raw_value: str,
             as_quantity: bool = True,
@@ -586,7 +583,7 @@ class Constraint(BaseConstraint):
     def printable_name(self) -> str:
         components = self.expand_name()
 
-        names: List[str] = []
+        names: list[str] = []
 
         if components.peer_index:
             names.append(f'{components.name.replace("_", "-")}[{components.peer_index}]')
@@ -622,8 +619,8 @@ class Constraint(BaseConstraint):
 
     def variants(
             self,
-            members: Optional[List['Constraint']] = None
-            ) -> Iterator[List['Constraint']]:
+            members: Optional[list['Constraint']] = None
+            ) -> Iterator[list['Constraint']]:
         """
         Generate all distinct variants of constraints covered by this one.
 
@@ -645,7 +642,7 @@ class And(CompoundConstraint):
     Represents constraints that are grouped in ``and`` fashion.
     """
 
-    def __init__(self, constraints: Optional[List[BaseConstraint]] = None) -> None:
+    def __init__(self, constraints: Optional[list[BaseConstraint]] = None) -> None:
         """
         Hold constraints that are grouped in ``and`` fashion.
 
@@ -656,8 +653,8 @@ class And(CompoundConstraint):
 
     def variants(
             self,
-            members: Optional[List[Constraint]] = None
-            ) -> Iterator[List[Constraint]]:
+            members: Optional[list[Constraint]] = None
+            ) -> Iterator[list[Constraint]]:
         """
         Generate all distinct variants of constraints covered by this one.
 
@@ -701,7 +698,7 @@ class Or(CompoundConstraint):
     Represents constraints that are grouped in ``or`` fashion.
     """
 
-    def __init__(self, constraints: Optional[List[BaseConstraint]] = None) -> None:
+    def __init__(self, constraints: Optional[list[BaseConstraint]] = None) -> None:
         """
         Hold constraints that are grouped in ``or`` fashion.
 
@@ -712,8 +709,8 @@ class Or(CompoundConstraint):
 
     def variants(
             self,
-            members: Optional[List[Constraint]] = None
-            ) -> Iterator[List[Constraint]]:
+            members: Optional[list[Constraint]] = None
+            ) -> Iterator[list[Constraint]]:
         """
         Generate all distinct variants of constraints covered by this one.
 
@@ -1175,7 +1172,7 @@ class Hardware(SpecBasedContainer[Spec, Spec]):
     spec: Spec
 
     @classmethod
-    def from_spec(cls: Type['Hardware'], spec: Spec) -> 'Hardware':
+    def from_spec(cls: type['Hardware'], spec: Spec) -> 'Hardware':
         if not spec:
             return Hardware(constraint=None, spec=spec)
 
@@ -1209,7 +1206,7 @@ class Hardware(SpecBasedContainer[Spec, Spec]):
     def report_support(
             self,
             *,
-            names: Optional[List[str]] = None,
+            names: Optional[list[str]] = None,
             check: Optional[Callable[[Constraint], bool]] = None,
             logger: tmt.log.Logger) -> None:
         """

--- a/tmt/libraries/__init__.py
+++ b/tmt/libraries/__init__.py
@@ -1,6 +1,6 @@
 """ Handle libraries """
 
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import fmf
 
@@ -12,7 +12,7 @@ from tmt.base import Dependency, DependencyFile, DependencyFmfId, DependencySimp
 from tmt.utils import Path
 
 # A beakerlib identifier type, can be a string or a fmf id (with extra beakerlib keys)
-ImportedIdentifiersType = Optional[List[Dependency]]
+ImportedIdentifiersType = Optional[list[Dependency]]
 
 # A Library type, can be Beakerlib or File
 # undefined references are ignored due to cyclic dependencies of these files,
@@ -20,8 +20,8 @@ ImportedIdentifiersType = Optional[List[Dependency]]
 LibraryType = Union['BeakerLib', 'File']  # type: ignore[name-defined] # noqa: F821
 
 # A type for Beakerlib dependencies
-LibraryDependenciesType = Tuple[
-    List[Dependency], List[Dependency], List['LibraryType']
+LibraryDependenciesType = tuple[
+    list[Dependency], list[Dependency], list['LibraryType']
     ]
 
 
@@ -105,8 +105,8 @@ def library_factory(
 
 def dependencies(
         *,
-        original_require: List[Dependency],
-        original_recommend: Optional[List[Dependency]] = None,
+        original_require: list[Dependency],
+        original_recommend: Optional[list[Dependency]] = None,
         parent: Optional[tmt.utils.Common] = None,
         imported_lib_ids: ImportedIdentifiersType = None,
         logger: tmt.log.Logger,
@@ -128,7 +128,7 @@ def dependencies(
     processed_require = set()
     processed_recommend = set()
     imported_lib_ids = imported_lib_ids or []
-    gathered_libraries: List[LibraryType] = []
+    gathered_libraries: list[LibraryType] = []
     original_require = original_require or []
     original_recommend = original_recommend or []
 

--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -1,6 +1,6 @@
 import re
 from tempfile import TemporaryDirectory
-from typing import Dict, Optional, Set, Union, cast
+from typing import Optional, Union, cast
 
 import fmf
 
@@ -29,8 +29,8 @@ STRIP_SUFFIX_FORGES = [
 
 
 class CommonWithLibraryCache(tmt.utils.Common):
-    _library_cache: Dict[str, 'BeakerLib']
-    _nonexistent_url: Set[str]
+    _library_cache: dict[str, 'BeakerLib']
+    _nonexistent_url: set[str]
 
 
 class BeakerLib(Library):
@@ -161,7 +161,7 @@ class BeakerLib(Library):
         return f"{self.repo}{self.name[self.name.rindex('/'):]}"
 
     @property
-    def _library_cache(self) -> Dict[str, 'BeakerLib']:
+    def _library_cache(self) -> dict[str, 'BeakerLib']:
         # Initialize library cache (indexed by the repository and library name)
         # FIXME: cast() - https://github.com/teemtee/tmt/issues/1372
         if not hasattr(self.parent, '_library_cache'):
@@ -170,7 +170,7 @@ class BeakerLib(Library):
         return cast(CommonWithLibraryCache, self.parent)._library_cache
 
     @property
-    def _nonexistent_url(self) -> Set[str]:
+    def _nonexistent_url(self) -> set[str]:
         # Set of url we tried to clone but didn't succeed
         if not hasattr(self.parent, '_nonexistent_url'):
             cast(CommonWithLibraryCache, self.parent)._nonexistent_url = set()

--- a/tmt/libraries/file.py
+++ b/tmt/libraries/file.py
@@ -1,5 +1,5 @@
 import shutil
-from typing import List, Optional
+from typing import Optional
 
 import fmf
 
@@ -42,7 +42,7 @@ class File(Library):
         self.format = 'file'
         self.repo = Path(target_location.name)
         self.name = "/files"
-        self.pattern: List[str] = identifier.pattern if hasattr(identifier, 'pattern') else []
+        self.pattern: list[str] = identifier.pattern if hasattr(identifier, 'pattern') else []
         self.source_location: Path = source_location
         self.target_location: Path = target_location
 
@@ -51,7 +51,7 @@ class File(Library):
         patterns = fmf.utils.listed(self.pattern, quote="'")
         self.parent.debug(
             f"Searching for patterns {patterns} in directory '{self.source_location}.")
-        files: List[Path] = tmt.utils.filter_paths(self.source_location, self.pattern)
+        files: list[Path] = tmt.utils.filter_paths(self.source_location, self.pattern)
         if not files:
             self.parent.debug('No files found.')
             raise tmt.utils.MetadataError(

--- a/tmt/lint.py
+++ b/tmt/lint.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 """
 Metadata linting.

--- a/tmt/lint.py
+++ b/tmt/lint.py
@@ -76,9 +76,7 @@ from typing import (
     Generic,
     Iterable,
     Iterator,
-    List,
     Optional,
-    Tuple,
     TypeVar,
     )
 
@@ -132,9 +130,9 @@ _OUTCOME_TO_COLOR = {
 
 
 #: Info on how a linter decided: linter itself, its outcome & the message.
-LinterRuling = Tuple['Linter', LinterOutcome, LinterOutcome, str]
+LinterRuling = tuple['Linter', LinterOutcome, LinterOutcome, str]
 #: A return value type of a single linter.
-LinterReturn = Iterator[Tuple[LinterOutcome, str]]
+LinterReturn = Iterator[tuple[LinterOutcome, str]]
 #: A linter itself, a callable method.
 LinterCallback = Callable[['Lintable'], LinterReturn]
 
@@ -173,7 +171,7 @@ class Linter:
         self.id = components['id'].strip()
         self.help = components['short'].strip()
 
-    def format(self) -> List[str]:
+    def format(self) -> list[str]:
         """
         Format the linter for printing or logging.
 
@@ -192,7 +190,7 @@ class Lintable(Generic[LintableT]):
     # Declare linter registry as a class variable, but do not initialize it. If initialized
     # here, the mapping would be shared by all classes, which is not a desirable attribute.
     # Instead, mapping will be created by `get_linter_registry()`.
-    _linter_registry: ClassVar[List[Linter]]
+    _linter_registry: ClassVar[list[Linter]]
 
     # Keep this method around, to correctly support Python's method resolution order.
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -200,7 +198,7 @@ class Lintable(Generic[LintableT]):
 
     # Cannot use @property as this must remain classmethod
     @classmethod
-    def get_linter_registry(cls) -> List[Linter]:
+    def get_linter_registry(cls) -> list[Linter]:
         """ Return - or initialize - linter registry """
 
         if not hasattr(cls, '_linter_registry'):
@@ -226,9 +224,9 @@ class Lintable(Generic[LintableT]):
     @classmethod
     def resolve_enabled_linters(
             cls,
-            enable_checks: Optional[List[str]] = None,
-            disable_checks: Optional[List[str]] = None
-            ) -> List[Linter]:
+            enable_checks: Optional[list[str]] = None,
+            disable_checks: Optional[list[str]] = None
+            ) -> list[Linter]:
         """
         Produce a list of enabled linters from all registered ones.
 
@@ -248,7 +246,7 @@ class Lintable(Generic[LintableT]):
             enabled and not disabled.
         """
 
-        linters: List[Linter] = []
+        linters: list[Linter] = []
 
         if not enable_checks:
             linters = cls.get_linter_registry()
@@ -273,10 +271,10 @@ class Lintable(Generic[LintableT]):
 
     def lint(
             self,
-            enable_checks: Optional[List[str]] = None,
-            disable_checks: Optional[List[str]] = None,
-            enforce_checks: Optional[List[str]] = None,
-            linters: Optional[List[Linter]] = None) -> Tuple[bool, List[LinterRuling]]:
+            enable_checks: Optional[list[str]] = None,
+            disable_checks: Optional[list[str]] = None,
+            enforce_checks: Optional[list[str]] = None,
+            linters: Optional[list[Linter]] = None) -> tuple[bool, list[LinterRuling]]:
         """
         Check the instance against a battery of linters and report results.
 
@@ -302,7 +300,7 @@ class Lintable(Generic[LintableT]):
             disable_checks=disable_checks)
 
         valid = True
-        rulings: List[LinterRuling] = []
+        rulings: list[LinterRuling] = []
 
         for linter in sorted(linters, key=lambda x: x.id):
             for outcome, message in linter.callback(self):
@@ -334,7 +332,7 @@ class Lintable(Generic[LintableT]):
             logging or help texts.
         """
 
-        hints: List[str] = []
+        hints: list[str] = []
 
         for linter in sorted(cls.get_linter_registry(), key=lambda x: x.id):
             hints += linter.format()
@@ -344,7 +342,7 @@ class Lintable(Generic[LintableT]):
 
 def filter_allowed_checks(
         rulings: Iterable[LinterRuling],
-        outcomes: Optional[List[LinterOutcome]] = None) -> Iterator[LinterRuling]:
+        outcomes: Optional[list[LinterOutcome]] = None) -> Iterator[LinterRuling]:
     """
     Filter only rulings whose outcomes are allowed.
 

--- a/tmt/lint.py
+++ b/tmt/lint.py
@@ -67,14 +67,13 @@ import dataclasses
 import enum
 import re
 import textwrap
+from collections.abc import Iterable, Iterator
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
     Generic,
-    Iterable,
-    Iterator,
     Optional,
     TypeVar,
     )

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -35,12 +35,8 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
-    List,
     Optional,
     Protocol,
-    Set,
-    Tuple,
     Union,
     cast,
     )
@@ -68,7 +64,7 @@ class Topic(enum.Enum):
     ADJUST_DECISIONS = 'adjust-decisions'
 
 
-DEFAULT_TOPICS: Set[Topic] = set()
+DEFAULT_TOPICS: set[Topic] = set()
 
 
 LABEL_FORMAT = '[{label}]'
@@ -122,7 +118,7 @@ def _debug_level_from_global_envvar() -> int:
         raise tmt.utils.GeneralError(f"Invalid debug level '{raw_value}', use an integer.")
 
 
-def decide_colorization(no_color: bool, force_color: bool) -> Tuple[bool, bool]:
+def decide_colorization(no_color: bool, force_color: bool) -> tuple[bool, bool]:
     """
     Decide whether the output and logging should be colorized.
 
@@ -181,7 +177,7 @@ def decide_colorization(no_color: bool, force_color: bool) -> Tuple[bool, bool]:
     return apply_colors_output, apply_colors_logging
 
 
-def render_labels(labels: List[str]) -> str:
+def render_labels(labels: list[str]) -> str:
     if not labels:
         return ''
 
@@ -198,7 +194,7 @@ def indent(
         value: Optional[LoggableValue] = None,
         color: Optional[str] = None,
         level: int = 0,
-        labels: Optional[List[str]] = None,
+        labels: Optional[list[str]] = None,
         labels_padding: int = 0) -> str:
     """
     Indent a key/value message.
@@ -262,7 +258,7 @@ class LogRecordDetails:
     color: Optional[str] = None
     shift: int = 0
 
-    logger_labels: List[str] = dataclasses.field(default_factory=list)
+    logger_labels: list[str] = dataclasses.field(default_factory=list)
     logger_labels_padding: int = 0
 
     logger_verbosity_level: int = 0
@@ -274,7 +270,7 @@ class LogRecordDetails:
     logger_quiet: bool = False
     ignore_quietness: bool = False
 
-    logger_topics: Set[Topic] = dataclasses.field(default_factory=set)
+    logger_topics: set[Topic] = dataclasses.field(default_factory=set)
     message_topic: Optional[Topic] = None
 
 
@@ -440,12 +436,12 @@ class Logger:
             self,
             actual_logger: logging.Logger,
             base_shift: int = 0,
-            labels: Optional[List[str]] = None,
+            labels: Optional[list[str]] = None,
             labels_padding: int = 0,
             verbosity_level: int = DEFAULT_VERBOSITY_LEVEL,
             debug_level: int = DEFAULT_DEBUG_LEVEL,
             quiet: bool = False,
-            topics: Optional[Set[Topic]] = None,
+            topics: Optional[set[Topic]] = None,
             apply_colors_output: bool = True,
             apply_colors_logging: bool = True
             ) -> None:
@@ -603,7 +599,7 @@ class Logger:
         to reflect options given to a tmt subcommand.
         """
 
-        actual_kwargs: Dict[str, Any] = {}
+        actual_kwargs: dict[str, Any] = {}
 
         if cli_invocation is not None:
             actual_kwargs = cli_invocation.options

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -4,7 +4,7 @@ import contextlib
 import dataclasses
 import re
 import textwrap
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Sequence, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Union
 
 import click
 
@@ -44,7 +44,7 @@ class Deprecated:
         return f'{message}.'
 
 
-MethodDictType = Dict[str, click.core.Command]
+MethodDictType = dict[str, click.core.Command]
 
 # Originating in click.decorators, an opaque type describing "decorator" functions
 # produced by click.option() calls: not options, but decorators, functions that attach
@@ -124,7 +124,7 @@ def option(
 
 
 # Verbose, debug and quiet output
-VERBOSITY_OPTIONS: List[ClickOptionDecoratorType] = [
+VERBOSITY_OPTIONS: list[ClickOptionDecoratorType] = [
     option(
         '-v', '--verbose', count=True, default=0,
         help='Show more details. Use multiple times to raise verbosity.'),
@@ -142,13 +142,13 @@ VERBOSITY_OPTIONS: List[ClickOptionDecoratorType] = [
     ]
 
 # Force and dry actions
-DRY_OPTIONS: List[ClickOptionDecoratorType] = [
+DRY_OPTIONS: list[ClickOptionDecoratorType] = [
     option(
         '-n', '--dry', is_flag=True,
         help='Run in dry mode. No changes, please.'),
     ]
 
-FORCE_DRY_OPTIONS: List[ClickOptionDecoratorType] = [
+FORCE_DRY_OPTIONS: list[ClickOptionDecoratorType] = [
     option(
         '-f', '--force', is_flag=True,
         help='Overwrite existing files and step data.'),
@@ -156,11 +156,11 @@ FORCE_DRY_OPTIONS: List[ClickOptionDecoratorType] = [
 
 
 # Fix action
-FIX_OPTIONS: List[ClickOptionDecoratorType] = [
+FIX_OPTIONS: list[ClickOptionDecoratorType] = [
     option('-F', '--fix', is_flag=True, help='Attempt to fix all discovered issues.')
     ]
 
-WORKDIR_ROOT_OPTIONS: List[ClickOptionDecoratorType] = [
+WORKDIR_ROOT_OPTIONS: list[ClickOptionDecoratorType] = [
     option(
         '--workdir-root', metavar='PATH', envvar='TMT_WORKDIR_ROOT',
         default=tmt.utils.WORKDIR_ROOT,
@@ -171,7 +171,7 @@ WORKDIR_ROOT_OPTIONS: List[ClickOptionDecoratorType] = [
     ]
 
 
-FILTER_OPTIONS: List[ClickOptionDecoratorType] = [
+FILTER_OPTIONS: list[ClickOptionDecoratorType] = [
     click.argument(
         'names', nargs=-1, metavar='[REGEXP|.]'),
     option(
@@ -198,7 +198,7 @@ FILTER_OPTIONS: List[ClickOptionDecoratorType] = [
     ]
 
 
-FILTER_OPTIONS_LONG: List[ClickOptionDecoratorType] = [
+FILTER_OPTIONS_LONG: list[ClickOptionDecoratorType] = [
     click.argument(
         'names', nargs=-1, metavar='[REGEXP|.]'),
     option(
@@ -225,7 +225,7 @@ FILTER_OPTIONS_LONG: List[ClickOptionDecoratorType] = [
     ]
 
 
-STORY_FLAGS_FILTER_OPTIONS: List[ClickOptionDecoratorType] = [
+STORY_FLAGS_FILTER_OPTIONS: list[ClickOptionDecoratorType] = [
     option(
         '--implemented', is_flag=True,
         help='Implemented stories only.'),
@@ -252,20 +252,20 @@ STORY_FLAGS_FILTER_OPTIONS: List[ClickOptionDecoratorType] = [
         help='Uncovered stories only.'),
     ]
 
-FMF_SOURCE_OPTIONS: List[ClickOptionDecoratorType] = [
+FMF_SOURCE_OPTIONS: list[ClickOptionDecoratorType] = [
     option(
         '--source', is_flag=True, help="Select by fmf source file names instead of object names."
         )
     ]
 
-REMOTE_PLAN_OPTIONS: List[ClickOptionDecoratorType] = [
+REMOTE_PLAN_OPTIONS: list[ClickOptionDecoratorType] = [
     option('-s', '--shallow', is_flag=True, help='Do not clone remote plan.')
     ]
 
 
 _lint_outcomes = [member.value for member in tmt.lint.LinterOutcome.__members__.values()]
 
-LINT_OPTIONS: List[ClickOptionDecoratorType] = [
+LINT_OPTIONS: list[ClickOptionDecoratorType] = [
     option(
         '--list-checks',
         is_flag=True,
@@ -303,7 +303,7 @@ LINT_OPTIONS: List[ClickOptionDecoratorType] = [
     ]
 
 
-ENVIRONMENT_OPTIONS: List[ClickOptionDecoratorType] = [
+ENVIRONMENT_OPTIONS: list[ClickOptionDecoratorType] = [
     option(
         '-e', '--environment',
         metavar='KEY=VALUE|@FILE',
@@ -323,7 +323,7 @@ ENVIRONMENT_OPTIONS: List[ClickOptionDecoratorType] = [
     ]
 
 
-def create_options_decorator(options: List[ClickOptionDecoratorType]) -> Callable[[FC], FC]:
+def create_options_decorator(options: list[ClickOptionDecoratorType]) -> Callable[[FC], FC]:
     def common_decorator(fn: FC) -> FC:
         for option in reversed(options):
             fn = option(fn)
@@ -378,7 +378,7 @@ def show_step_method_hints(
                     "available report options.", color='blue')
 
 
-def create_method_class(methods: MethodDictType) -> Type[click.Command]:
+def create_method_class(methods: MethodDictType) -> type[click.Command]:
     """
     Create special class to handle different options for each method
 
@@ -387,14 +387,14 @@ def create_method_class(methods: MethodDictType) -> Type[click.Command]:
     Methods should be already sorted according to their priority.
     """
 
-    def is_likely_subcommand(arg: str, subcommands: List[str]) -> bool:
+    def is_likely_subcommand(arg: str, subcommands: list[str]) -> bool:
         """ Return true if arg is the beginning characters of a subcommand """
         return any(subcommand.startswith(arg) for subcommand in subcommands)
 
     class MethodCommand(click.Command):
         _method: Optional[click.Command] = None
 
-        def _check_method(self, context: 'tmt.cli.Context', args: List[str]) -> None:
+        def _check_method(self, context: 'tmt.cli.Context', args: list[str]) -> None:
             """ Manually parse the --how option """
             how = None
             subcommands = (
@@ -406,7 +406,7 @@ def create_method_class(methods: MethodDictType) -> Type[click.Command]:
                         return option
                 return None
 
-            def _find_how(args: List[str]) -> Optional[str]:
+            def _find_how(args: list[str]) -> Optional[str]:
                 while args:
                     arg = args.pop(0)
 
@@ -501,8 +501,8 @@ def create_method_class(methods: MethodDictType) -> Type[click.Command]:
         def parse_args(  # type: ignore[override]
                 self,
                 context: 'tmt.cli.Context',
-                args: List[str]
-                ) -> List[str]:
+                args: list[str]
+                ) -> list[str]:
             self._check_method(context, args)
             if self._method is not None:
                 return self._method.parse_args(context, args)

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -4,7 +4,8 @@ import contextlib
 import dataclasses
 import re
 import textwrap
-from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Union
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import click
 

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -4,8 +4,9 @@ import importlib
 import os
 import pkgutil
 import sys
+from collections.abc import Iterator
 from importlib.metadata import entry_points
-from typing import Any, Generic, Iterator, Optional, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 import tmt
 import tmt.utils

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -5,7 +5,7 @@ import os
 import pkgutil
 import sys
 from importlib.metadata import entry_points
-from typing import Any, Dict, Generic, Iterator, List, Optional, Tuple, TypeVar
+from typing import Any, Generic, Iterator, Optional, TypeVar
 
 import tmt
 import tmt.utils
@@ -56,7 +56,7 @@ def discover(path: Path) -> Iterator[str]:
 # tmt.steps import tmt.export, and tmt.export import tmt.steps.STEPS. Until that
 # is resolved, to use `Exportable` in tmt.steps, we need a delayed import. Hence
 # the function.
-def _discover_packages() -> List[Tuple[str, Path]]:
+def _discover_packages() -> list[tuple[str, Path]]:
     from tmt.steps import STEPS
 
     return [
@@ -236,7 +236,7 @@ class PluginRegistry(Generic[RegisterableT]):
     annotations and more visible semantics.
     """
 
-    _plugins: Dict[str, RegisterableT]
+    _plugins: dict[str, RegisterableT]
 
     def __init__(self) -> None:
         self._plugins = {}

--- a/tmt/queue.py
+++ b/tmt/queue.py
@@ -1,6 +1,6 @@
 import dataclasses
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from typing import TYPE_CHECKING, Dict, Generic, Iterator, List, Optional, TypeVar
+from typing import TYPE_CHECKING, Generic, Iterator, Optional, TypeVar
 
 import fmf.utils
 
@@ -44,7 +44,7 @@ class _Task:
     """ A base class for tasks to be executed on one or more guests """
 
     #: A list of guests to execute the task on.
-    guests: List['Guest']
+    guests: list['Guest']
 
     #: A logger to use for logging events related to the task. It serves as
     #: a root logger for new loggers queue may spawn for each guest.
@@ -62,7 +62,7 @@ class _Task:
         raise NotImplementedError
 
     @property
-    def guest_ids(self) -> List[str]:
+    def guest_ids(self) -> list[str]:
         return [guest.multihost_name for guest in self.guests]
 
     def go(self) -> Iterator[TaskOutcome['Self']]:
@@ -119,7 +119,7 @@ class Task(_Task):
 
     def prepare_loggers(
             self,
-            logger: Logger) -> Dict[str, Logger]:
+            logger: Logger) -> dict[str, Logger]:
         """
         Create loggers for a set of guests.
 
@@ -128,7 +128,7 @@ class Task(_Task):
         labels need to be properly aligned for more readable output.
         """
 
-        loggers: Dict[str, Logger] = {}
+        loggers: dict[str, Logger] = {}
 
         # First, spawn all loggers, and set their labels if needed. Don't bother
         # with labels if there's just a single guest.
@@ -153,10 +153,10 @@ class Task(_Task):
         multiple_guests = len(self.guests) > 1
 
         new_loggers = self.prepare_loggers(self.logger)
-        old_loggers: Dict[str, Logger] = {}
+        old_loggers: dict[str, Logger] = {}
 
         with ThreadPoolExecutor(max_workers=len(self.guests)) as executor:
-            futures: Dict[Future[None], Guest] = {}
+            futures: dict[Future[None], Guest] = {}
 
             for guest in self.guests:
                 # Swap guest's logger for the one we prepared, with labels
@@ -221,7 +221,7 @@ class Task(_Task):
                 guest.inject_logger(old_logger)
 
 
-class Queue(List[TaskT]):
+class Queue(list[TaskT]):
     """ Queue class for running phases on guests """
 
     def __init__(self, name: str, logger: Logger) -> None:
@@ -256,7 +256,7 @@ class Queue(List[TaskT]):
                 f'{task.name} on {fmf.utils.listed(task.guest_ids)}',
                 color='cyan')
 
-            failed_outcomes: List[TaskOutcome[TaskT]] = []
+            failed_outcomes: list[TaskOutcome[TaskT]] = []
 
             for outcome in task.go():
                 if outcome.exc:

--- a/tmt/queue.py
+++ b/tmt/queue.py
@@ -1,6 +1,7 @@
 import dataclasses
+from collections.abc import Iterator
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
-from typing import TYPE_CHECKING, Generic, Iterator, Optional, TypeVar
+from typing import TYPE_CHECKING, Generic, Optional, TypeVar
 
 import fmf.utils
 

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -1,7 +1,7 @@
 import dataclasses
 import enum
 import re
-from typing import TYPE_CHECKING, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 import click
 import fmf
@@ -55,7 +55,7 @@ class ResultInterpret(enum.Enum):
         return value.name in list(ResultOutcome.__members__.keys())
 
 
-RESULT_OUTCOME_COLORS: Dict[ResultOutcome, str] = {
+RESULT_OUTCOME_COLORS: dict[ResultOutcome, str] = {
     ResultOutcome.PASS: 'green',
     ResultOutcome.FAIL: 'red',
     ResultOutcome.INFO: 'blue',
@@ -93,7 +93,7 @@ class BaseResult(SerializableContainer):
         unserialize=ResultOutcome.from_spec
         )
     note: Optional[str] = None
-    log: List[Path] = field(
+    log: list[Path] = field(
         default_factory=list,
         serialize=lambda logs: [str(log) for log in logs],
         unserialize=lambda value: [Path(log) for log in value])
@@ -107,7 +107,7 @@ class BaseResult(SerializableContainer):
 
         result = 'errr' if self.result == ResultOutcome.ERROR else self.result.value
 
-        components: List[str] = [
+        components: list[str] = [
             click.style(result, fg=RESULT_OUTCOME_COLORS[self.result]),
             self.name
             ]
@@ -138,14 +138,14 @@ class Result(BaseResult):
         serialize=lambda fmf_id: fmf_id.to_minimal_spec() if fmf_id is not None else {},
         unserialize=_unserialize_fmf_id
         )
-    ids: Dict[str, Optional[str]] = field(default_factory=dict)
+    ids: dict[str, Optional[str]] = field(default_factory=dict)
     guest: ResultGuestData = field(
         default_factory=ResultGuestData,
         serialize=lambda value: value.to_serialized(),  # type: ignore[attr-defined]
         unserialize=lambda serialized: ResultGuestData.from_serialized(serialized)
         )
 
-    check: List[CheckResult] = field(
+    check: list[CheckResult] = field(
         default_factory=list,
         serialize=lambda results: [result.to_serialized() for result in results],
         unserialize=lambda serialized: [
@@ -164,8 +164,8 @@ class Result(BaseResult):
             test: 'tmt.base.Test',
             result: ResultOutcome,
             note: Optional[str] = None,
-            ids: Optional[Dict[str, Optional[str]]] = None,
-            log: Optional[List[Path]] = None,
+            ids: Optional[dict[str, Optional[str]]] = None,
+            log: Optional[list[Path]] = None,
             guest: Optional['tmt.steps.provision.Guest'] = None) -> 'Result':
         """
         Create a result from a test instance.
@@ -264,7 +264,7 @@ class Result(BaseResult):
         return self
 
     @staticmethod
-    def total(results: List['Result']) -> Dict[ResultOutcome, int]:
+    def total(results: list['Result']) -> dict[ResultOutcome, int]:
         """ Return dictionary with total stats for given results """
         stats = {result: 0 for result in RESULT_OUTCOME_COLORS}
 
@@ -273,7 +273,7 @@ class Result(BaseResult):
         return stats
 
     @staticmethod
-    def summary(results: List['Result']) -> str:
+    def summary(results: list['Result']) -> str:
         """ Prepare a nice human summary of provided results """
         stats = Result.total(results)
         comments = []
@@ -305,7 +305,7 @@ class Result(BaseResult):
 
         result = 'errr' if self.result == ResultOutcome.ERROR else self.result.value
 
-        components: List[str] = [
+        components: list[str] = [
             click.style(result, fg=RESULT_OUTCOME_COLORS[self.result]),
             self.name
             ]

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -12,15 +12,10 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    DefaultDict,
-    Dict,
     Generic,
     Iterable,
     Iterator,
-    List,
     Optional,
-    Tuple,
-    Type,
     TypedDict,
     TypeVar,
     Union,
@@ -70,8 +65,8 @@ DEFAULT_PLUGIN_METHOD_ORDER: int = 50
 
 
 # Supported steps and actions
-STEPS: List[str] = ['discover', 'provision', 'prepare', 'execute', 'report', 'finish']
-ACTIONS: List[str] = ['login', 'reboot']
+STEPS: list[str] = ['discover', 'provision', 'prepare', 'execute', 'report', 'finish']
+ACTIONS: list[str] = ['login', 'reboot']
 
 # Step phase order
 PHASE_START = 10
@@ -125,7 +120,7 @@ class DefaultNameGenerator:
     the generator.
     """
 
-    def __init__(self, known_names: List[str]) -> None:
+    def __init__(self, known_names: list[str]) -> None:
         """
         Generator of names for that do not have any.
 
@@ -205,7 +200,7 @@ class Phase(tmt.utils.Common):
 PhaseT = TypeVar('PhaseT', bound=Phase)
 
 # A type alias for plugin classes
-PluginClass = Type['BasePlugin']
+PluginClass = type['BasePlugin']
 
 _RawStepData = TypedDict('_RawStepData', {
     'how': str,
@@ -213,7 +208,7 @@ _RawStepData = TypedDict('_RawStepData', {
     }, total=False)
 
 
-RawStepDataArgument = Union[_RawStepData, List[_RawStepData]]
+RawStepDataArgument = Union[_RawStepData, list[_RawStepData]]
 
 
 StepDataT = TypeVar('StepDataT', bound='StepData')
@@ -270,7 +265,7 @@ class StepData(
     # ignore[override]: expected, we need to accept one extra parameter, `logger`.
     @classmethod
     def from_spec(  # type: ignore[override]
-            cls: Type[StepDataT],
+            cls: type[StepDataT],
             raw_data: _RawStepData,
             logger: tmt.log.Logger) -> StepDataT:
         """ Convert from a specification file or from a CLI option """
@@ -278,7 +273,7 @@ class StepData(
         cls.pre_normalization(raw_data, logger)
 
         data = cls(name=raw_data['name'], how=raw_data['how'])
-        data._load_keys(cast(Dict[str, Any], raw_data), cls.__name__, logger)
+        data._load_keys(cast(dict[str, Any], raw_data), cls.__name__, logger)
 
         data.post_normalization(raw_data, logger)
 
@@ -298,7 +293,7 @@ class WhereableStepData:
     2. https://tmt.readthedocs.io/en/stable/spec/plans.html#spec-plans-prepare-where
     """
 
-    where: List[str] = field(
+    where: list[str] = field(
         default_factory=list,
         normalize=tmt.utils.normalize_string_list
         )
@@ -322,17 +317,17 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
     # command-line - code instantiating steps must be able to invalidate
     # and replace raw step data entries before they get normalized and become
     # the single source of information for plugins involved.
-    _data: List[StepData]
+    _data: list[StepData]
 
     #: Stores the original raw step data. Initialized by :py:meth:`__init__`
     #: or :py:meth:`wake`, and serves as a source for normalization performed
     #: by :py:meth:`_normalize_data`.
-    _raw_data: List[_RawStepData]
+    _raw_data: list[_RawStepData]
 
     # The step has pruning capability to remove all irrelevant files. All
     # important file and directory names located in workdir should be specified
     # in the list below to avoid deletion during pruning.
-    _preserved_workdir_members: List[str] = ['step.yaml']
+    _preserved_workdir_members: list[str] = ['step.yaml']
 
     def __init__(
             self,
@@ -350,7 +345,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
         # Initialize data
         self.plan: 'Plan' = plan
         self._status: Optional[str] = None
-        self._phases: List[Phase] = []
+        self._phases: list[Phase] = []
 
         # Normalize raw data to be a list of step configuration data, one item per
         # distinct step configuration. Make sure all items have `name`` and `how` keys.
@@ -378,13 +373,13 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
 
         self._set_default_values(self._raw_data)
 
-    def _check_duplicate_names(self, raw_data: List[_RawStepData]) -> None:
+    def _check_duplicate_names(self, raw_data: list[_RawStepData]) -> None:
         """ Check for duplicate names in phases """
 
         for name in tmt.utils.duplicates(raw_datum.get('name', None) for raw_datum in raw_data):
             raise tmt.utils.GeneralError(f"Duplicate phase name '{name}' in step '{self.name}'.")
 
-    def _set_default_values(self, raw_data: List[_RawStepData]) -> List[_RawStepData]:
+    def _set_default_values(self, raw_data: list[_RawStepData]) -> list[_RawStepData]:
         """ Set default values for ``name`` and ``how`` fields if not specified """
 
         name_generator = DefaultNameGenerator.from_raw_phases(raw_data)
@@ -403,8 +398,8 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
 
     def _normalize_data(
             self,
-            raw_data: List[_RawStepData],
-            logger: tmt.log.Logger) -> List[StepData]:
+            raw_data: list[_RawStepData],
+            logger: tmt.log.Logger) -> list[StepData]:
         """
         Normalize step data entries.
 
@@ -416,7 +411,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
 
         self._check_duplicate_names(raw_data)
 
-        data: List[StepData] = []
+        data: list[StepData] = []
 
         for raw_datum in raw_data:
             plugin = self._plugin_base_class.delegate(self, raw_data=raw_datum)
@@ -428,7 +423,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
     def _export(
             self,
             *,
-            keys: Optional[List[str]] = None,
+            keys: Optional[list[str]] = None,
             include_internal: bool = False) -> tmt.export._RawExportedInstance:
         # TODO: one day, this should recurse down into each materialized plugin,
         # to give them chance to affect the export of their data.
@@ -446,14 +441,14 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
         return self.__class__.__name__.lower()
 
     @property
-    def data(self) -> List[StepData]:
+    def data(self) -> list[StepData]:
         if not hasattr(self, '_data'):
             self._data = self._normalize_data(self._raw_data, self._logger)
 
         return self._data
 
     @data.setter
-    def data(self, data: List[StepData]) -> None:
+    def data(self, data: list[StepData]) -> None:
         self._data = data
 
     @property
@@ -527,7 +522,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
     def load(self) -> None:
         """ Load status and step data from the workdir """
         try:
-            raw_step_data: Dict[Any, Any] = tmt.utils.yaml_to_dict(self.read(Path('step.yaml')))
+            raw_step_data: dict[Any, Any] = tmt.utils.yaml_to_dict(self.read(Path('step.yaml')))
             self.debug('Successfully loaded step data.', level=2)
 
             self.data = [
@@ -544,7 +539,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
 
     def save(self) -> None:
         """ Save status and step data to the workdir """
-        content: Dict[str, Any] = {
+        content: dict[str, Any] = {
             'status': self.status(),
             'data': [datum.to_serialized() for datum in self.data]
             }
@@ -596,7 +591,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
 
         debug('Update phases by CLI invocations')
 
-        def _to_raw_step_datum(options: Dict[str, Any]) -> _RawStepData:
+        def _to_raw_step_datum(options: dict[str, Any]) -> _RawStepData:
             """
             Convert CLI options to fmf-like raw step data dictionary.
 
@@ -604,7 +599,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
             keys representing CLI options.
             """
 
-            def _iter_options() -> Iterator[Tuple[str, Any]]:
+            def _iter_options() -> Iterator[tuple[str, Any]]:
                 for name, value in options.items():
                     if name in ('update', 'update_missing', 'insert'):
                         continue
@@ -621,13 +616,13 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
         # modified by `--insert`, and entries may be modified as well. Note that we do not process
         # step data here, this list is not the input we iterate over - we process CLI invocations,
         # and based on their content we modify this list and its content.
-        raw_data: List[_RawStepData] = self._raw_data[:]
+        raw_data: list[_RawStepData] = self._raw_data[:]
 
         # Some invocations cannot be easily evaluated when we first spot them. To remain backward
         # compatible, `--update` without `--name` should result in all phases being converted into
         # what the `--update` brings in. In this list, we will collect "postponed" CLI invocations,
         # and we will get back to them once we're done with those we can apply immediately.
-        postponed_invocations: List['tmt.cli.CliInvocation'] = []
+        postponed_invocations: list['tmt.cli.CliInvocation'] = []
 
         name_generator = DefaultNameGenerator.from_raw_phases(raw_data)
 
@@ -780,7 +775,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
         for i, invocation in enumerate(postponed_invocations):
             debug(f'postponed invocation #{i}', str(invocation.options))
 
-            pruned_raw_data: List[_RawStepData] = []
+            pruned_raw_data: list[_RawStepData] = []
             incoming_raw_datum = _to_raw_step_datum(invocation.options)
 
             how = invocation.options['how']
@@ -852,19 +847,19 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
             self._phases.append(reboot_plugin)
 
     @overload
-    def phases(self, classes: None = None) -> List[Phase]:
+    def phases(self, classes: None = None) -> list[Phase]:
         pass
 
     @overload
-    def phases(self, classes: Type[PhaseT]) -> List[PhaseT]:
+    def phases(self, classes: type[PhaseT]) -> list[PhaseT]:
         pass
 
     @overload
-    def phases(self, classes: Tuple[Type[PhaseT], ...]) -> List[PhaseT]:
+    def phases(self, classes: tuple[type[PhaseT], ...]) -> list[PhaseT]:
         pass
 
-    def phases(self, classes: Optional[Union[Type[PhaseT],
-               Tuple[Type[PhaseT], ...]]] = None) -> List[PhaseT]:
+    def phases(self, classes: Optional[Union[type[PhaseT],
+               tuple[type[PhaseT], ...]]] = None) -> list[PhaseT]:
         """
         Iterate over phases by their order
 
@@ -874,7 +869,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
         """
 
         if classes is None:
-            _classes: Tuple[Union[Type[Phase], Type[PhaseT]], ...] = (Phase,)
+            _classes: tuple[Union[type[Phase], type[PhaseT]], ...] = (Phase,)
 
         elif not isinstance(classes, tuple):
             _classes = (classes,)
@@ -908,7 +903,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
         logger = logger.descend()
 
         # Collect all workdir members that shall not be removed
-        preserved_members: List[str] = self._preserved_workdir_members[:]
+        preserved_members: list[str] = self._preserved_workdir_members[:]
 
         # Do not prune plugin workdirs, each plugin decides what should
         # be pruned from the workdir and what should be kept there
@@ -932,7 +927,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
             except OSError as error:
                 logger.warn(f"Unable to remove '{member}': {error}")
 
-    def requires(self) -> List['tmt.base.Dependency']:
+    def requires(self) -> list['tmt.base.Dependency']:
         """
         Collect all requirements of all enabled plugins in this step.
 
@@ -974,7 +969,7 @@ class Method:
         self.order = order
 
         # Parse summary and description from provided doc string
-        lines: List[str] = [re.sub('^    ', '', line)
+        lines: list[str] = [re.sub('^    ', '', line)
                             for line in self.doc.split('\n')]
         self.summary: str = lines[0].strip()
         self.description: str = '\n'.join(lines[1:]).lstrip()
@@ -1039,7 +1034,7 @@ class BasePlugin(Phase, Generic[StepDataT]):
 
     # Deprecated, use @provides_method(...) instead. left for backward
     # compatibility with out-of-tree plugins.
-    _methods: List[Method] = []
+    _methods: list[Method] = []
 
     # Default implementation for all steps is shell
     # except for provision (virtual) and report (display)
@@ -1054,14 +1049,14 @@ class BasePlugin(Phase, Generic[StepDataT]):
     # subclasses.
     _supported_methods: 'tmt.plugins.PluginRegistry[Method]'
 
-    _data_class: Type[StepDataT]
+    _data_class: type[StepDataT]
     data: StepDataT
 
     # TODO: do we need this list? Can whatever code is using it use _data_class directly?
     # List of supported keys
     # (used for import/export to/from attributes during load and save)
     @property
-    def _keys(self) -> List[str]:
+    def _keys(self) -> list[str]:
         return list(self._data_class.keys())
 
     def __init__(
@@ -1102,12 +1097,12 @@ class BasePlugin(Phase, Generic[StepDataT]):
     def base_command(
             cls,
             usage: str,
-            method_class: Optional[Type[click.Command]] = None) -> click.Command:
+            method_class: Optional[type[click.Command]] = None) -> click.Command:
         """ Create base click command (common for all step plugins) """
         raise NotImplementedError
 
     @classmethod
-    def options(cls, how: Optional[str] = None) -> List[tmt.options.ClickOptionDecoratorType]:
+    def options(cls, how: Optional[str] = None) -> list[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options for given method """
         # Include common options supported across all plugins
         return [
@@ -1123,7 +1118,7 @@ class BasePlugin(Phase, Generic[StepDataT]):
     def command(cls) -> click.Command:
         """ Prepare click command for all supported methods """
         # Create one command for each supported method
-        commands: Dict[str, click.Command] = {}
+        commands: dict[str, click.Command] = {}
         method_overview: str = f'Supported methods ({cls.how} by default):\n\n\b'
         for method in cls.methods():
             assert method.class_ is not None
@@ -1180,7 +1175,7 @@ class BasePlugin(Phase, Generic[StepDataT]):
         return command
 
     @classmethod
-    def methods(cls) -> List[Method]:
+    def methods(cls) -> list[Method]:
         """ Return all supported methods ordered by priority """
         return sorted(cls._supported_methods.iter_plugins(), key=lambda method: method.order)
 
@@ -1302,7 +1297,7 @@ class BasePlugin(Phase, Generic[StepDataT]):
 
         return self.default(option, default)
 
-    def show(self, keys: Optional[List[str]] = None) -> None:
+    def show(self, keys: Optional[list[str]] = None) -> None:
         """ Show plugin details for given or all available keys """
         # Avoid circular imports
         import tmt.base
@@ -1372,7 +1367,7 @@ class BasePlugin(Phase, Generic[StepDataT]):
         """ Check if the plugin is enabled on the specific guest """
 
         # FIXME: cast() - typeless "dispatcher" method
-        where = cast(List[str], self.get('where'))
+        where = cast(list[str], self.get('where'))
 
         if not where:
             return True
@@ -1435,7 +1430,7 @@ class BasePlugin(Phase, Generic[StepDataT]):
         # Include order in verbose mode
         logger.verbose('order', self.order, 'magenta', level=3)
 
-    def requires(self) -> List['tmt.base.Dependency']:
+    def requires(self) -> list['tmt.base.Dependency']:
         """ All requirements of the plugin on the guest """
         return []
 
@@ -1483,10 +1478,10 @@ class Action(Phase, tmt.utils.MultiInvokableCommon):
     """ A special action performed during a normal step. """
 
     # Dictionary containing list of requested phases for each enabled step
-    _phases: Optional[Dict[str, List[int]]] = None
+    _phases: Optional[dict[str, list[int]]] = None
 
     @classmethod
-    def phases(cls, step: Step) -> List[int]:
+    def phases(cls, step: Step) -> list[int]:
         """ Return list of phases enabled for given step """
         # Build the phase list unless done before
         if cls._phases is None:
@@ -1498,10 +1493,10 @@ class Action(Phase, tmt.utils.MultiInvokableCommon):
             return []
 
     @classmethod
-    def _parse_phases(cls, step: Step) -> Dict[str, List[int]]:
+    def _parse_phases(cls, step: Step) -> dict[str, list[int]]:
         """ Parse options and store phase order """
         phases = {}
-        options: List[str] = cls._opt('step', default=[])
+        options: list[str] = cls._opt('step', default=[])
 
         # Use the end of the last enabled step if no --step given
         if not options:
@@ -1513,7 +1508,7 @@ class Action(Phase, tmt.utils.MultiInvokableCommon):
                     f"Plan for {step.name} is not set.")
             assert step.plan.my_run is not None  # narrow type
             if step.plan.my_run.opt('last'):
-                steps: List[Step] = [
+                steps: list[Step] = [
                     s for s in step.plan.steps() if s.status() == 'done']
                 login_during = steps[-1] if steps else None
             # Default to the last enabled step if no completed step found
@@ -1539,7 +1534,7 @@ class Action(Phase, tmt.utils.MultiInvokableCommon):
             except ValueError:
                 # Convert 'start' and 'end' aliases
                 try:
-                    phase = cast(Dict[str, int],
+                    phase = cast(dict[str, int],
                                  {'start': PHASE_START, 'end': PHASE_END})[phase]
                 except KeyError:
                     raise tmt.utils.GeneralError(f"Invalid phase '{phase}'.")
@@ -1586,7 +1581,7 @@ class Reboot(Action):
         return reboot
 
     @classmethod
-    def plugins(cls, step: Step) -> List['Reboot']:
+    def plugins(cls, step: Step) -> list['Reboot']:
         """ Return list of reboot instances for given step """
         if not Reboot._enabled:
             return []
@@ -1675,7 +1670,7 @@ class Login(Action):
         return login
 
     @classmethod
-    def plugins(cls, step: Step) -> List['Login']:
+    def plugins(cls, step: Step) -> list['Login']:
         """ Return list of login instances for given step """
         if not Login._enabled:
             return []
@@ -1688,11 +1683,11 @@ class Login(Action):
         if self._enabled_by_results(self.parent.plan.execute.results()):
             self._login()
 
-    def _enabled_by_results(self, results: List['tmt.base.Result']) -> bool:
+    def _enabled_by_results(self, results: list['tmt.base.Result']) -> bool:
         """ Verify possible test result condition """
         # Avoid circular imports
         from tmt.result import ResultOutcome
-        expected_results: Optional[List[ResultOutcome]] = [ResultOutcome.from_spec(
+        expected_results: Optional[list[ResultOutcome]] = [ResultOutcome.from_spec(
             raw_expected_result) for raw_expected_result in self.opt('when', [])]
 
         # Return True by default -> no expected results
@@ -1758,17 +1753,17 @@ class Topology(SerializableContainer):
 
     guest: Optional[GuestTopology]
 
-    guest_names: List[str]
-    guests: Dict[str, GuestTopology]
+    guest_names: list[str]
+    guests: dict[str, GuestTopology]
 
-    role_names: List[str]
-    roles: Dict[str, List[str]]
+    role_names: list[str]
+    roles: dict[str, list[str]]
 
-    def __init__(self, guests: List['Guest']) -> None:
-        roles: DefaultDict[str, List['Guest']] = collections.defaultdict(list)
+    def __init__(self, guests: list['Guest']) -> None:
+        roles: collections.defaultdict[str, list['Guest']] = collections.defaultdict(list)
 
         self.guest = None
-        self.guest_names: List[str] = []
+        self.guest_names: list[str] = []
         self.guests = {}
 
         for guest in guests:
@@ -1785,7 +1780,7 @@ class Topology(SerializableContainer):
             for role, role_guests in roles.items()
             }
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Convert to a mapping.
 
@@ -1842,10 +1837,10 @@ class Topology(SerializableContainer):
         filename = filename or f'{TEST_TOPOLOGY_FILENAME_BASE}.sh'
         filepath = dirpath / filename
 
-        lines: List[str] = []
+        lines: list[str] = []
 
         def _emit_guest(guest: GuestTopology, variable: str,
-                        key: Optional[str] = None) -> List[str]:
+                        key: Optional[str] = None) -> list[str]:
             return [
                 f'{variable}[{key or ""}name]="{guest.name}"',
                 f'{variable}[{key or ""}role]="{guest.role or ""}"',
@@ -1888,7 +1883,7 @@ class Topology(SerializableContainer):
             self,
             *,
             dirpath: Path,
-            filename_base: Optional[str] = None) -> List[Path]:
+            filename_base: Optional[str] = None) -> list[Path]:
         """
         Save the topology in files.
 
@@ -1992,7 +1987,7 @@ class PhaseQueue(Queue[QueuedPhase[StepDataT]]):
             self,
             *,
             phase: Union[Action, Plugin[StepDataT]],
-            guests: List['Guest']) -> None:
+            guests: list['Guest']) -> None:
         """
         Add a phase to queue.
 
@@ -2067,7 +2062,7 @@ def sync_with_guests(
 
     queue.enqueue_task(task)
 
-    failed_actions: List[TaskOutcome[GuestSyncTaskT]] = []
+    failed_actions: list[TaskOutcome[GuestSyncTaskT]] = []
 
     for outcome in queue.run():
         if outcome.exc:

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -202,10 +202,9 @@ PhaseT = TypeVar('PhaseT', bound=Phase)
 # A type alias for plugin classes
 PluginClass = type['BasePlugin']
 
-_RawStepData = TypedDict('_RawStepData', {
-    'how': str,
-    'name': str
-    }, total=False)
+class _RawStepData(TypedDict, total=False):
+    how: str
+    name: str
 
 
 RawStepDataArgument = Union[_RawStepData, list[_RawStepData]]

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -202,6 +202,7 @@ PhaseT = TypeVar('PhaseT', bound=Phase)
 # A type alias for plugin classes
 PluginClass = type['BasePlugin']
 
+
 class _RawStepData(TypedDict, total=False):
     how: str
     name: str

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -8,13 +8,12 @@ import itertools
 import re
 import shutil
 import textwrap
+from collections.abc import Iterable, Iterator
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
     Generic,
-    Iterable,
-    Iterator,
     Optional,
     TypedDict,
     TypeVar,

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -1,5 +1,6 @@
 import dataclasses
-from typing import TYPE_CHECKING, Any, Iterator, Optional, TypeVar, cast
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 
 import click
 from fmf.utils import listed

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Iterator, Optional, TypeVar, cast
 
 import click
 from fmf.utils import listed
@@ -62,7 +62,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT]):
     def base_command(
             cls,
             usage: str,
-            method_class: Optional[Type[click.Command]] = None) -> click.Command:
+            method_class: Optional[type[click.Command]] = None) -> click.Command:
         """ Create base click command (common for all discover plugins) """
 
         # Prepare general usage message for the step
@@ -86,7 +86,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT]):
             self,
             *,
             phase_name: Optional[str] = None,
-            enabled: Optional[bool] = None) -> List['tmt.Test']:
+            enabled: Optional[bool] = None) -> list['tmt.Test']:
         """
         Return discovered tests
 
@@ -127,7 +127,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT]):
             # FIXME: cast() - https://github.com/python/mypy/issues/7981
             # Note the missing Optional for values - to_minimal_dict() would
             # not include unset keys, therefore all values should be valid.
-            for key, value in cast(Dict[str, str], remote_plan_id.to_minimal_spec()).items():
+            for key, value in cast(dict[str, str], remote_plan_id.to_minimal_spec()).items():
                 self.verbose(f'import {key}', value, 'green')
 
 
@@ -147,7 +147,7 @@ class Discover(tmt.steps.Step):
         super().__init__(plan=plan, data=data, logger=logger)
 
         # Collection of discovered tests
-        self._tests: Dict[str, List[tmt.Test]] = {}
+        self._tests: dict[str, list[tmt.Test]] = {}
 
     def load(self) -> None:
         """ Load step data from the workdir """
@@ -177,7 +177,7 @@ class Discover(tmt.steps.Step):
         super().save()
 
         # Create tests.yaml with the full test data
-        raw_test_data: List['tmt.export._RawExportedInstance'] = []
+        raw_test_data: list['tmt.export._RawExportedInstance'] = []
 
         for phase_name, phase_tests in self._tests.items():
             for test in phase_tests:
@@ -317,7 +317,7 @@ class Discover(tmt.steps.Step):
         # TODO: This part should go into the 'fmf.py' module
         if self.opt('fmf_id'):
             if self.tests(enabled=True):
-                export_fmf_ids: List[str] = []
+                export_fmf_ids: list[str] = []
 
                 for test in self.tests(enabled=True):
                     fmf_id = test.fmf_id
@@ -344,7 +344,7 @@ class Discover(tmt.steps.Step):
             self,
             *,
             phase_name: Optional[str] = None,
-            enabled: Optional[bool] = None) -> List['tmt.Test']:
+            enabled: Optional[bool] = None) -> list['tmt.Test']:
         def _iter_all_tests() -> Iterator['tmt.Test']:
             for phase_tests in self._tests.values():
                 yield from phase_tests
@@ -361,7 +361,7 @@ class Discover(tmt.steps.Step):
 
         return [test for test in iterator() if test.enabled is enabled]
 
-    def requires(self) -> List['tmt.base.Dependency']:
+    def requires(self) -> list['tmt.base.Dependency']:
         """
         Collect all test requirements of all discovered tests in this step.
 
@@ -373,6 +373,6 @@ class Discover(tmt.steps.Step):
         """
         return flatten((test.require for test in self.tests(enabled=True)), unique=True)
 
-    def recommends(self) -> List['tmt.base.Dependency']:
+    def recommends(self) -> list['tmt.base.Dependency']:
         """ Return all packages recommended by tests """
         return flatten((test.recommend for test in self.tests(enabled=True)), unique=True)

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -4,7 +4,7 @@ import os
 import re
 import shutil
 import subprocess
-from typing import Any, List, Optional, cast
+from typing import Any, Optional, cast
 
 import fmf
 
@@ -53,14 +53,14 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
         help='Path to the metadata tree root.')
 
     # Selecting tests
-    test: List[str] = field(
+    test: list[str] = field(
         default_factory=list,
         option=('-t', '--test'),
         metavar='NAMES',
         multiple=True,
         help='Select tests by name.',
         normalize=tmt.utils.normalize_string_list)
-    link: List[str] = field(
+    link: list[str] = field(
         default_factory=list,
         option='--link',
         metavar="RELATION:TARGET",
@@ -69,14 +69,14 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
              Filter by linked objects (regular expressions are supported for both relation and
              target).
              """)
-    filter: List[str] = field(
+    filter: list[str] = field(
         default_factory=list,
         option=('-F', '--filter'),
         metavar='FILTERS',
         multiple=True,
         help='Include only tests matching the filter.',
         normalize=tmt.utils.normalize_string_list)
-    exclude: List[str] = field(
+    exclude: list[str] = field(
         default_factory=list,
         option=('-x', '--exclude'),
         metavar='REGEXP',
@@ -513,7 +513,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
 
         # Check the 'test --link' option first, then from discover
         # FIXME: cast() - typeless "dispatcher" method
-        raw_link_needles = cast(List[str], tmt.Test._opt('links', []) or self.get('link', []))
+        raw_link_needles = cast(list[str], tmt.Test._opt('links', []) or self.get('link', []))
         link_needles = [tmt.base.LinkNeedle.from_spec(
             raw_needle) for raw_needle in raw_link_needles]
 
@@ -637,7 +637,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             self,
             *,
             phase_name: Optional[str] = None,
-            enabled: Optional[bool] = None) -> List['tmt.Test']:
+            enabled: Optional[bool] = None) -> list['tmt.Test']:
         """ Return all discovered tests """
 
         if phase_name is not None and phase_name != self.name:

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -1,7 +1,7 @@
 import copy
 import dataclasses
 import shutil
-from typing import Any, Dict, List, Optional, Type, TypeVar, cast
+from typing import Any, Optional, TypeVar, cast
 
 import click
 import fmf
@@ -19,7 +19,7 @@ T = TypeVar('T', bound='TestDescription')
 
 @dataclasses.dataclass
 class TestDescription(
-        SpecBasedContainer[Dict[str, Any], Dict[str, Any]],
+        SpecBasedContainer[dict[str, Any], dict[str, Any]],
         tmt.utils.NormalizeKeysMixin,
         SerializableContainer):
     """
@@ -69,7 +69,7 @@ class TestDescription(
         unserialize=lambda serialized_link: tmt.base.Links(data=serialized_link)
         )
     id: Optional[str] = None
-    tag: List[str] = field(
+    tag: list[str] = field(
         default_factory=list,
         normalize=tmt.utils.normalize_string_list
         )
@@ -78,7 +78,7 @@ class TestDescription(
         normalize=lambda key_address, raw_value, logger:
             None if raw_value is None else str(raw_value)
         )
-    adjust: Optional[List[tmt.base._RawAdjustRule]] = field(
+    adjust: Optional[list[tmt.base._RawAdjustRule]] = field(
         default=None,
         normalize=lambda key_address, raw_value, logger: [] if raw_value is None else (
             [raw_value] if not isinstance(raw_value, list) else raw_value
@@ -86,11 +86,11 @@ class TestDescription(
         )
 
     # Basic test information
-    contact: List[str] = field(
+    contact: list[str] = field(
         default_factory=list,
         normalize=tmt.utils.normalize_string_list
         )
-    component: List[str] = field(
+    component: list[str] = field(
         default_factory=list,
         normalize=tmt.utils.normalize_string_list
         )
@@ -99,7 +99,7 @@ class TestDescription(
     path: Optional[str] = None
     framework: Optional[str] = None
     manual: bool = False
-    require: List[tmt.base.Dependency] = field(
+    require: list[tmt.base.Dependency] = field(
         default_factory=list,
         normalize=tmt.base.normalize_require,
         serialize=lambda requires: [require.to_spec() for require in requires],
@@ -107,7 +107,7 @@ class TestDescription(
             tmt.base.dependency_factory(require) for require in serialized_requires
             ]
         )
-    recommend: List[tmt.base.Dependency] = field(
+    recommend: list[tmt.base.Dependency] = field(
         default_factory=list,
         normalize=tmt.base.normalize_require,
         serialize=lambda recommends: [recommend.to_spec() for recommend in recommends],
@@ -128,8 +128,8 @@ class TestDescription(
     # type than the one declared in superclass.
     @classmethod
     def from_spec(  # type: ignore[override]
-            cls: Type[T],
-            raw_data: Dict[str, Any],
+            cls: type[T],
+            raw_data: dict[str, Any],
             logger: tmt.log.Logger) -> T:
         """ Convert from a specification file or from a CLI option """
 
@@ -138,7 +138,7 @@ class TestDescription(
 
         return data
 
-    def to_spec(self) -> Dict[str, Any]:
+    def to_spec(self) -> dict[str, Any]:
         """ Convert to a form suitable for saving in a specification file """
 
         data = super().to_spec()
@@ -152,11 +152,11 @@ class TestDescription(
 
 @dataclasses.dataclass
 class DiscoverShellData(tmt.steps.discover.DiscoverStepData):
-    tests: List[TestDescription] = field(
+    tests: list[TestDescription] = field(
         default_factory=list,
         normalize=lambda key_address, raw_value, logger: [
             TestDescription.from_spec(raw_datum, logger)
-            for raw_datum in cast(List[Dict[str, Any]], raw_value)
+            for raw_datum in cast(list[dict[str, Any]], raw_value)
             ],
         serialize=lambda tests: [
             test.to_serialized()
@@ -245,13 +245,13 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin[DiscoverShellData]):
 
     _data_class = DiscoverShellData
 
-    _tests: List[tmt.base.Test] = []
+    _tests: list[tmt.base.Test] = []
 
-    def show(self, keys: Optional[List[str]] = None) -> None:
+    def show(self, keys: Optional[list[str]] = None) -> None:
         """ Show config details """
         super().show([])
         # FIXME: cast() - typeless "dispatcher" method
-        tests = cast(List[TestDescription], self.get('tests'))
+        tests = cast(list[TestDescription], self.get('tests'))
         if tests:
             test_names = [test.name for test in tests]
             click.echo(tmt.utils.format('tests', test_names))
@@ -346,7 +346,7 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin[DiscoverShellData]):
             # it's not a supported test key, and it's given to the node itself anyway.
             # Note the exception for `duration` key - it's expected in the output
             # even if it still has its default value.
-            test_fmf_keys: Dict[str, Any] = {
+            test_fmf_keys: dict[str, Any] = {
                 key: value
                 for key, value in data.to_spec().items()
                 if key != 'name' and (key == 'duration' or value != data.default(key))
@@ -406,7 +406,7 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin[DiscoverShellData]):
             self,
             *,
             phase_name: Optional[str] = None,
-            enabled: Optional[bool] = None) -> List['tmt.Test']:
+            enabled: Optional[bool] = None) -> list['tmt.Test']:
 
         if phase_name is not None and phase_name != self.name:
             return []

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -2,7 +2,7 @@ import copy
 import dataclasses
 import datetime
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 
 import click
 import fmf
@@ -48,8 +48,8 @@ SCRIPTS_SRC_DIR = tmt.utils.resource_files('steps/execute/scripts')
 class Script:
     """ Represents a script provided by the internal executor """
     path: Path
-    aliases: List[Path]
-    related_variables: List[str]
+    aliases: list[Path]
+    related_variables: list[str]
 
 
 @dataclass
@@ -147,7 +147,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
     # Internal executor is the default implementation
     how = 'tmt'
 
-    scripts: Tuple['Script', ...] = ()
+    scripts: tuple['Script', ...] = ()
 
     _login_after_test: Optional[tmt.steps.Login] = None
 
@@ -162,7 +162,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             workdir: tmt.utils.WorkdirArgumentType = None,
             logger: tmt.log.Logger) -> None:
         super().__init__(logger=logger, step=step, data=data, workdir=workdir)
-        self._results: List[tmt.Result] = []
+        self._results: list[tmt.Result] = []
         if tmt.steps.Login._opt('test'):
             self._login_after_test = tmt.steps.Login(logger=logger, step=self.step, order=90)
 
@@ -170,7 +170,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
     def base_command(
             cls,
             usage: str,
-            method_class: Optional[Type[click.Command]] = None) -> click.Command:
+            method_class: Optional[type[click.Command]] = None) -> click.Command:
         """ Create base click command (common for all execute plugins) """
 
         # Prepare general usage message for the step
@@ -237,7 +237,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
         path = directory / filename
         return path if full else path.relative_to(self.step.workdir)
 
-    def prepare_tests(self, guest: Guest) -> List["tmt.Test"]:
+    def prepare_tests(self, guest: Guest) -> list["tmt.Test"]:
         """
         Prepare discovered tests for testing
 
@@ -245,7 +245,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
         the aggregated metadata in a file under the test data directory
         and finally return a list of discovered tests.
         """
-        tests: List[tmt.Test] = self.discover.tests(phase_name=self.discover_phase, enabled=True)
+        tests: list[tmt.Test] = self.discover.tests(phase_name=self.discover_phase, enabled=True)
         for test in tests:
             metadata_filename = self.data_path(
                 test, guest, filename=TEST_METADATA_FILENAME, full=True, create=True)
@@ -275,7 +275,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             / TEST_DATA \
             / TMT_REPORT_RESULT_SCRIPT.created_file
 
-    def load_tmt_report_results(self, test: "tmt.Test", guest: Guest) -> List["tmt.Result"]:
+    def load_tmt_report_results(self, test: "tmt.Test", guest: Guest) -> list["tmt.Result"]:
         """
         Load results from a file created by ``tmt-report-result`` script.
 
@@ -319,7 +319,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             note=note,
             guest=guest)]
 
-    def load_custom_results(self, test: "tmt.Test", guest: Guest) -> List["tmt.Result"]:
+    def load_custom_results(self, test: "tmt.Test", guest: Guest) -> list["tmt.Result"]:
         """
         Process custom results.yaml file created by the test itself.
         """
@@ -410,7 +410,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             self,
             test: "tmt.Test",
             guest: Guest,
-            logger: tmt.log.Logger) -> List[Result]:
+            logger: tmt.log.Logger) -> list[Result]:
         """ Check the test result """
 
         self.debug(f"Extract results of '{test.name}'.")
@@ -461,7 +461,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             f"https://tmt.readthedocs.io/en/stable/spec/tests.html#duration\n",
             mode='a', level=3)
 
-    def results(self) -> List["tmt.Result"]:
+    def results(self) -> list["tmt.Result"]:
         """ Return test results """
         raise NotImplementedError
 
@@ -472,9 +472,9 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             guest: Guest,
             test: 'tmt.base.Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,
-            logger: tmt.log.Logger) -> List[CheckResult]:
+            logger: tmt.log.Logger) -> list[CheckResult]:
 
-        results: List[CheckResult] = []
+        results: list[CheckResult] = []
 
         for check in test.check:
             with Stopwatch() as timer:
@@ -503,7 +503,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             guest: Guest,
             test: 'tmt.base.Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,
-            logger: tmt.log.Logger) -> List[CheckResult]:
+            logger: tmt.log.Logger) -> list[CheckResult]:
         return self._run_checks_for_test(
             event=CheckEvent.BEFORE_TEST,
             guest=guest,
@@ -518,7 +518,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             guest: Guest,
             test: 'tmt.base.Test',
             environment: Optional[tmt.utils.EnvironmentType] = None,
-            logger: tmt.log.Logger) -> List[CheckResult]:
+            logger: tmt.log.Logger) -> list[CheckResult]:
         return self._run_checks_for_test(
             event=CheckEvent.AFTER_TEST,
             guest=guest,
@@ -549,7 +549,7 @@ class Execute(tmt.steps.Step):
         """ Initialize execute step data """
         super().__init__(plan=plan, data=data, logger=logger)
         # List of Result() objects representing test results
-        self._results: List[tmt.Result] = []
+        self._results: list[tmt.Result] = []
 
     def load(self) -> None:
         """ Load test results """
@@ -659,7 +659,7 @@ class Execute(tmt.steps.Step):
                             if discover.enabled_on_guest(guest)
                             ])
 
-        failed_phases: List[TaskOutcome[QueuedPhase[ExecuteStepData]]] = []
+        failed_phases: list[TaskOutcome[QueuedPhase[ExecuteStepData]]] = []
 
         for phase_outcome in queue.run():
             if phase_outcome.exc:
@@ -695,7 +695,7 @@ class Execute(tmt.steps.Step):
         self.status('done')
         self.save()
 
-    def results(self) -> List["tmt.result.Result"]:
+    def results(self) -> list["tmt.result.Result"]:
         """
         Results from executed tests
 

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -3,7 +3,7 @@ import json
 import os
 import textwrap
 from contextlib import suppress
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Optional, cast
 
 import click
 import jinja2
@@ -142,7 +142,7 @@ class UpdatableMessage(tmt.utils.UpdatableMessage):
 
 @dataclasses.dataclass
 class ExecuteInternalData(tmt.steps.execute.ExecuteStepData):
-    script: List[ShellScript] = field(
+    script: list[ShellScript] = field(
         default_factory=list,
         option=('-s', '--script'),
         metavar='SCRIPT',
@@ -164,8 +164,8 @@ class ExecuteInternalData(tmt.steps.execute.ExecuteStepData):
 
     # ignore[override] & cast: two base classes define to_spec(), with conflicting
     # formal types.
-    def to_spec(self) -> Dict[str, Any]:  # type: ignore[override]
-        data = cast(Dict[str, Any], super().to_spec())
+    def to_spec(self) -> dict[str, Any]:  # type: ignore[override]
+        data = cast(dict[str, Any], super().to_spec())
         data['script'] = [str(script) for script in self.script]
 
         return data
@@ -246,11 +246,11 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
             test: Test,
             guest: Guest,
             extra_environment: Optional[EnvironmentType] = None,
-            logger: tmt.log.Logger) -> List[CheckResult]:
+            logger: tmt.log.Logger) -> list[CheckResult]:
         """ Run test on the guest """
         logger.debug(f"Execute '{test.name}' as a '{test.framework}' test.")
 
-        test_check_results: List[CheckResult] = []
+        test_check_results: list[CheckResult] = []
 
         # Test will be executed in it's own directory, relative to the workdir
         assert self.discover.workdir is not None  # narrow type
@@ -479,7 +479,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                 logger.verbose(
                     'test', test.summary or test.name, color='cyan', shift=1, level=2)
 
-                test_check_results: List[CheckResult] = self.execute(
+                test_check_results: list[CheckResult] = self.execute(
                     test=test,
                     guest=guest,
                     extra_environment=extra_environment,
@@ -569,10 +569,10 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         self.debug("Pull the plan data directory.", level=2)
         guest.pull(source=self.step.plan.data_directory)
 
-    def results(self) -> List[Result]:
+    def results(self) -> list[Result]:
         """ Return test results """
         return self._results
 
-    def requires(self) -> List[tmt.base.Dependency]:
+    def requires(self) -> list[tmt.base.Dependency]:
         """ All requirements of the plugin on the guest """
         return []

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, List, Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 import fmf.utils
 
@@ -46,21 +46,21 @@ class ExecuteUpgradeData(ExecuteInternalData):
         metavar='REVISION',
         help='Branch, tag or commit specifying the git revision.',
         normalize=normalize_ref)
-    test: List[str] = field(
+    test: list[str] = field(
         default_factory=list,
         option=('-t', '--test'),
         metavar='NAMES',
         multiple=True,
         help='Select tests by name.',
         normalize=tmt.utils.normalize_string_list)
-    filter: List[str] = field(
+    filter: list[str] = field(
         default_factory=list,
         option=('-F', '--filter'),
         metavar='FILTERS',
         multiple=True,
         help='Include only tests matching the filter.',
         normalize=tmt.utils.normalize_string_list)
-    exclude: List[str] = field(
+    exclude: list[str] = field(
         default_factory=list,
         option=('-x', '--exclude'),
         metavar='REGEXP',

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -1,6 +1,6 @@
 import copy
 import dataclasses
-from typing import TYPE_CHECKING, Any, List, Optional, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 
 import click
 import fmf
@@ -46,7 +46,7 @@ class FinishPlugin(tmt.steps.Plugin[FinishStepDataT]):
     def base_command(
             cls,
             usage: str,
-            method_class: Optional[Type[click.Command]] = None) -> click.Command:
+            method_class: Optional[type[click.Command]] = None) -> click.Command:
         """ Create base click command (common for all finish plugins) """
 
         # Prepare general usage message for the step
@@ -123,7 +123,7 @@ class Finish(tmt.steps.Step):
             return
 
         # Prepare guests
-        guest_copies: List[Guest] = []
+        guest_copies: list[Guest] = []
 
         for guest in self.plan.provision.guests():
             # Create a guest copy and change its parent so that the
@@ -146,7 +146,7 @@ class Finish(tmt.steps.Step):
                 guests=[guest for guest in guest_copies if phase.enabled_on_guest(guest)]
                 )
 
-        failed_phases: List[TaskOutcome[QueuedPhase[FinishStepData]]] = []
+        failed_phases: list[TaskOutcome[QueuedPhase[FinishStepData]]] = []
 
         for phase_outcome in queue.run():
             if not isinstance(phase_outcome.task.phase, FinishPlugin):

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Optional, cast
 
 import fmf
 
@@ -15,7 +15,7 @@ FINISH_WRAPPER_FILENAME = 'tmt-finish-wrapper.sh'
 
 @dataclasses.dataclass
 class FinishShellData(tmt.steps.finish.FinishStepData):
-    script: List[ShellScript] = field(
+    script: list[ShellScript] = field(
         default_factory=list,
         option=('-s', '--script'),
         multiple=True,
@@ -29,8 +29,8 @@ class FinishShellData(tmt.steps.finish.FinishStepData):
     # TODO: well, our brave new field() machinery should be able to deal with all of this...
     # ignore[override] & cast: two base classes define to_spec(), with conflicting
     # formal types.
-    def to_spec(self) -> Dict[str, Any]:  # type: ignore[override]
-        data = cast(Dict[str, Any], super().to_spec())
+    def to_spec(self) -> dict[str, Any]:  # type: ignore[override]
+        data = cast(dict[str, Any], super().to_spec())
         data['script'] = [str(script) for script in self.script]
 
         return data
@@ -65,7 +65,7 @@ class FinishShell(tmt.steps.finish.FinishPlugin[FinishShellData]):
         super().go(guest=guest, environment=environment, logger=logger)
 
         # Give a short summary
-        scripts: List[tmt.utils.ShellScript] = self.get('script')
+        scripts: list[tmt.utils.ShellScript] = self.get('script')
         overview = fmf.utils.listed(scripts, 'script')
         self.info('overview', f'{overview} found', 'green')
 

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -1,7 +1,7 @@
 import collections
 import copy
 import dataclasses
-from typing import TYPE_CHECKING, Any, DefaultDict, Dict, List, Optional, Type, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 
 import click
 import fmf
@@ -41,10 +41,10 @@ PrepareStepDataT = TypeVar('PrepareStepDataT', bound=PrepareStepData)
 
 
 class _RawPrepareStepData(tmt.steps._RawStepData, total=False):
-    package: List[str]
+    package: list[str]
     missing: str
-    roles: DefaultDict[str, List[str]]
-    hosts: Dict[str, str]
+    roles: collections.defaultdict[str, list[str]]
+    hosts: dict[str, str]
     order: int
     summary: str
 
@@ -63,7 +63,7 @@ class PreparePlugin(tmt.steps.Plugin[PrepareStepDataT]):
     def base_command(
             cls,
             usage: str,
-            method_class: Optional[Type[click.Command]] = None) -> click.Command:
+            method_class: Optional[type[click.Command]] = None) -> click.Command:
         """ Create base click command (common for all prepare plugins) """
 
         # Prepare general usage message for the step
@@ -98,7 +98,7 @@ class PreparePlugin(tmt.steps.Plugin[PrepareStepDataT]):
 
         # Show requested role if defined
         # FIXME: cast() - typeless "dispatcher" method
-        where = cast(List[str], self.get('where'))
+        where = cast(list[str], self.get('where'))
         if where:
             logger.info('where', fmf.utils.listed(where), 'green')
 
@@ -155,7 +155,7 @@ class Prepare(tmt.steps.Step):
             self.preparations_applied, 'preparation')
         self.info('summary', f'{preparations} applied', 'green', shift=1)
 
-    def _prepare_roles(self) -> DefaultDict[str, List[str]]:
+    def _prepare_roles(self) -> collections.defaultdict[str, list[str]]:
         """ Create a mapping of roles to guest names """
         role_mapping = collections.defaultdict(list)
         for guest in self.plan.provision.guests():
@@ -163,7 +163,7 @@ class Prepare(tmt.steps.Step):
                 role_mapping[guest.role].append(guest.name)
         return role_mapping
 
-    def _prepare_hosts(self) -> Dict[str, str]:
+    def _prepare_hosts(self) -> dict[str, str]:
         """ Create a mapping of guest names to IP addresses """
         host_mapping = {}
         for guest in self.plan.provision.guests():
@@ -230,7 +230,7 @@ class Prepare(tmt.steps.Step):
             self._phases.append(PreparePlugin.delegate(self, raw_data=data))
 
         # Prepare guests (including workdir sync)
-        guest_copies: List[Guest] = []
+        guest_copies: list[Guest] = []
 
         for guest in self.plan.provision.guests():
             # Create a guest copy and change its parent so that the
@@ -263,7 +263,7 @@ class Prepare(tmt.steps.Step):
                 guests=[guest for guest in guest_copies if phase.enabled_on_guest(guest)]
                 )
 
-        failed_phases: List[TaskOutcome[QueuedPhase[PrepareStepData]]] = []
+        failed_phases: list[TaskOutcome[QueuedPhase[PrepareStepData]]] = []
 
         for phase_outcome in queue.run():
             if not isinstance(phase_outcome.task.phase, PreparePlugin):

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -1,6 +1,6 @@
 import dataclasses
 import tempfile
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import requests
 
@@ -15,13 +15,13 @@ from tmt.utils import Path, PrepareError, field, retry_session
 
 
 class _RawAnsibleStepData(tmt.steps._RawStepData, total=False):
-    playbook: Union[str, List[str]]
-    playbooks: List[str]
+    playbook: Union[str, list[str]]
+    playbooks: list[str]
 
 
 @dataclasses.dataclass
 class PrepareAnsibleData(tmt.steps.prepare.PrepareStepData):
-    playbook: List[str] = field(
+    playbook: list[str] = field(
         default_factory=list,
         option=('-p', '--playbook'),
         multiple=True,

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -1,7 +1,7 @@
 import dataclasses
 import re
 import shutil
-from typing import List, Literal, Optional, Tuple, cast
+from typing import Literal, Optional, cast
 
 import fmf
 import fmf.utils
@@ -32,14 +32,14 @@ class InstallBase(tmt.utils.Common):
 
     skip_missing: bool = False
 
-    packages: List[str]
-    directories: List[Path]
-    exclude: List[str]
+    packages: list[str]
+    directories: list[Path]
+    exclude: list[str]
 
-    local_packages: List[Path]
-    remote_packages: List[str]
-    debuginfo_packages: List[str]
-    repository_packages: List[str]
+    local_packages: list[Path]
+    remote_packages: list[str]
+    debuginfo_packages: list[str]
+    repository_packages: list[str]
 
     rpms_directory: Path
 
@@ -55,7 +55,7 @@ class InstallBase(tmt.utils.Common):
 
         # Get package related data from the plugin
         self.packages = parent.get("package", [])
-        self.directories = cast(List[Path], parent.get("directory", []))
+        self.directories = cast(list[Path], parent.get("directory", []))
         self.exclude = parent.get("exclude", [])
 
         if not self.packages and not self.directories:
@@ -102,7 +102,7 @@ class InstallBase(tmt.utils.Common):
                     self.debug(f"Found rpm '{filepath}'.", level=3)
                     self.local_packages.append(filepath)
 
-    def prepare_command(self) -> Tuple[Command, Command]:
+    def prepare_command(self) -> tuple[Command, Command]:
         """ Prepare installation command and subcommand options """
         raise NotImplementedError
 
@@ -145,7 +145,7 @@ class InstallBase(tmt.utils.Common):
 
         return self.guest.execute(self.operation_script(subcommand, args))
 
-    def list_packages(self, packages: List[str], title: str) -> Command:
+    def list_packages(self, packages: list[str], title: str) -> Command:
         """ Show package info and return package names """
 
         # Show a brief summary by default
@@ -264,7 +264,7 @@ class InstallDnf(InstallBase):
     copr_plugin = "dnf-plugins-core"
     skip_missing_option = "--skip-broken"
 
-    def prepare_command(self) -> Tuple[Command, Command]:
+    def prepare_command(self) -> tuple[Command, Command]:
         """ Prepare installation command """
 
         options = Command('-y')
@@ -398,7 +398,7 @@ class InstallRpmOstree(InstallBase):
                 else:
                     self.required_packages.append(package)
 
-    def prepare_command(self) -> Tuple[Command, Command]:
+    def prepare_command(self) -> tuple[Command, Command]:
         """ Prepare installation command for rpm-ostree"""
 
         command = Command()
@@ -464,7 +464,7 @@ class InstallRpmOstree(InstallBase):
 
 @dataclasses.dataclass
 class PrepareInstallData(tmt.steps.prepare.PrepareStepData):
-    package: List[tmt.base.DependencySimple] = field(
+    package: list[tmt.base.DependencySimple] = field(
         default_factory=list,
         option=('-p', '--package'),
         metavar='PACKAGE',
@@ -482,7 +482,7 @@ class PrepareInstallData(tmt.steps.prepare.PrepareStepData):
             ]
         )
 
-    directory: List[Path] = field(
+    directory: list[Path] = field(
         default_factory=list,
         option=('-D', '--directory'),
         metavar='PATH',
@@ -491,7 +491,7 @@ class PrepareInstallData(tmt.steps.prepare.PrepareStepData):
         normalize=tmt.utils.normalize_path_list
         )
 
-    copr: List[str] = field(
+    copr: list[str] = field(
         default_factory=list,
         option=('-c', '--copr'),
         metavar='REPO',
@@ -500,7 +500,7 @@ class PrepareInstallData(tmt.steps.prepare.PrepareStepData):
         normalize=tmt.utils.normalize_string_list
         )
 
-    exclude: List[str] = field(
+    exclude: list[str] = field(
         default_factory=list,
         option=('-x', '--exclude'),
         metavar='PACKAGE',

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Optional, cast
 
 import fmf
 
@@ -16,7 +16,7 @@ PREPARE_WRAPPER_FILENAME = 'tmt-prepare-wrapper.sh'
 
 @dataclasses.dataclass
 class PrepareShellData(tmt.steps.prepare.PrepareStepData):
-    script: List[ShellScript] = field(
+    script: list[ShellScript] = field(
         default_factory=list,
         option=('-s', '--script'),
         multiple=True,
@@ -29,8 +29,8 @@ class PrepareShellData(tmt.steps.prepare.PrepareStepData):
 
     # ignore[override] & cast: two base classes define to_spec(), with conflicting
     # formal types.
-    def to_spec(self) -> Dict[str, Any]:  # type: ignore[override]
-        data = cast(Dict[str, Any], super().to_spec())
+    def to_spec(self) -> dict[str, Any]:  # type: ignore[override]
+        data = cast(dict[str, Any], super().to_spec())
         data['script'] = [str(script) for script in self.script]
 
         return data
@@ -69,7 +69,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
         environment = environment or {}
 
         # Give a short summary
-        scripts: List[tmt.utils.ShellScript] = self.get('script')
+        scripts: list[tmt.utils.ShellScript] = self.get('script')
         overview = fmf.utils.listed(scripts, 'script')
         logger.info('overview', f'{overview} found', 'green')
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -10,11 +10,11 @@ import shlex
 import string
 import subprocess
 import tempfile
+from collections.abc import Iterator
 from shlex import quote
 from typing import (
     TYPE_CHECKING,
     Any,
-    Iterator,
     Optional,
     TypeVar,
     Union,

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -1,6 +1,6 @@
 import dataclasses
 import datetime
-from typing import Any, Dict, List, Optional, TypedDict, cast
+from typing import Any, Optional, TypedDict, cast
 
 import requests
 
@@ -79,7 +79,7 @@ DEFAULT_RETRY_BACKOFF_FACTOR = 1
 def _normalize_user_data(
         key_address: str,
         raw_value: Any,
-        logger: tmt.log.Logger) -> Dict[str, str]:
+        logger: tmt.log.Logger) -> dict[str, str]:
     if isinstance(raw_value, dict):
         return {
             str(key).strip(): str(value).strip() for key, value in raw_value.items()
@@ -107,7 +107,7 @@ def _normalize_user_data(
 def _normalize_log_type(
         key_address: str,
         raw_value: Any,
-        logger: tmt.log.Logger) -> List[str]:
+        logger: tmt.log.Logger) -> list[str]:
     if isinstance(raw_value, str):
         return [raw_value]
 
@@ -162,14 +162,14 @@ class ArtemisGuestData(tmt.steps.provision.GuestSshData):
         option='--keyname',
         metavar='NAME',
         help='SSH key name.')
-    user_data: Dict[str, str] = field(
+    user_data: dict[str, str] = field(
         default_factory=dict,
         option='--user-data',
         metavar='KEY=VALUE',
         help='Optional data to attach to guest.',
         multiple=True,
         normalize=_normalize_user_data)
-    kickstart: Dict[str, str] = field(
+    kickstart: dict[str, str] = field(
         default_factory=dict,
         option='--kickstart',
         metavar='KEY=VALUE',
@@ -177,7 +177,7 @@ class ArtemisGuestData(tmt.steps.provision.GuestSshData):
         multiple=True,
         normalize=_normalize_user_data)
 
-    log_type: List[str] = field(
+    log_type: list[str] = field(
         default_factory=list,
         option='--log-type',
         choices=SUPPORTED_LOG_TYPES,
@@ -309,7 +309,7 @@ class ArtemisAPI:
             self,
             path: str,
             method: str = 'get',
-            request_kwargs: Optional[Dict[str, Any]] = None
+            request_kwargs: Optional[dict[str, Any]] = None
             ) -> requests.Response:
         """
         Base helper for Artemis API queries.
@@ -344,8 +344,8 @@ class ArtemisAPI:
     def create(
             self,
             path: str,
-            data: Dict[str, Any],
-            request_kwargs: Optional[Dict[str, Any]] = None
+            data: dict[str, Any],
+            request_kwargs: Optional[dict[str, Any]] = None
             ) -> requests.Response:
         """
         Create - or request creation of - a resource.
@@ -364,8 +364,8 @@ class ArtemisAPI:
     def inspect(
             self,
             path: str,
-            params: Optional[Dict[str, Any]] = None,
-            request_kwargs: Optional[Dict[str, Any]] = None
+            params: Optional[dict[str, Any]] = None,
+            request_kwargs: Optional[dict[str, Any]] = None
             ) -> requests.Response:
         """
         Inspect a resource.
@@ -386,7 +386,7 @@ class ArtemisAPI:
     def delete(
             self,
             path: str,
-            request_kwargs: Optional[Dict[str, Any]] = None
+            request_kwargs: Optional[dict[str, Any]] = None
             ) -> requests.Response:
         """
         Delete - or request removal of - a resource.
@@ -418,9 +418,9 @@ class GuestArtemis(tmt.GuestSsh):
     pool: Optional[str]
     priority_group: str
     keyname: str
-    user_data: Dict[str, str]
-    kickstart: Dict[str, str]
-    log_type: List[str]
+    user_data: dict[str, str]
+    kickstart: dict[str, str]
+    log_type: list[str]
     skip_prepare_verify_ssh: bool
     post_install_script: Optional[str]
 
@@ -449,7 +449,7 @@ class GuestArtemis(tmt.GuestSsh):
         return self.guest is not None
 
     def _create(self) -> None:
-        environment: Dict[str, Any] = {
+        environment: dict[str, Any] = {
             'hw': {
                 'arch': self.arch
                 },
@@ -464,7 +464,7 @@ class GuestArtemis(tmt.GuestSsh):
         elif self.kickstart:
             raise ProvisionError(f"API version '{self.api_version}' does not support kickstart.")
 
-        data: Dict[str, Any] = {
+        data: dict[str, Any] = {
             'environment': environment,
             'keyname': self.keyname,
             'priority_group': self.priority_group,

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Any, List, Optional, Union
+from typing import Any, Optional, Union
 
 import tmt
 import tmt.base
@@ -115,7 +115,7 @@ class GuestLocal(tmt.Guest):
             self,
             source: Optional[Path] = None,
             destination: Optional[Path] = None,
-            options: Optional[List[str]] = None,
+            options: Optional[list[str]] = None,
             superuser: bool = False) -> None:
         """ Nothing to be done to push workdir """
 
@@ -123,8 +123,8 @@ class GuestLocal(tmt.Guest):
             self,
             source: Optional[Path] = None,
             destination: Optional[Path] = None,
-            options: Optional[List[str]] = None,
-            extend_options: Optional[List[str]] = None) -> None:
+            options: Optional[list[str]] = None,
+            extend_options: Optional[list[str]] = None) -> None:
         """ Nothing to be done to pull workdir """
 
 

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -34,13 +34,10 @@ DEFAULT_PROVISION_TICK = 60  # poll job each minute
 
 # Type annotation for "data" package describing a guest instance. Passed
 # between load() and save() calls
-GuestInspectType = TypedDict(
-    'GuestInspectType', {
-        "status": str,
-        "system": str,
-        'address': Optional[str]
-        }
-    )
+class GuestInspectType(TypedDict):
+    status: str
+    system: str
+    address: Optional[str]
 
 
 SUPPORTED_HARDWARE_CONSTRAINTS: list[str] = [

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -5,7 +5,7 @@ import logging
 import os
 from contextlib import suppress
 from functools import wraps
-from typing import Any, Dict, List, Optional, Tuple, TypedDict, cast
+from typing import Any, Optional, TypedDict, cast
 
 import tmt
 import tmt.hardware
@@ -43,7 +43,7 @@ GuestInspectType = TypedDict(
     )
 
 
-SUPPORTED_HARDWARE_CONSTRAINTS: List[str] = [
+SUPPORTED_HARDWARE_CONSTRAINTS: list[str] = [
     'cpu.processors',
     'cpu.model',
     'disk.size',
@@ -63,7 +63,7 @@ OPERATOR_SIGN_TO_OPERATOR = {
     }
 
 
-def operator_to_beaker_op(operator: tmt.hardware.Operator, value: str) -> Tuple[str, str, bool]:
+def operator_to_beaker_op(operator: tmt.hardware.Operator, value: str) -> tuple[str, str, bool]:
     """
     Convert constraint operator to Beaker "op".
 
@@ -109,7 +109,7 @@ class MrackBaseHWElement:
     # types.
     name: str
 
-    def to_mrack(self) -> Dict[str, Any]:
+    def to_mrack(self) -> dict[str, Any]:
         """ Convert the element to Mrack-compatible dictionary tree """
         raise NotImplementedError
 
@@ -122,9 +122,9 @@ class MrackHWElement(MrackBaseHWElement):
     This type of element is not allowed to have any child elements.
     """
 
-    attributes: Dict[str, str] = dataclasses.field(default_factory=dict)
+    attributes: dict[str, str] = dataclasses.field(default_factory=dict)
 
-    def to_mrack(self) -> Dict[str, Any]:
+    def to_mrack(self) -> dict[str, Any]:
         return {
             self.name: self.attributes
             }
@@ -151,9 +151,9 @@ class MrackHWGroup(MrackBaseHWElement):
     This type of element is not allowed to have any attributes.
     """
 
-    children: List[MrackBaseHWElement] = dataclasses.field(default_factory=list)
+    children: list[MrackBaseHWElement] = dataclasses.field(default_factory=list)
 
-    def to_mrack(self) -> Dict[str, Any]:
+    def to_mrack(self) -> dict[str, Any]:
         # Another unexpected behavior of mrack dictionary tree: if there is just
         # a single child, it is "packed" into its parent as a key/dict item.
         if len(self.children) == 1 and self.name not in ('and', 'or'):
@@ -310,7 +310,7 @@ def import_and_load_mrack_deps(workdir: Any, name: str, logger: tmt.log.Logger) 
     # error: Class cannot subclass "BeakerTransformer" (has type "Any")
     # as mypy does not have type information for the BeakerTransformer class
     class TmtBeakerTransformer(BeakerTransformer):  # type: ignore[misc]
-        def _translate_tmt_hw(self, hw: tmt.hardware.Hardware) -> Dict[str, Any]:
+        def _translate_tmt_hw(self, hw: tmt.hardware.Hardware) -> dict[str, Any]:
             """ Return hw requirements from given hw dictionary """
 
             assert hw.constraint
@@ -327,12 +327,12 @@ def import_and_load_mrack_deps(workdir: Any, name: str, logger: tmt.log.Logger) 
                 'hostRequires': transformed.to_mrack()
                 }
 
-        def create_host_requirement(self, host: Dict[str, Any]) -> Dict[str, Any]:
+        def create_host_requirement(self, host: dict[str, Any]) -> dict[str, Any]:
             """ Create single input for Beaker provisioner """
             hardware = cast(Optional[tmt.hardware.Hardware], host.get('hardware'))
             if hardware and hardware.constraint:
                 host.update({"beaker": self._translate_tmt_hw(hardware)})
-            req: Dict[str, Any] = super().create_host_requirement(host)
+            req: dict[str, Any] = super().create_host_requirement(host)
             req.update({"whiteboard": host.get("tmt_name", req.get("whiteboard"))})
             return req
 
@@ -417,7 +417,7 @@ GUEST_STATE_COLORS = {
 
 class BeakerAPI:
     # req is a requirement passed to Beaker mrack provisioner
-    mrack_requirement: Dict[str, Any] = {}
+    mrack_requirement: dict[str, Any] = {}
     dsp_name: str = "Beaker"
 
     # wrapping around the __init__ with async wrapper does mangle the method
@@ -474,7 +474,7 @@ class BeakerAPI:
     @async_run
     async def create(
             self,
-            data: Dict[str, Any],
+            data: dict[str, Any],
             ) -> Any:
         """
         Create - or request creation of - a resource using mrack up.
@@ -557,7 +557,7 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
     def _create(self, tmt_name: str) -> None:
         """ Create beaker job xml request and submit it to Beaker hub """
 
-        data: Dict[str, Any] = {
+        data: dict[str, Any] = {
             'tmt_name': tmt_name,
             'hardware': self.hardware,
             'name': f'{self.image}-{self.arch}',

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -1,7 +1,7 @@
 import dataclasses
 import os
 from shlex import quote
-from typing import Any, List, Optional, Union, cast
+from typing import Any, Optional, Union, cast
 
 import tmt
 import tmt.base
@@ -298,7 +298,7 @@ class GuestContainer(tmt.Guest):
             self,
             source: Optional[Path] = None,
             destination: Optional[Path] = None,
-            options: Optional[List[str]] = None,
+            options: Optional[list[str]] = None,
             superuser: bool = False) -> None:
         """ Make sure that the workdir has a correct selinux context """
         if not self.is_ready:
@@ -320,8 +320,8 @@ class GuestContainer(tmt.Guest):
             self,
             source: Optional[Path] = None,
             destination: Optional[Path] = None,
-            options: Optional[List[str]] = None,
-            extend_options: Optional[List[str]] = None) -> None:
+            options: Optional[list[str]] = None,
+            extend_options: Optional[list[str]] = None) -> None:
         """ Nothing to be done to pull workdir """
         if not self.is_ready:
             return

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 
 import dataclasses
 import datetime

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -7,7 +7,7 @@ import platform
 import re
 import time
 import types
-from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import click
 import pint
@@ -285,7 +285,7 @@ class TestcloudGuestData(tmt.steps.provision.GuestSshData):
     def show(
             self,
             *,
-            keys: Optional[List[str]] = None,
+            keys: Optional[list[str]] = None,
             verbose: int = 0,
             logger: tmt.log.Logger) -> None:
 

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import TYPE_CHECKING, Any, Optional, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, cast
 
 import click
 
@@ -39,7 +39,7 @@ class ReportPlugin(tmt.steps.GuestlessPlugin[ReportStepDataT]):
     def base_command(
             cls,
             usage: str,
-            method_class: Optional[Type[click.Command]] = None) -> click.Command:
+            method_class: Optional[type[click.Command]] = None) -> click.Command:
         """ Create base click command (common for all report plugins) """
 
         # Prepare general usage message for the step

--- a/tmt/templates.py
+++ b/tmt/templates.py
@@ -1,6 +1,5 @@
 """ Default Templates """
 
-from typing import Dict
 
 INIT_TEMPLATES = ['mini', 'base', 'full']
 
@@ -8,8 +7,8 @@ INIT_TEMPLATES = ['mini', 'base', 'full']
 #  Test Templates
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TEST: Dict[str, str] = {}
-TEST_METADATA: Dict[str, str] = {}
+TEST: dict[str, str] = {}
+TEST_METADATA: dict[str, str] = {}
 
 TEST_METADATA['shell'] = """
 summary: Concise summary describing what the test does
@@ -68,7 +67,7 @@ DEFAULT_PLAN = f"""
         how: tmt
 """.lstrip()
 
-PLAN: Dict[str, str] = {}
+PLAN: dict[str, str] = {}
 
 PLAN['mini'] = """
 summary:
@@ -104,7 +103,7 @@ execute:
 #  Story Templates
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-STORY: Dict[str, str] = {}
+STORY: dict[str, str] = {}
 
 STORY['mini'] = """
 story: As a user I want to do this and that.

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -34,17 +34,13 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    Dict,
     Generic,
     Iterable,
     Iterator,
-    List,
     Literal,
     Optional,
     Pattern,
     Sequence,
-    Tuple,
-    Type,
     TypeVar,
     Union,
     cast,
@@ -242,7 +238,7 @@ class cached_property(Generic[T]):  # noqa: N801
         return value
 
 
-class FmfContext(Dict[str, List[str]]):
+class FmfContext(dict[str, list[str]]):
     """
     Represents an fmf context.
 
@@ -250,11 +246,11 @@ class FmfContext(Dict[str, List[str]]):
     and https://fmf.readthedocs.io/en/latest/context.html.
     """
 
-    def __init__(self, data: Optional[Dict[str, List[str]]] = None) -> None:
+    def __init__(self, data: Optional[dict[str, list[str]]] = None) -> None:
         super().__init__(data or {})
 
     @classmethod
-    def _normalize_command_line(cls, spec: List[str], logger: tmt.log.Logger) -> 'FmfContext':
+    def _normalize_command_line(cls, spec: list[str], logger: tmt.log.Logger) -> 'FmfContext':
         """
         Normalize command line fmf context specification.
 
@@ -271,7 +267,7 @@ class FmfContext(Dict[str, List[str]]):
     @classmethod
     def _normalize_fmf(
             cls,
-            spec: Dict[str, Union[str, List[str]]],
+            spec: dict[str, Union[str, list[str]]],
             logger: tmt.log.Logger) -> 'FmfContext':
         """
         Normalize fmf context specification from fmf node.
@@ -317,14 +313,14 @@ class FmfContext(Dict[str, List[str]]):
 
         raise NormalizationError(key_address, spec, 'a list of strings or a dictionary')
 
-    def to_spec(self) -> Dict[str, Any]:
+    def to_spec(self) -> dict[str, Any]:
         """ Convert to a form suitable for saving in a specification file """
 
         return dict(self)
 
 
 # A "environment" type, representing name/value environment variables.
-EnvironmentType = Dict[str, str]
+EnvironmentType = dict[str, str]
 
 # Workdir argument type, can be True, a string, a path or None
 WorkdirArgumentType = Union[Literal[True], Path, None]
@@ -336,7 +332,7 @@ WorkdirType = Optional[Path]
 PLAN_SKIP_WORKTREE_INIT = 'plan_skip_worktree_init'
 
 # List of schemas that need to be ignored in a plan
-PLAN_SCHEMA_IGNORED_IDS: List[str] = [
+PLAN_SCHEMA_IGNORED_IDS: list[str] = [
     '/schemas/provision/hardware',
     '/schemas/provision/kickstart'
     ]
@@ -410,7 +406,7 @@ class StreamLogger(Thread):
         super().__init__(daemon=True)
 
         self.stream = stream
-        self.output: List[str] = []
+        self.output: list[str] = []
         self.log_header = log_header
         self.logger = logger
         self.click_context = click_context
@@ -470,7 +466,7 @@ _CommandElement = str
 #: A single element of raw command line in its ``list`` form.
 RawCommandElement = Union[str, Path]
 #: A raw command line form, a list of elements.
-RawCommand = List[RawCommandElement]
+RawCommand = list[RawCommandElement]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -505,7 +501,7 @@ class ShellScript:
         return ShellScript(f'{self} || {other}')
 
     @classmethod
-    def from_scripts(cls, scripts: List['ShellScript']) -> 'ShellScript':
+    def from_scripts(cls, scripts: list['ShellScript']) -> 'ShellScript':
         """
         Create a single script from many shorter ones.
 
@@ -542,7 +538,7 @@ class Command:
     def __str__(self) -> str:
         return self.to_element()
 
-    def __add__(self, other: Union['Command', RawCommand, List[str]]) -> 'Command':
+    def __add__(self, other: Union['Command', RawCommand, list[str]]) -> 'Command':
         if isinstance(other, Command):
             return Command(*self._command, *other._command)
 
@@ -568,7 +564,7 @@ class Command:
 
         return ShellScript(' '.join(shlex.quote(s) for s in self._command))
 
-    def to_popen(self) -> List[str]:
+    def to_popen(self) -> list[str]:
         """ Convert a command to form accepted by :py:mod:`subprocess.Popen` """
 
         return list(self._command)
@@ -1032,7 +1028,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         return invocation.context.obj
 
     @property
-    def _cli_options(self) -> Dict[str, Any]:
+    def _cli_options(self) -> dict[str, Any]:
         """
         CLI options attached to the CLI invocation.
 
@@ -1503,11 +1499,11 @@ class _MultiInvokableCommonMeta(_CommonMeta):
     def __init__(cls, *args: Any, **kwargs: Any) -> None:  # noqa: N805
         super().__init__(*args, **kwargs)
 
-        cls.cli_invocations: List['tmt.cli.CliInvocation'] = []
+        cls.cli_invocations: list['tmt.cli.CliInvocation'] = []
 
 
 class MultiInvokableCommon(Common, metaclass=_MultiInvokableCommonMeta):
-    cli_invocations: List['tmt.cli.CliInvocation']
+    cli_invocations: list['tmt.cli.CliInvocation']
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -1550,7 +1546,7 @@ class GeneralError(Exception):
     def __init__(
             self,
             message: str,
-            causes: Optional[List[Exception]] = None,
+            causes: Optional[list[Exception]] = None,
             *args: Any,
             **kwargs: Any) -> None:
         """
@@ -1615,7 +1611,7 @@ class SpecificationError(MetadataError):
     def __init__(
             self,
             message: str,
-            validation_errors: Optional[List[Tuple[jsonschema.ValidationError, str]]] = None,
+            validation_errors: Optional[list[tuple[jsonschema.ValidationError, str]]] = None,
             *args: Any,
             **kwargs: Any) -> None:
         super().__init__(message, *args, **kwargs)
@@ -1698,7 +1694,7 @@ class WaitingTimedOutError(GeneralError):
 class RetryError(GeneralError):
     """ Retries unsuccessful """
 
-    def __init__(self, label: str, causes: List[Exception]) -> None:
+    def __init__(self, label: str, causes: list[Exception]) -> None:
         super().__init__(f"Retries of {label} unsuccessful.", causes)
 
 
@@ -1806,14 +1802,14 @@ def render_exception(exception: BaseException) -> Iterator[str]:
         yield ''
         yield from _indent(render_exception(cause))
 
-    def _render_causes(causes: List[BaseException]) -> Iterator[str]:
+    def _render_causes(causes: list[BaseException]) -> Iterator[str]:
         yield ''
         yield f'The exception was caused by {len(causes)} earlier exceptions'
 
         for number, cause in enumerate(causes, start=1):
             yield from _render_cause(number, cause)
 
-    causes: List[BaseException] = []
+    causes: list[BaseException] = []
 
     if isinstance(exception, GeneralError) and exception.causes:
         causes += exception.causes
@@ -1837,7 +1833,7 @@ def show_exception(exception: BaseException) -> None:
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
-def uniq(values: List[T]) -> List[T]:
+def uniq(values: list[T]) -> list[T]:
     """ Return a list of all unique items from ``values`` """
     return list(set(values))
 
@@ -1851,7 +1847,7 @@ def duplicates(values: Iterable[Optional[T]]) -> Iterator[T]:
         yield value
 
 
-def flatten(lists: Iterable[List[T]], unique: bool = False) -> List[T]:
+def flatten(lists: Iterable[list[T]], unique: bool = False) -> list[T]:
     """
     "Flatten" a list of lists into a single-level list.
 
@@ -1861,7 +1857,7 @@ def flatten(lists: Iterable[List[T]], unique: bool = False) -> List[T]:
     :returns: list of items from all given lists.
     """
 
-    flattened: List[T] = sum(lists, [])
+    flattened: list[T] = sum(lists, [])
 
     return uniq(flattened) if unique else flattened
 
@@ -1879,9 +1875,9 @@ def ascii(text: Any) -> bytes:
 
 
 def listify(
-        data: Union[Tuple[Any, ...], List[Any], str, Dict[Any, Any]],
+        data: Union[tuple[Any, ...], list[Any], str, dict[Any, Any]],
         split: bool = False,
-        keys: Optional[List[str]] = None) -> Union[List[Any], Dict[Any, Any]]:
+        keys: Optional[list[str]] = None) -> Union[list[Any], dict[Any, Any]]:
     """
     Ensure that variable is a list, convert if necessary
     For dictionaries check all items or only those with provided keys.
@@ -1926,7 +1922,7 @@ def get_full_metadata(fmf_tree_path: Path, node_path: str) -> Any:
     return fmf.Tree(fmf_tree_path).find(node_path).data
 
 
-def filter_paths(directory: Path, searching: List[str], files_only: bool = False) -> List[Path]:
+def filter_paths(directory: Path, searching: list[str], files_only: bool = False) -> list[Path]:
     """
     Filter files for specific paths we are searching for inside a directory
 
@@ -1935,7 +1931,7 @@ def filter_paths(directory: Path, searching: List[str], files_only: bool = False
     all_paths = list(directory.rglob('*'))  # get all filepaths for given dir recursively
     alldirs = [str(dir) for dir in all_paths if dir.is_dir()]
     allfiles = [str(file) for file in all_paths if not file.is_dir()]
-    found_paths: List[str] = []
+    found_paths: list[str] = []
 
     for search_string in searching:
         if search_string == '/':
@@ -2003,7 +1999,7 @@ def _add_file_vars(
         result[name] = str(value)
 
 
-def shell_to_dict(variables: Union[str, List[str]]) -> EnvironmentType:
+def shell_to_dict(variables: Union[str, list[str]]) -> EnvironmentType:
     """
     Convert shell-like variables into a dictionary
 
@@ -2028,7 +2024,7 @@ def shell_to_dict(variables: Union[str, List[str]]) -> EnvironmentType:
 
 def environment_to_dict(
         *,
-        variables: Union[str, List[str]],
+        variables: Union[str, list[str]],
         logger: tmt.log.Logger) -> EnvironmentType:
     """
     Convert environment variables into a dictionary
@@ -2318,7 +2314,7 @@ def modify_environ(
 
 
 def dict_to_yaml(
-        data: Union[Dict[str, Any], List[Any], 'tmt.base._RawFmfId'],
+        data: Union[dict[str, Any], list[Any], 'tmt.base._RawFmfId'],
         width: Optional[int] = None,
         sort: bool = False,
         start: bool = False) -> str:
@@ -2368,7 +2364,7 @@ YamlTypType = Literal['rt', 'safe', 'unsafe', 'base']
 
 
 def yaml_to_dict(data: Any,
-                 yaml_type: Optional[YamlTypType] = None) -> Dict[Any, Any]:
+                 yaml_type: Optional[YamlTypType] = None) -> dict[Any, Any]:
     """ Convert yaml into dictionary """
     yaml = YAML(typ=yaml_type)
     loaded_data = yaml.load(data)
@@ -2382,7 +2378,7 @@ def yaml_to_dict(data: Any,
 
 
 def yaml_to_list(data: Any,
-                 yaml_type: Optional[YamlTypType] = 'safe') -> List[Any]:
+                 yaml_type: Optional[YamlTypType] = 'safe') -> list[Any]:
     """ Convert yaml into list """
     yaml = YAML(typ=yaml_type)
     try:
@@ -2399,7 +2395,7 @@ def yaml_to_list(data: Any,
     return loaded_data
 
 
-def json_to_list(data: Any) -> List[Any]:
+def json_to_list(data: Any) -> list[Any]:
     """ Convert json into list """
 
     try:
@@ -2415,7 +2411,7 @@ def json_to_list(data: Any) -> List[Any]:
 
 
 #: A type representing compatible sources of keys and values.
-KeySource = Union[Dict[str, Any], fmf.Tree]
+KeySource = Union[dict[str, Any], fmf.Tree]
 
 #: Type of field's normalization callback.
 NormalizeCallback = Callable[[str, Any, tmt.log.Logger], T]
@@ -2436,7 +2432,7 @@ UnserializeCallback = Callable[[Any], T]
 #: reduces to data classes and data class instances. Our :py:class:`DataContainer`
 #: are perfectly compatible data classes, but some helper methods may be used
 #: on raw data classes, not just on ``DataContainer`` instances.
-ContainerClass: 'TypeAlias' = Type['DataclassInstance']
+ContainerClass: 'TypeAlias' = type['DataclassInstance']
 ContainerInstance: 'TypeAlias' = 'DataclassInstance'
 Container = Union[ContainerClass, ContainerInstance]
 
@@ -2465,7 +2461,7 @@ class FieldMetadata(Generic[T]):
 
     #: CLI option parameters, for lazy option creation.
     option_args: Optional['FieldCLIOption'] = None
-    option_kwargs: Optional[Dict[str, Any]] = None
+    option_kwargs: Optional[dict[str, Any]] = None
     option_choices: Union[None, Sequence[str], Callable[[], Sequence[str]]] = None
 
     #: A :py:func:`click.option` decorator defining a corresponding CLI option.
@@ -2521,7 +2517,7 @@ def container_values(container: ContainerInstance) -> Iterator[Any]:
         yield container.__dict__[field.name]
 
 
-def container_items(container: ContainerInstance) -> Iterator[Tuple[str, Any]]:
+def container_items(container: ContainerInstance) -> Iterator[tuple[str, Any]]:
     """ Iterate over key/value pairs in a container """
 
     for field in container_fields(container):
@@ -2531,22 +2527,22 @@ def container_items(container: ContainerInstance) -> Iterator[Tuple[str, Any]]:
 @overload
 def container_field(
         container: ContainerClass,
-        key: str) -> Tuple[str, str, dataclasses.Field[Any], 'FieldMetadata[Any]']:
+        key: str) -> tuple[str, str, dataclasses.Field[Any], 'FieldMetadata[Any]']:
     pass
 
 
 @overload
 def container_field(
         container: ContainerInstance,
-        key: str) -> Tuple[str, str, Any, dataclasses.Field[Any], 'FieldMetadata[Any]']:
+        key: str) -> tuple[str, str, Any, dataclasses.Field[Any], 'FieldMetadata[Any]']:
     pass
 
 
 def container_field(
         container: Container,
         key: str) -> Union[
-            Tuple[str, str, dataclasses.Field[Any], 'FieldMetadata[Any]'],
-            Tuple[str, str, Any, dataclasses.Field[Any], 'FieldMetadata[Any]']]:
+            tuple[str, str, dataclasses.Field[Any], 'FieldMetadata[Any]'],
+            tuple[str, str, Any, dataclasses.Field[Any], 'FieldMetadata[Any]']]:
     """
     Return a dataclass/data container field info by the field's name.
 
@@ -2584,7 +2580,7 @@ def container_field(
 class DataContainer:
     """ A base class for objects that have keys and values """
 
-    def to_dict(self) -> Dict[str, Any]:
+    def to_dict(self) -> dict[str, Any]:
         """
         Convert to a mapping.
 
@@ -2593,7 +2589,7 @@ class DataContainer:
 
         return dict(self.items())
 
-    def to_minimal_dict(self) -> Dict[str, Any]:
+    def to_minimal_dict(self) -> dict[str, Any]:
         """
         Convert to a mapping with unset keys omitted.
 
@@ -2618,7 +2614,7 @@ class DataContainer:
 
         yield from container_values(self)
 
-    def items(self) -> Iterator[Tuple[str, Any]]:
+    def items(self) -> Iterator[tuple[str, Any]]:
         """ Iterate over key/value pairs """
 
         yield from container_items(self)
@@ -2701,7 +2697,7 @@ SpecOutT = TypeVar('SpecOutT')
 
 class SpecBasedContainer(Generic[SpecInT, SpecOutT], DataContainer):
     @classmethod
-    def from_spec(cls: Type[SpecBasedContainerT], spec: SpecInT) -> SpecBasedContainerT:
+    def from_spec(cls: type[SpecBasedContainerT], spec: SpecInT) -> SpecBasedContainerT:
         """
         Convert from a specification file or from a CLI option
 
@@ -2761,7 +2757,7 @@ class SerializableContainer(DataContainer):
             setattr(obj, name, value)
 
     @classmethod
-    def extract_from(cls: Type[SerializableContainerDerivedType],
+    def extract_from(cls: type[SerializableContainerDerivedType],
                      obj: Any) -> SerializableContainerDerivedType:
         """ Extract keys from given object, and save them in a container """
 
@@ -2780,7 +2776,7 @@ class SerializableContainer(DataContainer):
     # them later.
     #
 
-    def to_serialized(self) -> Dict[str, Any]:
+    def to_serialized(self) -> dict[str, Any]:
         """
         Convert to a form suitable for saving in a file.
 
@@ -2789,7 +2785,7 @@ class SerializableContainer(DataContainer):
         See :py:meth:`from_serialized` for its counterpart.
         """
 
-        def _produce_serialized() -> Iterator[Tuple[str, Any]]:
+        def _produce_serialized() -> Iterator[tuple[str, Any]]:
             for key in container_keys(self):
                 _, option, value, _, metadata = container_field(self, key)
 
@@ -2811,8 +2807,8 @@ class SerializableContainer(DataContainer):
 
     @classmethod
     def from_serialized(
-            cls: Type[SerializableContainerDerivedType],
-            serialized: Dict[str, Any]) -> SerializableContainerDerivedType:
+            cls: type[SerializableContainerDerivedType],
+            serialized: dict[str, Any]) -> SerializableContainerDerivedType:
         """
         Convert from a serialized form loaded from a file.
 
@@ -2826,7 +2822,7 @@ class SerializableContainer(DataContainer):
         # already know what class to restore: this one.
         serialized.pop('__class__', None)
 
-        def _produce_unserialized() -> Iterator[Tuple[str, Any]]:
+        def _produce_unserialized() -> Iterator[tuple[str, Any]]:
             for option, value in serialized.items():
                 key = option_to_key(option)
 
@@ -2853,7 +2849,7 @@ class SerializableContainer(DataContainer):
     # silence mypy about the missing actual type.
     @staticmethod
     def unserialize(
-            serialized: Dict[str, Any],
+            serialized: dict[str, Any],
             logger: tmt.log.Logger
             ) -> SerializableContainerDerivedType:  # type: ignore[misc,type-var]
         """
@@ -2921,7 +2917,7 @@ def markdown_to_html(filename: Path) -> str:
 
 
 def shell_variables(
-        data: Union[List[str], Tuple[str, ...], Dict[str, Any]]) -> List[str]:
+        data: Union[list[str], tuple[str, ...], dict[str, Any]]) -> list[str]:
     """
     Prepare variables to be consumed by shell
 
@@ -3076,7 +3072,7 @@ def _format_bool(
 
 
 def _format_list(
-        value: List[Any],
+        value: list[Any],
         window_size: Optional[int],
         key_color: Optional[str],
         list_format: ListFormat,
@@ -3192,7 +3188,7 @@ def _format_str(
 
 
 def _format_dict(
-        value: Dict[Any, Any],
+        value: dict[Any, Any],
         window_size: Optional[int],
         key_color: Optional[str],
         list_format: ListFormat,
@@ -3232,7 +3228,7 @@ def _format_dict(
             # formatted as a list with one item.
             raise AssertionError
 
-        def _emit_list_entries(lines: List[str]) -> Iterator[str]:
+        def _emit_list_entries(lines: list[str]) -> Iterator[str]:
             for i, line in enumerate(lines):
                 if i == 0:
                     yield f'{_FORMAT_VALUE_LIST_ENTRY_INDENT}{line}'
@@ -3240,7 +3236,7 @@ def _format_dict(
                 else:
                     yield f'{_FORMAT_VALUE_DICT_ENTRY_INDENT}{line}'
 
-        def _emit_dict_entry(lines: List[str]) -> Iterator[str]:
+        def _emit_dict_entry(lines: list[str]) -> Iterator[str]:
             yield from (f'{_FORMAT_VALUE_DICT_ENTRY_INDENT}{line}' for line in lines)
 
         # UX: special handling of containers with just a single item, i.e. the
@@ -3331,7 +3327,7 @@ ValueFormatter = Callable[
 
 #: Available formatters, as ``type``/``formatter`` pairs. If a value is instance
 #: of ``type``, the ``formatter`` is called to render it.
-_VALUE_FORMATTERS: List[Tuple[Any, ValueFormatter]] = [
+_VALUE_FORMATTERS: list[tuple[Any, ValueFormatter]] = [
     (bool, _format_bool),
     (str, _format_str),
     (list, _format_list),
@@ -3344,7 +3340,7 @@ def _format_value(
         window_size: Optional[int] = None,
         key_color: Optional[str] = None,
         list_format: ListFormat = ListFormat.LISTED,
-        wrap: FormatWrap = 'auto') -> List[str]:
+        wrap: FormatWrap = 'auto') -> list[str]:
     """
     Render a nicely-formatted string representation of a value.
 
@@ -3429,7 +3425,7 @@ def format_value(
         # rendered across multiple lines, we need to add `-` prefix & indentation
         # to signal where items start and end visualy.
         if len(value) > 1 and any('\n' in formatted_item for formatted_item in formatted_value):
-            prefixed: List[str] = []
+            prefixed: list[str] = []
 
             for item in formatted_value:
                 for i, line in enumerate(item.splitlines()):
@@ -3446,7 +3442,7 @@ def format_value(
 
 def format(
         key: str,
-        value: Union[None, bool, str, List[Any], Dict[Any, Any]] = None,
+        value: Union[None, bool, str, list[Any], dict[Any, Any]] = None,
         indent: int = 24,
         window_size: int = OUTPUT_WIDTH,
         wrap: FormatWrap = 'auto',
@@ -3562,7 +3558,7 @@ def create_directory(
     # Streamline the logging a bit: wrap the creating with a function returning
     # a message & optional exception. Later we will send the message to debug
     # log, and maybe also to console.
-    def _create_directory() -> Tuple[str, Optional[Exception]]:
+    def _create_directory() -> tuple[str, Optional[Exception]]:
         if path.is_dir():
             return (f"{name.capitalize()} '{path}' already exists.", None)
 
@@ -3634,7 +3630,7 @@ def check_git_url(url: str) -> str:
         raise GitUrlError(f"Unable to contact remote git via '{url}'.")
 
 
-PUBLIC_GIT_URL_PATTERNS: List[Tuple[str, str]] = [
+PUBLIC_GIT_URL_PATTERNS: list[tuple[str, str]] = [
     # Gitlab on private namepace is synced to pkgs.devel.redhat.com
     # old: https://gitlab.com/redhat/rhel/tests/bash
     # old: git@gitlab.com:redhat/rhel/tests/bash
@@ -3684,7 +3680,7 @@ def public_git_url(url: str) -> str:
     return rewrite_git_url(url, PUBLIC_GIT_URL_PATTERNS)
 
 
-def rewrite_git_url(url: str, patterns: List[Tuple[str, str]]) -> str:
+def rewrite_git_url(url: str, patterns: list[tuple[str, str]]) -> str:
     """
     Rewrite git url based on supplied patterns
 
@@ -3738,7 +3734,7 @@ def inject_auth_git_url(url: str) -> str:
     return url
 
 
-CLONABLE_GIT_URL_PATTERNS: List[Tuple[str, str]] = [
+CLONABLE_GIT_URL_PATTERNS: list[tuple[str, str]] = [
     # git:// protocol is not possible for r/o access
     # old: git://pkgs.devel.redhat.com/tests/bash
     # new: https://pkgs.devel.redhat.com/git/tests/bash
@@ -3909,8 +3905,8 @@ class retry_session(contextlib.AbstractContextManager):  # type: ignore[type-arg
     def create(
             retries: int = DEFAULT_RETRY_SESSION_RETRIES,
             backoff_factor: float = DEFAULT_RETRY_SESSION_BACKOFF_FACTOR,
-            allowed_methods: Optional[Tuple[str, ...]] = None,
-            status_forcelist: Optional[Tuple[int, ...]] = None,
+            allowed_methods: Optional[tuple[str, ...]] = None,
+            status_forcelist: Optional[tuple[int, ...]] = None,
             timeout: Optional[int] = None
             ) -> requests.Session:
 
@@ -3950,8 +3946,8 @@ class retry_session(contextlib.AbstractContextManager):  # type: ignore[type-arg
             self,
             retries: int = DEFAULT_RETRY_SESSION_RETRIES,
             backoff_factor: float = DEFAULT_RETRY_SESSION_BACKOFF_FACTOR,
-            allowed_methods: Optional[Tuple[str, ...]] = None,
-            status_forcelist: Optional[Tuple[int, ...]] = None,
+            allowed_methods: Optional[tuple[str, ...]] = None,
+            status_forcelist: Optional[tuple[int, ...]] = None,
             timeout: Optional[int] = None
             ) -> None:
         self.retries = retries
@@ -4079,7 +4075,7 @@ def parse_yaml(content: str) -> EnvironmentType:
     return {key: str(value) for key, value in yaml_as_dict.items()}
 
 
-def validate_git_status(test: 'tmt.base.Test') -> Tuple[bool, str]:
+def validate_git_status(test: 'tmt.base.Test') -> tuple[bool, str]:
     """
     Validate that test has current metadata on fmf_id
 
@@ -4193,7 +4189,7 @@ def generate_runs(
         yield abs_child_path
 
 
-def load_run(run: 'tmt.base.Run') -> Tuple[bool, Optional[Exception]]:
+def load_run(run: 'tmt.base.Run') -> tuple[bool, Optional[Exception]]:
     """ Load a run and its steps from the workdir """
     try:
         run.load_from_workdir()
@@ -4209,7 +4205,7 @@ def load_run(run: 'tmt.base.Run') -> Tuple[bool, Optional[Exception]]:
 #  StructuredField
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-SFSectionValueType = Union[str, List[str]]
+SFSectionValueType = Union[str, list[str]]
 
 
 class StructuredField:
@@ -4374,8 +4370,8 @@ class StructuredField:
         self._footer: str = ""
         # Sections are internally stored in their serialized form, i.e. as
         # strings.
-        self._sections: Dict[str, str] = {}
-        self._order: List[str] = []
+        self._sections: dict[str, str] = {}
+        self._order: list[str] = []
         self._multi = multi
         if text is not None:
             self.load(text)
@@ -4492,9 +4488,9 @@ class StructuredField:
             result.append(self._footer)
         return "\n".join(result)
 
-    def _read_section(self, content: str) -> Dict[str, SFSectionValueType]:
+    def _read_section(self, content: str) -> dict[str, SFSectionValueType]:
         """ Parse config section and return ordered dictionary """
-        dictionary: Dict[str, SFSectionValueType] = OrderedDict()
+        dictionary: dict[str, SFSectionValueType] = OrderedDict()
         for line in content.split("\n"):
             # Remove comments and skip empty lines
             line = re.sub("#.*", "", line)
@@ -4518,7 +4514,7 @@ class StructuredField:
                 dictionary[key] = value
         return dictionary
 
-    def _write_section(self, dictionary: Dict[str, SFSectionValueType]) -> str:
+    def _write_section(self, dictionary: dict[str, SFSectionValueType]) -> str:
         """ Convert dictionary into a config section format """
         section = ""
         for key in dictionary:
@@ -4533,7 +4529,7 @@ class StructuredField:
     #  StructuredField Methods
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    def iterate(self) -> Iterator[Tuple[str, str]]:
+    def iterate(self) -> Iterator[tuple[str, str]]:
         """ Return (section, content) tuples for all sections """
         for section in self:
             yield section, self._sections[section]
@@ -4588,7 +4584,7 @@ class StructuredField:
             self._footer = content
         return self._footer
 
-    def sections(self) -> List[str]:
+    def sections(self) -> list[str]:
         """ Get the list of available sections """
         return self._order
 
@@ -4676,7 +4672,7 @@ class DistGitHandler:
     lookaside_server: str
     remote_substring: Pattern[str]
 
-    def url_and_name(self, cwd: Optional[Path] = None) -> List[Tuple[str, str]]:
+    def url_and_name(self, cwd: Optional[Path] = None) -> list[tuple[str, str]]:
         """
         Return list of urls and basenames of the used source
 
@@ -4711,7 +4707,7 @@ class DistGitHandler:
                 "No sources found in '{self.sources_file_name}' file.")
         return ret_values
 
-    def its_me(self, remotes: List[str]) -> bool:
+    def its_me(self, remotes: list[str]) -> bool:
         """ True if self can work with remotes """
         return any(self.remote_substring.search(item) for item in remotes)
 
@@ -4742,7 +4738,7 @@ class RedHatGitlab(DistGitHandler):
 
 
 def get_distgit_handler(
-        remotes: Optional[List[str]] = None,
+        remotes: Optional[list[str]] = None,
         usage_name: Optional[str] = None) -> DistGitHandler:
     """
     Return the right DistGitHandler
@@ -4760,7 +4756,7 @@ def get_distgit_handler(
     raise GeneralError(f"No known remote in '{remotes}'.")
 
 
-def get_distgit_handler_names() -> List[str]:
+def get_distgit_handler_names() -> list[str]:
     """ All known distgit handlers """
     return [i.usage_name for i in DistGitHandler.__subclasses__()]
 
@@ -4962,7 +4958,7 @@ class UpdatableMessage(contextlib.AbstractContextManager):  # type: ignore[type-
         self._update_message_area(value, color=color)
 
 
-def find_fmf_root(path: Path) -> List[Path]:
+def find_fmf_root(path: Path) -> list[Path]:
     """
     Search trough path and return all fmf roots that exist there
 
@@ -4994,8 +4990,8 @@ def find_fmf_root(path: Path) -> List[Path]:
 # tmt code is not actually "reading" it. Loaded schema is passed down to
 # jsonschema library, and while `Any` would be perfectly valid, let's use an
 # alias to make schema easier to track in our code.
-Schema = Dict[str, Any]
-SchemaStore = Dict[str, Schema]
+Schema = dict[str, Any]
+SchemaStore = dict[str, Schema]
 
 
 def _patch_plan_schema(schema: Schema, store: SchemaStore) -> None:
@@ -5030,7 +5026,7 @@ def _patch_plan_schema(schema: Schema, store: SchemaStore) -> None:
         step_plugin_schema_ids = [schema_id for schema_id in store if schema_id.startswith(
             step_schema_prefix) and schema_id not in PLAN_SCHEMA_IGNORED_IDS]
 
-        refs: List[Schema] = [
+        refs: list[Schema] = [
             {'$ref': schema_id} for schema_id in step_plugin_schema_ids
             ]
 
@@ -5161,7 +5157,7 @@ def _prenormalize_fmf_node(node: fmf.Tree, schema_name: str, logger: tmt.log.Log
     # Avoid possible circular imports
     import tmt.steps
 
-    def _process_step(step_name: str, step: Dict[Any, Any]) -> None:
+    def _process_step(step_name: str, step: dict[Any, Any]) -> None:
         """
         Process a single step configuration.
         """
@@ -5228,7 +5224,7 @@ def _prenormalize_fmf_node(node: fmf.Tree, schema_name: str, logger: tmt.log.Log
 def validate_fmf_node(
         node: fmf.Tree,
         schema_name: str,
-        logger: tmt.log.Logger) -> List[Tuple[jsonschema.ValidationError, str]]:
+        logger: tmt.log.Logger) -> list[tuple[jsonschema.ValidationError, str]]:
     """ Validate a given fmf node """
 
     node = _prenormalize_fmf_node(node, schema_name, logger)
@@ -5243,7 +5239,7 @@ def validate_fmf_node(
     # users to point finger on each and every issue. But don't throw the original
     # errors away!
 
-    errors: List[Tuple[jsonschema.ValidationError, str]] = []
+    errors: list[tuple[jsonschema.ValidationError, str]] = []
 
     for error in result.errors:
         path = f'{node.name}:{".".join(error.path)}'
@@ -5534,8 +5530,8 @@ def normalize_storage_size(
 
 def normalize_string_list(
         key_address: str,
-        value: Union[None, str, List[str]],
-        logger: tmt.log.Logger) -> List[str]:
+        value: Union[None, str, list[str]],
+        logger: tmt.log.Logger) -> list[str]:
     """
     Normalize a string-or-list-of-strings input value.
 
@@ -5582,8 +5578,8 @@ def normalize_path(
 
 def normalize_path_list(
         key_address: str,
-        value: Union[None, str, List[str]],
-        logger: tmt.log.Logger) -> List[Path]:
+        value: Union[None, str, list[str]],
+        logger: tmt.log.Logger) -> list[Path]:
     """
     Normalize a path-or-list-of-paths input value.
 
@@ -5618,8 +5614,8 @@ def normalize_path_list(
 
 def normalize_shell_script_list(
         key_address: str,
-        value: Union[None, str, List[str]],
-        logger: tmt.log.Logger) -> List[ShellScript]:
+        value: Union[None, str, list[str]],
+        logger: tmt.log.Logger) -> list[ShellScript]:
     """
     Normalize a string-or-list-of-strings input value.
 
@@ -5687,10 +5683,10 @@ class NormalizeKeysMixin(_CommonBase):
     """
 
     # If specified, keys would be iterated over in the order as listed here.
-    _KEYS_SHOW_ORDER: List[str] = []
+    _KEYS_SHOW_ORDER: list[str] = []
 
     @classmethod
-    def _iter_key_annotations(cls) -> Iterator[Tuple[str, Any]]:
+    def _iter_key_annotations(cls) -> Iterator[tuple[str, Any]]:
         """
         Iterate over keys' type annotations.
 
@@ -5702,7 +5698,7 @@ class NormalizeKeysMixin(_CommonBase):
             pairs of key name and its annotations.
         """
 
-        def _iter_class_annotations(klass: type) -> Iterator[Tuple[str, Any]]:
+        def _iter_class_annotations(klass: type) -> Iterator[tuple[str, Any]]:
             # Skip, needs fixes to become compatible
             if klass is Common:
                 return
@@ -5735,7 +5731,7 @@ class NormalizeKeysMixin(_CommonBase):
         for keyname, _ in cls._iter_key_annotations():
             yield keyname
 
-    def items(self) -> Iterator[Tuple[str, Any]]:
+    def items(self) -> Iterator[tuple[str, Any]]:
         """
         Iterate over keys and their values.
 
@@ -5754,14 +5750,14 @@ class NormalizeKeysMixin(_CommonBase):
     # TODO: exists for backward compatibility for the transition period. Once full
     # type annotations land, there should be no need for extra _keys attribute.
     @classmethod
-    def _keys(cls) -> List[str]:
+    def _keys(cls) -> list[str]:
         """ Return a list of names of object's keys. """
 
         return list(cls.keys())
 
     def _load_keys(
             self,
-            key_source: Dict[str, Any],
+            key_source: dict[str, Any],
             key_source_name: str,
             logger: tmt.log.Logger) -> None:
         """ Extract values for class-level attributes, and verify they match declared types. """
@@ -6074,7 +6070,7 @@ def default_template_environment() -> jinja2.Environment:
 
     def regex_search(
             string: str,
-            pattern: str) -> Union[Optional[str], Tuple[str, ...]]:
+            pattern: str) -> Union[Optional[str], tuple[str, ...]]:
         match = re.search(pattern, string)
 
         if match is None:
@@ -6227,7 +6223,7 @@ def retry(
     :param interval: amount of seconds to wait before a new try
     :param label: action to retry
     """
-    exceptions: List[Exception] = []
+    exceptions: list[Exception] = []
     for i in range(attempts):
         try:
             return func(*args, **kwargs)

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -26,7 +26,6 @@ import unicodedata
 import urllib.parse
 from collections import Counter, OrderedDict
 from contextlib import suppress
-from functools import lru_cache
 from threading import Thread
 from types import ModuleType
 from typing import (
@@ -2065,7 +2064,7 @@ def environment_to_dict(
     return result
 
 
-@lru_cache(maxsize=None)
+@functools.cache
 def environment_file_to_dict(
         *,
         filename: str,
@@ -3616,7 +3615,7 @@ def create_file(
 
 
 # Avoid multiple subprocess calls for the same url
-@lru_cache(maxsize=None)
+@functools.cache
 def check_git_url(url: str) -> str:
     """ Check that a remote git url is accessible """
     try:
@@ -3783,7 +3782,7 @@ def web_git_url(url: str, ref: str, path: Optional[Path] = None) -> str:
     return url
 
 
-@lru_cache(maxsize=None)
+@functools.cache
 def fmf_id(
         *,
         name: str,
@@ -5059,7 +5058,7 @@ def _load_schema(schema_filepath: Path) -> Schema:
         raise FileError(f"Failed to load schema file {schema_filepath}\n{exc}")
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def load_schema(schema_filepath: Path) -> Schema:
     """
     Load a JSON schema from a given filepath.
@@ -5078,7 +5077,7 @@ def load_schema(schema_filepath: Path) -> Schema:
     return schema
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def load_schema_store() -> SchemaStore:
     """
     Load all available JSON schemas, and put them into a "store".
@@ -6119,7 +6118,7 @@ def render_template_file(
         raise GeneralError(f"Could not render template '{template_filepath}'.") from exc
 
 
-@lru_cache(maxsize=None)
+@functools.cache
 def is_selinux_supported() -> bool:
     """
     Returns ``true`` if SELinux filesystem is supported by the kernel, ``false`` otherwise.

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -4654,8 +4654,7 @@ class StructuredField:
                 del (dictionary[item])
             except KeyError:
                 raise StructuredFieldError(
-                    "Unable to remove '{!r}' from section '{!r}'".format(
-                        ascii(item), ascii(section)))
+                    f"Unable to remove '{ascii(item)!r}' from section '{ascii(section)!r}'")
             self._sections[section] = self._write_section(dictionary)
 
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -25,7 +25,9 @@ import traceback
 import unicodedata
 import urllib.parse
 from collections import Counter, OrderedDict
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import suppress
+from re import Pattern
 from threading import Thread
 from types import ModuleType
 from typing import (
@@ -34,12 +36,8 @@ from typing import (
     Any,
     Callable,
     Generic,
-    Iterable,
-    Iterator,
     Literal,
     Optional,
-    Pattern,
-    Sequence,
     TypeVar,
     Union,
     cast,


### PR DESCRIPTION
With the move to Python 3.9 as a minimum version, we can use [pyupgrade](https://github.com/asottile/pyupgrade) to identify and fix deprecated syntax as well as enable `UP` ruff rule.

Vast majority of the line changes are due to PEP 585 – Type Hinting Generics in In Standard Collections.
See: https://docs.astral.sh/ruff/rules/non-pep585-annotation/ (UP006)

The rest of the changes are split into separate commit based on the ruff rule code and I assume they can be squashed once reviewed. 

For reasoning please see [ruff pyupgrade documentation](https://docs.astral.sh/ruff/rules/#pyupgrade-up) for each code.