### PR TITLE
Fix inheritance of some keys in provision step data

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -431,12 +431,25 @@ class GuestData(SerializableContainer):
     #: List of fields that are not allowed to be set via fmf keys/CLI options.
     _OPTIONLESS_FIELDS: tuple[str, ...] = ('guest', 'facts')
 
-    # guest role in the multihost scenario
-    role: Optional[str] = None
     # hostname or ip address
     guest: Optional[str] = None
-    # whether to run shell scripts in tests, prepare, and finish with sudo
-    become: bool = False
+
+    role: Optional[str] = field(
+        default=None,
+        option='--role',
+        metavar='ROLE',
+        help="""
+             Marks related guests so that common actions can be applied to all
+             such guests at once.
+             """
+        )
+
+    become: bool = field(
+        default=False,
+        is_flag=True,
+        option=('-b', '--become'),
+        help='Whether to run shell scripts in tests, prepare, and finish with sudo.'
+        )
 
     facts: GuestFacts = field(
         default_factory=GuestFacts,
@@ -1112,12 +1125,6 @@ class GuestSshData(GuestData):
         option=('-u', '--user'),
         metavar='USERNAME',
         help='Username to use for all guest operations.')
-    become: bool = field(
-        default=False,
-        is_flag=True,
-        option=('-b', '--become'),
-        help='Whether to run shell scripts in tests, prepare, and finish with sudo.'
-        )
     key: list[str] = field(
         default_factory=list,
         option=('-k', '--key'),

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -123,8 +123,11 @@ def _normalize_log_type(
 
 @dataclasses.dataclass
 class ArtemisGuestData(tmt.steps.provision.GuestSshData):
-    # Override parent class with our defaults
-    user: str = DEFAULT_USER
+    user: str = field(
+        default=DEFAULT_USER,
+        option=('-u', '--user'),
+        metavar='USERNAME',
+        help='Username to use for all guest operations.')
 
     # API
     api_url: str = field(

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -18,18 +18,19 @@ class ConnectGuestData(tmt.steps.provision.GuestSshData):
         if key != 'guest'
         )
 
+    # Override parent class with our defaults
     guest: Optional[str] = field(
         default=None,
         option=('-g', '--guest'),
         metavar='GUEST',
         help='Select remote host to connect to (hostname or ip).'
         )
-    user: Optional[str] = field(
+
+    user: str = field(
         default=DEFAULT_USER,
         option=('-u', '--user'),
         metavar='USERNAME',
-        help='Username to use for all guest operations.'
-        )
+        help='Username to use for all guest operations.')
 
     soft_reboot: Optional[ShellScript] = field(
         default=None,

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -368,13 +368,11 @@ def async_run(func: Any) -> Any:
 @dataclasses.dataclass
 class BeakerGuestData(tmt.steps.provision.GuestSshData):
     # Override parent class with our defaults
-    # Override parent class with our defaults
-    user: Optional[str] = field(
+    user: str = field(
         default=DEFAULT_USER,
         option=('-u', '--user'),
         metavar='USERNAME',
-        help='Username to use for all guest operations.'
-        )
+        help='Username to use for all guest operations.')
 
     # Guest request properties
     whiteboard: Optional[str] = field(

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -30,17 +30,12 @@ class PodmanGuestData(tmt.steps.provision.GuestData):
         option=('-i', '--image'),
         metavar='IMAGE',
         help='Select image to use. Short name or complete url.')
-    user: Optional[str] = field(
+    # Override parent class with our defaults
+    user: str = field(
         default=DEFAULT_USER,
         option=('-u', '--user'),
         metavar='USERNAME',
-        help='Username to use for all container operations.')
-    become: bool = field(
-        default=False,
-        is_flag=True,
-        option=('-b', '--become'),
-        help='Whether to run shell scripts in tests, prepare, and finish with sudo.'
-        )
+        help='Username to use for all guest operations.')
     force_pull: bool = field(
         default=False,
         option=('-p', '--pull', '--force-pull'),

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -228,7 +228,7 @@ def normalize_disk_size(key_address: str, value: Any, logger: tmt.log.Logger) ->
 @dataclasses.dataclass
 class TestcloudGuestData(tmt.steps.provision.GuestSshData):
     # Override parent class with our defaults
-    user: Optional[str] = field(
+    user: str = field(
         default=DEFAULT_USER,
         option=('-u', '--user'),
         metavar='USERNAME',


### PR DESCRIPTION
Some plugins did not inherit fields from the parent class correctly, which resulted in help texts being dropped, and `become` seems to be misplaced.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation