### PR TITLE
AVC check now saves a timestamp on guest instead of using runner's time

### DIFF
--- a/tests/test/check/data/plan.fmf
+++ b/tests/test/check/data/plan.fmf
@@ -3,3 +3,13 @@ execute:
 
 discover:
   how: fmf
+
+adjust:
+- when: provision_method == virtual
+  prepare+:
+    - name: Go back in time
+      how: shell
+      script: |
+        timedatectl set-ntp false &&
+        sleep 2 &&
+        timedatectl set-time -- -10s

--- a/tests/test/check/test-avc.sh
+++ b/tests/test/check/test-avc.sh
@@ -19,7 +19,7 @@ rlJournalStart
 
     for method in ${PROVISION_METHODS:-local}; do
         rlPhaseStartTest "Test harmless AVC check with $method"
-            rlRun "avc_log=$run/plan/execute/data/guest/default-0/avc/harmless-1/checks/avc-after-test.txt"
+            rlRun "avc_log=$run/plan/execute/data/guest/default-0/avc/harmless-1/checks/avc.txt"
 
             rlRun "tmt -c provision_method=$method run --id $run --scratch -a -vv provision -h $method test -n /avc/harmless"
 
@@ -30,13 +30,15 @@ rlJournalStart
 
             assert_check_result "avc as an after-test should pass" "pass" "after-test"
 
+            rlAssertGrep "# timestamp" "$avc_log"
+            rlAssertGrep "export AVC_SINCE=\"[[:digit:]]{2}/[[:digit:]]{2}/[[:digit:]]{4} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\"" "$avc_log" -E
             rlAssertGrep "<no matches>" "$avc_log"
         rlPhaseEnd
 
         rlPhaseStartTest "Test nasty AVC check with $method"
             rlRun "tmt -c provision_method=$method run --id $run --scratch -a -vvv provision -h $method test -n /avc/nasty"
 
-            rlRun "avc_log=$run/plan/execute/data/guest/default-0/avc/nasty-1/checks/avc-after-test.txt"
+            rlRun "avc_log=$run/plan/execute/data/guest/default-0/avc/nasty-1/checks/avc.txt"
 
             rlRun "cat $results"
             rlRun "cat $avc_log"
@@ -45,6 +47,8 @@ rlJournalStart
 
             assert_check_result "avc as an after-test should report AVC denials" "fail" "after-test"
 
+            rlAssertGrep "# timestamp" "$avc_log"
+            rlAssertGrep "export AVC_SINCE=\"[[:digit:]]{2}/[[:digit:]]{2}/[[:digit:]]{4} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}\"" "$avc_log" -E
             rlAssertGrep "avc:  denied" "$avc_log"
             rlAssertGrep "path=/root/passwd.log" "$avc_log"
         rlPhaseEnd

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -5,14 +5,18 @@ import tmt.log
 import tmt.steps.execute
 import tmt.steps.provision
 import tmt.utils
-from tmt.checks import Check, CheckEvent, CheckPlugin, provides_check
+from tmt.checks import Check, CheckPlugin, provides_check
 from tmt.result import CheckResult, ResultOutcome
 from tmt.utils import CommandOutput, Path, ShellScript, render_run_exception_streams
 
 if TYPE_CHECKING:
     from tmt.steps.execute import TestInvocation
 
-TEST_POST_AVC_FILENAME = 'avc-{event}.txt'
+#: The filename of the final check report file.
+TEST_POST_AVC_FILENAME = 'avc.txt'
+
+#: The filename of the file storing "since" timestamp for ``ausearch`` on the guest.
+AUSEARCH_TIMESTAMP_FILENAME = 'avc-timestamp.sh'
 
 #: Packages related to selinux and AVC reporting. Their versions would be made
 #: part of the report.
@@ -20,6 +24,239 @@ INTERESTING_PACKAGES = [
     'audit',
     'selinux-policy'
     ]
