### PR TITLE
Accept whole action name in the `try` command

### DIFF
--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -79,11 +79,11 @@ class Action(enum.Enum):
         return before + key + after + padding + self.description
 
     @classmethod
-    def find(cls, key: str) -> "Action":
-        """ Return action for given keyboard shortcut """
+    def find(cls, answer: str) -> "Action":
+        """ Return action for given keyboard input (shortcut or whole word) """
 
         for action in cls:
-            if action.key == key:
+            if answer in (action.key, action.action):
                 return action
 
         raise KeyError

--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -82,6 +82,8 @@ class Action(enum.Enum):
     def find(cls, answer: str) -> "Action":
         """ Return action for given keyboard input (shortcut or whole word) """
 
+        answer = answer.lower()
+
         for action in cls:
             if answer in (action.key, action.action):
                 return action


### PR DESCRIPTION
When I was trying out the `try` command I hit the similar issue as described in #2564, as not being able to see the highlighted letter, I typed out the whole action name which got denied.

Adding support for using whole action name in addition to the shortcut as it is relatively common e.g., interactive git rebase.

Related to #2564

Pull Request Checklist

* [x] implement the feature