### PR TITLE
Enable the full test execution using a label

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -56,6 +56,12 @@ jobs:
     targets:
       - fedora-all
       - epel-9
+    require:
+      label:
+        present:
+          - full test
+        absent:
+          - discuss
 
   # Test pull requests (provision)
   - job: tests
@@ -73,6 +79,12 @@ jobs:
           - tmt:
                 context:
                     how: provision
+    require:
+      label:
+        present:
+          - full test
+        absent:
+          - discuss
 
   # Test internal plugins
   - job: tests
@@ -89,6 +101,12 @@ jobs:
                 provisioning:
                     tags:
                         BusinessUnit: tmt
+    require:
+      label:
+        present:
+          - full test
+        absent:
+          - discuss
 
   # Test internal wow
   - job: tests
@@ -105,6 +123,12 @@ jobs:
                 provisioning:
                     tags:
                         BusinessUnit: tmt
+    require:
+      label:
+        present:
+          - full test
+        absent:
+          - discuss
 
   # Build commits to main
   - job: copr_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -52,22 +52,20 @@ jobs:
   - job: tests
     identifier: full
     trigger: pull_request
-    manual_trigger: true
     targets:
       - fedora-all
       - epel-9
     require:
-      label:
-        present:
-          - full test
-        absent:
-          - discuss
+        label:
+          present:
+            - full test
+          absent:
+            - discuss
 
   # Test pull requests (provision)
   - job: tests
     identifier: provision
     trigger: pull_request
-    manual_trigger: true
     use_internal_tf: True
     targets:
       - fedora-latest-stable
@@ -80,11 +78,11 @@ jobs:
                 context:
                     how: provision
     require:
-      label:
-        present:
-          - full test
-        absent:
-          - discuss
+        label:
+          present:
+            - full test
+          absent:
+            - discuss
 
   # Test internal plugins
   - job: tests
@@ -102,11 +100,11 @@ jobs:
                     tags:
                         BusinessUnit: tmt
     require:
-      label:
-        present:
-          - full test
-        absent:
-          - discuss
+        label:
+          present:
+            - full test
+          absent:
+            - discuss
 
   # Test internal wow
   - job: tests
@@ -124,11 +122,11 @@ jobs:
                     tags:
                         BusinessUnit: tmt
     require:
-      label:
-        present:
-          - full test
-        absent:
-          - discuss
+        label:
+          present:
+            - full test
+          absent:
+            - discuss
 
   # Build commits to main
   - job: copr_build

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -353,12 +353,10 @@ it, for example:
 
 By default only a core set of tests is executed against a newly
 created pull request and its updates to verify basic sanity of the
-change. In order to run the full test suite add the following
-comment to the pull request:
-
-.. code-block::
-
-   /packit test --identifier full
+change. Once the pull request content is ready for a thorough
+testing add the ``full test`` label and make sure that the
+``discuss`` label is not present. All future changes of the pull
+request will be tested with the full test coverage.
 
 
 Merging


### PR DESCRIPTION
Instead of having to repeatedly trigger full test suite using the `/packit test` commands, let's use the newly implemented `require` condition to enable all advanced test jobs by applying the label.

Pull Request Checklist

* [x] write the documentation
* [x] extend the test coverage