### PR TITLE
Rename `name` to `how` in test check specification

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -26,6 +26,10 @@ The :ref:`/spec/plans/report/polarion` report now supports the
 ``fips`` field to store information about whether the FIPS mode
 was enabled or disabled on the guest during the test execution.
 
+The ``name`` field of the :ref:`/spec/tests/check` specification
+has been renamed to ``how``, to be more aligned with how plugins
+are selected for step phases and export formats.
+
 
 tmt-1.29
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/spec/plans/results.fmf
+++ b/spec/plans/results.fmf
@@ -99,8 +99,8 @@ description: |
           # String, how long did the check run.
           duration: hh:mm:ss
 
-          # String, name of the check. Corresponds to the name used in test
-          # metadata.
+          # String, name of the check. Corresponds to the name of the check
+          # specified in test metadata.
           name: dummy
 
           # String, the place in test workflow when the check was executed.

--- a/spec/tests/check.fmf
+++ b/spec/tests/check.fmf
@@ -42,12 +42,14 @@ example:
 
   - |
     # Enable multiple checks, one of them would be disabled temporarily.
+    # Using `how` key to pick the check.
     check:
       - avc
       - kernel-panic
-      - name: test-inspector
+      - how: test-inspector
         enable: false
 
 link:
   - implemented-by: /tmt/checks
   - verified-by: /tests/test/check/avc
+  - verified-by: /tests/test/check/dmesg

--- a/tests/test/check/data/main.fmf
+++ b/tests/test/check/data/main.fmf
@@ -5,7 +5,7 @@
 
 /avc:
   check:
-    - avc
+    - how: avc
 
   /harmless:
     test: /bin/true

--- a/tmt/checks/__init__.py
+++ b/tmt/checks/__init__.py
@@ -64,7 +64,7 @@ def find_plugin(name: str) -> 'CheckPluginClass':
 
 # A "raw" test check as stored in fmf node data.
 class _RawCheck(TypedDict):
-    name: str
+    how: str
     enabled: bool
 
 
@@ -94,12 +94,12 @@ class Check(
     check implementation/plugin.
     """
 
-    name: str
+    how: str
     enabled: bool = field(default=True)
 
     @cached_property
     def plugin(self) -> 'CheckPluginClass':
-        return find_plugin(self.name)
+        return find_plugin(self.how)
 
     # ignore[override]: expected, we need to accept one extra parameter, `logger`.
     @classmethod
@@ -107,7 +107,7 @@ class Check(
             cls,
             raw_data: _RawCheck,
             logger: tmt.log.Logger) -> 'Check':
-        data = cls(name=raw_data['name'])
+        data = cls(how=raw_data['how'])
         data._load_keys(cast(dict[str, Any], raw_data), cls.__name__, logger)
 
         return data
@@ -174,7 +174,7 @@ class CheckPlugin(tmt.utils._CommonBase, Generic[CheckT]):
             logger: tmt.log.Logger) -> Check:
         """ Create a check data instance for the plugin """
 
-        return cast(CheckPlugin[CheckT], find_plugin(raw_data['name'])) \
+        return cast(CheckPlugin[CheckT], find_plugin(raw_data['how'])) \
             ._check_class.from_spec(raw_data, logger)
 
     @classmethod
@@ -207,7 +207,7 @@ def normalize_test_check(
     if isinstance(raw_test_check, str):
         try:
             return CheckPlugin.delegate(
-                raw_data={'name': raw_test_check, 'enabled': True},
+                raw_data={'how': raw_test_check, 'enabled': True},
                 logger=logger)
 
         except Exception as exc:

--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -486,7 +486,7 @@ definitions:
   check:
     type: object
     properties:
-      name:
+      how:
         type: string
 
       enabled:


### PR DESCRIPTION
This was a mistake, to pick a step/export/check/... implementation, tmt uses `how` key/option, while `name` labels objects.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] update the specification
* [x] adjust plugin docstring
* [x] modify the json schema
* [x] include a release note
