### PR TITLE
Remove `xfail` for the `multidict` issue on `rawhide`

### DIFF
--- a/tests/pip/install.fmf
+++ b/tests/pip/install.fmf
@@ -22,7 +22,3 @@ tier: null
     test: |
         /tmp/venv/bin/pip install .[all]
         /tmp/venv/bin/tmt --help
-    adjust:
-        result: xfail
-        when: distro == fedora-rawhide
-        because: https://github.com/aio-libs/multidict/issues/926


### PR DESCRIPTION
The issue has been fixed and the fix seems to make it into the `rawhide` compose.