+
+
+def _save_report(
+        invocation: 'TestInvocation',
+        report: list[str],
+        timestamp: datetime.datetime,
+        append: bool = False) -> Path:
+    """
+    Save the given report into check's report file.
+
+    :param invocation: test invocation to which the check belongs to.
+        The report file path would be in this invocation's
+        :py:attr:`check_files_path`.
+    :param report: lines of the report.
+    :param timestamp: time at which the report has been created. It will
+        be saved in the report file, before the report itself.
+    :param append: if set, the report would be appended to the report
+        file instead of overwriting it.
+    :returns: path to the report file.
+    """
+
+    from tmt.steps.execute import ExecutePlugin
+
+    report_filepath = invocation.check_files_path / TEST_POST_AVC_FILENAME
+
+    report = [
+        f'# Reported at {ExecutePlugin.format_timestamp(timestamp)}',
+        *report
+        ]
+
+    mode = 'a' if append else 'w'
+
+    invocation.phase.write(report_filepath, '\n'.join(report), mode=mode)
+
+    return report_filepath
+
+
+def _run_script(
+        *,
+        invocation: 'TestInvocation',
+        script: ShellScript,
+        needs_sudo: bool = False,
+        logger: tmt.log.Logger) -> Union[
+            tuple[CommandOutput, None],
+            tuple[None, tmt.utils.RunError]
+        ]:
+    """
+    A helper to run a script on the guest.
+
+    Instead of letting failed commands to interrupt execution by raising
+    exceptions, this helper intercepts them and returns them together
+    with command output. This let's us log them in the report file.
+
+    :returns: a tuple of two items, either a command output and
+        ``None``, or ``None`` and captured :py:class:`RunError`
+        describing the command failure.
+    """
+
+    if needs_sudo and invocation.guest.facts.is_superuser is False:
+        script = ShellScript(f'sudo {script.to_shell_command()}')
+
+    def _output_logger(
+            key: str,
+            value: Optional[str] = None,
+            color: Optional[str] = None,
+            shift: int = 2,
+            level: int = 3,
+            topic: Optional[tmt.log.Topic] = None) -> None:
+        logger.verbose(
+            key=key,
+            value=value,
+            color=color,
+            shift=shift,
+            level=level,
+            topic=topic)
+
+    try:
+        output = invocation.guest.execute(script, log=_output_logger, silent=True)
+
+        return output, None
+
+    except tmt.utils.RunError as exc:
+        return None, exc
+
+
+def _report_success(label: str, output: tmt.utils.CommandOutput) -> list[str]:
+    """ Format successfull command output for the report """
+
+    return [
+        f'# {label}',
+        output.stdout or '',
+        ''
+        ]
+
+
+def _report_failure(label: str, exc: tmt.utils.RunError) -> list[str]:
+    """ Format failed command output for the report """
+
+    return [
+        f'# {label}',
+        "\n".join(render_run_exception_streams(exc.stdout, exc.stderr, verbose=1)),
+        ''
+        ]
+
+
+def create_ausearch_timestamp(
+        invocation: 'TestInvocation',
+        logger: tmt.log.Logger) -> None:
+    """ Save a timestamp for ``ausearch`` in a file on the guest """
+
+    ausearch_timestamp_filepath = invocation.check_files_path / AUSEARCH_TIMESTAMP_FILENAME
+
+    report_timestamp = datetime.datetime.now(datetime.timezone.utc)
+    report: list[str] = []
+
+    script = ShellScript(f"""
+set -x
+export LC_ALL=en_US.UTF-8
+echo "export AVC_SINCE=\\"$( date "+%m/%d/%Y %H:%M:%S")\\"" > {ausearch_timestamp_filepath}
+cat {ausearch_timestamp_filepath}
+""")
+
+    output, exc = _run_script(
+        invocation=invocation,
+        script=script,
+        logger=logger)
+
+    if exc is None:
+        assert output is not None
+
+        report += _report_success('timestamp', output)
+
+    else:
+        report += _report_failure('timestamp', exc)
+
+    _save_report(invocation, report, report_timestamp)
+
+
+def create_final_report(
+        invocation: 'TestInvocation',
+        logger: tmt.log.Logger) -> tuple[ResultOutcome, Path]:
+    """ Collect the data, evaluate and create the final report """
+
+    if invocation.start_time is None:
+        raise tmt.utils.GeneralError(
+            "Test does not have start time recorded, cannot run AVC check.")
+
+    ausearch_timestamp_filepath = invocation.check_files_path / AUSEARCH_TIMESTAMP_FILENAME
+
+    # Collect all report components
+    report_timestamp = datetime.datetime.now(datetime.timezone.utc)
+    report: list[str] = []
+
+    # Flags indicating whether we were able to successfully fetch report components
+    got_sestatus, got_rpm, got_ausearch, got_denials = False, False, False, False
+
+    # Get the `sestatus` output.
+    output, exc = _run_script(
+        invocation=invocation,
+        script=ShellScript('sestatus'),
+        logger=logger)
+
+    if exc is None:
+        assert output is not None
+
+        got_sestatus = True
+
+        report += _report_success('sestatus', output)
+
+    else:
+        report += _report_failure('sestatus', exc)
+
+    # Record NVRs of interesting packages.
+    interesting_packages = ' '.join(INTERESTING_PACKAGES)
+    output, exc = _run_script(
+        invocation=invocation,
+        script=ShellScript(f'rpm -q {interesting_packages}'),
+        logger=logger)
+
+    if exc is None:
+        assert output is not None
+
+        got_rpm = True
+
+        report += _report_success(f'rpm -q {interesting_packages}', output)
+
+    else:
+        report += _report_failure(f'rpm -q {interesting_packages}', exc)
+
+    # Finally, run `ausearch`, to list AVC denials from the time the test started.
+    script = ShellScript(f"""
+set -x
+source {ausearch_timestamp_filepath}
+ausearch -i --input-logs -m AVC -m USER_AVC -m SELINUX_ERR -ts $AVC_SINCE
+""")
+    output, exc = _run_script(
+        invocation=invocation,
+        script=script,
+        needs_sudo=True,
+        logger=logger)
+
+    # `ausearch` outcome evaluation is a bit more complicated than the one for a simple
+    # `rpm -q`, because not all non-zero exit codes mean error.
+    if exc is None:
+        assert output is not None
+
+        got_ausearch = True
+        got_denials = True
+
+        report += [
+            '# ausearch',
+            "\n".join(render_run_exception_streams(output.stdout, output.stderr, verbose=1)),
+            ''
+            ]
+
+    else:
+        if exc.returncode == 1 and exc.stderr and '<no matches>' in exc.stderr.strip():
+            got_ausearch = True
+
+        report += _report_failure('ausearch', exc)
+
+    # If we were able to fetch all components successfully, pick the result based on `ausearch`
+    # output.
+    if all([got_sestatus, got_rpm, got_ausearch]):
+        outcome = ResultOutcome.FAIL if got_denials else ResultOutcome.PASS
+
+    # Otherwise, it's an error - we already made all output part of the report.
+    else:
+        outcome = ResultOutcome.ERROR
+
+    report_filepath = _save_report(invocation, report, report_timestamp, append=True)
+
+    return outcome, report_filepath
 
 
 @provides_check('avc')
@@ -30,7 +267,7 @@ class AvcDenials(CheckPlugin[Check]):
     The check collects SELinux AVC denials from the audit log,
     gathers details about them, and together with versions of
     the ``selinux-policy`` and related packages stores them in
-    a file after the test.
+    a report file after the test.
 
     .. code-block:: yaml
 
@@ -43,147 +280,16 @@ class AvcDenials(CheckPlugin[Check]):
     _check_class = Check
 
     @classmethod
-    def _save_report(
+    def before_test(
             cls,
+            *,
+            check: 'Check',
             invocation: 'TestInvocation',
-            event: CheckEvent,
-            logger: tmt.log.Logger) -> tuple[ResultOutcome, Path]:
+            environment: Optional[tmt.utils.EnvironmentType] = None,
+            logger: tmt.log.Logger) -> list[CheckResult]:
+        create_ausearch_timestamp(invocation, logger)
 
-        if invocation.start_time is None:
-            raise tmt.utils.GeneralError(
-                "Test does not have start time recorded, cannot run AVC check.")
-
-        from tmt.steps.execute import ExecutePlugin
-        report_timestamp = ExecutePlugin.format_timestamp(
-            datetime.datetime.now(datetime.timezone.utc))
-
-        assert invocation.phase.step.workdir is not None  # narrow type
-        path = invocation.check_files_path / TEST_POST_AVC_FILENAME.format(event=event.value)
-
-        def _output_logger(
-                key: str,
-                value: Optional[str] = None,
-                color: Optional[str] = None,
-                shift: int = 2,
-                level: int = 3,
-                topic: Optional[tmt.log.Topic] = None) -> None:
-            logger.verbose(
-                key=key,
-                value=value,
-                color=color,
-                shift=shift,
-                level=level,
-                topic=topic)
-
-        # Collect all report components
-        report: list[str] = [
-            f'# Acquired at {report_timestamp}'
-            ]
-
-        # Flags indicating whether we were able to successfully fetch report components
-        got_sestatus, got_rpm, got_ausearch, got_denials = False, False, False, False
-
-        def _run_script(
-                script: ShellScript,
-                needs_sudo: bool = False) -> Union[
-                    tuple[CommandOutput, Optional[tmt.utils.RunError]],
-                    tuple[Optional[CommandOutput], tmt.utils.RunError]
-                ]:
-            if needs_sudo and invocation.guest.facts.is_superuser is False:
-                script = ShellScript(f'sudo {script.to_shell_command()}')
-
-            try:
-                output = invocation.guest.execute(script, log=_output_logger, silent=True)
-
-                return output, None
-
-            except tmt.utils.RunError as exc:
-                return None, exc
-
-        def _report_success(label: str, output: tmt.utils.CommandOutput) -> list[str]:
-            return [
-                f'# {label}',
-                output.stdout or '',
-                ''
-                ]
-
-        def _report_failure(label: str, exc: tmt.utils.RunError) -> list[str]:
-            return [
-                f'# {label}',
-                "\n".join(render_run_exception_streams(exc.stdout, exc.stderr, verbose=1)),
-                ''
-                ]
-
-        # Get the `sestatus` output.
-        output, exc = _run_script(ShellScript('sestatus'))
-
-        if exc is None:
-            assert output is not None
-
-            got_sestatus = True
-
-            report += _report_success('sestatus', output)
-
-        else:
-            report += _report_failure('sestatus', exc)
-
-        # Record NVRs of interesting packages.
-        interesting_packages = ' '.join(INTERESTING_PACKAGES)
-        output, exc = _run_script(ShellScript(f'rpm -q {interesting_packages}'))
-
-        if exc is None:
-            assert output is not None
-
-            got_rpm = True
-
-            report += _report_success(f'rpm -q {interesting_packages}', output)
-
-        else:
-            report += _report_failure(f'rpm -q {interesting_packages}', exc)
-
-        # Finally, run `ausearch`, to list AVC denials from the time the test started.
-        start_timestamp = datetime.datetime.fromisoformat(invocation.start_time).timestamp()
-
-        script = ShellScript(f"""
-set -x
-export AVC_SINCE=$(LC_ALL=en_US.UTF-8 date "+%m/%d/%Y %H:%M:%S" --date="@{start_timestamp}")
-echo "$AVC_SINCE"
-ausearch -i --input-logs -m AVC -m USER_AVC -m SELINUX_ERR -ts $AVC_SINCE
-""")
-        output, exc = _run_script(script, needs_sudo=True)
-
-        # `ausearch` outcome evaluation is a bit more complicated than the one for a simple
-        # `rpm -q`, because not all non-zero exit codes mean error.
-        if exc is None:
-            assert output is not None
-
-            got_ausearch = True
-            got_denials = True
-
-            report += [
-                '# ausearch',
-                "\n".join(render_run_exception_streams(output.stdout, output.stderr, verbose=1)),
-                ''
-                ]
-
-        else:
-            if exc.returncode == 1 and exc.stderr and '<no matches>' in exc.stderr.strip():
-                got_ausearch = True
-
-            report += _report_failure('ausearch', exc)
-
-        # If we were able to fetch all components successfully, pick the result based on `ausearch`
-        # output.
-        if all([got_sestatus, got_rpm, got_ausearch]):
-            outcome = ResultOutcome.FAIL if got_denials else ResultOutcome.PASS
-
-        # Otherwise, it's an error - we already made all output part of the report.
-        else:
-            outcome = ResultOutcome.ERROR
-
-        invocation.phase.write(path, '\n'.join(report))
-
-        return outcome, path.relative_to(invocation.phase.step.workdir)
+        return []
 
     @classmethod
     def after_test(
@@ -193,6 +299,11 @@ ausearch -i --input-logs -m AVC -m USER_AVC -m SELINUX_ERR -ts $AVC_SINCE
             invocation: 'TestInvocation',
             environment: Optional[tmt.utils.EnvironmentType] = None,
             logger: tmt.log.Logger) -> list[CheckResult]:
-        outcome, path = cls._save_report(invocation, CheckEvent.AFTER_TEST, logger)
+        assert invocation.phase.step.workdir is not None  # narrow type
 
-        return [CheckResult(name='avc', result=outcome, log=[path])]
+        outcome, path = create_final_report(invocation, logger)
+
+        return [CheckResult(
+            name='avc',
+            result=outcome,
+            log=[path.relative_to(invocation.phase.step.workdir)])]

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -33,8 +33,9 @@ if TYPE_CHECKING:
     import tmt.steps.discover
     import tmt.steps.provision
 
-# Test data directory name
+# Test data and checks directory names
 TEST_DATA = 'data'
+CHECK_DATA = 'checks'
 
 # Default test framework
 DEFAULT_FRAMEWORK = 'shell'
@@ -181,9 +182,10 @@ class TestInvocation:
 
         path.mkdir(parents=True, exist_ok=True)
 
-        # Pre-create also the test data path - cannot use `self.test_data_path`,
-        # that would be an endless recursion.
+        # Pre-create also the test data and checks path - cannot use
+        # `self.test_data_path`, that would be an endless recursion.
         (path / TEST_DATA).mkdir(parents=True, exist_ok=True)
+        (path / CHECK_DATA).mkdir(parents=True, exist_ok=True)
 
         return path
 
@@ -211,9 +213,7 @@ class TestInvocation:
     def check_files_path(self) -> Path:
         """ Construct a directory path for check files needed by tmt """
 
-        path = self.path / "checks"
-        path.mkdir(exist_ok=True)
-        return path
+        return self.path / CHECK_DATA
 
     @tmt.utils.cached_property
     def reboot_request_path(self) -> Path:


### PR DESCRIPTION
Because of possible - and likely - difference in time between a tmt runner and guests, AVC check may be asked to collect events that were logged *before* the test started according to tmt's `start_time` timestamp. This would obviously lead to AVC check collecting no events, and reporting a success.

The patch instead saves a timestamp in a file on the guest, using proper locale setting, and uses this timestamp instead of tmt's `start_time`. This required a bit of refactoring, because now we need to run a shell script *before* the test, and all our helpers and reporting was implemented for the "after" phase only.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage