### PR TITLE
Prevent catching avc denials from previous tests

### DIFF
--- a/tests/test/check/data/main.fmf
+++ b/tests/test/check/data/main.fmf
@@ -13,6 +13,7 @@
 
   /harmless:
     test: /bin/true
+    order: 100
 
   /nasty:
     test: |

--- a/tests/test/check/data/plan.fmf
+++ b/tests/test/check/data/plan.fmf
@@ -12,4 +12,5 @@ adjust:
       script: |
         timedatectl set-ntp false &&
         sleep 2 &&
-        timedatectl set-time -- -10s
+        timedatectl set-time -- -10s &&
+        echo > /var/log/audit/audit.log

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -1,4 +1,5 @@
 import datetime
+import time
 from typing import TYPE_CHECKING, Optional, Union
 
 import tmt.log
@@ -138,6 +139,11 @@ def create_ausearch_timestamp(
 
     report_timestamp = datetime.datetime.now(datetime.timezone.utc)
     report: list[str] = []
+
+    # Wait one second before storing the timestamp because ausearch
+    # could catch denials from the previous test if they are executed
+    # during the same second
+    time.sleep(1)
 
     script = ShellScript(f"""
 set -x


### PR DESCRIPTION
Sleep one second before storing the timestamp.
Perform both checks under a single plan to safe on reboot.
Also clean up the audit log to get rid of irrelevant avc denials.