### PR TITLE
Convert environment handling into a dict-like class

### DIFF
--- a/tests/core/environment-file/test.sh
+++ b/tests/core/environment-file/test.sh
@@ -27,8 +27,9 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Bad dotenv format"
-        rlRun "tmt run -rvvvddd plan -n bad 2>&1 | tee output" 2
-        rlAssertGrep "Failed to extract variables.*data/bad" 'output'
+        rlRun -s "tmt run -rvvvddd plan -n bad" 2
+        rlAssertGrep "Failed to extract variables from 'dotenv' format." $rlRun_LOG
+        rlAssertGrep "not enough values to unpack (expected 2, got 1)" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Empty environment file"
@@ -37,19 +38,19 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Escape from the tree"
-        rlRun "tmt run -rvvvddd plan -n escape 2>&1 | tee output" 2
-        rlAssertGrep "path '/etc/secret' is outside" 'output'
+        rlRun -s "tmt run -rvvvddd plan -n escape" 2
+        rlAssertGrep "Failed to extract variables from file '/etc/secret' as it lies outside the metadata tree root '$(pwd)'." $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Fetch a remote file"
         # Good
-        rlRun "tmt plan show fetch/good | tee output"
-        rlAssertGrep "STR: O" 'output'
-        rlAssertGrep "INT: 0" 'output'
+        rlRun -s "tmt plan show fetch/good"
+        rlAssertGrep "STR: O" $rlRun_LOG
+        rlAssertGrep "INT: 0"  $rlRun_LOG
         # Bad
-        rlRun "tmt plan show fetch/bad 2>&1 | tee output" 2
-        rlAssertGrep "Failed to fetch the environment file" 'output'
-        rlAssertGrep "Not Found" 'output'
+        rlRun -s "tmt plan show fetch/bad" 2
+        rlAssertGrep "Failed to extract variables from URL '.*/tests/core/env/data/wrong.yaml'."  $rlRun_LOG -E
+        rlAssertGrep "404 Client Error: Not Found for url: .*/tests/core/env/data/wrong.yaml" $rlRun_LOG -E
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/unit/test_adjust.py
+++ b/tests/unit/test_adjust.py
@@ -5,13 +5,13 @@ from tmt.utils import ConvertError
 
 
 @pytest.fixture()
-def mini():
+def mini(root_logger):
     """ Minimal example """
-    return relevancy_to_adjust("distro = fedora: False")
+    return relevancy_to_adjust("distro = fedora: False", root_logger)
 
 
 @pytest.fixture()
