### PR TITLE
Update the common schema for the `check` key

### DIFF
--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -493,4 +493,4 @@ definitions:
         type: boolean
 
     required:
-      - name
+      - how


### PR DESCRIPTION
The `required` attribute was not updated in #2527. Let's fix this to get rid of irrelevant warnings.

Pull Request Checklist

* [x] modify the json schema