### PR TITLE
Remove expected fail from `/tests/pip/install/full`

### DIFF
--- a/tests/pip/install.fmf
+++ b/tests/pip/install.fmf
@@ -22,7 +22,3 @@ tier: null
     test: |
         /tmp/venv/bin/pip install .[all]
         /tmp/venv/bin/tmt --help
-    adjust:
-        result: xfail
-        when: distro >= fedora-39
-        because: https://github.com/aio-libs/aiohttp/issues/7229


### PR DESCRIPTION
The upstream issue has been fixed and released. Time to remove the temporary `xfail` from the test.

Pull Request Checklist

* [x] extend the test coverage