### PR TITLE
Fail `dmesg` check if it contains `Call Trace` or `segfault`

### DIFF
--- a/tests/test/check/data/main.fmf
+++ b/tests/test/check/data/main.fmf
@@ -1,7 +1,11 @@
 /dmesg:
-  test: /bin/true
+    check: dmesg
 
-  check: dmesg
+    /harmless:
+        test: /bin/true
+
+    /segfault:
+        test: echo Some segfault happened > /dev/kmsg
 
 /avc:
   check:

--- a/tests/test/check/test-dmesg.sh
+++ b/tests/test/check/test-dmesg.sh
@@ -3,7 +3,11 @@
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 function assert_check_result () {
-    rlAssertEquals "$1" "dmesg:$2" "$(yq -r ".[] | .check | .[] | select(.event == \"$3\") | \"\\(.name):\\(.result)\"" $results)"
+    comment="$1"
+    result="$2"
+    event="$3"
+    name="/dmesg/$4"
+    rlAssertEquals "$comment" "dmesg:$result" "$(yq -r ".[] | select(.name == \"$name\") | .check | .[] | select(.event == \"$event\") | \"\\(.name):\\(.result)\"" $results)"
 }
 
 
@@ -12,8 +16,10 @@ rlJournalStart
         rlRun "run=\$(mktemp -d)" 0 "Create run directory"
 
         rlRun "results=$run/plan/execute/results.yaml"
-        rlRun "dump_before=$run/plan/execute/data/guest/default-0/dmesg-1/checks/dmesg-before-test.txt"
-        rlRun "dump_after=$run/plan/execute/data/guest/default-0/dmesg-1/checks/dmesg-after-test.txt"
+        rlRun "harmless=$run/plan/execute/data/guest/default-0/dmesg/harmless-1"
+        rlRun "segfault=$run/plan/execute/data/guest/default-0/dmesg/segfault-2"
+        rlRun "dump_before=$harmless/checks/dmesg-before-test.txt"
+        rlRun "dump_after=$harmless/checks/dmesg-after-test.txt"
 
         rlRun "pushd data"
         rlRun "set -o pipefail"
@@ -21,13 +27,20 @@ rlJournalStart
 
     for method in ${PROVISION_METHODS:-local}; do
         rlPhaseStartTest "Test dmesg check with $method"
-            rlRun "tmt run --id $run --scratch -a -vv provision -h $method test -n dmesg"
+            # Segfault test only reproducible with virtual (needs root)
+            if [ "$method" = "virtual" ]; then
+                test_name=/dmesg
+            else
+                test_name=/dmesg/harmless
+            fi
+
+            rlRun "tmt run --id $run --scratch -a -vv provision -h $method test -n $test_name"
 
             rlRun "cat $results"
 
             rlAssertExists "$dump_before"
             if [ "$method" = "container" ]; then
-                assert_check_result "dmesg as a before-test should fail with containers" "error" "before-test"
+                assert_check_result "dmesg as a before-test should fail with containers" "error" "before-test" "harmless"
 
                 if rlIsFedora ">=40"; then
                     rlAssertGrep "dmesg: read kernel buffer failed: Operation not permitted" "$dump_before"
@@ -35,21 +48,24 @@ rlJournalStart
                     rlAssertGrep "dmesg: read kernel buffer failed: Permission denied" "$dump_before"
                 fi
             else
-                assert_check_result "dmesg as a before-test should pass" "pass" "before-test"
+                assert_check_result "dmesg as a before-test should pass" "pass" "before-test" "harmless"
             fi
             rlLogInfo "$(cat $dump_before)"
 
             rlAssertExists "$dump_after"
             if [ "$method" = "container" ]; then
-                assert_check_result "dmesg as a before-test should fail with containers" "error" "after-test"
+                assert_check_result "dmesg as an after-test should fail with containers" "error" "after-test" "harmless"
 
                 if rlIsFedora ">=40"; then
                     rlAssertGrep "dmesg: read kernel buffer failed: Operation not permitted" "$dump_after"
                 else
                     rlAssertGrep "dmesg: read kernel buffer failed: Permission denied" "$dump_after"
                 fi
+            elif [ "$method" = "virtual" ]; then
+                assert_check_result "dmesg as an after-test should fail" "fail" "after-test" "segfault"
+                rlAssertGrep "Some segfault happened" "$segfault/checks/dmesg-after-test.txt"
             else
-                assert_check_result "dmesg as a before-test should pass" "pass" "after-test"
+                assert_check_result "dmesg as an after-test should pass" "pass" "after-test" "harmless"
             fi
             rlLogInfo "$(cat $dump_after)"
         rlPhaseEnd


### PR DESCRIPTION
00:00:33 fail /rdma/pyverbs-tests-2 (on default-0) [1/1]
            	00:00:00 	pass dmesg (before-test check)
            	00:00:02 	pass avc (after-test check)
            	00:00:01 	**fail** dmesg (after-test check)

When users notice dmesg fail, they can go to check the dmesg output to see if it's a bug.

Fixes #2563.

Pull Request Checklist

* [x] implement the feature

