### PR TITLE
Expose actual guest HW description in guest topology

### DIFF
--- a/spec/plans/guest-topology.fmf
+++ b/spec/plans/guest-topology.fmf
@@ -113,7 +113,7 @@ description: |
         TMT_ROLES[role2]="guestN ..."
         ...
 
-    .. versionadded:: 1.31
+    .. versionadded:: 1.33
         Guest HW exposed via ``hardware`` key.
 
 example:

--- a/spec/plans/guest-topology.fmf
+++ b/spec/plans/guest-topology.fmf
@@ -22,6 +22,14 @@ description: |
 
     .. note::
 
+        The ``hardware`` key, describing the actual HW configuration of the
+        guest, as understood by tmt, is using
+        :ref:`hardware specification </spec/hardware>`
+        and as such is still a work in progress. Not all hardware properties
+        might be available yet.
+
+    .. note::
+
         The shell-friendly file is easy to ingest for a shell-based tests,
         it can be simply ``source``-ed. For parsing the YAML file in shell,
         pure shell parsers like https://github.com/sopos/yash can be used.
@@ -34,6 +42,7 @@ description: |
             name: ...
             role: ...
             hostname: ...
+            hardware: ...
 
         # List of names of all provisioned guests.
         guest-names:
@@ -48,10 +57,12 @@ description: |
                 name: guest1
                 role: ...
                 hostname: ...
+                hardware: ...
             guest2:
                 name: guest2
                 role: ...
                 hostname: ...
+                hardware: ...
             ...
 
         # List of all known roles.
@@ -101,6 +112,9 @@ description: |
         TMT_ROLES[role1]="guest1 guest2 ..."
         TMT_ROLES[role2]="guestN ..."
         ...
+
+    .. versionadded:: 1.31
+        Guest HW exposed via ``hardware`` key.
 
 example:
   - |

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -1401,16 +1401,21 @@ def parse_hw_requirements(spec: Spec) -> BaseConstraint:
 
 
 def simplify_actual_hardware(hardware: BaseConstraint) -> Spec:
-    assert isinstance(hardware, And)
-
     as_spec: Spec = {}
 
-    for constraint in hardware.constraints:
+    def _simplify_constraint(constraint: BaseConstraint) -> Spec:
         constraint_spec = constraint.to_spec()
 
         assert isinstance(constraint_spec, dict)
 
-        as_spec.update(constraint_spec)
+        return cast(dict[str, str], constraint_spec)
+
+    if isinstance(hardware, And):
+        for constraint in hardware.constraints:
+            as_spec.update(_simplify_constraint(constraint))
+
+    else:
+        as_spec.update(_simplify_constraint(hardware))
 
     return as_spec
 

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -1400,6 +1400,21 @@ def parse_hw_requirements(spec: Spec) -> BaseConstraint:
     return _parse_block(spec)
 
 
+def simplify_actual_hardware(hardware: BaseConstraint) -> Spec:
+    assert isinstance(hardware, And)
+
+    as_spec: Spec = {}
+
+    for constraint in hardware.constraints:
+        constraint_spec = constraint.to_spec()
+
+        assert isinstance(constraint_spec, dict)
+
+        as_spec.update(constraint_spec)
+
+    return as_spec
+
+
 @dataclasses.dataclass
 class Hardware(SpecBasedContainer[Spec, Spec]):
     constraint: Optional[BaseConstraint]

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -25,7 +25,7 @@ from tmt.result import CheckResult, Result, ResultGuestData, ResultOutcome
 from tmt.steps import Action, ActionTask, PhaseQueue, PluginTask, Step
 from tmt.steps.discover import Discover, DiscoverPlugin, DiscoverStepData
 from tmt.steps.provision import Guest
-from tmt.utils import Path, ShellScript, Stopwatch, cached_property, field
+from tmt.utils import Environment, Path, ShellScript, Stopwatch, cached_property, field
 
 if TYPE_CHECKING:
     import tmt.cli
@@ -270,6 +270,22 @@ class TestInvocation:
             return False
 
         return True
