### PR TITLE
Add documentation on tmt & regular expressions

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -591,6 +591,51 @@ example, an interactive mode would be enabled in this run::
       $ TMT_PLUGIN_DISCOVER_FMF_VERBOSE=2 tmt run -a discover -h fmf ...
 
 
+.. _regular-expressions:
+
+Regular Expressions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Many specification keys and command line options accept regular
+expressions, e.g. to filter a set of tests, ``tmt run ... test
+--name '^/foo'``. Whenever tmt works with regular expressions, the
+following rules apply.
+
+Python implementation
+    Since tmt is implemented in Python, Python's `re`__ package is
+    used for handling regular expressions. It comes with Python
+    standard library, and it is widely used and well documented.
+    For the deep dive into supported syntax, see
+    `Regular Expression Syntax`__ section, for a gentler
+    introduction there is a `Regular Expression`__ HOWTO.
+
+Search versus match
+    There are two ways how to check whether a regular expression
+    matches a string: "match" or "search":
+
+    * in the "match" mode, the pattern must match from the very
+      beginning of the string. For example, ``foo.ar`` would match
+      ``foobar`` but not ``/foobar``. It works in a "starts with"
+      fashion.
+    * on the other hand, the "search" mode is more similar to
+      "contains" approach, and allows pattern to match anywhere in
+      the string. In this mode, ``foo.ar`` would match both
+      ``foobar`` and ``/foobar``.
+
+    In both modes, any characters may follow the matching pattern,
+    e.g. regular expression ``foo.bar`` is the same as
+    ``foo.bar.*``.
+
+    tmt sticks to the "search" mode by default. But, to improve
+    user experience, some keys and command line options do use the
+    "match" mode. Such keys and options will note this in their
+    documentation or help texts.
+
+__ https://docs.python.org/3.9/library/re.html
+__ https://docs.python.org/3.9/library/re.html#regular-expression-syntax
+__ https://docs.python.org/3.9/howto/regex.html#regex-howto
+
+
 Links
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/stories/cli/plan.fmf
+++ b/stories/cli/plan.fmf
@@ -18,9 +18,12 @@ story: 'As a user I want to comfortably work with plans'
 
 /filter:
     story: 'Filter available plans'
-    description:
-        Search plans using a regular expression or a filter.
-        Use ``.`` to select plans under the current directory.
+    description: |
+        Search plans using a
+        :ref:`regular expression <regular-expressions>` or a
+        filter. Use ``.`` to select plans under the current
+        directory.
+
     example:
         - tmt plan ls .
         - tmt plan ls REGEXP

--- a/stories/cli/steps.fmf
+++ b/stories/cli/steps.fmf
@@ -174,11 +174,18 @@
 
         Instead, every step subcommand offers ``--allowed-how`` option
         which limits methods allowed to be used in the step. The option
-        accepts a regular expression allowed methods - names set with
-        ``how`` key or ``--how`` option - must match to be allowed.
+        accepts a :ref:`regular expression <regular-expressions>` that
+        allowed methods - names set with ``how`` key or ``--how`` option
+        - must match to be allowed.
 
         By default, the pattern is set to ``.*``, i.e. all plugins and
         all methods are allowed.
+
+        .. note::
+
+            Regular expression accepted by the ``--allowed-how``
+            option is applied in the "match" mode, i.e. it must
+            match from the start of the string.
 
         .. versionadded:: 1.31
 

--- a/stories/cli/story.fmf
+++ b/stories/cli/story.fmf
@@ -17,10 +17,12 @@ story: 'As a developer I want to comfortably work with stories'
 
 /filter:
     story: 'Search available stories'
-    description:
-        Search stories using a regular expression, a filter or
-        coverage status. Use ``.`` to select stories under the
+    description: |
+        Search stories using a
+        :ref:`regular expression <regular-expressions>`, a filter
+        or coverage status. Use ``.`` to select stories under the
         current directory.
+
     example:
         - tmt story ls .
         - tmt story ls REGEXP

--- a/stories/cli/test.fmf
+++ b/stories/cli/test.fmf
@@ -109,9 +109,10 @@ story: 'As a user I want to comfortably work with tests'
 
 /filter:
     story: 'Filter available tests'
-    description:
-        Search tests using a regular expression or a filter.
-        Use ``.`` to select tests under the current directory.
+    description: |
+        Search tests using a
+        :ref:`regular expression <regular-expressions>` or a
+        filter. Use ``.`` to select tests under the current directory.
     example:
         - tmt test ls .
         - tmt test ls REGEXP


### PR DESCRIPTION
Fixes https://github.com/teemtee/tmt/issues/2602.

The preview of tmt & regular expression would be at https://tmt--2646.org.readthedocs.build/en/2646/overview.html#regular-expressions

Pull Request Checklist

* [ ] write the documentation
* [ ] update the specification