### PR TITLE
Improve type-hints

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,14 +11,15 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import annotations
+
 import importlib
 import os
 import sys
-from typing import Optional
 
 import tmt.utils
 
-_POSSIBLE_THEMES: list[tuple[Optional[str], str]] = [
+_POSSIBLE_THEMES: list[tuple[str | None, str]] = [
     # Use renku as the default theme
     ('renku_sphinx_theme', 'renku'),
     # Fall back to sphinx_rtd_theme if available
@@ -59,7 +60,7 @@ def _load_theme(
 
 
 if 'TMT_DOCS_THEME' in os.environ:
-    theme_package_name: Optional[str]
+    theme_package_name: str | None
     theme_name: str
 
     theme_specs = os.environ['TMT_DOCS_THEME']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,7 @@ show_error_codes = true
 # annotations across module boundaries.
 follow_imports = "normal"
 
-python_version = "3.9"
+python_version = "3.11"
 files = ["tmt/"]
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
- [ ] Use `__future__.annotations`. This allows to use `3.11` syntax and typing checks while maintaining compatibility with older python versions.
- [x] Bump mypy python_version to 3.11
- [ ] Switch `cast` to a different approach. Not sure what/how to do for this one