### PR TITLE
Check for files in `rpm-ostree install` script

### DIFF
--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -3,22 +3,26 @@
 
 rlJournalStart
     rlPhaseStartSetup
+        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
         rlRun "pushd data"
 
         rlRun "export TMT_BOOT_TIMEOUT=300"
         rlRun "export TMT_CONNECT_TIMEOUT=300"
     rlPhaseEnd
 
+    # Prepare the common tmt command
+    tmt="tmt run --all --id $run --scratch -vvv"
+
     # Run basic tests against all enabled provision methods
     for method in ${PROVISION_METHODS:-container}; do
         provision="provision --how $method"
 
         rlPhaseStartTest "Install an existing package ($method)"
-            rlRun "tmt run -adddvvvr $provision plan --name existing"
+            rlRun "$tmt $provision plan --name existing"
         rlPhaseEnd
 
         rlPhaseStartTest "Report a missing package ($method)"
-            rlRun "tmt run -adddvvvr $provision plan --name missing" 2
+            rlRun "$tmt $provision plan --name missing" 2
         rlPhaseEnd
 
         # Add one extra CoreOS run for virtual provision
@@ -26,11 +30,13 @@ rlJournalStart
             provision="provision --how $method --image fedora-coreos"
 
             rlPhaseStartTest "Install an existing package ($method, CoreOS)"
-                rlRun "tmt run -adddvvvr $provision plan --name existing"
+                rlRun "$tmt $provision plan --name existing"
+                rlAssertGrep "rpm-ostree install.*tree" $run/log.txt
+                rlAssertNotGrep "rpm-ostree install.*/usr/bin/flock" $run/log.txt
             rlPhaseEnd
 
             rlPhaseStartTest "Report a missing package ($method, CoreOS)"
-                rlRun "tmt run -adddvvvr $provision plan --name missing" 2
+                rlRun "$tmt $provision plan --name missing" 2
             rlPhaseEnd
         fi
     done
@@ -43,30 +49,31 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Just enable copr"
-        rlRun "tmt run -adddvvvr plan --name copr"
+        rlRun "$tmt plan --name copr"
     rlPhaseEnd
 
     rlPhaseStartTest "Escape package names"
-        rlRun "tmt run -adddvvvr plan --name escape"
+        rlRun "$tmt plan --name escape"
     rlPhaseEnd
 
     rlPhaseStartTest "Exclude selected packages"
-        rlRun "tmt run -adddvvvr plan --name exclude"
+        rlRun "$tmt plan --name exclude"
     rlPhaseEnd
 
     rlPhaseStartTest "Install from epel7 copr"
-        rlRun "tmt run -adddvvvr plan --name epel7"
+        rlRun "$tmt plan --name epel7"
     rlPhaseEnd
 
     rlPhaseStartTest "Install remote packages"
-        rlRun "tmt run -adddvvvr plan --name epel8-remote"
+        rlRun "$tmt plan --name epel8-remote"
     rlPhaseEnd
 
     rlPhaseStartTest "Install debuginfo packages"
-        rlRun "tmt run -adddvvvr plan --name debuginfo"
+        rlRun "$tmt plan --name debuginfo"
     rlPhaseEnd
 
     rlPhaseStartCleanup
         rlRun "popd"
+        rlRun "rm -r $run" 0 "Remove run directory"
     rlPhaseEnd
 rlJournalEnd


### PR DESCRIPTION
When installing files (like /usr/bin/flock) installation check fails only with 'rpm -q' and on rpm-ostree system it might be a problem as it changes image digest (caused a failed upgrade test on our env)
Also installation will be faster with this check

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage