### PR TITLE
Create a `checks` directory to store avc/dmesg checks

### DIFF
--- a/tests/test/check/test-avc.sh
+++ b/tests/test/check/test-avc.sh
@@ -19,7 +19,7 @@ rlJournalStart
 
     for method in ${PROVISION_METHODS:-local}; do
         rlPhaseStartTest "Test harmless AVC check with $method"
-            rlRun "avc_log=$run/plan/execute/data/guest/default-0/avc/harmless-1/tmt-avc-after-test.txt"
+            rlRun "avc_log=$run/plan/execute/data/guest/default-0/avc/harmless-1/checks/avc-after-test.txt"
 
             rlRun "tmt -c provision_method=$method run --id $run --scratch -a -vv provision -h $method test -n /avc/harmless"
 
@@ -36,7 +36,7 @@ rlJournalStart
         rlPhaseStartTest "Test nasty AVC check with $method"
             rlRun "tmt -c provision_method=$method run --id $run --scratch -a -vv provision -h $method test -n /avc/nasty"
 
-            rlRun "avc_log=$run/plan/execute/data/guest/default-0/avc/nasty-1/tmt-avc-after-test.txt"
+            rlRun "avc_log=$run/plan/execute/data/guest/default-0/avc/nasty-1/checks/avc-after-test.txt"
 
             rlRun "cat $results"
             rlRun "cat $avc_log"

--- a/tests/test/check/test-dmesg.sh
+++ b/tests/test/check/test-dmesg.sh
@@ -12,8 +12,8 @@ rlJournalStart
         rlRun "run=\$(mktemp -d)" 0 "Create run directory"
 
         rlRun "results=$run/plan/execute/results.yaml"
-        rlRun "dump_before=$run/plan/execute/data/guest/default-0/dmesg-1/tmt-dmesg-before-test.txt"
-        rlRun "dump_after=$run/plan/execute/data/guest/default-0/dmesg-1/tmt-dmesg-after-test.txt"
+        rlRun "dump_before=$run/plan/execute/data/guest/default-0/dmesg-1/checks/dmesg-before-test.txt"
+        rlRun "dump_after=$run/plan/execute/data/guest/default-0/dmesg-1/checks/dmesg-after-test.txt"
 
         rlRun "pushd data"
         rlRun "set -o pipefail"

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -12,7 +12,7 @@ from tmt.utils import CommandOutput, Path, ShellScript, render_run_exception_str
 if TYPE_CHECKING:
     from tmt.steps.execute import TestInvocation
 
-TEST_POST_AVC_FILENAME = 'tmt-avc-{event}.txt'
+TEST_POST_AVC_FILENAME = 'avc-{event}.txt'
 
 
 @provides_check('avc')
@@ -51,11 +51,7 @@ class AvcDenials(CheckPlugin[Check]):
             datetime.datetime.now(datetime.timezone.utc))
 
         assert invocation.phase.step.workdir is not None  # narrow type
-
-        path = invocation.data_path(
-            filename=TEST_POST_AVC_FILENAME.format(event=event.value),
-            create=True,
-            full=True)
+        path = invocation.check_files_path / TEST_POST_AVC_FILENAME.format(event=event.value)
 
         def _output_logger(
                 key: str,

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -12,7 +12,7 @@ from tmt.utils import Path, render_run_exception_streams
 if TYPE_CHECKING:
     from tmt.steps.execute import TestInvocation
 
-TEST_POST_DMESG_FILENAME = 'tmt-dmesg-{event}.txt'
+TEST_POST_DMESG_FILENAME = 'dmesg-{event}.txt'
 
 
 @provides_check('dmesg')
@@ -69,10 +69,7 @@ class DmesgCheck(CheckPlugin[Check]):
 
         timestamp = ExecutePlugin.format_timestamp(datetime.datetime.now(datetime.timezone.utc))
 
-        path = invocation.data_path(
-            filename=TEST_POST_DMESG_FILENAME.format(event=event.value),
-            create=True,
-            full=True)
+        path = invocation.check_files_path / TEST_POST_DMESG_FILENAME.format(event=event.value)
 
         try:
             dmesg_output = cls._fetch_dmesg(invocation.guest, logger)

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -186,6 +186,13 @@ class TestInvocation:
         return path if full else path.relative_to(self.phase.step.workdir)
 
     @tmt.utils.cached_property
+    def check_files_path(self) -> Path:
+        """ Construct a directory path for check files needed by tmt """
+        path = self.data_path(create=True, full=True) / "checks"
+        path.mkdir(exist_ok=True)
+        return path
+
+    @tmt.utils.cached_property
     def reboot_request_path(self) -> Path:
         """ A path to the reboot request file """
         return self.data_path(full=True) \


### PR DESCRIPTION
For starters I've created the "check" directory for avc/dmesg files. I wanted to add topology files also, but they seem to be created before the `TestInvocation` `check_files_path` method is called by avc/dmesg creators and I was unable to figure out how to force `Topology` log creator to use it as well. I got `cached_property` type instead of Path when I tried to use it in the `save_yaml` or `save_bash` methods (after inserting `from tmt.steps.execute import TestInvocation` in them). I kinda know why it doesn't work, but I don't know how to get out of this situation.

Also - does this new cached_property/method need to be documented?  

Pull Request Checklist

* [x] implement the feature
