### PR TITLE
Making rhts metric value optional.

### DIFF
--- a/tests/execute/restraint/report-result/data/report.sh
+++ b/tests/execute/restraint/report-result/data/report.sh
@@ -33,10 +33,11 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest 'Verify mocked RHTS rhts-report-result file generated correctly.'
-        rlRun "rhts-report-result rhts-report SKIP /tmp/example_output.txt 1" 0 "Generating RHTS report of skipped test."
+        rlRun "rhts-report-result rhts-report SKIP /tmp/example_output.txt" 0 "Generating RHTS report of skipped test without optional metric."
         rlRun "ls $RESULT_FILE" 0 "Result report successfully generated."
         rlRun -s "cat $RESULT_FILE"
         rlAssertGrep 'TESTRESULT=SKIP' $rlRun_LOG
+	rlAssertGrep 'METRIC=$' $rlRun_LOG -E
         rlRun "rhts-report-result rhts-report PASS /tmp/example_output.txt 66" 0 "Generating RHTS report of passed test."
         rlRun -s "cat $RESULT_FILE"
         rlAssertGrep 'OUTPUTFILE=/tmp/example_output.txt' $rlRun_LOG

--- a/tests/execute/restraint/report-result/data/smoke.fmf
+++ b/tests/execute/restraint/report-result/data/smoke.fmf
@@ -17,7 +17,7 @@ description:
     test: rstrnt-report-result report WARN
 
 /rhts-good:
-    test: rhts-report-result rhts PASS /tmp/rhts-test 1
+    test: rhts-report-result rhts PASS /tmp/rhts-test
 
 /rhts-bad:
     test: rhts-report-result rhts FAIL /tmp/rhts-test 1

--- a/tmt/steps/execute/scripts/tmt-report-result
+++ b/tmt/steps/execute/scripts/tmt-report-result
@@ -62,7 +62,10 @@ if [[ "$0" == *"rhts-report-result"* ]]; then
     TESTNAME=$1
     TESTRESULT=$2
     outputFile=$3
-    METRIC=$4
+    METRIC=
+    if [ $# -gt 3 ];then
+        METRIC=$4
+    fi
     check_report_file
 fi
 


### PR DESCRIPTION
It's been identified in the following issue [2592](https://github.com/teemtee/tmt/issues/2592) that the 'metric' value of the rhts call needs to be optional. As such, I've updated the logic in the BASH script to set it as such and have also updated some of the tests to ensure that when called without that parameter that the report is still generated but without the value having been set to anything.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
