### PR TITLE
Introduce essential requirements

### DIFF
--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -29,7 +29,7 @@ rlJournalStart
             if [ "$step" = "provision" ]; then
                 rlRun "grep '^    $step$' -A12 output | grep -i interactive"
             elif [ "$step" = "prepare" ]; then
-                rlRun "grep '^    $step$' -A8 output | grep -i interactive"
+                rlRun "grep '^    $step$' -A17 output | grep -i interactive"
             elif [ "$step" = "execute" ]; then
                 rlRun "grep '^    $step$' -A9 output | grep -i interactive"
             else

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -45,7 +45,6 @@ from tmt.utils import (
     container_field,
     container_keys,
     field,
-    flatten,
     key_to_option,
     option_to_key,
     )
@@ -1063,21 +1062,6 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
             except OSError as error:
                 logger.warn(f"Unable to remove '{member}': {error}")
 
-    def requires(self) -> list['tmt.base.Dependency']:
-        """
-        Collect all requirements of all enabled plugins in this step.
-
-        Puts together a list of requirements which need to be installed on the
-        provisioned guest so that all enabled plugins of this step can be
-        successfully executed.
-
-        :returns: a list of requirements, with duplicaties removed.
-        """
-        return flatten(
-            (plugin.requires() for plugin in self.phases(classes=self._plugin_base_class)),
-            unique=True
-            )
-
 
 class Method:
     """ Step implementation method """
@@ -1591,8 +1575,16 @@ class BasePlugin(Phase, Generic[StepDataT]):
         # Include order in verbose mode
         logger.verbose('order', self.order, 'magenta', level=3)
 
-    def requires(self) -> list['tmt.base.Dependency']:
-        """ All requirements of the plugin on the guest """
+    def essential_requires(self) -> list['tmt.base.Dependency']:
+        """
+        Collect all essential requirements of the plugin.
+
+        Essential requirements of a plugin are necessary for the plugin to
+        perform its basic functionality.
+
+        :returns: a list of requirements.
+        """
+
         return []
 
     def prune(self, logger: tmt.log.Logger) -> None:

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -548,6 +548,16 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         """ Return test results """
         return self._results
 
-    def requires(self) -> list[tmt.base.Dependency]:
-        """ All requirements of the plugin on the guest """
-        return []
+    def essential_requires(self) -> list[tmt.base.Dependency]:
+        """
+        Collect all essential requirements of the plugin.
+
+        Essential requirements of a plugin are necessary for the plugin to
+        perform its basic functionality.
+
+        :returns: a list of requirements.
+        """
+
+        return [
+            tmt.base.DependencySimple('/usr/bin/flock')
+            ]

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -217,10 +217,11 @@ class Prepare(tmt.steps.Step):
             def as_key(self) -> frozenset['tmt.base.DependencySimple']:
                 return frozenset(collection.dependencies)
 
-        # All phases from all steps *except the `discover` step - see note below.
+        # All phases from all steps.
         phases = [
             phase
-            for step in (self.plan.provision,
+            for step in (self.plan.discover,
+                         self.plan.provision,
                          self.plan.prepare,
                          self.plan.execute,
                          self.plan.finish,
@@ -250,7 +251,7 @@ class Prepare(tmt.steps.Step):
                     continue
 
                 collected_requires[guest].dependencies += tmt.base.assert_simple_dependencies(
-                    phase.requires(),
+                    phase.essential_requires(),
                     'After beakerlib processing, tests may have only simple requirements',
                     self._logger)
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1099,8 +1099,16 @@ class Guest(tmt.utils.Common):
         return CheckRsyncOutcome.INSTALLED
 
     @classmethod
-    def requires(cls) -> list['tmt.base.Dependency']:
-        """ All requirements of the guest implementation """
+    def essential_requires(cls) -> list['tmt.base.Dependency']:
+        """
+        Collect all essential requirements of the guest.
+
+        Essential requirements of a guest are necessary for the guest to be
+        usable for testing.
+
+        :returns: a list of requirements.
+        """
+
         return []
 
 
@@ -1817,11 +1825,12 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin[ProvisionStepDataT]):
         """
         raise NotImplementedError
 
-    def requires(self) -> list['tmt.base.Dependency']:
+    def essential_requires(self) -> list['tmt.base.Dependency']:
         """
-        All requirements of the guest implementation.
+        Collect all essential requirements of the guest implementation.
 
-        Provide a list of requirements for the workdir sync.
+        Essential requirements of a guest are necessary for the guest to be
+        usable for testing.
 
         By default, plugin's guest class, :py:attr:`ProvisionPlugin._guest_class`,
         is asked to provide the list of required packages via
@@ -1830,7 +1839,7 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin[ProvisionStepDataT]):
         :returns: a list of requirements.
         """
 
-        return self._guest_class.requires()
+        return self._guest_class.essential_requires()
 
     @classmethod
     def options(cls, how: Optional[str] = None) -> list[tmt.options.ClickOptionDecoratorType]:


### PR DESCRIPTION
Essential requirements are requirements of tmt itself and its plugins, to perform their basic tasks on a guest. Rsync, of `/usr/bin/flock`, or `ausearch` for the AVC denial check.

It turns out the essential requirements were already present, `Step.requires` and `BasePlugin.requires` were returning exactly this.  But, `Discover.requires` was adding test requirements into the mix, muddying the waters. But, recently, thanks to work on guest-aware requirements and test framework requirements, installation of dependencies changed a bit:

* step requirements are no longer a thing. Once tmt tries to group requirements per guest, phases play the crucial role and their parent step is of no importance anymore.
* test requirements are collected in the similar way, checking tests directly rather than asking the discover step. The same applies to test framework requirements.

Together, this means we can safely drop `Step.requires` (and `Step.recommend`) because nobody is asking step classes anymore.

Then the patch renames `BasePlugin.requires` to `essential_requires` to better convey its purpose. And add the essential requirement of `/usr/bin/flock` needed by the internal execute plugin.

What the patch does not do: it does not move rsync installation - it's more entangled in the provisionign code, but its time will come -, and it does not extend essential requirements to checks, yet.

Pull Request Checklist

* [x] implement the feature