-def full():
+def full(root_logger):
     """ Full example """
     return relevancy_to_adjust("""
     # feature has been added in Fedora 33
@@ -24,20 +24,20 @@ def full():
 
     # try special operators
     collection contains httpd24 && fips defined: False
-    """.replace('    ', ''))
+    """.replace('    ', ''), root_logger)
 
 
-def check(condition, expected):
+def check(condition, expected, logger):
     """ Check condition against expected """
-    adjusted = relevancy_to_adjust(f"{condition}: False")[0]['when']
+    adjusted = relevancy_to_adjust(f"{condition}: False", logger)[0]['when']
     assert adjusted == expected
 
 
 # Valid rules
 
-def test_empty():
+def test_empty(root_logger):
     """ Empty relevancy """
-    assert relevancy_to_adjust('') == []
+    assert relevancy_to_adjust('', root_logger) == []
 
 
 def test_comments(full):
@@ -73,94 +73,95 @@ def test_condition(mini, full):
     assert full[3]['when'] == 'collection == httpd24 and fips is defined'
 
 
-def test_operators_basic():
+def test_operators_basic(root_logger):
     """ Basic operators unchanged """
-    check('component = python', 'component == python')
-    check('component == python', 'component == python')
-    check('arch == s390x', 'arch == s390x')
-    check('arch != s390x', 'arch != s390x')
+    check('component = python', 'component == python', root_logger)
+    check('component == python', 'component == python', root_logger)
+    check('arch == s390x', 'arch == s390x', root_logger)
+    check('arch != s390x', 'arch != s390x', root_logger)
 
 
-def test_operators_distro_name():
+def test_operators_distro_name(root_logger):
     """ Check distro name """
-    check('distro = fedora', 'distro == fedora')
-    check('distro == fedora', 'distro == fedora')
-    check('distro != fedora', 'distro != fedora')
+    check('distro = fedora', 'distro == fedora', root_logger)
+    check('distro == fedora', 'distro == fedora', root_logger)
+    check('distro != fedora', 'distro != fedora', root_logger)
 
 
-def test_operators_distro_major():
+def test_operators_distro_major(root_logger):
     """ Check distro major version """
-    check('distro < fedora-33', 'distro < fedora-33')
-    check('distro > fedora-33', 'distro > fedora-33')
-    check('distro <= fedora-33', 'distro <= fedora-33')
-    check('distro >= fedora-33', 'distro >= fedora-33')
+    check('distro < fedora-33', 'distro < fedora-33', root_logger)
+    check('distro > fedora-33', 'distro > fedora-33', root_logger)
+    check('distro <= fedora-33', 'distro <= fedora-33', root_logger)
+    check('distro >= fedora-33', 'distro >= fedora-33', root_logger)
 
 
-def test_operators_distro_minor():
+def test_operators_distro_minor(root_logger):
     """ Check distro minor version """
-    check('distro = centos-8.3', 'distro ~= centos-8.3')
-    check('distro == centos-8.3', 'distro ~= centos-8.3')
-    check('distro != centos-8.3', 'distro ~!= centos-8.3')
-    check('distro < centos-8.3', 'distro ~< centos-8.3')
-    check('distro > centos-8.3', 'distro ~> centos-8.3')
-    check('distro <= centos-8.3', 'distro ~<= centos-8.3')
-    check('distro >= centos-8.3', 'distro ~>= centos-8.3')
+    check('distro = centos-8.3', 'distro ~= centos-8.3', root_logger)
+    check('distro == centos-8.3', 'distro ~= centos-8.3', root_logger)
+    check('distro != centos-8.3', 'distro ~!= centos-8.3', root_logger)
+    check('distro < centos-8.3', 'distro ~< centos-8.3', root_logger)
+    check('distro > centos-8.3', 'distro ~> centos-8.3', root_logger)
+    check('distro <= centos-8.3', 'distro ~<= centos-8.3', root_logger)
+    check('distro >= centos-8.3', 'distro ~>= centos-8.3', root_logger)
 
 
-def test_operators_product():
+def test_operators_product(root_logger):
     """ Special handling for product """
     # rhscl
-    check('product = rhscl', 'product == rhscl')
-    check('product == rhscl', 'product == rhscl')
-    check('product != rhscl', 'product != rhscl')
+    check('product = rhscl', 'product == rhscl', root_logger)
+    check('product == rhscl', 'product == rhscl', root_logger)
+    check('product != rhscl', 'product != rhscl', root_logger)
     # rhscl-3
-    check('product < rhscl-3', 'product < rhscl-3')
-    check('product > rhscl-3', 'product > rhscl-3')
-    check('product <= rhscl-3', 'product <= rhscl-3')
-    check('product >= rhscl-3', 'product >= rhscl-3')
+    check('product < rhscl-3', 'product < rhscl-3', root_logger)
+    check('product > rhscl-3', 'product > rhscl-3', root_logger)
+    check('product <= rhscl-3', 'product <= rhscl-3', root_logger)
+    check('product >= rhscl-3', 'product >= rhscl-3', root_logger)
     # rhscl-3.3
-    check('product < rhscl-3.3', 'product ~< rhscl-3.3')
-    check('product > rhscl-3.3', 'product ~> rhscl-3.3')
-    check('product <= rhscl-3.3', 'product ~<= rhscl-3.3')
-    check('product >= rhscl-3.3', 'product ~>= rhscl-3.3')
+    check('product < rhscl-3.3', 'product ~< rhscl-3.3', root_logger)
+    check('product > rhscl-3.3', 'product ~> rhscl-3.3', root_logger)
+    check('product <= rhscl-3.3', 'product ~<= rhscl-3.3', root_logger)
+    check('product >= rhscl-3.3', 'product ~>= rhscl-3.3', root_logger)
 
 
-def test_operators_special():
+def test_operators_special(root_logger):
     """ Check 'defined' and 'contains' """
-    check('fips defined', 'fips is defined')
-    check('fips !defined', 'fips is not defined')
-    check('collection contains http24', 'collection == http24')
-    check('collection !contains http24', 'collection != http24')
+    check('fips defined', 'fips is defined', root_logger)
+    check('fips !defined', 'fips is not defined', root_logger)
+    check('collection contains http24', 'collection == http24', root_logger)
+    check('collection !contains http24', 'collection != http24', root_logger)
 
 
-def test_not_equal_comma_separated():
+def test_not_equal_comma_separated(root_logger):
     """ Special handling for comma-separated values with != """
     check(
         'distro != centos-7, centos-8',
-        'distro != centos-7 and distro != centos-8')
+        'distro != centos-7 and distro != centos-8',
+        root_logger)
 
 
 # Invalid rules
 
-def test_invalid_rule():
+def test_invalid_rule(root_logger):
     """ Invalid relevancy rule """
     with pytest.raises(ConvertError, match='Invalid.*rule'):
-        relevancy_to_adjust("weird")
+        relevancy_to_adjust("weird", root_logger)
 
 
-def test_invalid_decision():
+def test_invalid_decision(root_logger):
     """ Invalid relevancy decision """
     with pytest.raises(ConvertError, match='Invalid.*decision'):
-        relevancy_to_adjust("distro < fedora-33: weird")
+        relevancy_to_adjust("distro < fedora-33: weird", root_logger)
 
 
-def test_invalid_expression():
+def test_invalid_expression(root_logger):
     """ Invalid relevancy expression """
     with pytest.raises(ConvertError, match='Invalid.*expression'):
-        relevancy_to_adjust("distro * fedora-33: False")
+        relevancy_to_adjust("distro * fedora-33: False", root_logger)
 
 
-def test_invalid_operator():
+def test_invalid_operator(root_logger):
     """ Invalid relevancy operator """
     with pytest.raises(ConvertError, match='Invalid.*operator'):
-        relevancy_to_adjust("distro <> fedora-33: False")
+        relevancy_to_adjust("distro <> fedora-33: False", root_logger)

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -188,8 +188,8 @@ def test_expand_node_data(monkeypatch) -> None:
     # environment providing inputs.
 
     fmf_context = {
-        'WALDO': 'plugh',
-        'XYZZY': 'thud'
+        'WALDO': ['plugh'],
+        'XYZZY': ['thud']
         }
 
     environ = {

--- a/tmt/checks/__init__.py
+++ b/tmt/checks/__init__.py
@@ -127,7 +127,7 @@ class Check(
             *,
             event: CheckEvent,
             invocation: 'TestInvocation',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> list['CheckResult']:
         """
         Run the check.
