### PR TITLE
Extract "package manager" functionality into plugins

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -49,6 +49,8 @@ jobs:
                 name: /plans/features/(core|basic)
 
   # Test pull requests (full)
+  # Do not run extended unit tests, that plan gets its own job because
+  # of podman vs systemd-resolved flakiness.
   - job: tests
     identifier: full
     trigger: pull_request
@@ -61,6 +63,26 @@ jobs:
             - full test
           absent:
             - discuss
+    tf_extra_params:
+        test:
+            tmt:
+                name: '^(?!/plans/features/extended-unit-tests).*$'
+
+  - job: tests
+    identifier: extended-unit-tests
+    trigger: pull_request
+    targets:
+      - fedora-39
+    require:
+        label:
+          present:
+            - full test
+          absent:
+            - discuss
+    tf_extra_params:
+        test:
+            tmt:
+                name: '/plans/features/extended-unit-tests$'
 
   # Test pull requests (provision)
   - job: tests

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -72,7 +72,7 @@ jobs:
     identifier: extended-unit-tests
     trigger: pull_request
     targets:
-      - fedora-39
+      - fedora-latest-stable
     require:
         label:
           present:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,10 +34,6 @@ repos:
           - "requests>=2.25.1"       # 2.28.2 / 2.31.0
           - "ruamel.yaml>=0.16.6"    # 0.17.32 / 0.17.32
           - "urllib3>=1.26.5, <2.0"  # 1.26.16 / 2.0.4
-          # Help installation by reducing the set of inspected botocore release.
-          # There is *a lot* of them, and hatch might fetch many of them.
-          - "botocore>=1.25.10"      # 1.25.10 is the current one available for RHEL9
-          - "boto3>=1.22.10"         # 1.22.10 is the current one available for RHEL9
 
           # report-junit
           - "junit_xml>=1.9"
@@ -82,10 +78,6 @@ repos:
           - "requests>=2.25.1"       # 2.28.2 / 2.31.0
           - "ruamel.yaml>=0.16.6"    # 0.17.32 / 0.17.32
           - "urllib3>=1.26.5, <2.0"  # 1.26.16 / 2.0.4
-          # Help installation by reducing the set of inspected botocore release.
-          # There is *a lot* of them, and hatch might fetch many of them.
-          - "botocore>=1.25.10"      # 1.25.10 is the current one available for RHEL9
-          - "boto3>=1.22.10"         # 1.22.10 is the current one available for RHEL9
 
           # report-junit
           - "junit_xml>=1.9"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
           # Help installation by reducing the set of inspected botocore release.
           # There is *a lot* of them, and hatch might fetch many of them.
           - "botocore>=1.25.10"      # 1.25.10 is the current one available for RHEL9
+          - "boto3>=1.22.10"         # 1.22.10 is the current one available for RHEL9
 
           # report-junit
           - "junit_xml>=1.9"
@@ -82,6 +83,7 @@ repos:
           # Help installation by reducing the set of inspected botocore release.
           # There is *a lot* of them, and hatch might fetch many of them.
           - "botocore>=1.25.10"      # 1.25.10 is the current one available for RHEL9
+          - "boto3>=1.22.10"         # 1.22.10 is the current one available for RHEL9
 
           # report-junit
           - "junit_xml>=1.9"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,9 @@ repos:
           # which is the version a developer encounters given the requirements are not
           # frozen.
           - "types-Markdown"
-          - "types-requests"
+          # prevent conflict between types-requests and urllib3
+          - "types-requests<2.31.0.7; python_version < '3.10'"
+          - "types-requests; python_version >= '3.10'"
           - "types-setuptools"
           - "types-jsonschema"
           - "types-urllib3"
@@ -95,7 +97,9 @@ repos:
           # which is the version a developer encounters given the requirements are not
           # frozen.
           - "types-Markdown"
-          - "types-requests"
+          # prevent conflict between types-requests and urllib3
+          - "types-requests<2.31.0.7; python_version < '3.10'"
+          - "types-requests; python_version >= '3.10'"
           - "types-setuptools"
           - "types-jsonschema"
           - "types-urllib3"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,10 @@ repos:
           - "requests>=2.25.1"       # 2.28.2 / 2.31.0
           - "ruamel.yaml>=0.16.6"    # 0.17.32 / 0.17.32
           - "urllib3>=1.26.5, <2.0"  # 1.26.16 / 2.0.4
+          # Help installation by reducing the set of inspected botocore release.
+          # There is *a lot* of them, and hatch might fetch many of them.
+          - "botocore>=1.25.10"      # 1.25.10 is the current one available for RHEL9
+
           # report-junit
           - "junit_xml>=1.9"
 
@@ -75,6 +79,10 @@ repos:
           - "requests>=2.25.1"       # 2.28.2 / 2.31.0
           - "ruamel.yaml>=0.16.6"    # 0.17.32 / 0.17.32
           - "urllib3>=1.26.5, <2.0"  # 1.26.16 / 2.0.4
+          # Help installation by reducing the set of inspected botocore release.
+          # There is *a lot* of them, and hatch might fetch many of them.
+          - "botocore>=1.25.10"      # 1.25.10 is the current one available for RHEL9
+
           # report-junit
           - "junit_xml>=1.9"
 
@@ -122,3 +130,6 @@ repos:
         - "docutils>=0.16"         # 0.16 is the current one available for RHEL9
         - "pint<0.20"
         - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
+        # Help installation by reducing the set of inspected botocore release.
+        # There is *a lot* of them, and hatch might fetch many of them.
+        - "botocore>=1.25.10"      # 1.25.10 is the current one available for RHEL9

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ images:  ## Build tmt images for podman/docker
 ## Development
 ##
 develop: _deps  ## Install development requirements
-	sudo dnf install -y gcc git python3-nitrate {libvirt,krb5,libpq}-devel jq podman
+	sudo dnf install -y gcc git python3-nitrate {libvirt,krb5,libpq,python3}-devel jq podman buildah
 
 # Git vim tags and cleanup
 tags:

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -24,6 +24,13 @@ connections, and may force reboot of the guest when it becomes
 unresponsive. This is the first step towards helping tests handle kernel
 panics and similar situations.
 
+Internal implementation of basic package manager actions has been
+refactored. tmt now supports package implementations to be shipped as
+plugins, therefore allowing for tmt to work natively with distributions
+beyond the ecosystem of rpm-based distributions. As a preview, ``apt``,
+the package manager used by Debian and Ubuntu, has been included in this
+release.
+
 __ https://pagure.io/testcloud/
 
 

--- a/plans/features/basic.fmf
+++ b/plans/features/basic.fmf
@@ -6,3 +6,4 @@ description:
 discover:
     how: fmf
     filter: 'tier: 2 & tag:-provision-only'
+    exclude: '/tests/unit/.*?/extended'

--- a/plans/features/core.fmf
+++ b/plans/features/core.fmf
@@ -6,3 +6,15 @@ description:
 discover:
     how: fmf
     filter: 'tier: 0, 1 & tag:-provision-only'
+
+adjust+:
+  # /tests/unit/with-development-packages/* needs `hatch` but there seem
+  # to be none for CentOS Stream 9. Test will request it, but on CentOS,
+  # we need a `prepare` phase to install it from PyPI. If we find
+  # `hatch` packaged, we can drop this workaround.
+  - when: distro == centos-stream
+    prepare+:
+      - how: shell
+        script:
+          - pip3 install --user hatch || pip3 install hatch
+          - hatch --help

--- a/plans/features/core.fmf
+++ b/plans/features/core.fmf
@@ -6,15 +6,3 @@ description:
 discover:
     how: fmf
     filter: 'tier: 0, 1 & tag:-provision-only'
-
-adjust+:
-  # /tests/unit/with-development-packages/* needs `hatch` but there seem
-  # to be none for CentOS Stream 9. Test will request it, but on CentOS,
-  # we need a `prepare` phase to install it from PyPI. If we find
-  # `hatch` packaged, we can drop this workaround.
-  - when: distro == centos-stream
-    prepare+:
-      - how: shell
-        script:
-          - pip3 install --user hatch || pip3 install hatch
-          - hatch --help

--- a/plans/features/extended-unit-tests.fmf
+++ b/plans/features/extended-unit-tests.fmf
@@ -14,6 +14,7 @@ adjust+:
       - name: disable systemd resolved
         how: shell
         script: |
+            set -x
             systemctl unmask systemd-resolved
             systemctl disable systemd-resolved
             systemctl mask systemd-resolved
@@ -21,6 +22,7 @@ adjust+:
             systemctl restart NetworkManager
             sleep 5
             cat /etc/resolv.conf
+            ps xa | grep resolv
 
   - when: trigger == commit
     provision:

--- a/plans/features/extended-unit-tests.fmf
+++ b/plans/features/extended-unit-tests.fmf
@@ -1,0 +1,29 @@
+summary: Unit tests working with containers
+description: |
+    A subset of unit tests that spawns containers.
+
+discover:
+    how: fmf
+    test: '/tests/unit/.*?/extended'
+
+# Disable systemd-resolved to prevent dns failures
+# See: https://github.com/teemtee/tmt/issues/2063
+adjust+:
+  - when: initiator == packit and distro == fedora
+    prepare+:
+      - name: disable systemd resolved
+        how: shell
+        script: |
+            systemctl unmask systemd-resolved
+            systemctl disable systemd-resolved
+            systemctl mask systemd-resolved
+            rm -f /etc/resolv.conf
+            systemctl restart NetworkManager
+            sleep 5
+            cat /etc/resolv.conf
+
+  - when: trigger == commit
+    provision:
+        hardware:
+          cpu:
+            processors: ">= 8"

--- a/plans/features/extended-unit-tests.fmf
+++ b/plans/features/extended-unit-tests.fmf
@@ -17,12 +17,14 @@ adjust+:
             set -x
             systemctl unmask systemd-resolved
             systemctl disable systemd-resolved
+            systemctl stop systemd-resolved
             systemctl mask systemd-resolved
             rm -f /etc/resolv.conf
             systemctl restart NetworkManager
             sleep 5
             cat /etc/resolv.conf
             ps xa | grep resolv
+            netstat -pnl
 
   - when: trigger == commit
     provision:

--- a/plans/features/extended-unit-tests.fmf
+++ b/plans/features/extended-unit-tests.fmf
@@ -27,3 +27,14 @@ adjust+:
         hardware:
           cpu:
             processors: ">= 8"
+
+  # /tests/unit/with-development-packages/* needs `hatch` but there seem
+  # to be none for CentOS Stream 9. Test will request it, but on CentOS,
+  # we need a `prepare` phase to install it from PyPI. If we find
+  # `hatch` packaged, we can drop this workaround.
+  - when: distro == centos-stream
+    prepare+:
+      - how: shell
+        script:
+          - pip3 install --user hatch || pip3 install hatch
+          - hatch --help

--- a/plans/features/extended-unit-tests.fmf
+++ b/plans/features/extended-unit-tests.fmf
@@ -27,14 +27,3 @@ adjust+:
         hardware:
           cpu:
             processors: ">= 8"
