### PR TITLE
Make check plugin class generic over check class

### DIFF
--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -16,7 +16,9 @@ TEST_POST_AVC_FILENAME = 'tmt-avc-{event}.txt'
 
 
 @provides_check('avc')
-class AvcDenials(CheckPlugin):
+class AvcDenials(CheckPlugin[Check]):
+    _check_class = Check
+
     @classmethod
     def _save_report(
             cls,

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -16,7 +16,9 @@ TEST_POST_DMESG_FILENAME = 'tmt-dmesg-{event}.txt'
 
 
 @provides_check('dmesg')
-class DmesgCheck(CheckPlugin):
+class DmesgCheck(CheckPlugin[Check]):
+    _check_class = Check
+
     @classmethod
     def _fetch_dmesg(
             cls,


### PR DESCRIPTION
Makes typing nicer for check plugins that provide their custom `Check` subclass.

Pull Request Checklist

* [x] implement the feature