### PR TITLE
Add support for envvars import and export to Polarion

### DIFF
--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -862,7 +862,20 @@ def read_polarion_case(
 
     # Update description
     if polarion_case.description:
-        current_data['description'] = str(polarion_case.description)
+        description = str(polarion_case.description).replace('<br/>', '\n')
+        if 'Environment variables' in description:
+            description, envvars = description.split('Environment variables:', maxsplit=1)
+            if not current_data.get('environment'):
+                current_data['environment'] = {}
+            for envvar in envvars.splitlines():
+                envvar = envvar.strip()
+                if not envvar:
+                    continue  # skip empty lines
+                key, value = envvar.split('=', maxsplit=1)
+                current_data['environment'][key] = value
+            echo(style('environment variables:', fg='green'))
+            echo(format_value(current_data['environment']))
+        current_data['description'] = description
         echo(style('description: ', fg='green') + current_data['description'])
 
     # Update status

--- a/tmt/export/polarion.py
+++ b/tmt/export/polarion.py
@@ -219,6 +219,10 @@ def export_to_polarion(test: tmt.base.Test) -> None:
     description = summary
     if test.description:
         description += ' - ' + test.description
+    if test.environment:
+        description += '<br/>Environment variables:'
+        for key, value in test.environment.items():
+            description += f'<br/>{key}={value}'
     if not dry_mode:
         polarion_case.description = description
     echo(style('description: ', fg='green') + description)


### PR DESCRIPTION
Add support for importing and exporting test environment variables to Polarion.
Storing in description field as there are no suitable fields in Polarion.

Fixes #2547 

Pull Request Checklist

* [x] implement the feature