### PR TITLE
Add the `fips` field for the `polarion` report

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -22,6 +22,10 @@ changes. ``info`` results are now treated as ``pass`` results, and
 would be counted towards the succesfull exit code, ``0``, instead
 of the exit code ``2`` in older releases.
 
+The :ref:`/spec/plans/report/polarion` report now supports the
+``fips`` field to store information about whether the FIPS mode
+was enabled or disabled on the guest during the test execution.
+
 
 tmt-1.29
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tmt/schemas/report/polarion.yaml
+++ b/tmt/schemas/report/polarion.yaml
@@ -70,6 +70,9 @@ properties:
   composeid:
     type: string
 
+  fips:
+    type: boolean
+
 required:
   - how
   - project-id

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -171,6 +171,14 @@ class ReportPolarionData(tmt.steps.report.ReportStepData):
              """
         )
 
+    fips: bool = field(
+        default=False,
+        option=('--fips / --no-fips'),
+        is_flag=True,
+        show_default=True,
+        help='FIPS mode enabled or disabled for this run.'
+        )
+
 
 @tmt.steps.provides_method('polarion')
 class ReportPolarion(tmt.steps.report.ReportPlugin[ReportPolarionData]):
@@ -209,7 +217,7 @@ class ReportPolarion(tmt.steps.report.ReportPlugin[ReportPolarionData]):
         use_facts = self.get('use-facts', os.getenv('TMT_PLUGIN_REPORT_POLARION_USE_FACTS'))
         other_testrun_fields = [
             'description', 'planned_in', 'assignee', 'pool_team', 'arch', 'platform', 'build',
-            'sample_image', 'logs', 'compose_id']
+            'sample_image', 'logs', 'compose_id', 'fips']
 
         junit_suite = make_junit_xml(self)
         xml_tree = ElementTree.fromstring(junit_suite.to_xml_string([junit_suite]))
@@ -233,7 +241,7 @@ class ReportPolarion(tmt.steps.report.ReportPlugin[ReportPolarionData]):
         testsuites_properties = ElementTree.SubElement(xml_tree, 'properties')
         for name, value in properties.items():
             ElementTree.SubElement(testsuites_properties, 'property', attrib={
-                'name': name, 'value': value})
+                'name': name, 'value': str(value)})
 
         testsuite = xml_tree.find('testsuite')
         project_span_ids = xml_tree.find(


### PR DESCRIPTION
We have test scenarios with FIPS mode enabled or disabled. Adding this field, in order  we can mark it in polarion test run by tmt.

Tests:

made FIPS enabled in polarion test run:
fips: True
fips: Yes
fips: 1
 
made FIPS disabled in test run:
fips: False
fips: No
fips: 0
fips: 6
fips: test

made FIPS enabled in polarion test run:
export TMT_PLUGIN_REPORT_POLARION_FIPS=True


Pull Request Checklist

- [x] implement the feature

