### PR TITLE
Provision plugins use `self.data` instead of `self.get()`

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1813,7 +1813,7 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin[ProvisionStepDataT]):
         super().show(keys=keys)
 
         if show_hardware:
-            hardware: Optional[tmt.hardware.Hardware] = self.get('hardware')
+            hardware: Optional[tmt.hardware.Hardware] = self.data.hardware
 
             if hardware:
                 echo(tmt.utils.format('hardware', tmt.utils.dict_to_yaml(hardware.to_spec())))

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -697,17 +697,15 @@ class ProvisionArtemis(tmt.steps.provision.ProvisionPlugin[ProvisionArtemisData]
         """ Provision the guest """
         super().go()
 
-        api_version = self.get('api-version')
-
-        if api_version not in SUPPORTED_API_VERSIONS:
-            raise ArtemisProvisionError(f"API version '{api_version}' not supported.")
+        if self.data.api_version not in SUPPORTED_API_VERSIONS:
+            raise ArtemisProvisionError(f"API version '{self.data.api_version}' not supported.")
 
         try:
             user_data = {
                 key.strip(): value.strip()
                 for key, value in (
                     pair.split('=', 1)
-                    for pair in self.get('user-data')
+                    for pair in self.data.user_data
                     )
                 }
 

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -5,7 +5,7 @@ import tmt
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
-from tmt.utils import Command, ShellScript, field, key_to_option
+from tmt.utils import Command, ShellScript, field
 
 DEFAULT_USER = "root"
 
@@ -168,7 +168,7 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin[ProvisionConnectData]
         super().go()
 
         # Check guest and auth info
-        if not self.get('guest'):
+        if not self.data.guest:
             raise tmt.utils.SpecificationError(
                 'Provide a host name or an ip address to connect.')
 
@@ -176,13 +176,6 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin[ProvisionConnectData]
             raise tmt.utils.GeneralError(
                 "Custom soft and hard reboot commands are allowed "
                 "only with the '--feeling-safe' option.")
-
-        data = ConnectGuestData(**{
-            key: self.get(key_to_option(key))
-            # SIM118: Use `{key} in {dict}` instead of `{key} in {dict}.keys()`.
-            # "Type[ConnectGuestData]" has no attribute "__iter__" (not iterable)
-            for key in ConnectGuestData.keys()  # noqa: SIM118
-            })
 
         data = ConnectGuestData.from_plugin(self)
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -431,7 +431,7 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin[ProvisionPodmanData]):
     def default(self, option: str, default: Any = None) -> Any:
         """ Return default data for given option """
         if option == 'pull':
-            return self.get('force-pull', default=default)
+            return self.data.force_pull
 
         return super().default(option, default=default)
 

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -848,7 +848,7 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin[ProvisionTestcloudD
         """ Provision the testcloud instance """
         super().go()
 
-        if self.get('list-local-images'):
+        if self.data.list_local_images:
             self._print_local_images()
             # Clean up the run workdir and exit
             if self.step.plan.my_run:


### PR DESCRIPTION
Proper annotations, default values already honored, no need to call a method that cannot be annotated enough.

Pull Request Checklist

* [x] implement the feature