### PR TITLE
Allow `--update-missing` to change the default `how` value

### DIFF
--- a/tests/core/phases/data/plans.fmf
+++ b/tests/core/phases/data/plans.fmf
@@ -23,3 +23,7 @@ execute:
   report:
     - how: html
       order: 60
+
+/without-how:
+  report:
+    - order: 60

--- a/tests/core/phases/test.sh
+++ b/tests/core/phases/test.sh
@@ -160,6 +160,42 @@ default-1:html:50"
 default-1:html:never"
     rlPhaseEnd
 
+    rlPhaseStartTest "Test --update-missing preserves defined --how"
+        rlRun -s "$run plan -n /with-report \
+            report"
+
+        check "with-report" "One 'html' phase shall exist" "default-0:html:50"
+
+        rlRun -s "yq -r '.data | .[] | \"\\(.name):\\(.how)\"' $rundir/plans/with-report/report/step.yaml"
+        rlAssertEquals "default-0 shall be set to html how" "$(cat $rlRun_LOG)" "default-0:html"
+
+        rlRun -s "$run plan -n /with-report \
+            report --update-missing -h junit"
+
+        check "with-report" "One 'html' phase shall exist" "default-0:html:50"
+
+        rlRun -s "yq -r '.data | .[] | \"\\(.name):\\(.how)\"' $rundir/plans/with-report/report/step.yaml"
+        rlAssertEquals "default-0 shall be set to html how" "$(cat $rlRun_LOG)" "default-0:html"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test --update-missing sets undefined --how"
+        rlRun -s "$run plan -n /without-how \
+            report"
+
+        check "without-how" "One 'display' phase shall exist" "default-0:display:60"
+
+        rlRun -s "yq -r '.data | .[] | \"\\(.name):\\(.how)\"' $rundir/plans/without-how/report/step.yaml"
+        rlAssertEquals "default-0 shall be set to default how" "$(cat $rlRun_LOG)" "default-0:display"
+
+        rlRun -s "$run plan -n /without-how \
+            report --update-missing -h html"
+
+        check "without-how" "One 'html' phase shall exist" "default-0:html:60"
+
+        rlRun -s "yq -r '.data | .[] | \"\\(.name):\\(.how)\"' $rundir/plans/without-how/report/step.yaml"
+        rlAssertEquals "default-0 shall be set to html how" "$(cat $rlRun_LOG)" "default-0:html"
+    rlPhaseEnd
+
     rlPhaseStartTest "Test /with-order"
         rlRun -s "$run plan -n /with-order"
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1543,6 +1543,14 @@ class Plan(
     _original_plan: Optional['Plan'] = field(default=None, internal=True)
     _remote_plan_fmf_id: Optional[FmfId] = field(default=None, internal=True)
 
+    #: Used by steps to mark invocations that have been already applied to
+    #: this plan's phases. Needed to avoid the second evaluation in
+    #: py:meth:`Step.wake()`.
+    _applied_cli_invocations: list['tmt.cli.CliInvocation'] = field(
+        default_factory=list,
+        internal=True
+        )
+
     _extra_l2_keys = [
         'context',
         'environment',
@@ -1570,6 +1578,11 @@ class Plan(
             skip_validation=skip_validation,
             raise_on_validation_error=raise_on_validation_error,
             **kwargs)
+
+        # TODO: there is a bug in handling internal fields with `default_factory`
+        # set, incorrect default value is generated, and the field ends up being
+        # set to `None`. See https://github.com/teemtee/tmt/issues/2630.
+        self._applied_cli_invocations = []
 
         # Check for possible remote plan reference first
         reference = self.node.get(['plan', 'import'])

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -217,8 +217,8 @@ PluginClass = type['BasePlugin']  # type: ignore[type-arg]
 
 
 class _RawStepData(TypedDict, total=False):
-    how: str
-    name: str
+    how: Optional[str]
+    name: Optional[str]
 
 
 RawStepDataArgument = Union[_RawStepData, list[_RawStepData]]
@@ -284,6 +284,11 @@ class StepData(
         """ Convert from a specification file or from a CLI option """
 
         cls.pre_normalization(raw_data, logger)
+
+        # TODO: narrows type, but it would be better to not allow Optional `how`
+        # or `name` at this point. But that would require a dedicated type.
+        assert raw_data['name']
+        assert raw_data['how']
 
         data = cls(name=raw_data['name'], how=raw_data['how'])
         data._load_keys(cast(dict[str, Any], raw_data), cls.__name__, logger)
@@ -369,22 +374,29 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
 
         # Create an empty step by default (can be updated from cli)
         if data is None:
-            self._raw_data = [{}]
+            raw_data: list[_RawStepData] = [{}]
 
         # Convert to list if only a single config provided
         elif isinstance(data, dict):
-            self._raw_data = [data]
+            raw_data = [data]
 
         # List is as good as it gets
         elif isinstance(data, list):
-            self._raw_data = data
+            raw_data = data
 
         # Shout about invalid configuration
         else:
             raise tmt.utils.GeneralError(
                 f"Invalid '{self}' config in '{self.plan}'.")
 
-        self._set_default_values(self._raw_data)
+        raw_data = self._set_default_names(raw_data)
+        raw_data = self._apply_cli_invocations(raw_data)
+
+        self._raw_data = raw_data
+
+    @property
+    def _cli_invocation_logger(self) -> tmt.log.LoggingFunction:
+        return functools.partial(self.debug, level=4, topic=tmt.log.Topic.CLI_INVOCATIONS)
 
     def _check_duplicate_names(self, raw_data: list[_RawStepData]) -> None:
         """ Check for duplicate names in phases """
@@ -392,20 +404,49 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
         for name in tmt.utils.duplicates(raw_datum.get('name', None) for raw_datum in raw_data):
             raise tmt.utils.GeneralError(f"Duplicate phase name '{name}' in step '{self.name}'.")
 
-    def _set_default_values(self, raw_data: list[_RawStepData]) -> list[_RawStepData]:
-        """ Set default values for ``name`` and ``how`` fields if not specified """
+    def _set_default_names(self, raw_data: list[_RawStepData]) -> list[_RawStepData]:
+        """ Set default values for ``name`` keys if not specified """
+
+        debug1 = self._cli_invocation_logger
+        debug2 = functools.partial(debug1, shift=1)
+
+        debug1(f'Update {self.__class__.__name__.lower()} phases with default names')
 
         name_generator = DefaultNameGenerator.from_raw_phases(raw_data)
 
-        for _i, raw_datum in enumerate(raw_data):
+        for i, raw_datum in enumerate(raw_data):
+            debug2(f'raw step datum #{i} in ', str(raw_datum))
+
             # Add default unique names even to multiple configs so that the users
             # don't need to specify it if they don't care about the name
             if raw_datum.get('name', None) is None:
                 raw_datum['name'] = name_generator.get()
 
+                debug2(f"setting 'name' to default '{raw_datum['name']}'", shift=2)
+
+            debug2(f'raw step datum #{i} out', str(raw_datum))
+
+        return raw_data
+
+    def _set_default_how(self, raw_data: list[_RawStepData]) -> list[_RawStepData]:
+        """ Set default values for ``how`` keys if not specified """
+
+        debug1 = self._cli_invocation_logger
+        debug2 = functools.partial(debug1, shift=1)
+        debug3 = functools.partial(debug1, shift=2)
+
+        debug1(f'Update {self.__class__.__name__.lower()} phases with default how')
+
+        for i, raw_datum in enumerate(raw_data):
+            debug2(f'raw step datum #{i} in ', str(raw_datum))
+
             # Set 'how' to the default if not specified
             if raw_datum.get('how', None) is None:
                 raw_datum['how'] = self.DEFAULT_HOW
+
+                debug3(f"setting 'how' to default '{raw_datum['how']}'")
+
+            debug2(f'raw step datum #{i} out', str(raw_datum))
 
         return raw_data
 
@@ -431,6 +472,13 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
 
             data.append(plugin.data)
 
+        # A final bit of logging, to record what we ended up with after all inputs and fixups were
+        # applied.
+        debug = self._cli_invocation_logger
+
+        for i, datum in enumerate(data):
+            debug(f'final step data #{i}', str(datum))
+
         return data
 
     def _export(
@@ -443,7 +491,10 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
         def _export_datum(raw_datum: _RawStepData) -> _RawStepData:
             return cast(
                 _RawStepData,
-                {key_to_option(key): value for key, value in raw_datum.items()})
+                {
+                    key_to_option(key): value
+                    for key, value in raw_datum.items()
+                    })
 
         return cast(
             tmt.export._RawExportedInstance,
@@ -463,6 +514,11 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
     @data.setter
     def data(self, data: list[StepData]) -> None:
         self._data = data
+
+    @data.deleter
+    def data(self) -> None:
+        if hasattr(self, '_data'):
+            del self._data
 
     @property
     def enabled(self) -> Optional[bool]:
@@ -559,19 +615,27 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
         """ Load status and step data from the workdir """
         try:
             raw_step_data: dict[Any, Any] = tmt.utils.yaml_to_dict(self.read(Path('step.yaml')))
-            self.debug('Successfully loaded step data.', level=2)
 
-            self.data = [
-                StepData.unserialize(raw_datum, self._logger)
-                for raw_datum in raw_step_data['data']
-                ]
-            self._raw_data = [
-                datum.to_spec()
-                for datum in self.data
-                ]
-            self.status(raw_step_data['status'])
         except tmt.utils.GeneralError:
             self.debug('Step data not found.', level=2)
+            return
+
+        self.debug('Successfully loaded step data.', level=2)
+
+        self.data = [
+            StepData.unserialize(raw_datum, self._logger)
+            for raw_datum in raw_step_data['data']
+            ]
+        self._raw_data = [
+            datum.to_spec()
+            for datum in self.data
+            ]
+        self.status(raw_step_data['status'])
+
+        # After loading data, we need to make sure we re-apply all CLI
+        # invocations. They have already been applied to previous data, but we
+        # just throw those away.
+        self.plan._applied_cli_invocations = []
 
     def save(self) -> None:
         """ Save status and step data to the workdir """
@@ -616,6 +680,17 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
             self.debug('Step is done, not touching its data.')
             return
 
+        # Run through CLI invocations once more: `wake()` might have been called
+        # after load instead of step being populated via `__init__()`. If that's
+        # the case, we must make sure CLI invocation do take effect.
+        del self.data
+
+        raw_data = self._set_default_names(self._raw_data)
+        raw_data = self._apply_cli_invocations(raw_data)
+
+        self._raw_data = raw_data
+
+    def _apply_cli_invocations(self, raw_data: list[_RawStepData]) -> list[_RawStepData]:
         # Override step data with command line options
         #
         # Do NOT iterate over `self.data`: reading `self.data` would trigger materialization
@@ -625,9 +700,15 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
         # Instead, iterate over raw data, and replace incompatible plugins with the one given
         # on command line. There is no reason to ever let dropped plugin's `StepData` to
         # materialize when it's going to be thrown away anyway.
-        debug = functools.partial(self.debug, level=4, topic=tmt.log.Topic.CLI_INVOCATIONS)
 
-        debug('Update phases by CLI invocations')
+        # CLI processing is a nasty business, with many levels and much logging.
+        # Let's spawn a couple of helpers.
+        debug1 = self._cli_invocation_logger
+        debug2 = functools.partial(debug1, shift=1)
+        debug3 = functools.partial(debug1, shift=2)
+        debug4 = functools.partial(debug1, shift=3)
+
+        debug1(f'Update {self.__class__.__name__.lower()} phases by CLI invocations')
 
         def _to_raw_step_datum(options: dict[str, Any]) -> _RawStepData:
             """
@@ -654,7 +735,11 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
         # modified by `--insert`, and entries may be modified as well. Note that we do not process
         # step data here, this list is not the input we iterate over - we process CLI invocations,
         # and based on their content we modify this list and its content.
-        raw_data: list[_RawStepData] = self._raw_data[:]
+        #
+        # Making copy of the original list, to not overwrite whatever the caller
+        # gave us. Processing CLI is a tricky task, and let's introduce a bit of
+        # immutability into our lives.
+        raw_data = raw_data[:]
 
         # Some invocations cannot be easily evaluated when we first spot them. To remain backward
         # compatible, `--update` without `--name` should result in all phases being converted into
@@ -691,11 +776,9 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
             variable).
             """
 
-            local_debug = functools.partial(debug, shift=1)
-
-            local_debug('raw step datum', str(raw_datum))
-            local_debug('incoming raw step datum', str(incoming_raw_datum))
-            local_debug('CLI invocation', str(invocation.options))
+            debug3('raw step datum', str(raw_datum))
+            debug3('incoming raw step datum', str(incoming_raw_datum))
+            debug3('CLI invocation', str(invocation.options))
 
             for opt, value in incoming_raw_datum.items():
                 if opt == 'name':
@@ -704,15 +787,16 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
                 key = option_to_key(opt)
                 value_source = invocation.option_sources.get(key)
 
-                local_debug(f'{opt=} {key=} {value=} {value_source=}')
+                debug3(f'{opt=} {key=} {value=} {value_source=}')
 
                 # Ignore CLI input if it's been provided by option's default
                 if value_source not in (ParameterSource.COMMANDLINE, ParameterSource.ENVIRONMENT):
-                    debug('value not really given via CLI/env, no effect', shift=2)
+                    debug4('value not really given via CLI/env, no effect')
                     continue
 
+                # Ignore CLI input if `--missing-only` has been set and datum already has the key.
                 if missing_only and opt in raw_datum:
-                    debug('missing-only mode and key exists in raw datum, no effect', shift=2)
+                    debug4('missing-only mode and key exists in raw datum, no effect')
                     continue
 
                 # ignore[literal-required]: since raw_datum is a typed dict,
@@ -722,36 +806,44 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
                 # `_RawStepData` and we do expect there are keys we do not
                 # care about, keys that make sense to whatever plugin is
                 # materialized from the raw step data.
-                debug('apply invocation value', shift=2)
+                debug4('apply invocation value')
                 raw_datum[opt] = value  # type: ignore[literal-required]
 
-            local_debug('patched step datum', str(raw_datum))
+            debug3('patched step datum', str(raw_datum))
+
+            self.plan._applied_cli_invocations.append(invocation)
 
         # A bit of logging before we start messing with step data
         for i, raw_datum in enumerate(raw_data):
-            debug(f'raw step datum #{i}', str(raw_datum))
+            debug2(f'raw step datum #{i}', str(raw_datum))
 
         # The first pass, apply CLI invocations that can be applied
         for i, invocation in enumerate(self.__class__.cli_invocations):
-            debug(f'invocation #{i}', str(invocation.options))
+            debug2(f'invocation #{i}', str(invocation.options))
+
+            if invocation in self.plan._applied_cli_invocations:
+                debug3('already applied')
+                continue
 
             how: Optional[str] = invocation.options.get('how')
 
             if how is None:
-                debug('  how-less phase (postponed)')
+                debug3('how-less phase (postponed)')
 
                 postponed_invocations.append(invocation)
 
             elif invocation.options.get('insert'):
-                debug('  inserting new phase')
+                debug3('inserting new phase')
 
                 raw_datum = _to_raw_step_datum(invocation.options)
                 raw_datum = _ensure_name(raw_datum)
 
                 raw_data.append(raw_datum)
 
+                self.plan._applied_cli_invocations.append(invocation)
+
             elif invocation.options.get('update'):
-                debug('  updating existing phase')
+                debug3('updating existing phase')
 
                 needle = invocation.options.get('name')
 
@@ -771,12 +863,12 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
                             f"Cannot update phase '{needle}', no such name was found.")
 
                 else:
-                    debug('  needle-less update (postponed)')
+                    debug3('needle-less update (postponed)')
 
                     postponed_invocations.append(invocation)
 
             elif invocation.options.get('update_missing'):
-                debug('  updating existing phase (missing fields only)')
+                debug3('updating existing phase (missing fields only)')
 
                 needle = invocation.options.get('name')
 
@@ -800,18 +892,18 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
                             f"Cannot update phase '{needle}', no such name was found.")
 
                 else:
-                    debug('  needle-less update (postponed)')
+                    debug3('needle-less update (postponed)')
 
                     postponed_invocations.append(invocation)
 
             else:
-                debug('  action-less phase (postponed)')
+                debug3('action-less phase (postponed)')
 
                 postponed_invocations.append(invocation)
 
         # The second pass, evaluate postponed CLI invocations
         for i, invocation in enumerate(postponed_invocations):
-            debug(f'postponed invocation #{i}', str(invocation.options))
+            debug2(f'postponed invocation #{i}', str(invocation.options))
 
             pruned_raw_data: list[_RawStepData] = []
             incoming_raw_datum = _to_raw_step_datum(invocation.options)
@@ -823,21 +915,24 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
             how = invocation.options.get('how')
 
             for j, raw_datum in enumerate(raw_data):
-                debug(f'raw step datum #{j}', str(raw_datum))
+                debug2(f'raw step datum #{j}', str(raw_datum))
 
                 if how is None:
-                    debug('  compatible step data (how-less invocation)')
+                    debug3('compatible step data (how-less invocation)')
 
-                elif raw_datum['how'] == how:
-                    debug('  compatible step data')
+                elif raw_datum.get('how') is None:
+                    debug3('undefined method, cannot test compatibility')
+
+                elif raw_datum.get('how') == how:
+                    debug3('compatible step data')
 
                 else:
-                    debug('  incompatible step data')
+                    debug3('incompatible step data')
 
                     data_base = self._plugin_base_class._data_class
 
-                    debug('  compatible base', f'{data_base.__module__}.{data_base.__name__}')
-                    debug('  compatible keys', list(data_base.keys()))
+                    debug3('compatible base', f'{data_base.__module__}.{data_base.__name__}')
+                    debug3('compatible keys', list(data_base.keys()))
 
                     # Copy compatible keys only, ignore everything else
                     # SIM118: Use `{key} in {dict}` instead of `{key} in {dict}.keys()`.
@@ -863,16 +958,10 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
 
         # And bit of logging after re're done with CLI invocations
         for i, raw_datum in enumerate(raw_data):
-            debug(f'updated raw step datum #{i}', str(raw_datum))
+            debug2(f'updated raw step datum #{i}', str(raw_datum))
 
-        self._set_default_values(raw_data)
-        self.data = self._normalize_data(raw_data, self._logger)
-        self._raw_data = raw_data
-
-        # A final bit of logging, to record what we ended up with after all inputs and fixups were
-        # applied.
-        for i, datum in enumerate(self.data):
-            debug(f'final step data #{i}', str(datum))
+        raw_data = self._set_default_names(raw_data)
+        return self._set_default_how(raw_data)
 
     def setup_actions(self) -> None:
         """ Insert login and reboot plugins if requested """
@@ -1256,6 +1345,10 @@ class BasePlugin(Phase, Generic[StepDataT]):
         if data is not None:
             how = data.how
         elif raw_data is not None:
+            # TODO: narrows type, but it would be better to not allow Optional `how`
+            # at this point. But that would require a dedicated type.
+            assert raw_data['how']
+
             how = raw_data['how']
         else:
             raise tmt.utils.GeneralError('Either data or raw data must be given.')

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -5320,6 +5320,13 @@ def _prenormalize_fmf_node(node: fmf.Tree, schema_name: str, logger: tmt.log.Log
     if not isinstance(node.data, dict):
         return node
 
+    # Do NOT modify the given node! Changing it might taint or hide important
+    # keys the later processing could need in their original state. Namely, we
+    # need to initialize `how` to reach at least some schema, but CLI processing
+    # needs to realize `how` was not given, and therefore it's possible to be
+    # modified with `--update-missing`...
+    node = node.copy()
+
     # Avoid possible circular imports
     import tmt.steps
 


### PR DESCRIPTION
`--update-missing` did not touch `how`. However, when user did not specify `how` in a phase, they can reasonably expect `--update-missing` would set it. Unfortunately, tmt first resolves default values, and sets the `how` key to the default value, which makes it no longer missing when CLI invocations are being resolved.

The patch saves original, fmf-supplied `how` and `name`, and `--update-missing` checks whether `how` has been unset - if that's the case, `how` would be update if `--update-missing --how ...` is given by user.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage