### PR TITLE
Drop connection closed messages from test output

### DIFF
--- a/tests/execute/tty/test.sh
+++ b/tests/execute/tty/test.sh
@@ -33,6 +33,11 @@ rlJournalStart
             rlAssertGrep "out: finish: stdin: 0" $rlRun_LOG
             rlAssertGrep "out: finish: stdout: 0" $rlRun_LOG
             rlAssertGrep "out: finish: stderr: 0" $rlRun_LOG
+
+            # test for #2429, not related to tty
+            rlRun -s "tmt run --last report -vvv"
+            rlAssertNotGrep "Connection to.*closed" $rlRun_LOG
+            rlAssertNotGrep "Shared connection to.*closed" $rlRun_LOG
         rlPhaseEnd
 
        # NOTE: Our local provisioner cannot execute commands with a pty allocated

--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -1,5 +1,12 @@
+import os
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
 from tmt.log import Logger
-from tmt.steps.provision import Guest, GuestData
+from tmt.steps.provision import Guest, GuestData, GuestSsh, GuestSshData
+from tmt.utils import Command, CommandOutput
 
 
 def test_multihost_name(root_logger: Logger) -> None:
@@ -12,3 +19,56 @@ def test_multihost_name(root_logger: Logger) -> None:
         logger=root_logger,
         name='foo',
         data=GuestData(guest='bar', role='client')).multihost_name == 'foo (client)'
+
+
+@pytest.mark.parametrize(('stdout', 'expected'), [
+    (
+        # no-connection-closed
+        os.linesep + 'last-line' + os.linesep,
+        os.linesep + 'last-line' + os.linesep
+        ),
+    (
+        # connection-closed-not-last-line
+        os.linesep + 'Connection to 127.0.0.1 closed.' + os.linesep + 'last-line' + os.linesep,
+        os.linesep + 'Connection to 127.0.0.1 closed.' + os.linesep + 'last-line' + os.linesep
+        ),
+    (
+        # connection-closed
+        os.linesep + 'some-line' + os.linesep + 'Connection to 127.0.0.1 closed.' + os.linesep,
+        os.linesep + 'some-line' + os.linesep
+        ),
+    (
+        # shared-connection-closed
+        os.linesep + 'some-line' + os.linesep + 'Shared connection to 127.0.0.1 closed.' \
+        + os.linesep,
+        os.linesep + 'some-line' + os.linesep
+        )
+    ], ids=(
+    'no-connection-closed',
+    'connection-closed-not-last-line',
+    'connection-closed',
+    'shared-connection-closed'
+    ))
+def test_execute_no_connection_closed(
+        root_logger: Logger,
+        stdout: str,
+        expected: str,
+        monkeypatch: Any) -> None:
+    guest = GuestSsh(
+        logger=root_logger,
+        name='foo',
+        data=GuestSshData(guest='bar')
+        )
+
+    monkeypatch.setattr(
+        guest,
+        '_run_guest_command',
+        MagicMock(return_value=CommandOutput(stdout=stdout, stderr=None))
+        )
+    monkeypatch.setattr(guest, 'parent', MagicMock())
+
+    output = guest.execute(Command('some-command'), test_session=True)
+    assert output.stdout == expected
+
+    output = guest.execute(Command('some-command'))
+    assert output.stdout == stdout


### PR DESCRIPTION
A follow-up for closed #2524.

We decided to go with editing the output.
Avoiding splitting output and using regular expressions to make sure the code is fast and memory efficient in case the output is large.

Resolves #2429

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
