### PR TITLE
Run ssh command with `-o LogLevel=QUIET`

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -26,6 +26,10 @@ The :ref:`/spec/plans/report/polarion` report now supports the
 ``fips`` field to store information about whether the FIPS mode
 was enabled or disabled on the guest during the test execution.
 
+The verbose ssh client messages like ``Shared connection to X closed``
+do not spoil the test output anymore. The verbose messages are still
+kept when debug mode set.
+
 
 tmt-1.29
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/provision/ssh-options/main.fmf
+++ b/tests/provision/ssh-options/main.fmf
@@ -1,4 +1,4 @@
-summary: Check that custom SSH options are used
+summary: Check SSH options are correctly set and possible to customize
 enabled: false
 adjust:
   - when: how == full

--- a/tests/provision/ssh-options/test.sh
+++ b/tests/provision/ssh-options/test.sh
@@ -11,9 +11,19 @@ rlJournalStart
     rlPhaseEnd
 
     for provision_method in $PROVISION_METHODS; do
-        rlPhaseStartTest "Test with provision $provision_method"
+        rlPhaseStartTest "Test with provision $provision_method - check defaults and edited ServerAliveCountMax"
             rlRun "tmt run --scratch -vvi $run -a provision -h $provision_method --ssh-option ServerAliveCountMax=123456789"
+            rlAssertGrep "Run command: ssh .*-oForwardX11=no" "$run/log.txt"
+            rlAssertGrep "Run command: ssh .*-oStrictHostKeyChecking=no" "$run/log.txt"
+            rlAssertGrep "Run command: ssh .*-oUserKnownHostsFile=/dev/null" "$run/log.txt"
+            rlAssertGrep "Run command: ssh .*-oServerAliveInterval=60" "$run/log.txt"
             rlAssertGrep "Run command: ssh .*-oServerAliveCountMax=123456789" "$run/log.txt"
+            rlAssertGrep "Run command: ssh .*-oLogLevel=QUIET" "$run/log.txt"
+        rlPhaseEnd
+
+        rlPhaseStartTest "Test with provision $provision_method - no LogLevel=QUIET with debug"
+            rlRun "tmt run --scratch -dvvi $run -a provision -h $provision_method --ssh-option ServerAliveCountMax=123456789"
+            rlAssertNotGrep "Run command: ssh .*-oLogLevel=QUIET" "$run/log.txt"
         rlPhaseEnd
     done
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1177,6 +1177,8 @@ class GuestSsh(Guest):
             # received from the server for a long time (#868).
             '-oServerAliveInterval=60',
             '-oServerAliveCountMax=5',
+            # Avoid noisy ssh client messages spoiling test output (#2429).
+            '-o LogLevel=QUIET'
             ]
         if self.key or self.password:
             # Skip ssh-agent (it adds additional identities)

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1177,8 +1177,6 @@ class GuestSsh(Guest):
             # received from the server for a long time (#868).
             '-oServerAliveInterval=60',
             '-oServerAliveCountMax=5',
-            # Avoid noisy ssh client messages spoiling test output (#2429).
-            '-o LogLevel=QUIET'
             ]
         if self.key or self.password:
             # Skip ssh-agent (it adds additional identities)
@@ -1190,6 +1188,10 @@ class GuestSsh(Guest):
                 options.extend(['-i', key])
         if self.password:
             options.extend(['-oPasswordAuthentication=yes'])
+        if self.debug_level == 0:
+            # Avoid noisy ssh client messages spoiling test output (#2429).
+            # Enabled only when debug mode is not set.
+            options.extend(['-oLogLevel=QUIET'])
 
         # Use the shared master connection
         options.append(f'-S{self._ssh_socket()}')

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1188,10 +1188,6 @@ class GuestSsh(Guest):
                 options.extend(['-i', key])
         if self.password:
             options.extend(['-oPasswordAuthentication=yes'])
-        if self.debug_level == 0:
-            # Avoid noisy ssh client messages spoiling test output (#2429).
-            # Enabled only when debug mode is not set.
-            options.extend(['-oLogLevel=QUIET'])
 
         # Use the shared master connection
         options.append(f'-S{self._ssh_socket()}')
@@ -1296,6 +1292,14 @@ class GuestSsh(Guest):
         :param cwd: execute command in this directory on the guest.
         :param env: if set, set these environment variables before running the command.
         :param friendly_command: nice, human-friendly representation of the command.
+        :param test_session: if set, indicates test execution.
+        :param silent: if set, logging of steps taken by this function would be
+            reduced.
+        :param log: a logging function to use for logging of command output. By
+            default, ``self._logger.debug`` is used.
+        :param interactive: if set, the command would be executed in an interactive
+            manner, i.e. with stdout and stdout connected to terminal for live
+            interaction with user.
         """
 
         # Abort if guest is unavailable
@@ -1316,6 +1320,11 @@ class GuestSsh(Guest):
         # and a single `-t` wouldn't have the necessary effect.
         if test_session:
             ssh_command += Command('-tt')
+
+            # Avoid noisy ssh client messages spoiling test output (#2429).
+            # Enabled only when debug mode is not set.
+            if self.debug_level == 0:
+                ssh_command += Command('-oLogLevel=QUIET')
 
         # Accumulate all necessary commands - they will form a "shell" script, a single
         # string passed to SSH to execute on the remote machine.


### PR DESCRIPTION
To avoid ssh spoiling the output with the messages:

* Warning: Permanently added '[127.0.0.1]:10023' (ED25519) to the list of known hosts.
* Connection to 127.0.0.1 closed.

So:

```
            test: /script-00
                cmd: echo "hello"
                out: Warning: Permanently added '[127.0.0.1]:10023' (ED25519) to the list of known hosts.
                out: hello
                out: Connection to 127.0.0.1 closed.
                00:00:00 pass /script-00 (on default-0) [1/1]
```

Becomes:

```
            test: /script-00
                cmd: echo "hello"
                out: hello
                00:00:00 pass /script-00 (on default-0) [1/1]
```

Resolves #2429

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [x] mention the version
* [x] include a release note