@@ -204,7 +204,7 @@ class CheckPlugin(tmt.utils._CommonBase, Generic[CheckT]):
             *,
             check: CheckT,
             invocation: 'TestInvocation',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> list['CheckResult']:
         return []
 
@@ -214,7 +214,7 @@ class CheckPlugin(tmt.utils._CommonBase, Generic[CheckT]):
             *,
             check: CheckT,
             invocation: 'TestInvocation',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> list['CheckResult']:
         return []
 

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -310,7 +310,7 @@ class AvcDenials(CheckPlugin[Check]):
             *,
             check: 'Check',
             invocation: 'TestInvocation',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> list[CheckResult]:
         if invocation.guest.facts.has_selinux:
             create_ausearch_timestamp(invocation, logger)
@@ -323,7 +323,7 @@ class AvcDenials(CheckPlugin[Check]):
             *,
             check: 'Check',
             invocation: 'TestInvocation',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> list[CheckResult]:
         if not invocation.guest.facts.has_selinux:
             return [CheckResult(

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -130,7 +130,7 @@ class DmesgCheck(CheckPlugin[Check]):
             *,
             check: 'Check',
             invocation: 'TestInvocation',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> list[CheckResult]:
         if not invocation.guest.facts.has_capability(GuestCapability.SYSLOG_ACTION_READ_ALL):
             return [CheckResult(name='dmesg', result=ResultOutcome.SKIP)]
@@ -145,7 +145,7 @@ class DmesgCheck(CheckPlugin[Check]):
             *,
             check: 'Check',
             invocation: 'TestInvocation',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> list[CheckResult]:
         if not invocation.guest.facts.has_capability(GuestCapability.SYSLOG_ACTION_READ_ALL):
             return [CheckResult(name='dmesg', result=ResultOutcome.SKIP)]

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -834,7 +834,7 @@ def tests_import(
         if not (case or plan):
             raise tmt.utils.GeneralError(
                 "Option --case or --plan is mandatory when using --manual.")
-        tmt.convert.read_manual(plan, case, disabled, with_script)
+        tmt.convert.read_manual(plan, case, disabled, with_script, context.obj.logger)
         return
 
     if not paths:
@@ -849,7 +849,7 @@ def tests_import(
         # Gather old metadata and store them as fmf
         common, individual = tmt.convert.read(
             path, makefile, restraint, nitrate, polarion, polarion_case_id, link_polarion,
-            purpose, disabled, types, general, dry)
+            purpose, disabled, types, general, dry, context.obj.logger)
         # Add path to common metadata if there are virtual test cases
         if individual:
             # TODO: fmf is not annotated yet, fmf.Tree.root is seen by pyright as possibly

--- a/tmt/frameworks/__init__.py
+++ b/tmt/frameworks/__init__.py
@@ -62,7 +62,7 @@ class TestFramework:
     def get_environment_variables(
             cls,
             invocation: 'TestInvocation',
-            logger: tmt.log.Logger) -> tmt.utils.EnvironmentType:
+            logger: tmt.log.Logger) -> tmt.utils.Environment:
         """
         Provide additional environment variables for the test.
 
@@ -73,7 +73,7 @@ class TestFramework:
             might have already collected.
         """
 
-        return {}
+        return tmt.utils.Environment()
 
     @classmethod
     def get_test_command(

--- a/tmt/frameworks/beakerlib.py
+++ b/tmt/frameworks/beakerlib.py
@@ -8,7 +8,7 @@ import tmt.steps.execute
 import tmt.utils
 from tmt.frameworks import TestFramework, provides_framework
 from tmt.result import ResultOutcome
-from tmt.utils import Path
+from tmt.utils import Environment, EnvVarValue, Path
 
 if TYPE_CHECKING:
     from tmt.base import DependencySimple, Test
@@ -31,12 +31,13 @@ class Beakerlib(TestFramework):
     def get_environment_variables(
             cls,
             invocation: 'TestInvocation',
-            logger: tmt.log.Logger) -> tmt.utils.EnvironmentType:
+            logger: tmt.log.Logger) -> tmt.utils.Environment:
 
-        return {
-            'BEAKERLIB_DIR': str(invocation.path),
-            'BEAKERLIB_COMMAND_SUBMIT_LOG': f'bash {tmt.steps.execute.TMT_FILE_SUBMIT_SCRIPT.path}'
-            }
+        return Environment({
+            'BEAKERLIB_DIR': EnvVarValue(invocation.path),
+            'BEAKERLIB_COMMAND_SUBMIT_LOG': EnvVarValue(
+                f'bash {tmt.steps.execute.TMT_FILE_SUBMIT_SCRIPT.path}')
+            })
 
     @classmethod
     def get_pull_options(

--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -12,7 +12,7 @@ import tmt.utils
 from tmt.base import DependencyFmfId, DependencySimple
 from tmt.convert import write
 from tmt.steps.discover import Discover
-from tmt.utils import Command, Path
+from tmt.utils import Command, Environment, EnvVarValue, Path
 
 from . import Library, LibraryError
 
@@ -225,7 +225,7 @@ class BeakerLib(Library):
                                 url=self.url,
                                 destination=Path(tmp),
                                 shallow=True,
-                                env={"GIT_ASKPASS": "echo"},
+                                env=Environment({"GIT_ASKPASS": EnvVarValue("echo")}),
                                 logger=self._logger)
                         except (tmt.utils.RunError, tmt.utils.RetryError):
                             self.parent.debug(f"Repository '{self.url}' not found.")
@@ -268,7 +268,7 @@ class BeakerLib(Library):
                             url=self.url,
                             destination=clone_dir,
                             shallow=self.ref is None,
-                            env={"GIT_ASKPASS": "echo"},
+                            env=Environment({"GIT_ASKPASS": EnvVarValue("echo")}),
                             logger=self._logger)
 
                     # Detect the default branch from the origin

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -36,7 +36,8 @@ import tmt.utils
 from tmt.options import option, show_step_method_hints
 from tmt.utils import (
     DEFAULT_NAME,
-    EnvironmentType,
+    Environment,
+    EnvVarValue,
     GeneralError,
     Path,
     RunError,
@@ -1627,7 +1628,7 @@ class Plugin(BasePlugin[StepDataT]):
             self,
             *,
             guest: 'Guest',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> None:
         """ Perform actions shared among plugins when beginning their tasks """
 
@@ -1865,7 +1866,7 @@ class Login(Action):
     def _login(
             self,
             cwd: Optional[Path] = None,
-            env: Optional[tmt.utils.EnvironmentType] = None) -> None:
+            env: Optional[tmt.utils.Environment] = None) -> None:
         """ Run the interactive command """
         scripts = [
             tmt.utils.ShellScript(script)
@@ -1894,7 +1895,7 @@ class Login(Action):
             self,
             result: 'tmt.base.Result',
             cwd: Optional[Path] = None,
-            env: Optional[tmt.utils.EnvironmentType] = None) -> None:
+            env: Optional[tmt.utils.Environment] = None) -> None:
         """ Check and login after test execution """
         if self._enabled_by_results([result]):
             self._login(cwd, env)
