### PR TITLE
Fix reporting of schema errors without the `$id` key

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -932,8 +932,12 @@ class Core(
                     return
 
                 for bad_property in match.group(1).replace("'", '').replace(' ', '').split(','):
-                    yield LinterOutcome.WARN, \
-                        f'key "{bad_property}" not recognized by schema {error.schema["$id"]}'
+                    if '$id' in error.schema:
+                        yield LinterOutcome.WARN, \
+                            f'key "{bad_property}" not recognized by schema {error.schema["$id"]}'
+                    else:
+                        yield LinterOutcome.WARN, \
+                            'key "{bad_property}" not recognized by schema'
 
             # A key not recognized, but when patternProperties are allowed. In that case,
             # the key is both not listed and not matching the pattern.


### PR DESCRIPTION
It seems that sometimes jsonschema package does not propagate `$id` key, which must be taken care of to avoid `KeyError`.

Fixes #2651.

Pull Request Checklist

* [x] implement the feature