### PR TITLE
Remove the dns failures workaround

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -13,17 +13,3 @@ adjust:
         how: install
         directory: tmp/RPMS/noarch
     when: how == full
-
-    # Disable systemd-resolved to prevent dns failures
-    # See: https://github.com/teemtee/tmt/issues/2063
-  - prepare+:
-      - name: disable-systemd-resolved
-        how: shell
-        script: |
-            systemctl disable systemd-resolved
-            systemctl mask systemd-resolved
-            rm -f /etc/resolv.conf
-            systemctl restart NetworkManager
-            sleep 3
-            cat /etc/resolv.conf
-    when: initiator == packit and distro == fedora


### PR DESCRIPTION
It seems that after introducing the retry functionality the dns failures appear no more. So, perhaps, the workaround is no more needed.

Pull Request Checklist

* [x] implement the feature