### PR TITLE
Fix `tmt import --dry` and Polarion import file name

### DIFF
--- a/tmt/options.py
+++ b/tmt/options.py
@@ -145,7 +145,7 @@ VERBOSITY_OPTIONS: list[ClickOptionDecoratorType] = [
 # Force, dry and run again actions
 DRY_OPTIONS: list[ClickOptionDecoratorType] = [
     option(
-        '-n', '--dry', is_flag=True,
+        '-n', '--dry', is_flag=True, default=False,
         help='Run in dry mode. No changes, please.'),
     ]
 


### PR DESCRIPTION
`tmt import --dry` was never respected, let's fix that
Also fixed polarion import filename to use default `main.fmf` when there is only a single test case and name is not forced with argument `--polarion-case-id`

Pull Request Checklist

* [x] implement the feature