### PR TITLE
Introduce "topology" addresses for guests

### DIFF
--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -13,12 +13,12 @@ def test_multihost_name(root_logger: Logger) -> None:
     assert Guest(
         logger=root_logger,
         name='foo',
-        data=GuestData(guest='bar')).multihost_name == 'foo'
+        data=GuestData(primary_address='bar')).multihost_name == 'foo'
 
     assert Guest(
         logger=root_logger,
         name='foo',
-        data=GuestData(guest='bar', role='client')).multihost_name == 'foo (client)'
+        data=GuestData(primary_address='bar', role='client')).multihost_name == 'foo (client)'
 
 
 @pytest.mark.parametrize(('stdout', 'expected'), [
@@ -57,7 +57,7 @@ def test_execute_no_connection_closed(
     guest = GuestSsh(
         logger=root_logger,
         name='foo',
-        data=GuestSshData(guest='bar')
+        data=GuestSshData(primary_address='bar')
         )
 
     monkeypatch.setattr(

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -3238,7 +3238,7 @@ class Run(tmt.utils.Common):
 
         return tmt.steps.provision.local.GuestLocal(
             data=tmt.steps.provision.GuestData(
-                guest='localhost',
+                primary_address='localhost',
                 role=None),
             name='tmt runner',
             logger=self._logger)

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -1911,7 +1911,7 @@ class GuestTopology(SerializableContainer):
     def __init__(self, guest: 'Guest') -> None:
         self.name = guest.name
         self.role = guest.role
-        self.hostname = guest.guest
+        self.hostname = guest.topology_address
 
 
 @dataclasses.dataclass(init=False)

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -494,7 +494,7 @@ class GuestArtemis(tmt.GuestSsh):
 
         # FIXME: A more robust solution should be provided. Currently just
         #        return True if self.guest is not None
-        return self.guest is not None
+        return self.primary_address is not None
 
     def _create(self) -> None:
         environment: dict[str, Any] = {
@@ -620,8 +620,7 @@ class GuestArtemis(tmt.GuestSsh):
                     f'Failed to provision in the given amount '
                     f'of time (--provision-timeout={self.provision_timeout}).')
 
-        self.guest = guest_info['address']
-        self.info('address', self.guest, 'green')
+        self.primary_address = self.topology_address = guest_info['address']
 
     def start(self) -> None:
         """
@@ -632,8 +631,11 @@ class GuestArtemis(tmt.GuestSsh):
         load() is completed so all guest data should be available.
         """
 
-        if self.guestname is None or self.guest is None:
+        if self.guestname is None or self.primary_address is None:
             self._create()
+
+        self.verbose('primary address', self.primary_address, 'green')
+        self.verbose('topology address', self.topology_address, 'green')
 
     def remove(self) -> None:
         """ Remove the guest """

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -102,10 +102,18 @@ class GuestLocal(tmt.Guest):
             on_process_start=on_process_start,
             **kwargs)
 
+    def start(self) -> None:
+        """ Start the guest """
+
+        self.debug(f"Doing nothing to start guest '{self.primary_address}'.")
+
+        self.verbose('primary address', self.primary_address, 'green')
+        self.verbose('topology address', self.topology_address, 'green')
+
     def stop(self) -> None:
         """ Stop the guest """
 
-        self.debug(f"Doing nothing to stop guest '{self.guest}'.")
+        self.debug(f"Doing nothing to stop guest '{self.primary_address}'.")
 
     def reboot(self,
                hard: bool = False,
@@ -113,7 +121,7 @@ class GuestLocal(tmt.Guest):
                timeout: Optional[int] = None) -> bool:
         """ Reboot the guest, return True if successful """
 
-        self.debug(f"Doing nothing to reboot guest '{self.guest}'.")
+        self.debug(f"Doing nothing to reboot guest '{self.primary_address}'.")
 
         return False
 
@@ -171,7 +179,7 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin[ProvisionLocalData]):
 
         # Create a GuestLocal instance
         data = tmt.steps.provision.GuestData.from_plugin(self)
-        data.guest = 'localhost'
+        data.primary_address = 'localhost'
 
         data.show(verbose=self.verbosity_level, logger=self._logger)
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -184,8 +184,9 @@ class GuestContainer(tmt.Guest):
         # Mount the whole plan directory in the container
         workdir = self.parent.plan.workdir
 
-        self.container = self.guest = self._tmt_name()
-        self.verbose('name', self.container, 'green')
+        self.container = self.primary_address = self.topology_address = self._tmt_name()
+        self.verbose('primary address', self.primary_address, 'green')
+        self.verbose('topology address', self.topology_address, 'green')
 
         additional_args = []
 

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -759,11 +759,12 @@ class GuestTestcloud(tmt.GuestSsh):
                 libvirt.libvirtError) as error:
             raise ProvisionError(
                 f'Failed to boot testcloud instance ({error}).')
-        self.guest = self._instance.get_ip()
+        self.primary_address = self.topology_address = self._instance.get_ip()
         self.port = int(self._instance.get_instance_port())
-        self.verbose('ip', self.guest, 'green')
+        self.verbose('primary address', self.primary_address, 'green')
+        self.verbose('topology address', self.topology_address, 'green')
         self.verbose('port', self.port, 'green')
-        self._instance.create_ip_file(self.guest)
+        self._instance.create_ip_file(self.primary_address)
 
         # Wait a bit until the box is up
         if not self.reconnect(
@@ -783,7 +784,7 @@ class GuestTestcloud(tmt.GuestSsh):
         """ Stop provisioned guest """
         super().stop()
         # Stop only if the instance successfully booted
-        if self._instance and self.guest:
+        if self._instance and self.primary_address:
             self.debug(f"Stopping testcloud instance '{self.instance_name}'.")
             assert testcloud is not None
             try:

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -234,7 +234,8 @@ class ReportPolarion(tmt.steps.report.ReportPlugin[ReportPolarionData]):
             if param:
                 properties[f"polarion-custom-{tr_field.replace('_', '')}"] = param
         if use_facts:
-            properties['polarion-custom-hostname'] = self.step.plan.provision.guests()[0].guest
+            properties['polarion-custom-hostname'] = \
+                self.step.plan.provision.guests()[0].primary_address
             properties['polarion-custom-arch'] = self.step.plan.provision.guests()[0].facts.arch
         if template:
             properties['polarion-testrun-template-id'] = template


### PR DESCRIPTION
Besides a current "guest" attribute - now called "primary address", the patch adds "topology address" for guests to use when talking to each other. As of now, the topology address of a guest is the same as its primary address, but we expected that to change.

Related to https://github.com/teemtee/tmt/issues/2620

Pull Request Checklist

* [x] implement the feature