### PR TITLE
Make checks smarter about environments in which they should not run

### DIFF
--- a/tests/test/check/test-dmesg.sh
+++ b/tests/test/check/test-dmesg.sh
@@ -38,36 +38,37 @@ rlJournalStart
 
             rlRun "cat $results"
 
-            rlAssertExists "$dump_before"
             if [ "$method" = "container" ]; then
-                assert_check_result "dmesg as a before-test should fail with containers" "error" "before-test" "harmless"
+                assert_check_result "dmesg as a before-test should skip with containers" "skip" "before-test" "harmless"
 
-                if rlIsFedora ">=38"; then
-                    rlAssertGrep "dmesg: read kernel buffer failed: Operation not permitted" "$dump_before"
-                else
-                    rlAssertGrep "dmesg: read kernel buffer failed: Permission denied" "$dump_before"
-                fi
+                rlAssertNotExists "$dump_before"
+
             else
                 assert_check_result "dmesg as a before-test should pass" "pass" "before-test" "harmless"
+
+                rlAssertExists "$dump_before"
+                rlLogInfo "$(cat $dump_before)"
             fi
-            rlLogInfo "$(cat $dump_before)"
 
-            rlAssertExists "$dump_after"
             if [ "$method" = "container" ]; then
-                assert_check_result "dmesg as an after-test should fail with containers" "error" "after-test" "harmless"
+                assert_check_result "dmesg as an after-test should skip with containers" "skip" "after-test" "harmless"
 
-                if rlIsFedora ">=38"; then
-                    rlAssertGrep "dmesg: read kernel buffer failed: Operation not permitted" "$dump_after"
-                else
-                    rlAssertGrep "dmesg: read kernel buffer failed: Permission denied" "$dump_after"
-                fi
+                rlAssertNotExists "$dump_after"
+
             elif [ "$method" = "virtual" ]; then
                 assert_check_result "dmesg as an after-test should fail" "fail" "after-test" "segfault"
+
+                rlAssertExists "$dump_after"
+                rlLogInfo "$(cat $dump_after)"
+
                 rlAssertGrep "Some segfault happened" "$segfault/checks/dmesg-after-test.txt"
+
             else
                 assert_check_result "dmesg as an after-test should pass" "pass" "after-test" "harmless"
+
+                rlAssertExists "$dump_after"
+                rlLogInfo "$(cat $dump_after)"
             fi
-            rlLogInfo "$(cat $dump_after)"
         rlPhaseEnd
     done
 

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -293,7 +293,8 @@ class AvcDenials(CheckPlugin[Check]):
             invocation: 'TestInvocation',
             environment: Optional[tmt.utils.EnvironmentType] = None,
             logger: tmt.log.Logger) -> list[CheckResult]:
-        create_ausearch_timestamp(invocation, logger)
+        if invocation.guest.facts.has_selinux:
+            create_ausearch_timestamp(invocation, logger)
 
         return []
 
@@ -305,6 +306,11 @@ class AvcDenials(CheckPlugin[Check]):
             invocation: 'TestInvocation',
             environment: Optional[tmt.utils.EnvironmentType] = None,
             logger: tmt.log.Logger) -> list[CheckResult]:
+        if not invocation.guest.facts.has_selinux:
+            return [CheckResult(
+                name='avc',
+                result=ResultOutcome.SKIP)]
+
         assert invocation.phase.step.workdir is not None  # narrow type
 
         outcome, path = create_final_report(invocation, logger)

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -9,6 +9,7 @@ import tmt.log
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils
+from tmt.steps.provision import GuestCapability
 from tmt.utils import Command, OnProcessStartCallback, Path, ShellScript, field, retry
 
 # Timeout in seconds of waiting for a connection
@@ -455,6 +456,11 @@ class ProvisionPodman(tmt.steps.provision.ProvisionPlugin[ProvisionPodmanData]):
             name=self.name,
             parent=self.step)
         self._guest.start()
+
+        # TODO: this might be allowed with `--privileged`...
+        self._guest.facts.capabilities[GuestCapability.SYSLOG_ACTION_READ_ALL] = False
+        # ... while this seems to be forbidden completely.
+        self._guest.facts.capabilities[GuestCapability.SYSLOG_ACTION_READ_CLEAR] = False
 
     def guest(self) -> Optional[GuestContainer]:
         """ Return the provisioned guest """


### PR DESCRIPTION
There are some conditions in which checks would not succeed, or turn into no-op. Adding basic "capabilities" (`man 7 capabilities`, `man 2 syslog`) which checks can then inspect.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage