### PR TITLE
Run a callback when command process starts

### DIFF
--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -3,6 +3,7 @@ import dataclasses
 import datetime
 import json
 import os
+import subprocess
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, cast
@@ -150,6 +151,11 @@ class TestInvocation:
     phase: 'ExecutePlugin[Any]'
     test: 'tmt.base.Test'
     guest: Guest
+
+    #: Process running the test. What binary it is depends on the guest
+    #: implementation and the test, it may be, for example, a shell process,
+    #: SSH process, or a ``podman`` process.
+    process: Optional[subprocess.Popen[bytes]] = None
 
     return_code: Optional[int] = None
     start_time: Optional[str] = None

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -42,6 +42,7 @@ from tmt.plugins import PluginRegistry
 from tmt.steps import Action, ActionTask, PhaseQueue
 from tmt.utils import (
     Command,
+    OnProcessStartCallback,
     Path,
     SerializableContainer,
     ShellScript,
@@ -899,6 +900,7 @@ class Guest(tmt.utils.Common):
                 silent: bool = False,
                 log: Optional[tmt.log.LoggingFunction] = None,
                 interactive: bool = False,
+                on_process_start: Optional[OnProcessStartCallback] = None,
                 **kwargs: Any) -> tmt.utils.CommandOutput:
         pass
 
@@ -913,6 +915,7 @@ class Guest(tmt.utils.Common):
                 silent: bool = False,
                 log: Optional[tmt.log.LoggingFunction] = None,
                 interactive: bool = False,
+                on_process_start: Optional[OnProcessStartCallback] = None,
                 **kwargs: Any) -> tmt.utils.CommandOutput:
         pass
 
@@ -926,6 +929,7 @@ class Guest(tmt.utils.Common):
                 silent: bool = False,
                 log: Optional[tmt.log.LoggingFunction] = None,
                 interactive: bool = False,
+                on_process_start: Optional[OnProcessStartCallback] = None,
                 **kwargs: Any) -> tmt.utils.CommandOutput:
         """
         Execute a command on the guest.
@@ -1298,6 +1302,7 @@ class GuestSsh(Guest):
                 silent: bool = False,
                 log: Optional[tmt.log.LoggingFunction] = None,
                 interactive: bool = False,
+                on_process_start: Optional[OnProcessStartCallback] = None,
                 **kwargs: Any) -> tmt.utils.CommandOutput:
         """
         Execute a command on the guest.
@@ -1359,6 +1364,7 @@ class GuestSsh(Guest):
             silent=silent,
             cwd=cwd,
             interactive=interactive,
+            on_process_start=on_process_start,
             **kwargs)
 
     def push(self,

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -7,7 +7,7 @@ import tmt.log
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
-from tmt.utils import Command, Path, ShellScript
+from tmt.utils import Command, OnProcessStartCallback, Path, ShellScript
 
 
 @dataclasses.dataclass
@@ -76,6 +76,7 @@ class GuestLocal(tmt.Guest):
                 silent: bool = False,
                 log: Optional[tmt.log.LoggingFunction] = None,
                 interactive: bool = False,
+                on_process_start: Optional[OnProcessStartCallback] = None,
                 **kwargs: Any) -> tmt.utils.CommandOutput:
         """ Execute command on localhost """
         # Prepare the environment (plan/cli variables override)
@@ -98,6 +99,7 @@ class GuestLocal(tmt.Guest):
             silent=silent,
             cwd=cwd,
             interactive=interactive,
+            on_process_start=on_process_start,
             **kwargs)
 
     def stop(self) -> None:

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -9,7 +9,7 @@ import tmt.log
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
-from tmt.utils import Command, Path, ShellScript, field, retry
+from tmt.utils import Command, OnProcessStartCallback, Path, ShellScript, field, retry
 
 # Timeout in seconds of waiting for a connection
 CONNECTION_TIMEOUT = 60
@@ -298,6 +298,7 @@ class GuestContainer(tmt.Guest):
                 silent: bool = False,
                 log: Optional[tmt.log.LoggingFunction] = None,
                 interactive: bool = False,
+                on_process_start: Optional[OnProcessStartCallback] = None,
                 **kwargs: Any) -> tmt.utils.CommandOutput:
         """ Execute given commands in podman via shell """
         if not self.container and not self.is_dry_run:
@@ -342,6 +343,7 @@ class GuestContainer(tmt.Guest):
             friendly_command=friendly_command or str(command),
             silent=silent,
             interactive=interactive,
+            on_process_start=on_process_start,
             **kwargs)
 
     def push(


### PR DESCRIPTION
When `Command.run()` spawns new process for the given command, by calling `subprocess.Popen`, an optional callable provided by `run()` caller would be called.

Generally, of not much use, but an async watchdog check might need to interrupt the local process managing the test. It might be a SSH process, or `podman exec`, but it runs in a thread started by an `execute` plugin. Plugin calls `guest.execute(test_command, ...)`, and `guest.execute()` wait for the command to complete. But, if the watchdog, running in another thread, detects the guest is lost, unresponsive, there are two options:

* mark the invocation with a "guest dead" label, and wait for the test process to terminate (by running out of time, or getting killed by network timeouts, etc.), or
* mark the invocation with a "guest dead" label, and kill the local test process. To do this, watchdog in thread B must have access to PID of a process started in thread A. The callback would allow the plugin to store process in the test invocation instance.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation