### PR TITLE
Get rid of the too many empty new lines

### DIFF
--- a/tmt/queue.py
+++ b/tmt/queue.py
@@ -236,10 +236,10 @@ class Queue(list[TaskT]):
 
         self.append(task)
 
-        self._logger.info(
+        self._logger.verbose(
             f'queued {self.name} task #{len(self)}',
             f'{task.name} on {fmf.utils.listed(task.guest_ids)}',
-            color='cyan')
+            color='cyan', level=3)
 
     def run(self) -> Iterator[TaskOutcome[TaskT]]:
         """
@@ -250,12 +250,12 @@ class Queue(list[TaskT]):
         """
 
         for i, task in enumerate(self):
-            self._logger.info('')
+            self._logger.verbose('', level=3)
 
-            self._logger.info(
+            self._logger.verbose(
                 f'{self.name} task #{i + 1}',
                 f'{task.name} on {fmf.utils.listed(task.guest_ids)}',
-                color='cyan')
+                color='cyan', level=3)
 
             failed_outcomes: list[TaskOutcome[TaskT]] = []
 

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -776,9 +776,6 @@ class Execute(tmt.steps.Step):
                 causes=[outcome.exc for outcome in failed_phases if outcome.exc is not None]
                 )
 
-        # To separate "execute" from the follow-up logging visually
-        self.info('')
-
         # Give a summary, update status and save
         self.summary()
         self.status('done')

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -165,7 +165,7 @@ class Finish(tmt.steps.Step):
                 )
 
         # To separate "finish" from "pull" queue visually
-        self.info('')
+        self.verbose('', level=3)
 
         # Pull artifacts created in the plan data directory
         # if there was at least one plugin executed
@@ -180,7 +180,7 @@ class Finish(tmt.steps.Step):
                 self._logger)
 
             # To separate "finish" from "pull" queue visually
-            self.info('')
+            self.verbose('', level=3)
 
         # Stop and remove provisioned guests
         for guest in self.plan.provision.guests():

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -251,7 +251,7 @@ class Prepare(tmt.steps.Step):
                 self._logger)
 
             # To separate "push" from "prepare" queue visually
-            self.info('')
+            self.verbose('', level=3)
 
         queue: PhaseQueue[PrepareStepData] = PhaseQueue(
             'prepare',
@@ -284,7 +284,7 @@ class Prepare(tmt.steps.Step):
                 causes=[outcome.exc for outcome in failed_phases if outcome.exc is not None]
                 )
 
-        self.info('')
+        self.verbose('', level=3)
 
         # Pull artifacts created in the plan data directory
         # if there was at least one plugin executed
@@ -299,7 +299,7 @@ class Prepare(tmt.steps.Step):
                 self._logger)
 
             # To separate "prepare" from "pull" queue visually
-            self.info('')
+            self.verbose('', level=3)
 
         # Give a summary, update status and save
         self.summary()

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -4928,7 +4928,9 @@ class UpdatableMessage(contextlib.AbstractContextManager):  # type: ignore[type-
         if self.clear_on_exit:
             self.clear()
 
-        sys.stdout.write('\n')
+        if self.enabled:
+            sys.stdout.write('\n')
+
         sys.stdout.flush()
 
     def clear(self) -> None:


### PR DESCRIPTION
They are useful in some cases (like visually separating phases) and at the same time quite disturbing or even ugly when there's just a single/simple step config.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
