### PR TITLE
Simplify the debuginfo installation test

### DIFF
--- a/tests/pip/install.fmf
+++ b/tests/pip/install.fmf
@@ -22,3 +22,7 @@ tier: null
     test: |
         /tmp/venv/bin/pip install .[all]
         /tmp/venv/bin/tmt --help
+    adjust:
+        result: xfail
+        when: distro == fedora-rawhide
+        because: https://github.com/aio-libs/multidict/issues/926

--- a/tests/prepare/install/data/debuginfo.fmf
+++ b/tests/prepare/install/data/debuginfo.fmf
@@ -1,39 +1,23 @@
-summary:
-    Install debuginfo packages
+summary: Install debuginfo packages
+
 prepare:
-  - name: debuginfo
     how: install
-    package:
-      - grep-debuginfo
-      - elfutils-debuginfod-debuginfo
+    package: grep-debuginfo
+
 execute:
-    script:
-      - rpm -q grep-debuginfo grep-debugsource
-      - rpm -q elfutils-debuginfo elfutils-debugsource
+    script: rpm -q grep-debuginfo grep-debugsource
 
 /fedora:
     summary+: " on Fedora"
 
-/centos-8:
-    summary+: " on CentOS 8"
+/ubi8:
+    summary+: " on Red Hat Universal Base Image 8"
     provision+:
-        image: centos:stream8
+        image: ubi8
 
-    # FIXME This is needed for CentOS 8, but why? Filed:
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1964505
-    prepare+:
-      - name: enable-debuginfo-repo
-        script:
-          - dnf install -y 'dnf-command(config-manager)'
-          - dnf config-manager --enable debuginfo
-        order: 10
-
-/centos-7:
-    summary+: " on CentOS 7"
+/centos-stream-9:
+    summary+: " on CentOS Stream 9"
     provision+:
-        image: centos:7
-    prepare:
-        how: install
-        package: grep-debuginfo
-    execute:
-        script: rpm -q grep-debuginfo
+        image: centos:stream9
+    # FIXME: Disabled because of missing `flock` on the guest
+    enabled: false

--- a/tests/unit/test_steps_prepare.py
+++ b/tests/unit/test_steps_prepare.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock, patch
+
+import tmt
+from tmt.log import Logger
+from tmt.steps.prepare.install import InstallBase
+
+
+def prepare_command(self):
+    """ Fake prepare_command() for InstallBase """
+    return ("command", "options")
+
+
+def get(what, default=None):
+    """ Fake get() for parent PrepareInstall """
+
+    if what == "directory":
+        return []
+
+    if what == "missing":
+        return "skip"
+
+    if what == "package":
+        return [
+            # Regular packages
+            "wget",
+            "debuginfo-something",
+            "elfutils-debuginfod",
+            # Debuginfo packages
+            "grep-debuginfo",
+            "elfutils-debuginfod-debuginfo",
+            ]
+
+    return None
+
+
+@patch.object(tmt.steps.prepare.install.InstallBase, 'prepare_command', prepare_command)
+def test_debuginfo():
+    """ Check debuginfo package parsing """
+
+    logger = Logger.create()
+    parent = MagicMock()
+    parent.get = get
+    guest = MagicMock()
+
+    install = InstallBase(parent=parent, logger=logger, guest=guest)
+
+    assert install.repository_packages == [
+        "wget",
+        "debuginfo-something",
+        "elfutils-debuginfod",
+        ]
+    assert install.debuginfo_packages == [
+        "grep",
+        "elfutils-debuginfod",
+        ]


### PR DESCRIPTION
Instead of `centos-stream-8` which has broken mirrors and has end of life in couple of months, let's test against `ubi8`. Add a test for `centos-stream-9` (disable until `flock` issue is fixed) and drop `centos-7`.

Pull Request Checklist

* [x] extend the test coverage