### PR TITLE
Refactor running of interactive commands

### DIFF
--- a/tests/execute/duration/data/long.sh
+++ b/tests/execute/duration/data/long.sh
@@ -4,6 +4,6 @@
 rlJournalStart
     rlPhaseStartTest
         rlPass "Passing assert"
-        sleep 120 # Way more than timeout of 5 seconds imposed by `duration`
+        sleep 20 # Way more than timeout of 5 seconds imposed by `duration`
     rlPhaseEnd
 rlJournalEnd

--- a/tests/execute/duration/data/test.fmf
+++ b/tests/execute/duration/data/test.fmf
@@ -12,7 +12,7 @@
     duration: 5s
 
     /shell:
-        test: sleep 120s
+        test: sleep 20s
     /beakerlib:
         framework: beakerlib
         test: ./long.sh

--- a/tests/execute/duration/main.fmf
+++ b/tests/execute/duration/main.fmf
@@ -1,7 +1,7 @@
 summary: Verify that the test duration is correctly handled
 environment:
     PROVISION_METHODS: "local container"
-duration: 10m
+duration: 20m
 
 adjust:
     when: how == full

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -644,6 +644,7 @@ def test_run_interactive_joined(tmppath, root_logger):
         log=None,
         logger=root_logger)
     assert output.stdout is None
+    assert output.stderr is None
 
 
 def test_run_not_joined_stdout(root_logger):

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -39,6 +39,7 @@ from tmt.utils import (
     EnvironmentType,
     GeneralError,
     Path,
+    RunError,
     SerializableContainer,
     SpecBasedContainer,
     cached_property,
@@ -1874,8 +1875,13 @@ class Login(Action):
                 cwd = None
             # Execute all requested commands
             for script in scripts:
-                self.debug(f"Run '{script}' in interactive mode.")
-                guest.execute(script, interactive=True, cwd=cwd, env=env)
+                try:
+                    guest.execute(script, interactive=True, cwd=cwd, env=env)
+
+                except RunError as exc:
+                    # Interactive mode can return non-zero if the last command failed,
+                    # ignore errors here.
+                    self.warn(f'Command exited with non-zero exit code {exc.returncode}.')
         self.info('login', 'Interactive shell finished', color='yellow')
 
     def after_test(


### PR DESCRIPTION
* more unified implementation,
* raises `RunError` when command fails, dealing with the fallout is left to the caller,
* `login` may ignore it, `execute/internal` will not - interactive tests apparently could not fail.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage