### PR TITLE
Fix `/tests/plan/import` to not use special ref

### DIFF
--- a/tests/plan/import/modify-data/plans.fmf
+++ b/tests/plan/import/modify-data/plans.fmf
@@ -22,7 +22,6 @@
         plan:
             import:
                 url: https://github.com/teemtee/tmt
-                ref: test-import-env-ordering
                 path: /tests/plan/import/modify-data
                 name: /plans/imported/bare
 
@@ -39,7 +38,6 @@
         plan:
             import:
                 url: https://github.com/teemtee/tmt
-                ref: test-import-env-ordering
                 path: /tests/plan/import/modify-data
                 name: /plans/imported/with-environment
 


### PR DESCRIPTION
This was needed when test was under development, now it can clone `main`.

Pull Request Checklist

* [x] implement the feature