### PR TITLE
Fix `egrep` warning in `/plans/install/docs`

### DIFF
--- a/plans/install/docs.fmf
+++ b/plans/install/docs.fmf
@@ -14,4 +14,4 @@ execute:
         set -o pipefail
         pip3 install .[docs]
         make -C docs html 2>&1 | tee output
-        egrep 'ERROR|WARNING' output && exit 1 || exit 0
+        grep -E 'ERROR|WARNING' output && exit 1 || exit 0


### PR DESCRIPTION
The test started to fail. Seems that `egrep` is obsoleted:

    warning: egrep is obsolescent; using grep -E

Let's use the recommendation to get rid of the warning.

Pull Request Checklist

* [x] extend the test coverage