@@ -2074,14 +2075,14 @@ class Topology(SerializableContainer):
             dirpath: Path,
             guest: 'Guest',
             filename_base: Optional[Path] = None,
-            logger: tmt.log.Logger) -> EnvironmentType:
+            logger: tmt.log.Logger) -> Environment:
         """
         Save and push topology to a given guest.
         """
 
         topology_filepaths = self.save(dirpath=dirpath, filename_base=filename_base)
 
-        environment: EnvironmentType = {}
+        environment = Environment()
 
         for filepath in topology_filepaths:
             logger.debug('test topology', filepath)
@@ -2092,10 +2093,10 @@ class Topology(SerializableContainer):
                 options=["-s", "-p", "--chmod=755"])
 
             if filepath.suffix == '.sh':
-                environment['TMT_TOPOLOGY_BASH'] = str(filepath)
+                environment['TMT_TOPOLOGY_BASH'] = EnvVarValue(filepath)
 
             elif filepath.suffix == '.yaml':
-                environment['TMT_TOPOLOGY_YAML'] = str(filepath)
+                environment['TMT_TOPOLOGY_YAML'] = EnvVarValue(filepath)
 
             else:
                 raise tmt.utils.GeneralError(f"Unhandled topology file '{filepath}'.")

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -16,7 +16,7 @@ import tmt.options
 import tmt.steps
 import tmt.steps.discover
 import tmt.utils
