### PR TITLE
Cleanup logging in `tmt.utils.create_file()`

### DIFF
--- a/tests/test/create/test.sh
+++ b/tests/test/create/test.sh
@@ -22,7 +22,7 @@ rlJournalStart
     rlPhaseStartTest "Existing directory and files"
         rlRun -s "tmt test create test_shell --template shell" \
             2 "test already exists"
-        rlAssertGrep "File '$tmp/test_shell/main.fmf' already exists." \
+        rlAssertGrep "Test metadata '$tmp/test_shell/main.fmf' already exists." \
             "${rlRun_LOG}"
         rlAssertGrep "Test directory '$tmp/test_shell' already exists." \
             "${rlRun_LOG}"

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1255,16 +1255,23 @@ class Test(
                     logger=logger)
 
             # Create metadata
-            metadata_path = directory_path / 'main.fmf'
             tmt.utils.create_file(
-                path=metadata_path, content=metadata_content,
-                name='test metadata', dry=dry, force=force)
+                path=directory_path / 'main.fmf',
+                name='test metadata',
+                content=metadata_content,
+                dry=dry,
+                force=force,
+                logger=logger)
 
             # Create script
-            script_path = directory_path / 'test.sh'
             tmt.utils.create_file(
-                path=script_path, content=script_content,
-                name='test script', dry=dry, force=force, mode=0o755)
+                path=directory_path / 'test.sh',
+                name='test script',
+                content=script_content,
+                mode=0o755,
+                dry=dry,
+                force=force,
+                logger=logger)
 
     @property
     def manual_test_path(self) -> Path:
@@ -1889,8 +1896,12 @@ class Plan(
                 logger=logger)
 
             tmt.utils.create_file(
-                path=plan_path, content=plan_content,
-                name='plan', dry=dry, force=force)
+                path=plan_path,
+                name='plan',
+                content=plan_content,
+                dry=dry,
+                force=force,
+                logger=logger)
 
     def _iter_steps(self,
                     enabled_only: bool = True,
@@ -2597,8 +2608,12 @@ class Story(
                 logger=logger)
 
             tmt.utils.create_file(
-                path=story_path, content=story_content,
-                name='story', dry=dry, force=force)
+                path=story_path,
+                name='story',
+                content=story_content,
+                dry=dry,
+                force=force,
+                logger=logger)
 
     @staticmethod
     def overview(tree: 'Tree') -> None:


### PR DESCRIPTION
Just like `create_directory()`, `create_file()` was laos mixing console and logging together. Patch clears how logging and console output interact, and introduces injected logger to align with the rest of code.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation