### PR TITLE
Prepare and finish plugins use `self.data` instead of `self.get()`

### DIFF
--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -68,8 +68,7 @@ class FinishShell(tmt.steps.finish.FinishPlugin[FinishShellData]):
         super().go(guest=guest, environment=environment, logger=logger)
 
         # Give a short summary
-        scripts: list[tmt.utils.ShellScript] = self.get('script')
-        overview = fmf.utils.listed(scripts, 'script')
+        overview = fmf.utils.listed(self.data.script, 'script')
         self.info('overview', f'{overview} found', 'green')
 
         workdir = self.step.plan.worktree
@@ -81,7 +80,7 @@ class FinishShell(tmt.steps.finish.FinishPlugin[FinishShellData]):
         logger.debug('finish wrapper', finish_wrapper_path, level=3)
 
         # Execute each script on the guest
-        for script in scripts:
+        for script in self.data.script:
             self.verbose('script', script, 'green')
             script_with_options = tmt.utils.ShellScript(f'{tmt.utils.SHELL_OPTIONS}; {script}')
             self.write(finish_wrapper_path, str(script_with_options), 'w')

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -97,10 +97,8 @@ class PreparePlugin(tmt.steps.Plugin[PrepareStepDataT]):
             logger.info('guest', guest.name, 'green')
 
         # Show requested role if defined
-        # FIXME: cast() - typeless "dispatcher" method
-        where = cast(list[str], self.get('where'))
-        if where:
-            logger.info('where', fmf.utils.listed(where), 'green')
+        if self.data.where:
+            logger.info('where', fmf.utils.listed(self.data.where), 'green')
 
 
 class Prepare(tmt.steps.Step):

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -111,7 +111,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
         super().go(guest=guest, environment=environment, logger=logger)
 
         # Apply each playbook on the guest
-        for playbook in self.get('playbook'):
+        for playbook in self.data.playbook:
             logger.info('playbook', playbook, 'green')
 
             lowercased_playbook = playbook.lower()
@@ -148,4 +148,4 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
 
                 logger.info('playbook-path', playbook_path, 'green')
 
-            guest.ansible(playbook_path, self.get('extra-args'))
+            guest.ansible(playbook_path, extra_args=self.data.extra_args)

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -70,8 +70,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
         environment = environment or {}
 
         # Give a short summary
-        scripts: list[tmt.utils.ShellScript] = self.get('script')
-        overview = fmf.utils.listed(scripts, 'script')
+        overview = fmf.utils.listed(self.data.script, 'script')
         logger.info('overview', f'{overview} found', 'green')
 
         workdir = self.step.plan.worktree
@@ -95,7 +94,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
         logger.debug('prepare wrapper', prepare_wrapper_path, level=3)
 
         # Execute each script on the guest (with default shell options)
-        for script in scripts:
+        for script in self.data.script:
             logger.verbose('script', script, 'green')
             script_with_options = tmt.utils.ShellScript(f'{tmt.utils.SHELL_OPTIONS}; {script}')
             self.write(prepare_wrapper_path, str(script_with_options), 'w')


### PR DESCRIPTION
Proper annotations, default values already honored, no need to call a method that cannot be annotated enough.

Pull Request Checklist

* [x] implement the feature