### PR TITLE
Add support for `cpu.flag` hardware requirement

### DIFF
--- a/spec/hardware/cpu.fmf
+++ b/spec/hardware/cpu.fmf
@@ -56,6 +56,15 @@ description: |
     model, stepping and corresponding names. ``/proc/cpuinfo`` and ``lscpu``
     are also useful resources.
 
+    .. versionchanged:: 1.31
+       ``beaker`` plugin supports ``cpu.flag``
+
+    .. versionchanged:: 1.30
+       ``artemis`` plugin supports ``cpu.flag`` with Artemis 0.0.67
+
+    .. versionchanged:: 1.27
+       ``beaker`` plugin supports ``cpu.model`` and ``cpu.processors``
+
 example:
   - |
     # Request a rather stronger guest.
@@ -76,6 +85,5 @@ example:
 
 link:
   - implemented-by: /tmt/steps/provision/artemis.py
-    note: "``cpu.flag`` not supported yet"
   - implemented-by: /tmt/steps/provision/mrack.py
-    note: "``cpu.processors`` and ``cpu.model`` only"
+    note: "``cpu.flag``, ``cpu.processors``, ``cpu.model`` only"

--- a/tests/unit/test_hardware.py
+++ b/tests/unit/test_hardware.py
@@ -106,6 +106,10 @@ def test_parse_maximal_constraint() -> None:
             model-name: "!~ Haswell"
             family: "< 6"
             family-name: Skylake
+            flag:
+              - avx
+              - "= avx2"
+              - "!= smep"
         disk:
             - size: 40 GiB
             - size: 120 GiB
@@ -125,5 +129,9 @@ def test_parse_maximal_constraint() -> None:
     """
 
     hw = parse_hw(hw_spec)
+
+    assert hw.constraint is not None
+
+    print(tmt.utils.dict_to_yaml(hw.constraint.to_spec()))
 
     assert hw.to_spec() == tmt.utils.yaml_to_dict(hw_spec)

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -973,6 +973,22 @@ def _parse_cpu(spec: Spec) -> BaseConstraint:
         if constraint_name in spec
         ]
 
+    if 'flag' in spec:
+        flag_group = And()
+
+        for flag_spec in spec['flag']:
+            constraint = TextConstraint.from_specification('cpu.flag', flag_spec)
+
+            if constraint.operator == Operator.EQ:
+                constraint.change_operator(Operator.CONTAINS)
+
+            elif constraint.operator == Operator.NEQ:
+                constraint.change_operator(Operator.NOTCONTAINS)
+
+            flag_group.constraints += [constraint]
+
+        group.constraints += [flag_group]
+
     return group
 
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -394,7 +394,13 @@ def normalize_hardware(
         for raw_datum in raw_hardware:
             components = tmt.hardware.ConstraintComponents.from_spec(raw_datum)
 
-            if components.child_name:
+            if components.name == 'cpu' and components.child_name == 'flag':
+                if 'flag' not in merged['cpu']:
+                    merged['cpu']['flag'] = []
+
+                merged['cpu']['flag'].append(f'{components.operator} {components.value}')
+
+            elif components.child_name:
                 merged[components.name][components.child_name] = \
                     f'{components.operator} {components.value}'
 

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -41,6 +41,7 @@ class GuestInspectType(TypedDict):
 
 
 SUPPORTED_HARDWARE_CONSTRAINTS: list[str] = [
+    'cpu.flag',
     'cpu.processors',
     'cpu.model',
     'disk.size',
@@ -246,6 +247,17 @@ def constraint_to_beaker_filter(
             actual_value)
 
     if name == "cpu":
+        if child_name == 'flag':
+            beaker_operator = OPERATOR_SIGN_TO_OPERATOR[tmt.hardware.Operator.EQ] \
+                if constraint.operator is tmt.hardware.Operator.CONTAINS \
+                else OPERATOR_SIGN_TO_OPERATOR[tmt.hardware.Operator.NEQ]
+            actual_value = str(constraint.value)
+
+            return MrackHWGroup(
+                'cpu',
+                children=[MrackHWBinOp('flag', beaker_operator, actual_value)]
+                )
+
         beaker_operator, actual_value, _ = operator_to_beaker_op(
             constraint.operator,
             str(constraint.value))


### PR DESCRIPTION
Starting with Artemis and Beaker plugins first. Artemis requires its own part of implementation.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] update the specification
* [x] mention the version
