### PR TITLE
Add check to prevent `tmt try` deleting imported libraries

### DIFF
--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -207,6 +207,10 @@ class BeakerLib(Library):
         # Check if the library was already fetched
         try:
             library = self._library_cache[str(self)]
+            # Check in case "tmt try retest" deleted the libs
+            assert self.parent.workdir
+            if not (self.parent.workdir / self.dest / self.repo).exists():
+                raise FileNotFoundError
             # The url must be identical
             if library.url != self.url:
                 # tmt guessed url so try if repo exists
@@ -244,7 +248,7 @@ class BeakerLib(Library):
             # Reuse the existing metadata tree
             self.tree: fmf.Tree = library.tree
         # Fetch the library and add it to the index
-        except KeyError:
+        except (KeyError, FileNotFoundError):
             self.parent.debug(f"Fetch library '{self}'.", level=3)
             # Prepare path, clone the repository, checkout ref
             assert self.parent.workdir


### PR DESCRIPTION
Re-testing with tmt try failed to import libraries after the first time.

The issue was in `fetch `method checking whether there is info about library loaded in the class' `_library_cache` property (which it was from the first time) but in the meantime discover step completely recreated the tree structure /var/tmp/tmt/run-number/default/plan/discover, thus deleting the `libs` directory as well. Libraries were then considered fetched by tmt discover step, but unable to rlImport by the test itself, because they were actually missing.

Pull Request Checklist
* [x] implement the feature

Fixes issue #2623