-from tmt.utils import Command, Path, field
+from tmt.utils import Command, Environment, EnvVarValue, Path, field
 
 
 def normalize_ref(
@@ -360,7 +360,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 url=url,
                 destination=self.testdir,
                 shallow=ref is None,
-                env={"GIT_ASKPASS": "echo"},
+                env=Environment({"GIT_ASKPASS": EnvVarValue("echo")}),
                 logger=self._logger)
             git_root = self.testdir
         # Copy git repository root to workdir
@@ -650,7 +650,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
         # Add TMT_SOURCE_DIR variable for each test
         if dist_git_source:
             for test in self._tests:
-                test.environment['TMT_SOURCE_DIR'] = str(sourcedir)
+                test.environment['TMT_SOURCE_DIR'] = EnvVarValue(sourcedir)
 
     def tests(
             self,

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -380,7 +380,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             self,
             *,
             guest: 'Guest',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> None:
         super().go(guest=guest, environment=environment, logger=logger)
         logger.verbose('exit-first', self.data.exit_first, 'green', level=2)
@@ -621,7 +621,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             *,
             event: CheckEvent,
             invocation: TestInvocation,
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> list[CheckResult]:
 
         results: list[CheckResult] = []
@@ -649,7 +649,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             self,
             *,
             invocation: TestInvocation,
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> list[CheckResult]:
         return self._run_checks_for_test(
             event=CheckEvent.BEFORE_TEST,
@@ -662,7 +662,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT]):
             self,
             *,
             invocation: TestInvocation,
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> list[CheckResult]:
         return self._run_checks_for_test(
             event=CheckEvent.AFTER_TEST,

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -15,7 +15,7 @@ from tmt.steps.discover import Discover, DiscoverPlugin, DiscoverStepData
 from tmt.steps.discover.fmf import DiscoverFmf, DiscoverFmfStepData, normalize_ref
 from tmt.steps.execute import ExecutePlugin
 from tmt.steps.execute.internal import ExecuteInternal, ExecuteInternalData
-from tmt.utils import Path, field
+from tmt.utils import Environment, EnvVarValue, Path, field
 
 STATUS_VARIABLE = 'IN_PLACE_UPGRADE'
 BEFORE_UPGRADE_PREFIX = 'old'
@@ -169,7 +169,7 @@ class ExecuteUpgrade(ExecuteInternal):
             self,
             *,
             guest: 'tmt.steps.provision.Guest',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> None:
         """ Execute available tests """
         # Inform about the how, skip the actual execution
@@ -337,7 +337,10 @@ class ExecuteUpgrade(ExecuteInternal):
             names_backup.append(test.name)
             test.name = f'/{prefix}/{test.name.lstrip("/")}'
 
-        self._run_tests(guest=guest, extra_environment={STATUS_VARIABLE: prefix}, logger=logger)
+        self._run_tests(
+            guest=guest,
+            extra_environment=Environment({STATUS_VARIABLE: EnvVarValue(prefix)}),
+            logger=logger)
 
         tests = self.discover.tests(enabled=True)
         for i, test in enumerate(tests):

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -62,7 +62,7 @@ class FinishShell(tmt.steps.finish.FinishPlugin[FinishShellData]):
             self,
             *,
             guest: 'Guest',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> None:
         """ Perform finishing tasks on given guest """
         super().go(guest=guest, environment=environment, logger=logger)

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -96,7 +96,7 @@ class PreparePlugin(tmt.steps.Plugin[PrepareStepDataT]):
             self,
             *,
             guest: 'tmt.steps.provision.Guest',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> None:
         """ Prepare the guest (common actions) """
         super().go(guest=guest, environment=environment, logger=logger)

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -108,7 +108,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
             self,
             *,
             guest: 'Guest',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> None:
         """ Prepare the guests """
         super().go(guest=guest, environment=environment, logger=logger)

--- a/tmt/steps/prepare/feature.py
+++ b/tmt/steps/prepare/feature.py
@@ -126,7 +126,7 @@ class PrepareFeature(tmt.steps.prepare.PreparePlugin[PrepareFeatureData]):
             self,
             *,
             guest: 'Guest',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> None:
         """ Prepare the guests """
         super().go(guest=guest, environment=environment, logger=logger)

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -588,7 +588,7 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
             self,
             *,
             guest: 'Guest',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> None:
         """ Perform preparation for the guests """
         super().go(guest=guest, environment=environment, logger=logger)

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -60,12 +60,12 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             self,
             *,
             guest: 'Guest',
-            environment: Optional[tmt.utils.EnvironmentType] = None,
+            environment: Optional[tmt.utils.Environment] = None,
             logger: tmt.log.Logger) -> None:
         """ Prepare the guests """
         super().go(guest=guest, environment=environment, logger=logger)
 
