### PR TITLE
Add .py file extension to docs scripts

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -60,13 +60,13 @@ spec:
 stories:
 	mkdir -p stories
 
-spec/lint.rst: $(SCRIPTSDIR)/generate-lint-checks lint-checks.rst.j2 $(TMTDIR)/base.py
-	$(SCRIPTSDIR)/generate-lint-checks lint-checks.rst.j2 $@
+spec/lint.rst: $(SCRIPTSDIR)/generate-lint-checks.py lint-checks.rst.j2 $(TMTDIR)/base.py
+	$(SCRIPTSDIR)/generate-lint-checks.py lint-checks.rst.j2 $@
 
 generate-lint-checks: spec spec/lint.rst  ## Generate documentation sources for lint checks
 
 generate-stories: stories  ## Generate documentation sources for stories
-	$(SCRIPTSDIR)/generate-stories story.rst.j2
+	$(SCRIPTSDIR)/generate-stories.py story.rst.j2
 
 ##
 ## Help!

--- a/docs/scripts/generate-lint-checks.py
+++ b/docs/scripts/generate-lint-checks.py
@@ -9,7 +9,7 @@ from tmt.lint import Linter
 from tmt.utils import Path, render_template_file
 
 HELP = textwrap.dedent("""
-Usage: generate-lint-checks <TEMPLATE-PATH> <OUTPUT-PATH>
+Usage: generate-lint-checks.py <TEMPLATE-PATH> <OUTPUT-PATH>
 
 Generate docs for all known lint checks.
 """).strip()

--- a/docs/scripts/generate-stories.py
+++ b/docs/scripts/generate-stories.py
@@ -8,7 +8,7 @@ import tmt.plugins
 from tmt.utils import Path
 
 HELP = textwrap.dedent("""
-Usage: generate-stories <TEMPLATE-PATH>
+Usage: generate-stories.py <TEMPLATE-PATH>
 
 Generate pages for stories from their fmf specifications.
 """).strip()


### PR DESCRIPTION

Files in `docs/scripts/` are missing `.py` extension. This makes them ignored by linters.  
I noticed this when running ruff didn't report any issue, even when explicitly asking to check `docs` directory.