### PR TITLE
Extend `duration` of `/tests/core/escaping` a bit

### DIFF
--- a/tests/core/escaping/data/tests/main.fmf
+++ b/tests/core/escaping/data/tests/main.fmf
@@ -1,5 +1,5 @@
 framework: shell
-duration: 1s
+duration: 5s
 require: []
 test: "true"
 


### PR DESCRIPTION
Seems that some slow machines just cannot make this under one second as the test failed several times recently.