### PR TITLE
Set acl permissions on workdir root to ensure multi-user access when umask is `0027`

### DIFF
--- a/examples/plugins/provision.py
+++ b/examples/plugins/provision.py
@@ -88,6 +88,7 @@ class ProvisionExample(tmt.steps.provision.ProvisionPlugin):
 
         self._guest = GuestExample(data, name=self.name, parent=self.step)
         self._guest.start()
+        self._guest.setup()
 
     def guest(self):
         """
@@ -110,6 +111,7 @@ class GuestExample(tmt.Guest):
     user ....... user name to log in
     key ........ private key
     password ... password
+    become ..... whether to run the scripts with sudo
 
     These are by default imported into instance attributes (see the
     class attribute '_keys' in tmt.Guest class).
@@ -189,6 +191,16 @@ class GuestExample(tmt.Guest):
 
         raise tmt.utils.ProvisionError(
             "All attempts to provision a machine with example failed.")
+
+    def setup(self):
+        """
+        Setup the guest
+
+        This should include all necessary configurations inside the instance
+        to get the plans to work. For example, ensure the permissions in
+        TMT_WORKDIR_ROOT will work if the user is non-root.
+        """
+        print("setup() called")
 
     # For advanced development
     def execute(self, command, **kwargs):

--- a/tests/provision/become/data/umask.fmf
+++ b/tests/provision/become/data/umask.fmf
@@ -1,0 +1,14 @@
+summary: Check that become works when instance umask is restricted
+description:
+    Ensures that become works when used in virtual instances with
+    umask set to 0027 like in hardened OSs.
+provision+:
+    become: true
+discover:
+    tests:
+      - name: Beakerlib test to generate report files on guest
+        test: ./umask.sh
+        framework: beakerlib
+prepare:
+    how: shell
+    script: "echo 'umask 0027' >> /etc/profile; echo 'umask 0027' >> /etc/bashrc"

--- a/tests/provision/become/data/umask.sh
+++ b/tests/provision/become/data/umask.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun -s "echo HELLO > output" 0 "Say something"
+        rlAssertGrep "HELLO" "output"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/provision/become/main.fmf
+++ b/tests/provision/become/main.fmf
@@ -6,3 +6,4 @@ tag+:
   - provision-only
   - provision-container
   - provision-virtual
+duration: 24m

--- a/tests/provision/become/test.sh
+++ b/tests/provision/become/test.sh
@@ -37,6 +37,12 @@ rlJournalStart
         rlRun "tmt --context provisiontest=$PROVISION_HOW run -rvvv plan --name /prepare-finish/user/scripts"
     rlPhaseEnd
 
+    if [[ "$PROVISION_HOW" == "virtual" ]]; then
+        rlPhaseStartTest "$PROVISION_HOW, umask with become=true"
+            rlRun "tmt --context provisiontest=$PROVISION_HOW run -rvvv plan --name /umask"
+        rlPhaseEnd
+    fi
+
     rlPhaseStartCleanup
         rlRun "popd"
         if [[ "$PROVISION_HOW" == "container" ]]; then

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -759,6 +759,7 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin[ProvisionArtemisData]
             name=self.name,
             parent=self.step)
         self._guest.start()
+        self._guest.setup()
 
     def guest(self) -> Optional[GuestArtemis]:
         """ Return the provisioned guest """

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -229,6 +229,7 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin[ProvisionConnectData]
             data=data,
             name=self.name,
             parent=self.step)
+        self._guest.setup()
 
     def guest(self) -> Optional[tmt.GuestSsh]:
         """ Return the provisioned guest """

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -187,6 +187,7 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin[ProvisionLocalData]):
             self.warn("The 'local' provision plugin does not support hardware requirements.")
 
         self._guest = GuestLocal(logger=self._logger, data=data, name=self.name, parent=self.step)
+        self._guest.setup()
 
     def guest(self) -> Optional[GuestLocal]:
         """ Return the provisioned guest """

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -811,6 +811,7 @@ class ProvisionBeaker(tmt.steps.provision.ProvisionPlugin[ProvisionBeakerData]):
             logger=self._logger,
             )
         self._guest.start()
+        self._guest.setup()
 
     def guest(self) -> Optional[GuestBeaker]:
         """ Return the provisioned guest """

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -457,6 +457,7 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin[ProvisionPodmanData]):
             name=self.name,
             parent=self.step)
         self._guest.start()
+        self._guest.setup()
 
         # TODO: this might be allowed with `--privileged`...
         self._guest.facts.capabilities[GuestCapability.SYSLOG_ACTION_READ_ALL] = False

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -956,6 +956,7 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin[ProvisionTestcloudD
             name=self.name,
             parent=self.step)
         self._guest.start()
+        self._guest.setup()
 
     def guest(self) -> Optional[tmt.Guest]:
         """ Return the provisioned guest """


### PR DESCRIPTION
In machines with umask set to `0027` it is necessary to setup an acl to overide it so the workdir root directory stays multi-user access. This is specially necessary on machines accessed with a non-root user, that are hardened to CIS Level 1 guidelines.

It is happening in version 1.29.0.

Fixes: #2496

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation (docstrings)
* [x] extend the test coverage
* [x] update the specification (N/A)
* [x] adjust plugin docstring
* [x] modify the json schema (N/A)
* [x] mention the version
* [x] include a release note (the PR title)
