### PR TITLE
Handle the `ctrl-d` shortcut in `tmt try`

### DIFF
--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -196,7 +196,11 @@ class Try(tmt.utils.Common):
                     {c('q')}{a('uit')}       clean up the run and quit the session
                 """))
 
-            answer = input("> ")
+            try:
+                answer = input("> ")
+            except EOFError:
+                return "quit"
+
             try:
                 self.print("")
                 return {


### PR DESCRIPTION
Using the `ctrl-d` shortcut is a common way to exit a shell. Let's map that to a `quit` action to provide a natural user experience.

Pull Request Checklist

* [x] implement the feature