### PR TITLE
Drop no longer needed `tmt.utils.copytree()`

### DIFF
--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -1,4 +1,5 @@
 import re
+import shutil
 from tempfile import TemporaryDirectory
 from typing import Optional, Union, cast
 
@@ -293,15 +294,15 @@ class BeakerLib(Library):
                         self.parent.debug(f"Failed to find library {self} at {self.url}")
                         raise LibraryError
                     self.parent.debug(f"Library {self} is copied into {directory}")
-                    tmt.utils.copytree(library_path, local_library_path, dirs_exist_ok=True)
+                    shutil.copytree(library_path, local_library_path, dirs_exist_ok=True)
 
                     # Remove metadata file(s) and create one with full data
                     self._merge_metadata(library_path, local_library_path)
 
                     # Copy fmf metadata
-                    tmt.utils.copytree(clone_dir / '.fmf', directory / '.fmf', dirs_exist_ok=True)
+                    shutil.copytree(clone_dir / '.fmf', directory / '.fmf', dirs_exist_ok=True)
                     if self.path:
-                        tmt.utils.copytree(
+                        shutil.copytree(
                             clone_dir / self.path.unrooted() / '.fmf',
                             directory / self.path.unrooted() / '.fmf',
                             dirs_exist_ok=True)
@@ -317,12 +318,12 @@ class BeakerLib(Library):
                     self.parent.debug(
                         f"Copy local library '{self.fmf_node_path}' to '{directory}'.", level=3)
                     # Copy only the required library
-                    tmt.utils.copytree(
+                    shutil.copytree(
                         library_path, local_library_path, symlinks=True, dirs_exist_ok=True)
                     # Remove metadata file(s) and create one with full data
                     self._merge_metadata(library_path, local_library_path)
                     # Copy fmf metadata
-                    tmt.utils.copytree(self.path / '.fmf', directory / '.fmf', dirs_exist_ok=True)
+                    shutil.copytree(self.path / '.fmf', directory / '.fmf', dirs_exist_ok=True)
             except (tmt.utils.RunError, tmt.utils.GitUrlError) as error:
                 assert self.url is not None
                 # Fallback to install during the prepare step if in rpm format

--- a/tmt/libraries/file.py
+++ b/tmt/libraries/file.py
@@ -74,7 +74,7 @@ class File(Library):
             target_path = Path(self.target_location) / local_path
             if path.is_dir():
                 try:
-                    tmt.utils.copytree(path, target_path, dirs_exist_ok=True)
+                    shutil.copytree(path, target_path, dirs_exist_ok=True)
                 except shutil.Error as exc:  # ignore individual files exist error
                     self.parent.debug(str(exc))
             else:

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -494,7 +494,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
 
             # Now copy dist_git_extract into tests
             if not self.is_dry_run:
-                tmt.utils.copytree(
+                shutil.copytree(
                     dist_git_extract,
                     self.testdir,
                     symlinks=True,
@@ -584,8 +584,10 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             # Save fmf metadata
             clonedir = self.clone_dirpath / 'tests'
             for path in tmt.utils.filter_paths(self.testdir, ['.fmf']):
-                tmt.utils.copytree(
-                    path, clonedir / path.relative_to(self.testdir), dirs_exist_ok=True)
+                shutil.copytree(
+                    path,
+                    clonedir / path.relative_to(self.testdir),
+                    dirs_exist_ok=True)
 
             # Save upgrade plan
             upgrade_path = self.get('upgrade_path')
@@ -604,10 +606,11 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 # Save only current test data
                 assert test.path is not None  # narrow type
                 relative_test_path = test.path.unrooted()
-                tmt.utils.copytree(
+                shutil.copytree(
                     self.testdir / relative_test_path,
                     clonedir / relative_test_path,
                     dirs_exist_ok=True)
+
                 # Copy all parent main.fmf files
                 parent_dir = relative_test_path
                 while parent_dir.resolve() != Path.cwd().resolve():

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1935,20 +1935,6 @@ def ascii(text: Any) -> bytes:
     return unicodedata.normalize('NFKD', text).encode('ascii', 'ignore')
 
 
-def copytree(
-        src: Path,
-        dst: Path,
-        symlinks: bool = False,
-        dirs_exist_ok: bool = False,
-        ) -> Path:
-    """ Similar to shutil.copytree but with dirs_exist_ok for Python < 3.8 """
-    # FIXME fix all usages, we don't need this function any more
-    return cast(
-        Path,
-        shutil.copytree(src=src, dst=dst, symlinks=symlinks,
-                        dirs_exist_ok=dirs_exist_ok))
-
-
 def get_full_metadata(fmf_tree_path: Path, node_path: str) -> Any:
     """
     Get full metadata for a node in any fmf tree


### PR DESCRIPTION
It has been a mere wrapper for `shutil.copytree()` with no added value, and it can be removed.

Pull Request Checklist

* [x] implement the feature