### PR TITLE
[RFC] docs: tweak docs to include how to see details about test failures

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -80,6 +80,14 @@ Run all or selected steps for each plan::
     tmt run discover
     tmt run prepare execute
 
+See any failures from a previous run::
+
+    tmt run --last report -vvv
+
+Show test output while running::
+
+    tmt run -vvv
+
 List tests, show details, check against the specification::
 
     tmt tests ls


### PR DESCRIPTION
One common issue that most new users (like me) face when writing tests is that the tests will not work flawlessly on the first try.

Hence seeing details what went wrong in the examples will help to get started with tmt quicker. This commit adds examples for this as small doc addition in the `Examples` section.

Pull Request Checklist

* ~[ ] implement the feature~
* [x] write the documentation
* ~[ ] extend the test coverage~
* ~[ ] update the specification~
* ~[ ] adjust plugin docstring~
* ~[ ] modify the json schema~
* ~[ ] mention the version~
* ~[ ] include a release note~
