### PR TITLE
Custom soft/hard reboot commands for the connect provision plugin

### DIFF
--- a/tests/provision/reboot/main.fmf
+++ b/tests/provision/reboot/main.fmf
@@ -2,5 +2,5 @@ summary: Check that the reboot command works
 adjust:
   - when: how == full
     environment:
-        PROVISION_METHODS: container virtual
+        PROVISION_METHODS: container connect virtual
     tag+: [additional_coverage]

--- a/tests/provision/reboot/test.sh
+++ b/tests/provision/reboot/test.sh
@@ -8,6 +8,7 @@ rlJournalStart
     rlPhaseStartSetup
         rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
         rlRun "run=\$(mktemp -d)" 0 "Create run directory"
+        rlRun "run_connect=\$(mktemp -d)" 0 "Create run directory for connect plugin"
         rlRun "pushd $tmp"
         rlRun "set -o pipefail"
         rlRun "tmt init"
@@ -42,9 +43,51 @@ rlJournalStart
         rlPhaseEnd
     fi
 
+    if [[ "$PROVISION_METHODS" =~ connect ]]; then
+        rlPhaseStartTest "Connect"
+            rlRun "tmt run --scratch -i $run provision -h virtual"
+
+            guest_ip="$(yq -r '."default-0" | .guest' $run/plan/provision/guests.yaml)"
+            guest_port="$(yq -r '."default-0" | .port' $run/plan/provision/guests.yaml)"
+            guest_key="$(yq -r '."default-0" | .key[0]' $run/plan/provision/guests.yaml)"
+
+            provision="provision -h connect --guest $guest_ip --port $guest_port --key $guest_key"
+
+            # Soft reboot
+            rlRun -s "tmt -vv run --scratch -i $run_connect $provision reboot --step provision"
+            rlAssertGrep "Reboot finished" $rlRun_LOG
+
+            # Hard reboot
+            rlRun -s "tmt -vv run --scratch -i $run_connect $provision reboot --step provision --hard" 2
+            rlAssertGrep "fail: Guest 'default-0' does not support hard reboot." $rlRun_LOG
+
+            # Custom reboot commands
+            # The command is pretty what would tmt run anyway, minus the envvars
+            custom_reboot="ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -p $guest_port -i $guest_key root@$guest_ip reboot"
+
+            # Soft reboot
+            rlRun -s "tmt -vv run                --scratch -i $run_connect $provision --soft-reboot '$custom_reboot' reboot --step provision" 2
+            rlAssertGrep "Custom soft and hard reboot commands are allowed only with the '--feeling-safe' option." $rlRun_LOG
+
+            rlRun -s "tmt -vv --feeling-safe run --scratch -i $run_connect $provision --soft-reboot '$custom_reboot' reboot --step provision"
+            rlAssertGrep "Reboot finished" $rlRun_LOG
+            rlAssertGrep "cmd: /bin/bash -c '$custom_reboot'" $rlRun_LOG
+
+            # Hard reboot
+            rlRun -s "tmt -vv run                --scratch -i $run_connect $provision --hard-reboot '$custom_reboot' reboot --step provision" 2
+            rlAssertGrep "Custom soft and hard reboot commands are allowed only with the '--feeling-safe' option." $rlRun_LOG
+
+            rlRun -s "tmt -vv --feeling-safe run --scratch -i $run_connect $provision --hard-reboot '$custom_reboot' reboot --step provision --hard"
+            rlAssertGrep "Reboot finished" $rlRun_LOG
+            rlAssertGrep "cmd: /bin/bash -c '$custom_reboot'" $rlRun_LOG
+
+            rlRun "tmt run -i $run finish"
+        rlPhaseEnd
+    fi
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $tmp" 0 "Remove tmp directory"
-        rlRun "rm -r $run" 0 "Remove run directory"
+        rlRun "rm -r $run $run_connect" 0 "Remove run directories"
     rlPhaseEnd
 rlJournalEnd

--- a/tmt/schemas/provision/connect.yaml
+++ b/tmt/schemas/provision/connect.yaml
@@ -45,5 +45,11 @@ properties:
     minimum: 0
     maximum: 65535
 
+  soft-reboot:
+    type: string
+
+  hard-reboot:
+    type: string
+
 required:
   - how


### PR DESCRIPTION
To support a watchdog check
(https://github.com/teemtee/tmt/issues/1523), tmt must learn more about rebooting a guest, especially when the SSH connection is no longer available. The patch begins by extending the `connect` plugin to support custom commands. This will help with the testing and local runs.

Imagine a Beaker box, reserved outside of tmt, used with `connect` plugin. The test may render the box unresponsive, in which case the SSH & a remote `reboot` command are not possible. For local runs and testing we can provide `connect` with info to trigger reboot even in those conditions, e.g. with `soft-reboot: bkr system-power --action reboot $IP`.

This comes with a bit of refactoring, to allow `reboot` to run a command on the runner rather than on the guest.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] modify the json schema