### PR TITLE
Use a different pidfile location for the full test

### DIFF
--- a/tests/full/test.sh
+++ b/tests/full/test.sh
@@ -195,7 +195,7 @@ EOF
         rlPhaseStartTest "Test: $plan"
             RUN="run$(echo $plan | tr '/' '-')"
             # Core of the test runs as $USER, -l should clear all BEAKER_envs.
-            rlRun "su -l -c 'cd $USER_HOME/tmt; tmt -c how=full run --id $USER_HOME/$RUN -vvv -a report -h html plans --name $plan $TEST_CMD' $USER"
+            rlRun "su -l -c 'cd $USER_HOME/tmt; TMT_TEST_PIDFILE_ROOT=/tmp tmt -c how=full run --id $USER_HOME/$RUN -vvv -a report -h html plans --name $plan $TEST_CMD' $USER"
 
             # Upload file so one can review ASAP
             rlRun "tar czf /tmp/$RUN.tgz  --exclude *.qcow2 $USER_HOME/$RUN"


### PR DESCRIPTION
This is needed in order to prevent clash between test executed under the root user and a regular user on the same guest. Proper fix for this needs to be clarified, so just to make it working again for now.

Pull Request Checklist

* [x] extend the test coverage