-        environment = environment or {}
+        environment = environment or tmt.utils.Environment()
 
         # Give a short summary
         overview = fmf.utils.listed(self.data.script, 'script')

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -829,12 +829,12 @@ class Guest(tmt.utils.Common):
 
     def _prepare_environment(
         self,
-        execute_environment: Optional[tmt.utils.EnvironmentType] = None
-            ) -> tmt.utils.EnvironmentType:
+        execute_environment: Optional[tmt.utils.Environment] = None
+            ) -> tmt.utils.Environment:
         """ Prepare dict of environment variables """
         # Prepare environment variables so they can be correctly passed
         # to shell. Create a copy to prevent modifying source.
-        environment: tmt.utils.EnvironmentType = {}
+        environment = tmt.utils.Environment()
         environment.update(execute_environment or {})
         # Plan environment and variables provided on the command line
         # override environment provided to execute().
@@ -844,7 +844,7 @@ class Guest(tmt.utils.Common):
         return environment
 
     @staticmethod
-    def _export_environment(environment: tmt.utils.EnvironmentType) -> list[ShellScript]:
+    def _export_environment(environment: tmt.utils.Environment) -> list[ShellScript]:
         """ Prepare shell export of environment variables """
         if not environment:
             return []
@@ -859,7 +859,7 @@ class Guest(tmt.utils.Common):
             friendly_command: Optional[str] = None,
             silent: bool = False,
             cwd: Optional[Path] = None,
-            env: Optional[tmt.utils.EnvironmentType] = None,
+            env: Optional[tmt.utils.Environment] = None,
             interactive: bool = False,
             log: Optional[tmt.log.LoggingFunction] = None,
             **kwargs: Any) -> tmt.utils.CommandOutput:
