### PR TITLE
Ignore tarballs and generated man page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,10 +32,12 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+tmt.1
 
 # Testing
 .mypy_cache
 .pytest_cache
+*.tgz
 
 # Virtual environment
 .env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,8 @@ include = [
     "/.fmf",
     ]
 
+artifacts = ["tmt.1"]
+
 [tool.hatch.envs.default]
 platforms = ["linux"]
 


### PR DESCRIPTION
Prevent comitting `tests/full/repo_copy.tgz` and man page generated from the `overview.rst`.