### PR TITLE
When cloning a logger, give it its own copy of labels

### DIFF
--- a/tmt/log.py
+++ b/tmt/log.py
@@ -519,7 +519,7 @@ class Logger:
         return Logger(
             self._logger,
             base_shift=self._base_shift,
-            labels=self.labels,
+            labels=self.labels[:],
             labels_padding=self.labels_padding,
             verbosity_level=self.verbosity_level,
             debug_level=self.debug_level,
@@ -553,7 +553,7 @@ class Logger:
         return Logger(
             actual_logger,
             base_shift=self._base_shift + extra_shift,
-            labels=self.labels,
+            labels=self.labels[:],
             labels_padding=self.labels_padding,
             verbosity_level=self.verbosity_level,
             debug_level=self.debug_level,


### PR DESCRIPTION
Otherwise, changing labels for the original logger would affect its children as well.

Discovered as a prerequisite for https://github.com/teemtee/tmt/pull/2412/

Pull Request Checklist

* [x] implement the feature