-
-  # /tests/unit/with-development-packages/* needs `hatch` but there seem
-  # to be none for CentOS Stream 9. Test will request it, but on CentOS,
-  # we need a `prepare` phase to install it from PyPI. If we find
-  # `hatch` packaged, we can drop this workaround.
-  - when: distro == centos-stream
-    prepare+:
-      - how: shell
-        script:
-          - pip3 install --user hatch || pip3 install hatch
-          - hatch --help

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -17,7 +17,8 @@ prepare+:
       # have to run as root to do that, and who's running tmt test suite
       # as root?
       #
-      - pip3 install --user yq || pip3 install yq
+      - pip3 install --user hatch yq || pip3 install hatch yq
+      - hatch --help
       - yq --help
 
 # Use the internal executor

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -31,3 +31,10 @@ adjust:
         how: install
         directory: tmp/RPMS/noarch
     when: how == full
+
+  - when: distro == centos-stream-9
+    prepare+:
+      - name: Install recent pip
+        how: shell
+        script:
+          - pip3 install --user pip

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -31,10 +31,3 @@ adjust:
         how: install
         directory: tmp/RPMS/noarch
     when: how == full
-
-  - when: distro == centos-stream-9
-    prepare+:
-      - name: Install recent pip
-        how: shell
-        script:
-          - pip3 install --user pip

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -17,8 +17,7 @@ prepare+:
       # have to run as root to do that, and who's running tmt test suite
       # as root?
       #
-      - pip3 install --user hatch yq || pip3 install hatch yq
-      - hatch --help
+      - pip3 install --user yq || pip3 install yq
       - yq --help
 
 # Use the internal executor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,6 @@ dependencies = [              # F39 / PyPI
     "requests>=2.25.1",       # 2.28.2 / 2.31.0
     "ruamel.yaml>=0.16.6",    # 0.17.32 / 0.17.32
     "urllib3>=1.26.5, <3.0",  # 1.26.16 / 2.0.4
-    # Help installation by reducing the set of inspected botocore release.
-    # There is *a lot* of them, and hatch might fetch many of them.
-    "botocore>=1.25.10",      # 1.25.10 is the current one available for RHEL9
-    "boto3>=1.22.10",         # 1.22.10 is the current one available for RHEL9
     ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,9 @@ dependencies = [
     # which is the version a developer encounters given the requirements are not
     # frozen.
     "types-Markdown",
-    "types-requests",
+    # prevent conflict between types-requests and urllib3
+    "types-requests<2.31.0.7; python_version < '3.10'",
+    "types-requests; python_version >= '3.10'",
     "types-setuptools",
     "types-jsonschema",
     "types-urllib3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [              # F39 / PyPI
     "requests>=2.25.1",       # 2.28.2 / 2.31.0
     "ruamel.yaml>=0.16.6",    # 0.17.32 / 0.17.32
     "urllib3>=1.26.5, <3.0",  # 1.26.16 / 2.0.4
+    # Help installation by reducing the set of inspected botocore release.
+    # There is *a lot* of them, and hatch might fetch many of them.
+    "botocore>=1.25.10",      # 1.25.10 is the current one available for RHEL9
     ]
 
 [project.optional-dependencies]
@@ -119,6 +122,8 @@ dependencies = [
     "mypy",
     "pytest",
     "python-coveralls",
+    "pytest-container",
+    "pytest-xdist",
     "requre",
     "yq==3.1.1",
     "pre-commit",
@@ -141,16 +146,16 @@ lint = ["autopep8 {args:.}", "ruff --fix {args:.}"]
 type = ["mypy {args:tmt}"]
 check = ["lint", "type"]
 
-unit = "pytest -vvv -ra --showlocals tests/unit"
-smoke = "pytest -vvv -ra --showlocals tests/unit/test_cli.py"
+unit = "pytest -vvv -ra --showlocals -n 0 tests/unit"
+smoke = "pytest -vvv -ra --showlocals -n 0 tests/unit/test_cli.py"
 cov = [
-    "coverage run --source=tmt -m pytest -vvv -ra --showlocals tests",
+    "coverage run --source=tmt -m pytest -vvv -ra --showlocals -n 0 tests",
     "coverage report",
     "coverage annotate",
     ]
 requre = [
     "cd {root}/tests/integration",
-    "pytest -vvv -ra --showlocals",
+    "pytest -vvv -ra --showlocals -n 0",
     "requre-patch purge --replaces :milestone_url:str:SomeText --replaces :latency:float:0 tests/integration/test_data/test_nitrate/*",
     ]
 
@@ -314,4 +319,7 @@ extend-immutable-calls = ["tmt.utils.field"]
 known-first-party = ["tmt"]
 
 [tool.pytest.ini_options]
-markers = ["web: tests which need to access the web"]
+markers = [
+    "containers: tests which need to spawn containers",
+    "web: tests which need to access the web"
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [              # F39 / PyPI
     # Help installation by reducing the set of inspected botocore release.
     # There is *a lot* of them, and hatch might fetch many of them.
     "botocore>=1.25.10",      # 1.25.10 is the current one available for RHEL9
+    "boto3>=1.22.10",         # 1.22.10 is the current one available for RHEL9
     ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,6 +159,11 @@ requre = [
     "requre-patch purge --replaces :milestone_url:str:SomeText --replaces :latency:float:0 tests/integration/test_data/test_nitrate/*",
     ]
 
+[tool.hatch.envs.dev-not-editable]
+template = "dev"
+description = "Same as 'dev', but not using editable install"
+dev-mode = false
+
 [tool.hatch.envs.test]
 template = "dev"
 description = "Run scripts with multiple Python versions"

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -1,10 +1,64 @@
 summary: Python unit tests
 description:
     Run all available python unit tests using pytest.
-test: python3 -m pytest -vvv -ra --showlocals
-framework: shell
-require:
-  - python3-pytest
+duration: 30m
 environment:
     LANG: en_US.UTF-8
-tier: 0
+
+    ENABLE_PARALLELIZATION: "no"
+    ENABLE_CONTAINERS: "no"
+    WITH_SYSTEM_PACKAGES: "no"
+
+require+:
+  - gcc
+  - git
+  - python3-nitrate
+  - libvirt-devel
+  - krb5-devel
+  - libpq-devel
+  - python3-devel
+  - jq
+  - podman
+  - buildah
+
+# Run against development packages via `hatch`.
+/with-development-packages:
+    enabled: true
+
+    /basic:
+        summary: Basic unit tests (development packages)
+        tier: 0
+
+    /extended:
+        summary: Extended unit tests (development packages)
+        tier: 2
+        duration: 1h
+
+        environment+: &extended_environment
+            ENABLE_PARALLELIZATION: "yes"
+            ENABLE_CONTAINERS: "yes"
+
+# Run against system, distro-packaged ones via `venv`.
+/with-system-packages:
+    enabled: false
+
+    environment+:
+        WITH_SYSTEM_PACKAGES: "yes"
+
+    require+:
+      - python3-pytest
+
+    adjust+:
+      - when: initiator == packit
+        enabled: true
+
+    /basic:
+        summary: Basic unit tests (system packages)
+        tier: 0
+
+    /extended:
+        summary: Extended unit tests (system packages)
+        tier: 2
+        duration: 1h
+
+        environment+: *extended_environment

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -13,6 +13,7 @@ adjust+:
   - when: distro == centos-stream-9
     environment+:
       HATCH_ENVIRONMENT: dev-not-editable
+    duration: 1h
 
 require+:
   - gcc
@@ -44,6 +45,10 @@ require+:
             ENABLE_PARALLELIZATION: "yes"
             ENABLE_CONTAINERS: "yes"
 
+        adjust+:
+          - when: distro == centos-stream-9
+            duration: 2h
+
 # Run against system, distro-packaged ones via `venv`.
 /with-system-packages:
     enabled: false
@@ -68,3 +73,7 @@ require+:
         duration: 1h
 
         environment+: *extended_environment
+
+        adjust+:
+          - when: distro == centos-stream-9
+            duration: 2h

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -20,20 +20,11 @@ require+:
   - jq
   - podman
   - buildah
+  - hatch
 
 # Run against development packages via `hatch`.
 /with-development-packages:
     enabled: true
-
-    # /tests/unit/with-development-packages/* needs `hatch` but there seem
-    # to be none for CentOS Stream 9. Test will request it, but on CentOS,
-    # we need a `prepare` phase to install it from PyPI. If we find
-    # `hatch` packaged, we can drop this workaround and make `hatch` a
-    # regular required package.
-    adjust+:
-      - when: distro == centos-stream
-        require+:
-          - hatch
 
     /basic:
         summary: Basic unit tests (development packages)

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -29,7 +29,13 @@ require+:
 
 # Run against development packages via `hatch`.
 /with-development-packages:
-    enabled: true
+    enabled: false
+
+    adjust+:
+      - when: initiator is not defined or distro == fedora-39
+        because: Enable locally or in CI on Fedora 39
+
+        enabled: true
 
     /basic:
         summary: Basic unit tests (development packages)
@@ -56,6 +62,8 @@ require+:
 
     adjust+:
       - when: initiator == packit
+        because: Enable in CI only
+
         enabled: true
 
     /basic:

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -13,7 +13,6 @@ adjust+:
   - when: distro == centos-stream-9
     environment+:
       HATCH_ENVIRONMENT: dev-not-editable
-    duration: 1h
 
 require+:
   - gcc
@@ -45,10 +44,6 @@ require+:
             ENABLE_PARALLELIZATION: "yes"
             ENABLE_CONTAINERS: "yes"
 
-        adjust+:
-          - when: distro == centos-stream-9
-            duration: 2h
-
 # Run against system, distro-packaged ones via `venv`.
 /with-system-packages:
     enabled: false
@@ -73,7 +68,3 @@ require+:
         duration: 1h
 
         environment+: *extended_environment
-
-        adjust+:
-          - when: distro == centos-stream-9
-            duration: 2h

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -9,6 +9,11 @@ environment:
     ENABLE_CONTAINERS: "no"
     WITH_SYSTEM_PACKAGES: "no"
 
+adjust+:
+  - when: distro == centos-stream-9
+    environment+:
+      HATCH_ENVIRONMENT: dev-not-editable
+
 require+:
   - gcc
   - git

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -25,6 +25,16 @@ require+:
 /with-development-packages:
     enabled: true
 
+    # /tests/unit/with-development-packages/* needs `hatch` but there seem
+    # to be none for CentOS Stream 9. Test will request it, but on CentOS,
+    # we need a `prepare` phase to install it from PyPI. If we find
+    # `hatch` packaged, we can drop this workaround and make `hatch` a
+    # regular required package.
+    adjust+:
+      - when: distro == centos-stream
+        require+:
+          - hatch
+
     /basic:
         summary: Basic unit tests (development packages)
         tier: 0

--- a/tests/unit/test.sh
+++ b/tests/unit/test.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        ENABLE_PARALLELIZATION="${ENABLE_PARALLELIZATION:-no}"
+        ENABLE_CONTAINERS="${ENABLE_CONTAINERS:-no}"
+        # TODO: `test` seems more natural, but creates 3 environments,
+        # one per available Python installation. I need to check whether
+        # to disable or take advantage of it.
+        HATCH_ENVIRONMENT="${HATCH_ENVIRONMENT:-dev}"
+
+        rlLogInfo "ENABLE_PARALLELIZATION=$ENABLE_PARALLELIZATION"
+        rlLogInfo "ENABLE_CONTAINERS=$ENABLE_CONTAINERS"
+        rlLogInfo "WITH_SYSTEM_PACKAGES=$WITH_SYSTEM_PACKAGES"
+        rlLogInfo "HATCH_ENVIRONMENT=$HATCH_ENVIRONMENT"
+
+        if [ "$ENABLE_PARALLELIZATION" = "yes" ]; then
+            PYTEST_PARALLELIZE="-n auto"
+        else
+            PYTEST_PARALLELIZE="-n 0"
+        fi
+
+        if [ "$ENABLE_CONTAINERS" = "yes" ]; then
+            PYTEST_MARK="-m containers"
+        else
+            PYTEST_MARK="-m 'not containers'"
+        fi
+
+        rlLogInfo "PYTEST_PARALLELIZE=$PYTEST_PARALLELIZE"
+        rlLogInfo "PYTEST_MARK=$PYTEST_MARK"
+
+        rlRun "PYTEST_COMMAND='pytest -vvv -ra --showlocals'"
+    rlPhaseEnd
+
+    if [ "$WITH_SYSTEM_PACKAGES" = "yes" ]; then
+        rlPhaseStartTest "Unit tests against system Python packages"
+            rlRun "TEST_VENV=$(mktemp -d)"
+
+            rlRun "python3 -m venv $TEST_VENV --system-site-packages"
+            rlRun "$TEST_VENV/bin/pip install pytest-container pytest-xdist"
+
+            # Note: we're not in the root directory!
+            rlRun "$TEST_VENV/bin/python3 -m $PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK ."
+
+            rlRun "rm -rf $TEST_VENV"
+        rlPhaseEnd
+    else
+        rlPhaseStartTest "Unit tests"
+            rlRun "hatch -v run $HATCH_ENVIRONMENT:$PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK tests/unit"
+        rlPhaseEnd
+    fi
+
+    rlPhaseStartCleanup
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/unit/test.sh
+++ b/tests/unit/test.sh
@@ -32,6 +32,10 @@ rlJournalStart
         rlLogInfo "PYTEST_MARK=$PYTEST_MARK"
 
         rlRun "PYTEST_COMMAND='pytest -vvv -ra --showlocals'"
+
+        rlLogInfo "pip is $(which pip), $(pip --version)"
+        rlLogInfo "hatch is $(which hatch), $(hatch --version)"
+        rlLogInfo "hatch is $(which hatch), $(hatch --version)"
     rlPhaseEnd
 
     if [ "$WITH_SYSTEM_PACKAGES" = "yes" ]; then
@@ -48,7 +52,7 @@ rlJournalStart
         rlPhaseEnd
     else
         rlPhaseStartTest "Unit tests"
-            rlRun "hatch -v run $HATCH_ENVIRONMENT:$PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK tests/unit"
+            rlRun "hatch -vvvv run $HATCH_ENVIRONMENT:$PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK tests/unit"
         rlPhaseEnd
     fi
 

--- a/tests/unit/test.sh
+++ b/tests/unit/test.sh
@@ -51,9 +51,9 @@ rlJournalStart
         rlPhaseEnd
     else
         rlPhaseStartTest "Unit tests"
-            # Only pip 21.3+ will be able to install project in editable mode.
-            # See https://github.com/pypa/hatch/discussions/806#discussioncomment-5503233
-            rlRun "hatch -vvvv run $HATCH_ENVIRONMENT:pip install -U 'pip>=21.3'"
+            if rlIsCentOS; then
+                rlRun "hatch -vv run $HATCH_ENVIRONMENT:ls" 1
+            fi
 
             rlRun "hatch -vvvv run $HATCH_ENVIRONMENT:$PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK tests/unit"
         rlPhaseEnd

--- a/tests/unit/test.sh
+++ b/tests/unit/test.sh
@@ -35,7 +35,6 @@ rlJournalStart
 
         rlLogInfo "pip is $(which pip), $(pip --version)"
         rlLogInfo "hatch is $(which hatch), $(hatch --version)"
-        rlLogInfo "hatch is $(which hatch), $(hatch --version)"
     rlPhaseEnd
 
     if [ "$WITH_SYSTEM_PACKAGES" = "yes" ]; then
@@ -52,6 +51,10 @@ rlJournalStart
         rlPhaseEnd
     else
         rlPhaseStartTest "Unit tests"
+            # Only pip 21.3+ will be able to install project in editable mode.
+            # See https://github.com/pypa/hatch/discussions/806#discussioncomment-5503233
+            rlRun "hatch -vvvv run $HATCH_ENVIRONMENT:pip install -U '>=21.3'"
+
             rlRun "hatch -vvvv run $HATCH_ENVIRONMENT:$PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK tests/unit"
         rlPhaseEnd
     fi

--- a/tests/unit/test.sh
+++ b/tests/unit/test.sh
@@ -53,7 +53,7 @@ rlJournalStart
         rlPhaseStartTest "Unit tests"
             # Only pip 21.3+ will be able to install project in editable mode.
             # See https://github.com/pypa/hatch/discussions/806#discussioncomment-5503233
-            rlRun "hatch -vvvv run $HATCH_ENVIRONMENT:pip install -U '>=21.3'"
+            rlRun "hatch -vvvv run $HATCH_ENVIRONMENT:pip install -U 'pip>=21.3'"
 
             rlRun "hatch -vvvv run $HATCH_ENVIRONMENT:$PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK tests/unit"
         rlPhaseEnd

--- a/tests/unit/test.sh
+++ b/tests/unit/test.sh
@@ -52,10 +52,10 @@ rlJournalStart
     else
         rlPhaseStartTest "Unit tests"
             if rlIsCentOS; then
-                rlRun "hatch -vv run $HATCH_ENVIRONMENT:ls" 1
+                rlRun "hatch -v run $HATCH_ENVIRONMENT:ls" 1
             fi
 
-            rlRun "hatch -vvvv run $HATCH_ENVIRONMENT:$PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK tests/unit"
+            rlRun "hatch -v run $HATCH_ENVIRONMENT:$PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK tests/unit"
         rlPhaseEnd
     fi
 

--- a/tests/unit/test.sh
+++ b/tests/unit/test.sh
@@ -51,10 +51,6 @@ rlJournalStart
         rlPhaseEnd
     else
         rlPhaseStartTest "Unit tests"
-            if rlIsCentOS; then
-                rlRun "hatch -v run $HATCH_ENVIRONMENT:ls" 1
-            fi
-
             rlRun "hatch -v run $HATCH_ENVIRONMENT:$PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK tests/unit"
         rlPhaseEnd
     fi

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1,0 +1,954 @@
+from collections.abc import Iterator
+from inspect import isclass
+from typing import Optional
+
+import _pytest.logging
+import pytest
+from pytest_container import Container
+from pytest_container.container import ContainerData
+
+import tmt.log
+import tmt.package_managers
+import tmt.package_managers.apt
+import tmt.package_managers.dnf
+import tmt.package_managers.rpm_ostree
+import tmt.plugins
+import tmt.steps.provision.podman
+import tmt.utils
+from tmt.package_managers import (
+    FileSystemPath,
+    Installable,
+    Options,
+    Package,
+    PackageManager,
+    PackageManagerClass,
+    )
+from tmt.steps.provision.podman import GuestContainer, PodmanGuestData
+from tmt.utils import ShellScript
+
+from . import MATCH, assert_log
+
+# We will need a logger...
+logger = tmt.Logger.create()
+logger.add_console_handler()
+
+# Explore available plugins
+tmt.plugins.explore(logger)
+
+
+CONTAINER_FEDORA_RAWHIDE = Container(url='registry.fedoraproject.org/fedora:rawhide')
+CONTAINER_FEDORA_39 = Container(url='registry.fedoraproject.org/fedora:39')
+CONTAINER_CENTOS_STREAM_8 = Container(url='quay.io/centos/centos:stream8')
+CONTAINER_CENTOS_7 = Container(url='quay.io/centos/centos:7')
+CONTAINER_UBUNTU_2204 = Container(url='docker.io/library/ubuntu:22.04')
+CONTAINER_FEDORA_COREOS = Container(url='quay.io/fedora/fedora-coreos:stable')
+
+PACKAGE_MANAGER_DNF5 = tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.get_plugin('dnf5')
+PACKAGE_MANAGER_DNF = tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.get_plugin('dnf')
+PACKAGE_MANAGER_YUM = tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.get_plugin('yum')
+PACKAGE_MANAGER_APT = tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.get_plugin('apt')
+PACKAGE_MANAGER_RPMOSTREE = tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY \
+    .get_plugin('rpm-ostree')
+
+
+CONTAINER_BASE_MATRIX = [
+    # Fedora
+    (CONTAINER_FEDORA_RAWHIDE, PACKAGE_MANAGER_DNF5),
+    (CONTAINER_FEDORA_RAWHIDE, PACKAGE_MANAGER_DNF),
+    (CONTAINER_FEDORA_RAWHIDE, PACKAGE_MANAGER_YUM),
+
+    (CONTAINER_FEDORA_39, PACKAGE_MANAGER_DNF5),
+    (CONTAINER_FEDORA_39, PACKAGE_MANAGER_DNF),
+    (CONTAINER_FEDORA_39, PACKAGE_MANAGER_YUM),
+
+    # CentOS Stream
+    (CONTAINER_CENTOS_STREAM_8, PACKAGE_MANAGER_DNF),
+    (CONTAINER_CENTOS_STREAM_8, PACKAGE_MANAGER_YUM),
+
+    # CentOS
+    (CONTAINER_CENTOS_7, PACKAGE_MANAGER_YUM),
+
+    # Ubuntu
+    (CONTAINER_UBUNTU_2204, PACKAGE_MANAGER_APT),
+
+    # Fedora CoreOS
+    (CONTAINER_FEDORA_COREOS, PACKAGE_MANAGER_RPMOSTREE),
+    ]
+
+CONTAINER_MATRIX_IDS = [
+    f'{container.url} / {package_manager_class.__name__.lower()}'
+    for container, package_manager_class in CONTAINER_BASE_MATRIX
+    ]
+
+
+@pytest.fixture(name='guest')
+def fixture_guest(container: ContainerData, root_logger: tmt.log.Logger) -> GuestContainer:
+    guest_data = PodmanGuestData(
+        image=container.image_url_or_id,
+        container=container.container_id
+        )
+
+    guest = GuestContainer(
+        logger=root_logger,
+        data=guest_data,
+        name='dummy-container')
+
+    guest.start()
+
+    return guest
+
+
+@pytest.fixture(name='guest_per_test')
+def fixture_guest_per_test(
+        container_per_test: ContainerData,
+        root_logger: tmt.log.Logger) -> GuestContainer:
+    guest_data = PodmanGuestData(
+        image=container_per_test.image_url_or_id,
+        container=container_per_test.container_id
+        )
+
+    guest = GuestContainer(
+        logger=root_logger,
+        data=guest_data,
+        name='dummy-container')
+
+    guest.start()
+
+    return guest
+
+
+def create_package_manager(
+        container: ContainerData,
+        guest: GuestContainer,
+        package_manager_class: PackageManagerClass,
+        logger: tmt.log.Logger) -> PackageManager:
+    guest_data = tmt.steps.provision.podman.PodmanGuestData(
+        image=container.image_url_or_id,
+        container=container.container_id
+        )
+
+    guest = tmt.steps.provision.podman.GuestContainer(
+        logger=logger,
+        data=guest_data,
+        name='dummy-container')
+    guest.start()
+
+    if package_manager_class is tmt.package_managers.dnf.Dnf5:
+        guest.execute(ShellScript('dnf install --nogpgcheck -y dnf5'))
+
+    elif package_manager_class is tmt.package_managers.apt.Apt:
+        guest.execute(ShellScript('apt update'))
+
+    return package_manager_class(guest=guest, logger=logger)
+
+
+def _parametrize_test_install() -> \
+        Iterator[tuple[Container, PackageManagerClass, str, Optional[str], Optional[str]]]:
+
+    for container, package_manager_class in CONTAINER_BASE_MATRIX:
+        if package_manager_class is tmt.package_managers.dnf.Yum:
+            yield container, \
+                package_manager_class, \
+                r"rpm -q --whatprovides tree \|\| yum install -y  tree && rpm -q --whatprovides tree", \
+                'Installed:\n  tree', \
+                None  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf:
+            yield container, \
+                package_manager_class, \
+                r"rpm -q --whatprovides tree \|\| dnf install -y  tree", \
+                'Installed:\n  tree', \
+                None
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf5:
+            yield container, \
+                package_manager_class, \
+                r"rpm -q --whatprovides tree \|\| dnf5 install -y  tree", \
+                None, \
+                None
+
+        elif package_manager_class is tmt.package_managers.apt.Apt:
+            yield container, \
+                package_manager_class, \
+                r"export DEBIAN_FRONTEND=noninteractive; dpkg-query --show tree \|\| apt install -y  tree", \
+                'Setting up tree', \
+                None  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
+            yield container, \
+                package_manager_class, \
+                r"rpm -q --whatprovides tree \|\| rpm-ostree install --apply-live --idempotent --allow-inactive  tree", \
+                'Installing: tree', \
+                None  # noqa: E501
+
+        else:
+            pytest.fail(f"Unhandled package manager class '{package_manager_class}'.")
+
+
+@pytest.mark.containers()
+@pytest.mark.parametrize(('container_per_test',
+                          'package_manager_class',
+                          'expected_command',
+                          'expected_stdout',
+                          'expected_stderr'),
+                         list(_parametrize_test_install()),
+                         indirect=["container_per_test"],
+                         ids=CONTAINER_MATRIX_IDS)
+def test_install(
+        container_per_test: ContainerData,
+        guest_per_test: GuestContainer,
+        package_manager_class: PackageManagerClass,
+        expected_command: str,
+        expected_stdout: Optional[str],
+        expected_stderr: Optional[str],
+        root_logger: tmt.log.Logger,
+        caplog: _pytest.logging.LogCaptureFixture) -> None:
+    package_manager = create_package_manager(
+        container_per_test,
+        guest_per_test,
+        package_manager_class,
+        root_logger)
+
+    output = package_manager.install(Package('tree'))
+
+    assert_log(caplog, message=MATCH(
+        rf"Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+
+    if expected_stdout:
+        assert output.stdout is not None
+        assert expected_stdout in output.stdout
+
+    if expected_stderr:
+        assert output.stderr is not None
+        assert expected_stderr in output.stderr
+
+
+def _parametrize_test_install_nonexistent() -> \
+        Iterator[tuple[Container, PackageManagerClass, str, Optional[str], Optional[str]]]:
+
+    for container, package_manager_class in CONTAINER_BASE_MATRIX:
+        if package_manager_class is tmt.package_managers.dnf.Dnf5:
+            yield container, \
+                package_manager_class, \
+                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf5 install -y  tree-but-spelled-wrong", \
+                None, \
+                'No match for argument: tree-but-spelled-wrong'  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf:
+            yield container, \
+                package_manager_class, \
+                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf install -y  tree-but-spelled-wrong", \
+                None, \
+                'Error: Unable to find a match: tree-but-spelled-wrong'  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.dnf.Yum:
+            if 'fedora' in container.url:
+                yield container, \
+                    package_manager_class, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong", \
+                    None, \
+                    'Error: Unable to find a match: tree-but-spelled-wrong'  # noqa: E501
+
+            elif 'centos' in container.url and 'centos:7' not in container.url:
+                yield container, \
+                    package_manager_class, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong", \
+                    'No match for argument: tree-but-spelled-wrong', \
+                    'Error: Unable to find a match: tree-but-spelled-wrong'  # noqa: E501
+
+            else:
+                yield container, \
+                    package_manager_class, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong", \
+                    'No package tree-but-spelled-wrong available.', \
+                    'Error: Nothing to do'  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.apt.Apt:
+            yield container, \
+                package_manager_class, \
+                r"export DEBIAN_FRONTEND=noninteractive; dpkg-query --show tree-but-spelled-wrong \|\| apt install -y  tree-but-spelled-wrong", \
+                None, \
+                'E: Unable to locate package tree-but-spelled-wrong'  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
+            yield container, \
+                package_manager_class, \
+                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| rpm-ostree install --apply-live --idempotent --allow-inactive  tree-but-spelled-wrong", \
+                'no package provides tree-but-spelled-wrong', \
+                'error: Packages not found: tree-but-spelled-wrong'  # noqa: E501
+
+        else:
+            pytest.fail(f"Unhandled package manager class '{package_manager_class}'.")
+
+
+@pytest.mark.containers()
+@pytest.mark.parametrize(('container',
+                          'package_manager_class',
+                          'expected_command',
+                          'expected_stdout',
+                          'expected_stderr'),
+                         list(_parametrize_test_install_nonexistent()),
+                         indirect=["container"],
+                         ids=CONTAINER_MATRIX_IDS)
+def test_install_nonexistent(
+        container: ContainerData,
+        guest: GuestContainer,
+        package_manager_class: PackageManagerClass,
+        expected_command: str,
+        expected_stdout: Optional[str],
+        expected_stderr: Optional[str],
+        root_logger: tmt.log.Logger,
+        caplog: _pytest.logging.LogCaptureFixture) -> None:
+    package_manager = create_package_manager(container, guest, package_manager_class, root_logger)
+
+    with pytest.raises(tmt.utils.RunError) as excinfo:
+        package_manager.install(Package('tree-but-spelled-wrong'))
+
+    assert_log(caplog, message=MATCH(
+        rf"Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+
+    assert excinfo.type is tmt.utils.RunError
+    assert excinfo.value.returncode != 0
+
+    if expected_stdout:
+        assert excinfo.value.stdout is not None
+        assert expected_stdout in excinfo.value.stdout
+
+    if expected_stderr:
+        assert excinfo.value.stderr is not None
+        assert expected_stderr in excinfo.value.stderr
+
+
+def _parametrize_test_install_nonexistent_skip() -> \
+        Iterator[tuple[Container, PackageManagerClass, str, Optional[str], Optional[str]]]:
+
+    for container, package_manager_class in CONTAINER_BASE_MATRIX:
+        if package_manager_class is tmt.package_managers.dnf.Dnf5:
+            yield container, \
+                package_manager_class, \
+                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf5 install -y --skip-unavailable tree-but-spelled-wrong", \
+                None, \
+                None  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf:
+            yield container, \
+                package_manager_class, \
+                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf install -y --skip-broken tree-but-spelled-wrong", \
+                'No match for argument: tree-but-spelled-wrong', \
+                None  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.dnf.Yum:
+            if 'fedora' in container.url:  # noqa: SIM114
+                yield container, \
+                    package_manager_class, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true", \
+                    'No match for argument: tree-but-spelled-wrong', \
+                    None  # noqa: E501
+
+            elif 'centos' in container.url and 'centos:7' not in container.url:
+                yield container, \
+                    package_manager_class, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true", \
+                    'No match for argument: tree-but-spelled-wrong', \
+                    None  # noqa: E501
+
+            else:
+                yield container, \
+                    package_manager_class, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true", \
+                    'No package tree-but-spelled-wrong available.', \
+                    'Error: Nothing to do'  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.apt.Apt:
+            yield container, \
+                package_manager_class, \
+                r"export DEBIAN_FRONTEND=noninteractive; dpkg-query --show tree-but-spelled-wrong \|\| apt install -y --ignore-missing tree-but-spelled-wrong \|\| /bin/true", \
+                None, \
+                'E: Unable to locate package tree-but-spelled-wrong'  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
+            yield container, \
+                package_manager_class, \
+                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| rpm-ostree install --apply-live --idempotent --allow-inactive  tree-but-spelled-wrong \|\| /bin/true", \
+                'no package provides tree-but-spelled-wrong', \
+                'error: Packages not found: tree-but-spelled-wrong'  # noqa: E501
+
+        else:
+            pytest.fail(f"Unhandled package manager class '{package_manager_class}'.")
+
+
+@pytest.mark.containers()
+@pytest.mark.parametrize(('container',
+                          'package_manager_class',
+                          'expected_command',
+                          'expected_stdout',
+                          'expected_stderr'),
+                         list(_parametrize_test_install_nonexistent_skip()),
+                         indirect=["container"],
+                         ids=CONTAINER_MATRIX_IDS)
+def test_install_nonexistent_skip(
+        container: ContainerData,
+        guest: GuestContainer,
+        package_manager_class: PackageManagerClass,
+        expected_command: str,
+        expected_stdout: Optional[str],
+        expected_stderr: Optional[str],
+        root_logger: tmt.log.Logger,
+        caplog: _pytest.logging.LogCaptureFixture) -> None:
+    package_manager = create_package_manager(container, guest, package_manager_class, root_logger)
+
+    output = package_manager.install(
+        Package('tree-but-spelled-wrong'),
+        options=Options(skip_missing=True)
+        )
+
+    assert_log(caplog, message=MATCH(
+        rf"Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+
+    if expected_stdout:
+        assert output.stdout is not None
+        assert expected_stdout in output.stdout
+
+    if expected_stderr:
+        assert output.stderr is not None
+        assert expected_stderr in output.stderr
+
+
+def _parametrize_test_install_dont_check_first() -> \
+        Iterator[tuple[Container, PackageManagerClass, str, Optional[str], Optional[str]]]:
+
+    for container, package_manager_class in CONTAINER_BASE_MATRIX:
+        if package_manager_class is tmt.package_managers.dnf.Dnf5:
+            yield container, \
+                package_manager_class, \
+                r"dnf5 install -y  tree", \
+                None, \
+                None
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf:
+            yield container, \
+                package_manager_class, \
+                r"dnf install -y  tree", \
+                'Installed:\n  tree', \
+                None
+
+        elif package_manager_class is tmt.package_managers.dnf.Yum:
+            yield container, \
+                package_manager_class, \
+                r"yum install -y  tree && rpm -q --whatprovides tree", \
+                'Installed:\n  tree', \
+                None
+
+        elif package_manager_class is tmt.package_managers.apt.Apt:
+            yield container, \
+                package_manager_class, \
+                r"export DEBIAN_FRONTEND=noninteractive; apt install -y  tree", \
+                'Setting up tree', \
+                None
+
+        elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
+            yield container, \
+                package_manager_class, \
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive  tree", \
+                'Installing: tree', \
+                None
+
+        else:
+            pytest.fail(f"Unhandled package manager class '{package_manager_class}'.")
+
+
+@pytest.mark.containers()
+@pytest.mark.parametrize(('container_per_test',
+                          'package_manager_class',
+                          'expected_command',
+                          'expected_stdout',
+                          'expected_stderr'),
+                         list(_parametrize_test_install_dont_check_first()),
+                         indirect=["container_per_test"],
+                         ids=CONTAINER_MATRIX_IDS)
+def test_install_dont_check_first(
+        container_per_test: ContainerData,
+        guest_per_test: GuestContainer,
+        package_manager_class: PackageManagerClass,
+        expected_command: str,
+        expected_stdout: Optional[str],
+        expected_stderr: Optional[str],
+        root_logger: tmt.log.Logger,
+        caplog: _pytest.logging.LogCaptureFixture) -> None:
+    package_manager = create_package_manager(
+        container_per_test,
+        guest_per_test,
+        package_manager_class,
+        root_logger)
+
+    output = package_manager.install(
+        Package('tree'),
+        options=Options(check_first=False)
+        )
+
+    assert_log(caplog, message=MATCH(
+        rf"Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+
+    if expected_stdout:
+        assert output.stdout is not None
+        assert expected_stdout in output.stdout
+
+    if expected_stderr:
+        assert output.stderr is not None
+        assert expected_stderr in output.stderr
+
+
+def _parametrize_test_reinstall() -> Iterator[tuple[
+        Container, PackageManagerClass, Optional[str], Optional[str], Optional[str]]]:
+
+    for container, package_manager_class in CONTAINER_BASE_MATRIX:
+        if package_manager_class is tmt.package_managers.dnf.Yum:
+            if 'centos:7' in container.url:
+                yield container, \
+                    package_manager_class, \
+                    True, \
+                    r"rpm -q --whatprovides tar && yum reinstall -y  tar && rpm -q --whatprovides tar", \
+                    'Reinstalling:\n tar', \
+                    None  # noqa: E501
+
+            else:
+                yield container, \
+                    package_manager_class, \
+                    True, \
+                    r"rpm -q --whatprovides tar && yum reinstall -y  tar && rpm -q --whatprovides tar", \
+                    'Reinstalled:\n  tar', \
+                    None  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf:
+            yield container, \
+                package_manager_class, \
+                True, \
+                r"rpm -q --whatprovides tar && dnf reinstall -y  tar", \
+                'Reinstalled:\n  tar', \
+                None
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf5:
+            yield container, \
+                package_manager_class, \
+                True, \
+                r"rpm -q --whatprovides tar && dnf5 reinstall -y  tar", \
+                'Reinstalling tar', \
+                None
+
+        elif package_manager_class is tmt.package_managers.apt.Apt:
+            yield container, \
+                package_manager_class, \
+                True, \
+                r"export DEBIAN_FRONTEND=noninteractive; dpkg-query --show tar && apt reinstall -y  tar", \
+                'Setting up tar', \
+                None  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
+            yield container, \
+                package_manager_class, \
+                False, \
+                None, \
+                None, \
+                None
+
+        else:
+            pytest.fail(f"Unhandled package manager class '{package_manager_class}'.")
+
+
+@pytest.mark.containers()
+@pytest.mark.parametrize(('container_per_test',
+                          'package_manager_class',
+                          'supported',
+                          'expected_command',
+                          'expected_stdout',
+                          'expected_stderr'),
+                         list(_parametrize_test_reinstall()),
+                         indirect=["container_per_test"],
+                         ids=CONTAINER_MATRIX_IDS)
+def test_reinstall(
+        container_per_test: ContainerData,
+        guest_per_test: GuestContainer,
+        package_manager_class: PackageManagerClass,
+        supported: bool,
+        expected_command: Optional[str],
+        expected_stdout: Optional[str],
+        expected_stderr: Optional[str],
+        root_logger: tmt.log.Logger,
+        caplog: _pytest.logging.LogCaptureFixture) -> None:
+    package_manager = create_package_manager(
+        container_per_test,
+        guest_per_test,
+        package_manager_class,
+        root_logger)
+
+    if supported:
+        assert expected_command is not None
+
+        output = package_manager.reinstall(Package('tar'))
+
+        assert_log(caplog, message=MATCH(
+            rf"Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+
+    else:
+        with pytest.raises(tmt.utils.GeneralError) as excinfo:
+            package_manager.reinstall(Package('tar'))
+
+        assert excinfo.value.message \
+            == "rpm-ostree does not support reinstall operation."
+
+    if expected_stdout:
+        assert output.stdout is not None
+        assert expected_stdout in output.stdout
+
+    if expected_stderr:
+        assert output.stderr is not None
+        assert expected_stderr in output.stderr
+
+
+def _generate_test_reinstall_nonexistent_matrix() -> Iterator[tuple[
+        Container, PackageManagerClass, Optional[str], Optional[str], Optional[str]]]:
+
+    for container, package_manager_class in CONTAINER_BASE_MATRIX:
+        if package_manager_class is tmt.package_managers.dnf.Dnf5:
+            yield container, \
+                package_manager_class, \
+                True, \
+                r"rpm -q --whatprovides tree-but-spelled-wrong && dnf5 reinstall -y  tree-but-spelled-wrong", \
+                'no package provides tree-but-spelled-wrong', \
+                None  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf:
+            yield container, \
+                package_manager_class, \
+                True, \
+                r"rpm -q --whatprovides tree-but-spelled-wrong && dnf reinstall -y  tree-but-spelled-wrong", \
+                'no package provides tree-but-spelled-wrong', \
+                None  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.dnf.Yum:
+            if 'fedora' in container.url:  # noqa: SIM114
+                yield container, \
+                    package_manager_class, \
+                    True, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong && yum reinstall -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong", \
+                    'no package provides tree-but-spelled-wrong', \
+                    None  # noqa: E501
+
+            elif 'centos' in container.url and 'centos:7' not in container.url:
+                yield container, \
+                    package_manager_class, \
+                    True, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong && yum reinstall -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong", \
+                    'no package provides tree-but-spelled-wrong', \
+                    None  # noqa: E501
+
+            else:
+                yield container, \
+                    package_manager_class, \
+                    True, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong && yum reinstall -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong", \
+                    'no package provides tree-but-spelled-wrong', \
+                None  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.apt.Apt:
+            yield container, \
+                package_manager_class, \
+                True, \
+                r"export DEBIAN_FRONTEND=noninteractive; dpkg-query --show tree-but-spelled-wrong && apt reinstall -y  tree-but-spelled-wrong", \
+                None, \
+                'dpkg-query: no packages found matching tree-but-spelled-wrong'  # noqa: E501
+
+        elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
+            yield container, \
+                package_manager_class, \
+                False, \
+                None, \
+                None, \
+                None
+
+        else:
+            pytest.fail(f"Unhandled package manager class '{package_manager_class}'.")
+
+
+@pytest.mark.containers()
+@pytest.mark.parametrize(('container',
+                          'package_manager_class',
+                          'supported',
+                          'expected_command',
+                          'expected_stdout',
+                          'expected_stderr'),
+                         list(_generate_test_reinstall_nonexistent_matrix()),
+                         indirect=["container"],
+                         ids=CONTAINER_MATRIX_IDS)
+def test_reinstall_nonexistent(
+        container: ContainerData,
+        guest: GuestContainer,
+        package_manager_class: PackageManagerClass,
+        supported: bool,
+        expected_command: str,
+        expected_stdout: Optional[str],
+        expected_stderr: Optional[str],
+        root_logger: tmt.log.Logger,
+        caplog: _pytest.logging.LogCaptureFixture) -> None:
+    package_manager = create_package_manager(container, guest, package_manager_class, root_logger)
+
+    if supported:
+        assert expected_command is not None
+
+        with pytest.raises(tmt.utils.RunError) as excinfo:
+            package_manager.reinstall(Package('tree-but-spelled-wrong'))
+
+        assert_log(caplog, message=MATCH(
+            rf"Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+
+        assert excinfo.type is tmt.utils.RunError
+        assert excinfo.value.returncode != 0
+
+    else:
+        with pytest.raises(tmt.utils.GeneralError) as excinfo:
+            package_manager.reinstall(Package('tree-but-spelled-wrong'))
+
+        assert excinfo.value.message \
+            == "rpm-ostree does not support reinstall operation."
+
+    if expected_stdout:
+        assert excinfo.value.stdout is not None
+        assert expected_stdout in excinfo.value.stdout
+
+    if expected_stderr:
+        assert excinfo.value.stderr is not None
+        assert expected_stderr in excinfo.value.stderr
+
+
+def _generate_test_check_presence() -> Iterator[
+        tuple[Container, PackageManagerClass, Installable, str, Optional[str], Optional[str]]]:
+
+    for container, package_manager_class in CONTAINER_BASE_MATRIX:
+        if package_manager_class is tmt.package_managers.dnf.Dnf5:
+            yield container, \
+                package_manager_class, \
+                Package('util-linux-core'), \
+                True, \
+                r"rpm -q --whatprovides util-linux-core", \
+                r'\s+out:\s+util-linux-core-', \
+                None
+
+            yield container, \
+                package_manager_class, \
+                Package('tree-but-spelled-wrong'), \
+                False, \
+                r"rpm -q --whatprovides tree-but-spelled-wrong", \
+                r'\s+out:\s+no package provides tree-but-spelled-wrong', \
+                None
+
+            yield container, \
+                package_manager_class, \
+                FileSystemPath('/usr/bin/flock'), \
+                True, \
+                r"rpm -q --whatprovides /usr/bin/flock", \
+                r'\s+out:\s+util-linux-core-', \
+                None
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf:
+            if 'centos:stream8' in container.url:
+                yield container, \
+                    package_manager_class, \
+                    Package('util-linux'), \
+                    True, \
+                    r"rpm -q --whatprovides util-linux", \
+                    r'\s+out:\s+util-linux-', \
+                    None
+
+                yield container, \
+                    package_manager_class, \
+                    Package('tree-but-spelled-wrong'), \
+                    False, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong", \
+                    r'\s+out:\s+no package provides tree-but-spelled-wrong', \
+                    None
+
+                yield container, \
+                    package_manager_class, \
+                    FileSystemPath('/usr/bin/flock'), \
+                    True, \
+                    r"rpm -q --whatprovides /usr/bin/flock", \
+                    r'\s+out:\s+util-linux-', \
+                    None
+
+            else:
+                yield container, \
+                    package_manager_class, \
+                    Package('util-linux-core'), \
+                    True, \
+                    r"rpm -q --whatprovides util-linux-core", \
+                    r'\s+out:\s+util-linux-core-', \
+                    None
+
+                yield container, \
+                    package_manager_class, \
+                    Package('tree-but-spelled-wrong'), \
+                    False, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong", \
+                    r'\s+out:\s+no package provides tree-but-spelled-wrong', \
+                    None
+
+                yield container, \
+                    package_manager_class, \
+                    FileSystemPath('/usr/bin/flock'), \
+                    True, \
+                    r"rpm -q --whatprovides /usr/bin/flock", \
+                    r'\s+out:\s+util-linux-core-', \
+                    None
+
+        elif package_manager_class is tmt.package_managers.dnf.Yum:
+            if 'centos:stream8' in container.url or 'centos:7' in container.url:
+                yield container, \
+                    package_manager_class, \
+                    Package('util-linux'), \
+                    True, \
+                    r"rpm -q --whatprovides util-linux", \
+                    r'\s+out:\s+util-linux-', \
+                    None
+
+                yield container, \
+                    package_manager_class, \
+                    Package('tree-but-spelled-wrong'), \
+                    False, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong", \
+                    r'\s+out:\s+no package provides tree-but-spelled-wrong', \
+                    None
+
+                yield container, \
+                    package_manager_class, \
+                    FileSystemPath('/usr/bin/flock'), \
+                    True, \
+                    r"rpm -q --whatprovides /usr/bin/flock", \
+                    r'\s+out:\s+util-linux-', \
+                    None
+
+            else:
+                yield container, \
+                    package_manager_class, \
+                    Package('util-linux-core'), \
+                    True, \
+                    r"rpm -q --whatprovides util-linux-core", \
+                    r'\s+out:\s+util-linux-core-', \
+                    None
+
+                yield container, \
+                    package_manager_class, \
+                    Package('tree-but-spelled-wrong'), \
+                    False, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong", \
+                    r'\s+out:\s+no package provides tree-but-spelled-wrong', \
+                    None
+
+                yield container, \
+                    package_manager_class, \
+                    FileSystemPath('/usr/bin/flock'), \
+                    True, \
+                    r"rpm -q --whatprovides /usr/bin/flock", \
+                    r'\s+out:\s+util-linux-core-', \
+                    None
+
+        elif package_manager_class is tmt.package_managers.apt.Apt:
+            yield container, \
+                package_manager_class, \
+                Package('util-linux'), \
+                True, \
+                r"dpkg-query --show util-linux", \
+                r'\s+out:\s+util-linux', \
+                None
+
+            yield container, \
+                package_manager_class, \
+                Package('tree-but-spelled-wrong'), \
+                False, \
+                r"dpkg-query --show tree-but-spelled-wrong", \
+                None, \
+                r'\s+err:\s+dpkg-query: no packages found matching tree-but-spelled-wrong'
+
+            yield container, \
+                package_manager_class, \
+                FileSystemPath('/usr/bin/flock'), \
+                True, \
+                r"dpkg-query --show util-linux", \
+                r'\s+out:\s+util-linux', \
+                None
+
+        elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
+            yield container, \
+                package_manager_class, \
+                Package('util-linux'), \
+                True, \
+                r"rpm -q --whatprovides util-linux", \
+                r'\s+out:\s+util-linux', \
+                None
+
+            yield container, \
+                package_manager_class, \
+                Package('tree-but-spelled-wrong'), \
+                False, \
+                r"rpm -q --whatprovides tree-but-spelled-wrong", \
+                r'\s+out:\s+no package provides tree-but-spelled-wrong', \
+                None
+
+            yield container, \
+                package_manager_class, \
+                FileSystemPath('/usr/bin/flock'), \
+                True, \
+                r"rpm -qf /usr/bin/flock", \
+                r'\s+out:\s+util-linux-core', \
+                None
+
+        else:
+            pytest.fail(f"Unhandled package manager class '{package_manager_class}'.")
+
+
+def _generate_test_check_presence_ids(value) -> str:
+    if isinstance(value, Container):
+        return value.url
+
+    if isclass(value) and issubclass(value, tmt.package_managers.PackageManager):
+        return value.__name__.lower()
+
+    if isinstance(value, (Package, FileSystemPath)):
+        return str(value)
+
+    return ''
+
+
+@pytest.mark.containers()
+@pytest.mark.parametrize(('container',
+                          'package_manager_class',
+                          'installable',
+                          'expected_result',
+                          'expected_command',
+                          'expected_stdout',
+                          'expected_stderr'),
+                         list(_generate_test_check_presence()),
+                         indirect=["container"],
+                         ids=_generate_test_check_presence_ids)
+def test_check_presence(
+        container: ContainerData,
+        guest: GuestContainer,
+        package_manager_class: PackageManagerClass,
+        installable: Installable,
+        expected_result: bool,
+        expected_command: str,
+        expected_stdout: Optional[str],
+        expected_stderr: Optional[str],
+        root_logger: tmt.log.Logger,
+        caplog: _pytest.logging.LogCaptureFixture) -> None:
+    package_manager = create_package_manager(container, guest, package_manager_class, root_logger)
+
+    assert package_manager.check_presence(installable) == {installable: expected_result}
+
+    assert_log(caplog, message=MATCH(
+        rf"Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+
+    if expected_stdout:
+        assert_log(caplog, remove_colors=True, message=MATCH(expected_stdout))
+
+    if expected_stderr:
+        assert_log(caplog, remove_colors=True, message=MATCH(expected_stderr))

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -727,10 +727,10 @@ def _generate_test_check_presence() -> Iterator[
         if package_manager_class is tmt.package_managers.dnf.Dnf5:
             yield container, \
                 package_manager_class, \
-                Package('util-linux-core'), \
+                Package('coreutils'), \
                 True, \
-                r"rpm -q --whatprovides util-linux-core", \
-                r'\s+out:\s+util-linux-core-', \
+                r"rpm -q --whatprovides coreutils", \
+                r'\s+out:\s+coreutils-', \
                 None
 
             yield container, \
@@ -743,10 +743,10 @@ def _generate_test_check_presence() -> Iterator[
 
             yield container, \
                 package_manager_class, \
-                FileSystemPath('/usr/bin/flock'), \
+                FileSystemPath('/usr/bin/arch'), \
                 True, \
-                r"rpm -q --whatprovides /usr/bin/flock", \
-                r'\s+out:\s+util-linux-core-', \
+                r"rpm -q --whatprovides /usr/bin/arch", \
+                r'\s+out:\s+coreutils-', \
                 None
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf:
@@ -773,6 +773,31 @@ def _generate_test_check_presence() -> Iterator[
                     True, \
                     r"rpm -q --whatprovides /usr/bin/flock", \
                     r'\s+out:\s+util-linux-', \
+                    None
+
+            elif 'fedora:rawhide' in container.url:
+                yield container, \
+                    package_manager_class, \
+                    Package('coreutils'), \
+                    True, \
+                    r"rpm -q --whatprovides coreutils", \
+                    r'\s+out:\s+coreutils-', \
+                    None
+
+                yield container, \
+                    package_manager_class, \
+                    Package('tree-but-spelled-wrong'), \
+                    False, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong", \
+                    r'\s+out:\s+no package provides tree-but-spelled-wrong', \
+                    None
+
+                yield container, \
+                    package_manager_class, \
+                    FileSystemPath('/usr/bin/arch'), \
+                    True, \
+                    r"rpm -q --whatprovides /usr/bin/arch", \
+                    r'\s+out:\s+coreutils-', \
                     None
 
             else:
@@ -824,6 +849,31 @@ def _generate_test_check_presence() -> Iterator[
                     True, \
                     r"rpm -q --whatprovides /usr/bin/flock", \
                     r'\s+out:\s+util-linux-', \
+                    None
+
+            elif 'fedora:rawhide' in container.url:
+                yield container, \
+                    package_manager_class, \
+                    Package('coreutils'), \
+                    True, \
+                    r"rpm -q --whatprovides coreutils", \
+                    r'\s+out:\s+coreutils-', \
+                    None
+
+                yield container, \
+                    package_manager_class, \
+                    Package('tree-but-spelled-wrong'), \
+                    False, \
+                    r"rpm -q --whatprovides tree-but-spelled-wrong", \
+                    r'\s+out:\s+no package provides tree-but-spelled-wrong', \
+                    None
+
+                yield container, \
+                    package_manager_class, \
+                    FileSystemPath('/usr/bin/arch'), \
+                    True, \
+                    r"rpm -q --whatprovides /usr/bin/arch", \
+                    r'\s+out:\s+coreutils-', \
                     None
 
             else:

--- a/tests/unit/test_steps_prepare.py
+++ b/tests/unit/test_steps_prepare.py
@@ -1,50 +1,32 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import tmt
-from tmt.log import Logger
+from tmt.base import DependencySimple
 from tmt.steps.prepare.install import InstallBase
 
 
-def prepare_command(self):
-    """ Fake prepare_command() for InstallBase """
-    return ("command", "options")
-
-
-def get(what, default=None):
-    """ Fake get() for parent PrepareInstall """
-
-    if what == "directory":
-        return []
-
-    if what == "missing":
-        return "skip"
-
-    if what == "package":
-        return [
-            # Regular packages
-            "wget",
-            "debuginfo-something",
-            "elfutils-debuginfod",
-            # Debuginfo packages
-            "grep-debuginfo",
-            "elfutils-debuginfod-debuginfo",
-            ]
-
-    return None
-
-
-@patch.object(tmt.steps.prepare.install.InstallBase, 'prepare_command', prepare_command)
-def test_debuginfo():
+def test_debuginfo(root_logger):
     """ Check debuginfo package parsing """
 
-    logger = Logger.create()
     parent = MagicMock()
-    parent.get = get
     guest = MagicMock()
 
-    install = InstallBase(parent=parent, logger=logger, guest=guest)
+    install = InstallBase(
+        parent=parent,
+        dependencies=[
+            # Regular packages
+            DependencySimple("wget"),
+            DependencySimple("debuginfo-something"),
+            DependencySimple("elfutils-debuginfod"),
+            # Debuginfo packages
+            DependencySimple("grep-debuginfo"),
+            DependencySimple("elfutils-debuginfod-debuginfo"),
+            ],
+        directories=[],
+        exclude=[],
+        logger=root_logger,
+        guest=guest)
 
-    assert install.repository_packages == [
+    assert install.packages == [
         "wget",
         "debuginfo-something",
         "elfutils-debuginfod",

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -1,0 +1,184 @@
+import dataclasses
+import shlex
+import sys
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+
+import tmt
+import tmt.log
+import tmt.plugins
+import tmt.utils
+from tmt.utils import Command, CommandOutput, Path
+
+if TYPE_CHECKING:
+    from tmt.steps.provision import Guest
+
+    # Using TypeAlias and typing-extensions under the guard of TYPE_CHECKING,
+    # to avoid the necessity of requiring the package in runtime. This way,
+    # we can deal with it in build time and when running tests.
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
+
+    #: A type of package manager names.
+    GuestPackageManager: TypeAlias = str
+
+
+#
+# Installable objects
+#
+class Package(str):
+    """ A package name """
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, (Package, PackageUrl, FileSystemPath, PackagePath)):
+            raise NotImplementedError
+
+        return str(self) < str(other)
+
+
+class PackageUrl(str):
+    """ A URL of a package file """
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, (Package, PackageUrl, FileSystemPath, PackagePath)):
+            raise NotImplementedError
+
+        return str(self) < str(other)
+
+
+class FileSystemPath(Path):
+    """ A filesystem path provided by a package """
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, (Package, PackageUrl, FileSystemPath, PackagePath)):
+            raise NotImplementedError
+
+        return str(self) < str(other)
+
+
+class PackagePath(Path):
+    """ A path to a package file """
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, (Package, PackageUrl, FileSystemPath, PackagePath)):
+            raise NotImplementedError
+
+        return str(self) < str(other)
+
+
+#: All installable objects.
+Installable = Union[Package, FileSystemPath, PackagePath, PackageUrl]
+
+
+PackageManagerClass = type['PackageManager']
+
+
+_PACKAGE_MANAGER_PLUGIN_REGISTRY: tmt.plugins.PluginRegistry[PackageManagerClass] = \
+    tmt.plugins.PluginRegistry()
+
+
+def provides_package_manager(
+        package_manager: str) -> Callable[[PackageManagerClass], PackageManagerClass]:
+    """
+    A decorator for registering package managers.
+
+    Decorate a package manager plugin class to register a package manager.
+    """
+
+    def _provides_package_manager(package_manager_cls: PackageManagerClass) -> PackageManagerClass:
+        _PACKAGE_MANAGER_PLUGIN_REGISTRY.register_plugin(
+            plugin_id=package_manager,
+            plugin=package_manager_cls,
+            logger=tmt.log.Logger.get_bootstrap_logger())
+
+        return package_manager_cls
+
+    return _provides_package_manager
+
+
+def find_package_manager(name: 'GuestPackageManager') -> 'PackageManagerClass':
+    """
+    Find a package manager by its name.
+
+    :raises GeneralError: when the plugin does not exist.
+    """
+
+    plugin = _PACKAGE_MANAGER_PLUGIN_REGISTRY.get_plugin(name)
+
+    if plugin is None:
+        raise tmt.utils.GeneralError(
+            f"Package manager '{name}' was not found in package manager registry.")
+
+    return plugin
+
+
+def escape_installables(*installables: Installable) -> Iterator[str]:
+    for installable in installables:
+        yield shlex.quote(str(installable))
+
+
+# TODO: find a better name, "options" is soooo overloaded...
+@dataclasses.dataclass(frozen=True)
+class Options:
+    #: A list of packages to exclude from installation.
+    excluded_packages: list[Package] = dataclasses.field(default_factory=list)
+
+    #: If set, a failure to install a given package would not cause an error.
+    skip_missing: bool = False
+
+    #: If set, check whether the package is already installed, and do not
+    #: attempt to install it if it is already present.
+    check_first: bool = True
+
+    #: If set, install packages under this path instead of the usual system
+    #: root.
+    install_root: Optional[Path] = None
+
+    #: If set, instruct package manager to behave as if the distribution release
+    #: was ``release_version``.
+    release_version: Optional[str] = None
+
+
+class PackageManager(tmt.utils.Common):
+    """ A base class for package manager plugins """
+
+    #: A command to run to check whether the package manager is available on
+    #: a guest.
+    probe_command: Command
+
+    command: Command
+    options: Command
+
+    def __init__(self, *, guest: 'Guest', logger: tmt.log.Logger) -> None:
+        super().__init__(logger=logger)
+
+        self.guest = guest
+        self.command, self.options = self.prepare_command()
+
+    def prepare_command(self) -> tuple[Command, Command]:
+        """ Prepare installation command and subcommand options """
+        raise NotImplementedError
+
+    def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
+        """ Return a presence status for each given installable """
+        raise NotImplementedError
+
+    def install(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        raise NotImplementedError
+
+    def reinstall(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        raise NotImplementedError
+
+    def install_debuginfo(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        raise NotImplementedError

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -1,0 +1,195 @@
+import re
+from typing import Optional, Union
+
+import tmt.package_managers
+import tmt.utils
+from tmt.package_managers import (
+    FileSystemPath,
+    Installable,
+    Options,
+    Package,
+    PackagePath,
+    escape_installables,
+    provides_package_manager,
+    )
+from tmt.utils import (
+    Command,
+    CommandOutput,
+    Environment,
+    EnvVarValue,
+    GeneralError,
+    RunError,
+    ShellScript,
+    )
+
+ReducedPackages = list[Union[Package, PackagePath]]
+
+
+@provides_package_manager('apt')
+class Apt(tmt.package_managers.PackageManager):
+    probe_command = Command('apt', '--version')
+
+    install_command = Command('install')
+
+    _sudo_prefix: Command
+
+    def prepare_command(self) -> tuple[Command, Command]:
+        """ Prepare installation command for apt """
+
+        if self.guest.facts.is_superuser is False:
+            self._sudo_prefix = Command('sudo')
+
+        else:
+            self._sudo_prefix = Command()
+
+        command = Command()
+        options = Command('-y')
+
+        command += self._sudo_prefix
+        command += Command('apt')
+
+        return (command, options)
+
+    def _enable_apt_file(self) -> None:
+        self.install(Package('apt-file'))
+        self.guest.execute(ShellScript(f'{self._sudo_prefix} apt-file update'))
+
+    def path_to_package(self, path: FileSystemPath) -> Package:
+        """
+        Find a package providing given filesystem path.
+
+        This is not trivial as some are used to from ``yum`` or ``dnf``,
+        it requires installation of ``apt-file`` utility and building
+        an index of packages and filesystem paths.
+        """
+
+        self._enable_apt_file()
+
+        output = self.guest.execute(ShellScript(f'apt-file search {path} || exit 0'))
+
+        assert output.stdout is not None
+
+        package_names = output.stdout.strip().splitlines()
+
+        if not package_names:
+            raise GeneralError(f"No package provides {path}.")
+
+        return Package(package_names[0].split(':')[0])
+
+    def _reduce_to_packages(self, *installables: Installable) -> ReducedPackages:
+        packages: ReducedPackages = []
+
+        for installable in installables:
+            if isinstance(installable, (Package, PackagePath)):
+                packages.append(installable)
+
+            elif isinstance(installable, FileSystemPath):
+                packages.append(self.path_to_package(installable))
+
+            else:
+                raise GeneralError(f"Package specification '{installable}' is not supported.")
+
+        return packages
+
+    def _construct_presence_script(
+            self, *installables: Installable) -> tuple[ReducedPackages, ShellScript]:
+        reduced_packages = self._reduce_to_packages(*installables)
+
+        return reduced_packages, ShellScript(
+            f'dpkg-query --show {" ".join(escape_installables(*reduced_packages))}')
+
+    def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
+        reduced_packages, presence_script = self._construct_presence_script(*installables)
+
+        try:
+            output = self.guest.execute(presence_script)
+            stdout, stderr = output.stdout, output.stderr
+
+        except RunError as exc:
+            stdout, stderr = exc.stdout, exc.stderr
+
+        if stdout is None or stderr is None:
+            raise GeneralError("apt presence check provided no output")
+
+        results: dict[Installable, bool] = {}
+
+        for installable, package in zip(installables, reduced_packages):
+            match = re.search(
+                rf'dpkg-query: no packages found matching {re.escape(str(package))}', stderr)
+
+            if match is not None:
+                results[installable] = False
+                continue
+
+            match = re.search(rf'^{re.escape(str(package))}\s', stdout)
+
+            if match is not None:
+                results[installable] = True
+                continue
+
+        return results
+
+    def _extra_options(self, options: Options) -> Command:
+        extra_options = Command()
+
+        if options.skip_missing:
+            extra_options += Command('--ignore-missing')
+
+        return extra_options
+
+    def install(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        options = options or Options()
+
+        extra_options = self._extra_options(options)
+        packages = self._reduce_to_packages(*installables)
+
+        script = ShellScript(
+            f'{self.command.to_script()} install '
+            f'{self.options.to_script()} {extra_options} '
+            f'{" ".join(escape_installables(*packages))}')
+
+        if options.check_first:
+            script = self._construct_presence_script(*packages)[1] | script
+
+        # TODO: find a better way to handle `skip_missing`, this may hide other
+        # kinds of errors. But `--ignore-missing` does not turn exit code into
+        # zero :/
+        if options.skip_missing:
+            script = script | ShellScript('/bin/true')
+
+        return self.guest.execute(script, env=Environment({
+            'DEBIAN_FRONTEND': EnvVarValue('noninteractive')
+            }))
+
+    def reinstall(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        options = options or Options()
+
+        extra_options = self._extra_options(options)
+        packages = self._reduce_to_packages(*installables)
+
+        script = ShellScript(
+            f'{self.command.to_script()} reinstall '
+            f'{self.options.to_script()} {extra_options} '
+            f'{" ".join(escape_installables(*packages))}')
+
+        if options.check_first:
+            script = self._construct_presence_script(*packages)[1] & script
+
+        if options.skip_missing:
+            script = script | ShellScript('/bin/true')
+
+        return self.guest.execute(script, env=Environment({
+            'DEBIAN_FRONTEND': EnvVarValue('noninteractive')
+            }))
+
+    def install_debuginfo(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        raise tmt.utils.GeneralError("There is no support for debuginfo packages in apt.")

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -1,0 +1,218 @@
+import re
+from typing import Optional, cast
+
+import tmt.package_managers
+from tmt.package_managers import (
+    FileSystemPath,
+    Installable,
+    Options,
+    escape_installables,
+    provides_package_manager,
+    )
+from tmt.utils import Command, CommandOutput, GeneralError, RunError, ShellScript
+
+
+@provides_package_manager('dnf')
+class Dnf(tmt.package_managers.PackageManager):
+    probe_command = Command('dnf', '--version')
+
+    _base_command = Command('dnf')
+
+    skip_missing_option = '--skip-broken'
+
+    def prepare_command(self) -> tuple[Command, Command]:
+        options = Command('-y')
+        command = Command()
+
+        if self.guest.facts.is_superuser is False:
+            command += Command('sudo')
+
+        command += self._base_command
+
+        return (command, options)
+
+    def _extra_dnf_options(self, options: Options) -> Command:
+        """ Collect additional options for ``yum``/``dnf`` based on given options """
+
+        extra_options = Command()
+
+        for package in options.excluded_packages:
+            extra_options += Command('--exclude', package)
+
+        if options.skip_missing:
+            extra_options += Command(self.skip_missing_option)
+
+        return extra_options
+
+    def _construct_presence_script(self, *installables: Installable) -> ShellScript:
+        return ShellScript(
+            f'rpm -q --whatprovides {" ".join(escape_installables(*installables))}'
+            )
+
+    def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
+        try:
+            output = self.guest.execute(self._construct_presence_script(*installables))
+            stdout = output.stdout
+
+        except RunError as exc:
+            stdout = exc.stdout
+
+        if stdout is None:
+            raise GeneralError("rpm presence check provided no output")
+
+        results: dict[Installable, bool] = {}
+
+        for line, installable in zip(stdout.strip().splitlines(), installables):
+            match = re.match(rf'package {re.escape(str(installable))} is not installed', line)
+            if match is not None:
+                results[installable] = False
+                continue
+
+            match = re.match(rf'no package provides {re.escape(str(installable))}', line)
+            if match is not None:
+                results[installable] = False
+                continue
+
+            results[installable] = True
+
+        return results
+
+    def _construct_install_script(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> ShellScript:
+        options = options or Options()
+
+        extra_options = self._extra_dnf_options(options)
+
+        script = ShellScript(
+            f'{self.command.to_script()} install '
+            f'{self.options.to_script()} {extra_options} '
+            f'{" ".join(escape_installables(*installables))}')
+
+        if options.check_first:
+            script = self._construct_presence_script(*installables) | script
+
+        return script
+
+    def _construct_reinstall_script(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> ShellScript:
+        options = options or Options()
+
+        extra_options = self._extra_dnf_options(options)
+
+        script = ShellScript(
+            f'{self.command.to_script()} reinstall '
+            f'{self.options.to_script()} {extra_options} '
+            f'{" ".join(escape_installables(*installables))}')
+
+        if options.check_first:
+            script = self._construct_presence_script(*installables) & script
+
+        return script
+
+    def install(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        return self.guest.execute(self._construct_install_script(
+            *installables,
+            options=options))
+
+    def reinstall(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        return self.guest.execute(self._construct_reinstall_script(
+            *installables,
+            options=options
+            ))
+
+    def install_debuginfo(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        # Make sure debuginfo-install is present on the target system
+        self.install(FileSystemPath('/usr/bin/debuginfo-install'))
+
+        options = options or Options()
+
+        extra_options = self._extra_dnf_options(options)
+
+        return self.guest.execute(ShellScript(
+            f'debuginfo-install -y '
+            f'{self.options.to_script()} {extra_options} '
+            f'{" ".join(escape_installables(*installables))}'))
+
+
+@provides_package_manager('dnf5')
+class Dnf5(Dnf):
+    probe_command = Command('dnf5', '--version')
+
+    _base_command = Command('dnf5')
+    skip_missing_option = '--skip-unavailable'
+
+
+@provides_package_manager('yum')
+class Yum(Dnf):
+    probe_command = Command('yum', '--version')
+
+    _base_command = Command('yum')
+
+    # TODO: get rid of those `type: ignore` below. I think it's caused by the
+    # decorator, it might be messing with the class inheritance as seen by pyright,
+    # but mypy sees no issue, pytest sees no issue, everything works. Silencing
+    # for now.
+    def install(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+
+        options = options or Options()
+
+        script = cast(  # type: ignore[redundant-cast]
+            ShellScript,
+            self._construct_install_script(  # type: ignore[reportGeneralIssues,unused-ignore]
+                *installables,
+                options=options
+                ))
+
+        # Extra ignore/check for yum to workaround BZ#1920176
+        if options.skip_missing:
+            script |= ShellScript('/bin/true')
+
+        else:
+            script &= cast(  # type: ignore[redundant-cast]
+                ShellScript,
+                self._construct_presence_script(  # type: ignore[reportGeneralIssues,unused-ignore]
+                    *installables))
+
+        return self.guest.execute(script)
+
+    def reinstall(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+
+        options = options or Options()
+
+        script = cast(  # type: ignore[redundant-cast]
+            ShellScript,
+            self._construct_reinstall_script(  # type: ignore[reportGeneralIssues,unused-ignore]
+                *installables,
+                options=options
+                ))
+
+        # Extra ignore/check for yum to workaround BZ#1920176
+        if options.skip_missing:
+            script |= ShellScript('/bin/true')
+
+        else:
+            script &= cast(  # type: ignore[redundant-cast]
+                ShellScript,
+                self._construct_presence_script(  # type: ignore[reportGeneralIssues,unused-ignore]
+                    *installables))
+
+        return self.guest.execute(script)

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -1,0 +1,134 @@
+import re
+from typing import Optional
+
+import tmt.package_managers
+import tmt.utils
+from tmt.package_managers import (
+    FileSystemPath,
+    Installable,
+    Options,
+    escape_installables,
+    provides_package_manager,
+    )
+from tmt.utils import Command, CommandOutput, GeneralError, RunError, ShellScript
+
+
+@provides_package_manager('rpm-ostree')
+class RpmOstree(tmt.package_managers.PackageManager):
+    probe_command = Command('stat', '/run/ostree-booted')
+
+    def prepare_command(self) -> tuple[Command, Command]:
+        """ Prepare installation command for rpm-ostree"""
+
+        command = Command()
+
+        if self.guest.facts.is_superuser is False:
+            command += Command('sudo')
+
+        command += Command('rpm-ostree')
+
+        options = Command('--apply-live', '--idempotent', '--allow-inactive')
+
+        return (command, options)
+
+    def _construct_presence_script(self, *installables: Installable) -> ShellScript:
+        if len(installables) == 1 and isinstance(installables[0], FileSystemPath):
+            return ShellScript(f'rpm -qf {installables[0]}')
+
+        return ShellScript(
+            f'rpm -q --whatprovides {" ".join(escape_installables(*installables))}')
+
+    def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
+        if len(installables) == 1 and isinstance(installables[0], FileSystemPath):
+            try:
+                self.guest.execute(ShellScript(f'rpm -qf {installables[0]}'))
+
+            except RunError as exc:
+                if exc.returncode == 1:
+                    return {installables[0]: False}
+
+                raise exc
+
+            return {installables[0]: True}
+
+        try:
+            output = self.guest.execute(ShellScript(
+                f'rpm -q --whatprovides {" ".join(escape_installables(*installables))}'))
+            stdout = output.stdout
+
+        except RunError as exc:
+            stdout = exc.stdout
+
+        if stdout is None:
+            raise GeneralError("rpm presence check provided no output")
+
+        results: dict[Installable, bool] = {}
+
+        for line, installable in zip(stdout.strip().splitlines(), installables):
+            match = re.match(rf'package {re.escape(str(installable))} is not installed', line)
+            if match is not None:
+                results[installable] = False
+                continue
+
+            match = re.match(rf'no package provides {re.escape(str(installable))}', line)
+            if match is not None:
+                results[installable] = False
+                continue
+
+            results[installable] = True
+
+        return results
+
+    def _extra_options(
+            self,
+            options: Options) -> Command:
+        extra_options = Command()
+
+        for package in options.excluded_packages:
+            self.warn("There is no support for rpm-ostree exclude,"
+                      f" package '{package}' may still be installed.")
+
+        if options.install_root is not None:
+            extra_options += Command(f'--installroot={options.install_root}')
+
+        if options.release_version is not None:
+            extra_options += Command(f'--releasever={options.release_version}')
+
+        return extra_options
+
+    def install(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        if len(installables) != 1:
+            raise GeneralError(
+                "rpm-ostree package manager does not support installation of multiple packages.")
+
+        options = options or Options()
+
+        extra_options = self._extra_options(options)
+
+        script = ShellScript(
+            f'{self.command.to_script()} install '
+            f'{self.options.to_script()} {extra_options} '
+            f'{" ".join(escape_installables(*installables))}')
+
+        if options.check_first:
+            script = self._construct_presence_script(*installables) | script
+
+        if options.skip_missing:
+            script = script | ShellScript('/bin/true')
+
+        return self.guest.execute(script)
+
+    def reinstall(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        raise GeneralError("rpm-ostree does not support reinstall operation.")
+
+    def install_debuginfo(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        raise GeneralError("rpm-ostree does not support debuginfo packages.")

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -68,6 +68,7 @@ def _discover_packages() -> list[tuple[str, Path]]:
         ('tmt.export', Path('export')),
         ('tmt.frameworks', Path('frameworks')),
         ('tmt.checks', Path('checks')),
+        ('tmt.package_managers', Path('package_managers')),
         ]
 
 
@@ -298,3 +299,6 @@ class PluginRegistry(Generic[RegisterableT]):
 
     def iter_plugins(self) -> Iterator[RegisterableT]:
         yield from self._plugins.values()
+
+    def items(self) -> Iterator[tuple[str, RegisterableT]]:
+        yield from self._plugins.items()

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -158,6 +158,19 @@ class GuestContainer(tmt.Guest):
         """ Start provisioned guest """
         if self.is_dry_run:
             return
+
+        if self.container:
+            self.primary_address = self.topology_address = self.container
+
+            self.verbose('primary address', self.primary_address, 'green')
+            self.verbose('topology address', self.topology_address, 'green')
+
+            return
+
+        self.container = self.primary_address = self.topology_address = self._tmt_name()
+        self.verbose('primary address', self.primary_address, 'green')
+        self.verbose('topology address', self.topology_address, 'green')
+
         # Check if the image is available
         assert self.image is not None
 
@@ -184,9 +197,7 @@ class GuestContainer(tmt.Guest):
         # Mount the whole plan directory in the container
         workdir = self.parent.plan.workdir
 
-        self.container = self.primary_address = self.topology_address = self._tmt_name()
-        self.verbose('primary address', self.primary_address, 'green')
-        self.verbose('topology address', self.topology_address, 'green')
+        self.verbose('name', self.container, 'green')
 
         additional_args = []
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1064,13 +1064,25 @@ class ShellScript:
         return self._script
 
     def __add__(self, other: 'ShellScript') -> 'ShellScript':
+        if not other:
+            return self
+
         return ShellScript.from_scripts([self, other])
 
     def __and__(self, other: 'ShellScript') -> 'ShellScript':
+        if not other:
+            return self
+
         return ShellScript(f'{self} && {other}')
 
     def __or__(self, other: 'ShellScript') -> 'ShellScript':
+        if not other:
+            return self
+
         return ShellScript(f'{self} || {other}')
+
+    def __bool__(self) -> bool:
+        return bool(self._script)
 
     @classmethod
     def from_scripts(cls, scripts: list['ShellScript']) -> 'ShellScript':
@@ -1083,7 +1095,7 @@ class ShellScript:
         :param scripts: scripts to merge into one.
         """
 
-        return ShellScript('; '.join(script._script for script in scripts))
+        return ShellScript('; '.join(script._script for script in scripts if bool(script)))
 
     def to_element(self) -> _CommandElement:
         """ Convert a shell script to a command element """


### PR DESCRIPTION
More and more we see the need for primitives like "install a package". Plugins start to require packages to be present on guests, we already do have `prepare/install` plugin, and the upcoming all mighty install plugin. To support all these functions, `tmt.package_managers` would provide necessary primites, allowing implementations to be shipped as plugins.

The patch starts building the primitives, converting `tmt.steps.prepare.install` to use them in the process.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [x] include a release note