+
+    def inject_topology(self, environment: Environment) -> tmt.steps.Topology:
+        """
+        Collect and install the guest topology and make it visible to test.
+
+        :param environment: environment to update with topology variables.
+        :returns: instantiated topology container.
+        """
+
+        return tmt.steps.Topology.inject(
+            environment=environment,
+            guests=self.phase.step.plan.provision.guests(),
+            guest=self.guest,
+            dirpath=self.path,
+            logger=self.logger
+            )
 
     def handle_restart(self) -> bool:
         """

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -325,13 +325,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
             options=["-s", "-p", "--chmod=755"])
 
         # Create topology files
-        topology = tmt.steps.Topology(self.step.plan.provision.guests())
-        topology.guest = tmt.steps.GuestTopology(guest)
-
-        environment.update(topology.push(
-            dirpath=invocation.path,
-            guest=guest,
-            logger=logger))
+        invocation.inject_topology(environment)
 
         command: str
         if guest.become and not guest.facts.is_superuser:

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -67,12 +67,24 @@ class FinishShell(tmt.steps.finish.FinishPlugin[FinishShellData]):
         """ Perform finishing tasks on given guest """
         super().go(guest=guest, environment=environment, logger=logger)
 
+        environment = environment or tmt.utils.Environment()
+
         # Give a short summary
         overview = fmf.utils.listed(self.data.script, 'script')
         self.info('overview', f'{overview} found', 'green')
 
         workdir = self.step.plan.worktree
         assert workdir is not None  # narrow type
+
+        if not self.is_dry_run:
+            tmt.steps.Topology.inject(
+                environment=environment,
+                guests=self.step.plan.provision.guests(),
+                guest=guest,
+                dirpath=workdir,
+                filename_base=safe_filename(tmt.steps.TEST_TOPOLOGY_FILENAME_BASE, self, guest),
+                logger=logger
+                )
 
         finish_wrapper_filename = safe_filename(FINISH_WRAPPER_FILENAME, self, guest)
         finish_wrapper_path = workdir / finish_wrapper_filename

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -76,16 +76,14 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
         assert workdir is not None  # narrow type
 
         if not self.is_dry_run:
-            topology = tmt.steps.Topology(self.step.plan.provision.guests())
-            topology.guest = tmt.steps.GuestTopology(guest)
-
-            environment.update(
-                topology.push(
-                    dirpath=workdir,
-                    guest=guest,
-                    logger=logger,
-                    filename_base=safe_filename(tmt.steps.TEST_TOPOLOGY_FILENAME_BASE, self, guest)
-                    ))
+            tmt.steps.Topology.inject(
+                environment=environment,
+                guests=self.step.plan.provision.guests(),
+                guest=guest,
+                dirpath=workdir,
+                filename_base=safe_filename(tmt.steps.TEST_TOPOLOGY_FILENAME_BASE, self, guest),
+                logger=logger
+                )
 
         prepare_wrapper_filename = safe_filename(PREPARE_WRAPPER_FILENAME, self, guest)
         prepare_wrapper_path = workdir / prepare_wrapper_filename

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -749,6 +749,12 @@ class Guest(tmt.utils.Common):
         return tmt.package_managers.find_package_manager(
             self.facts.package_manager)(guest=self, logger=self._logger)
 
+    @property
+    def actual_hardware(self) -> tmt.hardware.BaseConstraint:
+        """ An actual HW configuration expressed with tmt hardware specification """
+
+        raise NotImplementedError
+
     @classmethod
     def options(cls, how: Optional[str] = None) -> list[tmt.options.ClickOptionDecoratorType]:
         """ Prepare command line options related to guests """
@@ -862,6 +868,19 @@ class Guest(tmt.utils.Common):
 
             elif key in GUEST_FACTS_VERBOSE_FIELDS:
                 self.verbose(key_formatted, value_formatted, color='green')
+
+        if self.hardware and self.hardware.constraint:
+            self.info(
+                'hardware',
+                tmt.utils.dict_to_yaml(self.hardware.to_spec()).strip(),
+                color='green')
+
+        self.info(
+            'actual hardware',
+            tmt.utils.dict_to_yaml(
+                tmt.hardware.simplify_actual_hardware(
+                    self.actual_hardware)).strip(),
+            color='green')
 
     def _ansible_verbosity(self) -> list[str]:
         """ Prepare verbose level based on the --debug option count """

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -498,6 +498,16 @@ class GuestArtemis(tmt.GuestSsh):
         #        return True if self.guest is not None
         return self.primary_address is not None
 
+    @property
+    def actual_hardware(self) -> tmt.hardware.BaseConstraint:
+        return tmt.hardware.parse_hw_requirements(
+            tmt.utils.yaml_to_dict(
+                f"""
+                arch: {self.arch}
+                """
+                )
+            )
+
     def _create(self) -> None:
         environment: dict[str, Any] = {
             'hw': {

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -2,6 +2,7 @@ import dataclasses
 from typing import Any, Optional, Union
 
 import tmt
+import tmt.hardware
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
@@ -84,6 +85,16 @@ class GuestConnect(tmt.steps.provision.GuestSsh):
 
     soft_reboot: Optional[ShellScript]
     hard_reboot: Optional[ShellScript]
+
+    @property
+    def actual_hardware(self) -> tmt.hardware.BaseConstraint:
+        return tmt.hardware.parse_hw_requirements(
+            tmt.utils.yaml_to_dict(
+                f"""
+                arch: {self.facts.arch}
+                """
+                )
+            )
 
     def reboot(
             self,

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -1,8 +1,10 @@
 import dataclasses
+import os
 from typing import Any, Optional, Union
 
 import tmt
 import tmt.base
+import tmt.hardware
 import tmt.log
 import tmt.steps
 import tmt.steps.provision
@@ -25,6 +27,19 @@ class GuestLocal(tmt.Guest):
     def is_ready(self) -> bool:
         """ Local is always ready """
         return True
+
+    @property
+    def actual_hardware(self) -> tmt.hardware.BaseConstraint:
+        memory = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+
+        return tmt.hardware.parse_hw_requirements(
+            tmt.utils.yaml_to_dict(
+                f"""
+                arch: {self.facts.arch}
+                memory: {memory} bytes
+                """
+                )
+            )
 
     def _run_ansible(
             self,

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -823,6 +823,16 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
         except mrack.errors.MrackError:
             return False
 
+    @property
+    def actual_hardware(self) -> tmt.hardware.BaseConstraint:
+        return tmt.hardware.parse_hw_requirements(
+            tmt.utils.yaml_to_dict(
+                f"""
+                arch: {self.arch}
+                """
+                )
+            )
+
     def _create(self, tmt_name: str) -> None:
         """ Create beaker job xml request and submit it to Beaker hub """
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -5,6 +5,7 @@ from typing import Any, Optional, Union, cast
 
 import tmt
 import tmt.base
+import tmt.hardware
 import tmt.log
 import tmt.steps
 import tmt.steps.provision
@@ -113,6 +114,16 @@ class GuestContainer(tmt.Guest):
             self.container
             ))
         return str(cmd_output.stdout).strip() == 'true'
+
+    @property
+    def actual_hardware(self) -> tmt.hardware.BaseConstraint:
+        return tmt.hardware.parse_hw_requirements(
+            tmt.utils.yaml_to_dict(
+                f"""
+                arch: {self.facts.arch}
+                """
+                )
+            )
 
     def wake(self) -> None:
         """ Wake up the guest """


### PR DESCRIPTION
Related to https://github.com/teemtee/tmt/issues/2402. The patch
bootstraps `hardware` field in the guest topology content, and populates
it it very basic content. Extending it with more info, e.g. `disk` or
`system`, will be task for future patches.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [ ] extend the test coverage - filed https://github.com/teemtee/tmt/issues/2585 for more
* [x] update the specification
* [x] mention the version
* [ ] include a release note
