### PR TITLE
Raise an error when loading pre-1.24 `tests.yaml`

### DIFF
--- a/tests/backward-compatibility/main.fmf
+++ b/tests/backward-compatibility/main.fmf
@@ -1,0 +1,2 @@
+summary: Verify features oriented at backward compatibility
+tier: 1

--- a/tests/backward-compatibility/test.sh
+++ b/tests/backward-compatibility/test.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "rundir=$(mktemp -d)" 0 "Create tmt rundir"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify tests.yaml without discover_phase is correctly refused"
+        rlRun "tests_yaml=$rundir/plans/features/core/discover/tests.yaml"
+
+        # Generate a tests.yaml...
+        rlRun "tmt -vv run -i $rundir discover plan -n '^/plans/features/core$'"
+
+        # ... then drop all `discover-phase` keys from discovered test metadata...
+        rlRun "yq -y -r 'del(.[].\"discover-phase\")' $tests_yaml > $tests_yaml.edited"
+        rlRun "mv $tests_yaml.edited $tests_yaml"
+
+        # ... and run tmt once more to see it report it's not possible to load tests.yaml.
+        rlRun -s "tmt -vv run -i $rundir report" 2
+
+        rlAssertGrep "Could not load '$tests_yaml' whose format is not compatible with tmt 1.24 and newer." $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "rm -rf $rundir" 0 "Remove tmt rundir"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -160,6 +160,22 @@ class Discover(tmt.steps.Step):
             self._tests = {}
 
             for raw_test_datum in raw_test_data:
+                # The name of `discover` phases providing the test was added in 1.24.
+                # Unfortunatelly, the field is required for correct work of `execute`,
+                # now when it is parallel in nature. Without it, it's not possible
+                # to pick the right `discover` phase which then provides the list
+                # of tests to execute. Therefore raising an error instead of guessing
+                # what the phase could be.
+                if key_to_option('discover_phase') not in raw_test_datum:
+                    # TODO: there should be a method for creating workdir-aware paths...
+                    path = self.workdir / Path('tests.yaml') if self.workdir \
+                        else Path('tests.yaml')
+
+                    raise tmt.utils.BackwardIncompatibleDataError(
+                        f"Could not load '{path}' whose format is not compatible "
+                        "with tmt 1.24 and newer."
+                        )
+
                 phase_name = raw_test_datum.pop(key_to_option('discover_phase'))
 
                 if phase_name not in self._tests:

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1784,6 +1784,10 @@ class RetryError(GeneralError):
         super().__init__(f"Retries of '{label}' unsuccessful.", causes)
 
 
+class BackwardIncompatibleDataError(GeneralError):
+    """ A backward incompatible data cannot be processed """
+
+
 # Step exceptions
 
 
@@ -4306,11 +4310,14 @@ def load_run(run: 'tmt.base.Run') -> tuple[bool, Optional[Exception]]:
     """ Load a run and its steps from the workdir """
     try:
         run.load_from_workdir()
+
+        for plan in run.plans:
+            for step in plan.steps(enabled_only=False):
+                step.load()
+
     except GeneralError as error:
         return False, error
-    for plan in run.plans:
-        for step in plan.steps(enabled_only=False):
-            step.load()
+
     return True, None
 
 


### PR DESCRIPTION
`discover-phase` was added in 1.24, which is essential for correct work of `execute` in parallelized, multi-host world we inhabit these days. Emit an error and/or warning to rather than let `tmt status` crash on incompatible `tests.yaml`.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage