### PR TITLE
Move invocation-related fields out of `Test` class

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1073,19 +1073,6 @@ class Test(
         default=0,
         internal=True)
 
-    data_path: Optional[Path] = field(
-        default=None,
-        internal=True,
-        serialize=lambda path: None if path is None else str(path),
-        unserialize=lambda value: None if value is None else Path(value)
-        )
-
-    return_code: Optional[int] = field(default=None, internal=True)
-    start_time: Optional[str] = field(default=None, internal=True)
-    end_time: Optional[str] = field(default=None, internal=True)
-    real_duration: Optional[str] = field(default=None, internal=True)
-    _reboot_count: int = field(default=0, internal=True)
-
     _KEYS_SHOW_ORDER = [
         # Basic test information
         'summary',

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -24,7 +24,7 @@ class AvcDenials(CheckPlugin):
             event: CheckEvent,
             logger: tmt.log.Logger) -> tuple[ResultOutcome, Path]:
 
-        if invocation.test.start_time is None:
+        if invocation.start_time is None:
             raise tmt.utils.GeneralError(
                 "Test does not have start time recorded, cannot run AVC check.")
 
@@ -120,7 +120,7 @@ class AvcDenials(CheckPlugin):
             report += _report_failure('rpm -q selinux-policy', exc)
 
         # Finally, run `ausearch`, to list AVC denials from the time the test started.
-        start_timestamp = datetime.datetime.fromisoformat(invocation.test.start_time).timestamp()
+        start_timestamp = datetime.datetime.fromisoformat(invocation.start_time).timestamp()
 
         script = ShellScript(f"""
 set -x

--- a/tmt/frameworks/beakerlib.py
+++ b/tmt/frameworks/beakerlib.py
@@ -58,12 +58,11 @@ class Beakerlib(TestFramework):
             logger.debug(f"Unable to read '{beakerlib_results_file}'.", level=3)
             note = 'beakerlib: TestResults FileError'
 
-            return [tmt.Result.from_test(
-                test=invocation.test,
+            return [tmt.Result.from_test_invocation(
+                invocation=invocation,
                 result=ResultOutcome.ERROR,
                 note=note,
-                log=log,
-                guest=invocation.guest)]
+                log=log)]
 
         search_result = re.search('TESTRESULT_RESULT_STRING=(.*)', results)
         # States are: started, incomplete and complete
@@ -82,23 +81,22 @@ class Beakerlib(TestFramework):
                 f"No '{missing_piece}' found in '{beakerlib_results_file}'{hint}.",
                 level=3)
             note = 'beakerlib: Result/State missing'
-            return [tmt.Result.from_test(
-                test=invocation.test,
+            return [tmt.Result.from_test_invocation(
+                invocation=invocation,
                 result=ResultOutcome.ERROR,
                 note=note,
-                log=log,
-                guest=invocation.guest)]
+                log=log)]
 
         result = search_result.group(1)
         state = search_state.group(1)
 
         # Check if it was killed by timeout (set by tmt executor)
         actual_result = ResultOutcome.ERROR
-        if invocation.test.return_code == tmt.utils.ProcessExitCodes.TIMEOUT:
+        if invocation.return_code == tmt.utils.ProcessExitCodes.TIMEOUT:
             note = 'timeout'
             invocation.phase.timeout_hint(invocation)
 
-        elif tmt.utils.ProcessExitCodes.is_pidfile(invocation.test.return_code):
+        elif tmt.utils.ProcessExitCodes.is_pidfile(invocation.return_code):
             note = 'pidfile locking'
 
         # Test results should be in complete state
@@ -107,9 +105,8 @@ class Beakerlib(TestFramework):
         # Finally we have a valid result
         else:
             actual_result = ResultOutcome.from_spec(result.lower())
-        return [tmt.Result.from_test(
-            test=invocation.test,
+        return [tmt.Result.from_test_invocation(
+            invocation=invocation,
             result=actual_result,
             note=note,
-            log=log,
-            guest=invocation.guest)]
+            log=log)]

--- a/tmt/frameworks/shell.py
+++ b/tmt/frameworks/shell.py
@@ -29,25 +29,24 @@ class Shell(TestFramework):
             invocation: 'TestInvocation',
             logger: tmt.log.Logger) -> list[tmt.result.Result]:
         """ Check result of a shell test """
-        assert invocation.test.return_code is not None
+        assert invocation.return_code is not None
         note = None
 
         try:
             # Process the exit code and prepare the log path
-            result = {0: ResultOutcome.PASS, 1: ResultOutcome.FAIL}[invocation.test.return_code]
+            result = {0: ResultOutcome.PASS, 1: ResultOutcome.FAIL}[invocation.return_code]
         except KeyError:
             result = ResultOutcome.ERROR
             # Add note about the exceeded duration
-            if invocation.test.return_code == tmt.utils.ProcessExitCodes.TIMEOUT:
+            if invocation.return_code == tmt.utils.ProcessExitCodes.TIMEOUT:
                 note = 'timeout'
                 invocation.phase.timeout_hint(invocation)
 
-            elif tmt.utils.ProcessExitCodes.is_pidfile(invocation.test.return_code):
+            elif tmt.utils.ProcessExitCodes.is_pidfile(invocation.return_code):
                 note = 'pidfile locking'
 
-        return [tmt.Result.from_test(
-            test=invocation.test,
+        return [tmt.Result.from_test_invocation(
+            invocation=invocation,
             result=result,
             log=[invocation.data_path(tmt.steps.execute.TEST_OUTPUT_FILENAME)],
-            note=note,
-            guest=invocation.guest)]
+            note=note)]


### PR DESCRIPTION
Fields that reflect parameters of a single test invocation cannot live in the `Test` class: an instance will be shared by multiple threads when being executed on multiple guests, and therefore `return_code` & co. cannot be owned by `Test`.

Pull Request Checklist

* [x] implement the feature
