### PR TITLE
Add sphinx-builder `linkcheck`

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: [ html ]
+        builder: [ html, linkcheck ]
         include:
           # Run default html builder with warnings as error
           - builder: html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ dependencies = ["tmt[docs]"]
 # script) e.g. -E, -d, and -D. These should not affect generated documentation
 # files below, but it may be providing additional metadata for RTD to index.
 html = "sphinx-build -b html {root}/docs {root}/docs/_build {args}"
+linkcheck = "sphinx-build -b linkcheck {root}/docs {root}/docs/_build {args}"
 man = [
     "cp {root}/docs/header.txt {root}/man.rst",
     "tail -n+8 docs/overview.rst >> {root}/man.rst",


### PR DESCRIPTION
Depends on: #2483

There are a bunch of linkcheck failures, many of which come from the auto-generated pages. Not sure how these should be handled