@@ -964,7 +964,7 @@ class Guest(tmt.utils.Common):
     def execute(self,
                 command: tmt.utils.ShellScript,
                 cwd: Optional[Path] = None,
-                env: Optional[tmt.utils.EnvironmentType] = None,
+                env: Optional[tmt.utils.Environment] = None,
                 friendly_command: Optional[str] = None,
                 test_session: bool = False,
                 tty: bool = False,
@@ -979,7 +979,7 @@ class Guest(tmt.utils.Common):
     def execute(self,
                 command: tmt.utils.Command,
                 cwd: Optional[Path] = None,
-                env: Optional[tmt.utils.EnvironmentType] = None,
+                env: Optional[tmt.utils.Environment] = None,
                 friendly_command: Optional[str] = None,
                 test_session: bool = False,
                 tty: bool = False,
@@ -993,7 +993,7 @@ class Guest(tmt.utils.Common):
     def execute(self,
                 command: Union[tmt.utils.Command, tmt.utils.ShellScript],
                 cwd: Optional[Path] = None,
-                env: Optional[tmt.utils.EnvironmentType] = None,
+                env: Optional[tmt.utils.Environment] = None,
                 friendly_command: Optional[str] = None,
                 test_session: bool = False,
                 tty: bool = False,
@@ -1368,7 +1368,7 @@ class GuestSsh(Guest):
     def execute(self,
                 command: Union[tmt.utils.Command, tmt.utils.ShellScript],
                 cwd: Optional[Path] = None,
-                env: Optional[tmt.utils.EnvironmentType] = None,
+                env: Optional[tmt.utils.Environment] = None,
                 friendly_command: Optional[str] = None,
                 test_session: bool = False,
                 tty: bool = False,

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -69,7 +69,7 @@ class GuestLocal(tmt.Guest):
     def execute(self,
                 command: Union[Command, ShellScript],
                 cwd: Optional[Path] = None,
-                env: Optional[tmt.utils.EnvironmentType] = None,
+                env: Optional[tmt.utils.Environment] = None,
                 friendly_command: Optional[str] = None,
                 test_session: bool = False,
                 tty: bool = False,
@@ -80,7 +80,7 @@ class GuestLocal(tmt.Guest):
                 **kwargs: Any) -> tmt.utils.CommandOutput:
         """ Execute command on localhost """
         # Prepare the environment (plan/cli variables override)
-        environment: tmt.utils.EnvironmentType = {}
+        environment = tmt.utils.Environment()
         environment.update(env or {})
         if self.parent:
             environment.update(self.parent.plan.environment)

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -288,7 +288,7 @@ class GuestContainer(tmt.Guest):
     def execute(self,
                 command: Union[tmt.utils.Command, tmt.utils.ShellScript],
                 cwd: Optional[Path] = None,
-                env: Optional[tmt.utils.EnvironmentType] = None,
+                env: Optional[tmt.utils.Environment] = None,
                 friendly_command: Optional[str] = None,
                 test_session: bool = False,
                 tty: bool = False,


### PR DESCRIPTION
In a move similar to how fmf context is now implemented, environment variables are now stored in a custom dict-like class. This has several advantages:

* various "constructors" can now be namespaced and exist as class methods of `Environment` class. This should improve their naming scheme, documentation and cleanliness of global namespace.
* explicit conversions when environment corsses boundaries between various subsystems (fmf -> tmt, tmt -> subprocess, tmt -> state files like `tests.yaml`, etc.) Rather than relying on "string is always fine" we will be able to provide more targetted errors.
* later tmt will need to learn about "secrets", i.e. environment variables that may never be revealed in logs or output. As of now, everything is a string, but with custom classes we will be able to provide different implementations for regular envvars and for secrets. Plus, the explicit conversion from "environment variable" to "loggable/saveable string" will help us catch places where secrets would leak into open.

And what about disadvantages?

* it's more verbose - `Environment()` instead of `{}`, `EnvvarValue` instead of a plain string.
* bigger patch - environments are commonly used, they tend to affect many places.
* slight API changes - to sort out possibly puzzling function names.

## What's left

* [x] more docstrings for constructors
* [x] better naming of constructors: `from_files` is fine, `from_sequence` or `from_spec` is not. Review.
* [x] consider implicit YAML representer, but this might conflict with serialization fo secrets in the future.

## Pull Request Checklist

* [x] implement the feature
* [x] write the documentation