### PR TITLE
Copy top level `main.fmf` during testdir pruning

### DIFF
--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -614,11 +614,11 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 # Copy all parent main.fmf files
                 parent_dir = relative_test_path
                 while parent_dir.resolve() != Path.cwd().resolve():
+                    parent_dir = parent_dir.parent
                     if (self.testdir / parent_dir / 'main.fmf').exists():
                         shutil.copyfile(
                             self.testdir / parent_dir / 'main.fmf',
                             clonedir / parent_dir / 'main.fmf')
-                    parent_dir = parent_dir.parent
 
             # Prefix test path with 'tests' and possible 'path' prefix
             assert test.path is not None  # narrow type


### PR DESCRIPTION
Top level main.fmf was not copied when discover prune argument was used, although this shouldn't cause any problems as all the data from fmf files is already loaded.

Pull Request Checklist

* [x] implement the feature
