### PR TITLE
Enable the `avc` check for all `tmt` tests

### DIFF
--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -4,3 +4,7 @@ contact: Petr Šplíchal <psplicha@redhat.com>
 tier: 2
 tag: [container, virtual]
 require: [tmt]
+
+adjust:
+  - check: [avc]
+    when: initiator == packit


### PR DESCRIPTION
Let's check for AVC denials when initiated by Packit.

Pull Request Checklist

* [x] extend the test coverage