### PR TITLE
Clear test invocation data path use and derived paths

### DIFF
--- a/tmt/frameworks/beakerlib.py
+++ b/tmt/frameworks/beakerlib.py
@@ -23,7 +23,7 @@ class Beakerlib(TestFramework):
             logger: tmt.log.Logger) -> tmt.utils.EnvironmentType:
 
         return {
-            'BEAKERLIB_DIR': str(invocation.data_path(full=True)),
+            'BEAKERLIB_DIR': str(invocation.path),
             'BEAKERLIB_COMMAND_SUBMIT_LOG': f'bash {tmt.steps.execute.TMT_FILE_SUBMIT_SCRIPT.path}'
             }
 
@@ -34,7 +34,7 @@ class Beakerlib(TestFramework):
             logger: tmt.log.Logger) -> list[str]:
         return [
             '--exclude',
-            str(invocation.data_path("backup*", full=True))
+            str(invocation.path / "backup*")
             ]
 
     @classmethod
@@ -47,11 +47,11 @@ class Beakerlib(TestFramework):
         note: Optional[str] = None
         log: list[Path] = []
         for filename in [tmt.steps.execute.TEST_OUTPUT_FILENAME, 'journal.txt']:
-            if invocation.data_path(filename, full=True).is_file():
-                log.append(invocation.data_path(filename))
+            if (invocation.path / filename).is_file():
+                log.append(invocation.relative_path / filename)
 
         # Check beakerlib log for the result
-        beakerlib_results_filepath = invocation.data_path('TestResults', full=True)
+        beakerlib_results_filepath = invocation.path / 'TestResults'
 
         try:
             results = invocation.phase.read(beakerlib_results_filepath, level=3)

--- a/tmt/frameworks/shell.py
+++ b/tmt/frameworks/shell.py
@@ -48,5 +48,5 @@ class Shell(TestFramework):
         return [tmt.Result.from_test_invocation(
             invocation=invocation,
             result=result,
-            log=[invocation.data_path(tmt.steps.execute.TEST_OUTPUT_FILENAME)],
+            log=[invocation.relative_path / tmt.steps.execute.TEST_OUTPUT_FILENAME],
             note=note)]

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -229,7 +229,7 @@ class Result(BaseResult):
             ids=ids,
             log=log or [],
             guest=guest_data,
-            data_path=invocation.data_path('data'))
+            data_path=invocation.relative_test_data_path)
 
         return _result.interpret_result(ResultInterpret(
             invocation.test.result) if invocation.test.result else ResultInterpret.RESPECT)


### PR DESCRIPTION
There was a "data path" tied to a test invocation, then there was a "test data path" which was the "data path" plus one more `/data`. The patch turns `TestInvocation.data_path()` into `TestInvocation.path`, adds caching and defines the test data path. Together, they should provide clearer view on paths related to a test and its invocations, simplifying the related code.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation