### PR TITLE
Enable `additional_coverage` tests for pull requests

### DIFF
--- a/tests/discover/main.fmf
+++ b/tests/discover/main.fmf
@@ -37,11 +37,6 @@ tier: 3
 /distgit:
     summary: Get tests from the source tarball from dist-git lookaside
     test: ./distgit.sh
-    enabled: false
-    adjust+:
-    - enabled: true
-      when: how == full or trigger == commit
-      tag+: [additional_coverage]
 
 /dynamic-ref:
     /fmf:

--- a/tests/execute/nonroot/main.fmf
+++ b/tests/execute/nonroot/main.fmf
@@ -1,6 +1,5 @@
 summary: Scripts used in execute are pushed via sudo
 tag:
-- additional_coverage
 - virtual
 - provision-virtual
 - provision-only

--- a/tests/execute/reboot/main.fmf
+++ b/tests/execute/reboot/main.fmf
@@ -20,31 +20,20 @@ tier: 4
     test: ./efi.sh
     enabled: false
 
-
 /multi-part:
     summary: Verify reboot during multiple consecutive tests
     test: ./multi-part.sh
 
-
 /shorten-timeout:
     summary: Verify that timeout shortening works
     test: ./shorten-timeout.sh
-    enabled: false
-
-    adjust+:
-      - enabled: true
-        when: how == full
-        because: this can be run only with full virtualization
-        tag+: [additional_coverage]
-
+    tag+:
+      - provision-only
+      - provision-virtual
 
 /reuse-provision:
     summary: Verify that provision can be reused for reboot
     test: ./reuse.sh
-    enabled: false
-
-    adjust+:
-      - enabled: true
-        when: how == full
-        because: this can be run only with full virtualization
-        tag+: [additional_coverage]
+    tag+:
+      - provision-only
+      - provision-virtual

--- a/tests/execute/reboot/reuse.sh
+++ b/tests/execute/reboot/reuse.sh
@@ -20,7 +20,7 @@ rlJournalStart
     rlPhaseStartTest "Reuse the same provision"
         rlRun "tmt run -i $provision_run provision -h virtual"
         guests="$provision_run/plan/provision/guests.yaml"
-        guest=$(get_value "guest" "$guests")
+        guest=$(get_value "primary-address" "$guests")
         port=$(get_value "port" "$guests")
         user=$(get_value "user" "$guests")
         key=$(get_value "key" "$guests")

--- a/tests/execute/upgrade/full.sh
+++ b/tests/execute/upgrade/full.sh
@@ -5,24 +5,27 @@ rlJournalStart
     rlPhaseStartSetup
         rlRun "source fedora-version.sh"
         rlRun "pushd data"
-        rlRun "set -o pipefail"
         rlRun "run=/var/tmp/tmt/run-upgrade"
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun -s "tmt -c distro=fedora-${PREVIOUS_VERSION} \
-         -c upgrade-path="${UPGRADE_PATH}" \
-         run --scratch -vvvdddi $run --rm --before finish \
-         plan -n /plan/path" 0 "Run the upgrade test"
+        # Perform the full distro upgrade
+        rlRun -s "tmt \
+            --context distro=fedora-${PREVIOUS_VERSION} \
+            --context upgrade-path="${UPGRADE_PATH}" \
+            run --id $run --scratch --rm -vvv --before finish \
+            plan --name /plan/path" 0 "Run the upgrade test"
+
         # 1 test before + 3 upgrade tasks + 1 test after
         rlAssertGrep "5 tests passed" $rlRun_LOG
+
         # Check that the IN_PLACE_UPGRADE variable was set
         rlAssertGrep "IN_PLACE_UPGRADE=old" "$run/plan/path/execute/data/guest/default-0/old/test-1/output.txt"
         rlAssertGrep "IN_PLACE_UPGRADE=new" "$run/plan/path/execute/data/guest/default-0/new/test-1/output.txt"
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun "tmt run -l finish" 0 "Stop the guest and remove the workdir"
+        rlRun "tmt run --id $run finish" 0 "Stop the guest and remove the workdir"
         rlRun "popd"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/execute/upgrade/main.fmf
+++ b/tests/execute/upgrade/main.fmf
@@ -2,16 +2,13 @@ duration: 10m
 tier: 4
 
 /full:
-    summary: Perform a full upgrade from F35 to F36
+    summary: Perform a full distro upgrade
     test: ./full.sh
     # dnf upgrade is run, this may take quite long
     duration: 1h
-    # requires nested virtualization (runs in VM)
-    enabled: false
-    adjust+:
-      - enabled: true
-        when: how == full
-        tag+: [additional_coverage]
+    tag+:
+      - provision-only
+      - provision-virtual
 
 /simple:
     summary: Run a single task from upgrades repo

--- a/tests/libraries/pruning/main.fmf
+++ b/tests/libraries/pruning/main.fmf
@@ -4,3 +4,4 @@ description:
 tag+:
   - provision-virtual
   - provision-only
+duration: 10m

--- a/tests/multihost/web/main.fmf
+++ b/tests/multihost/web/main.fmf
@@ -7,9 +7,6 @@ description:
     role. Check that the page is correctly served to both clients.
 framework: shell
 test: cd data && tmt run -vvv
-
-enabled: false
-adjust:
-  - enabled: true
-    when: how == full
-    tag+: [additional_coverage]
+tag+:
+  - provision-only
+  - provision-virtual

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -419,7 +419,9 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
             source=invocation.path,
             extend_options=test.test_framework.get_pull_options(invocation, logger))
 
-        # Produce list of results
+        # Extract test results and store them in the invocation. Note
+        # that these results will be overwritten with a fresh set of
+        # results after a successful reboot in the middle of a test.
         invocation.results = self.extract_results(invocation, logger)
 
         invocation.check_results += self.run_checks_after_test(

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -420,8 +420,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
             extend_options=test.test_framework.get_pull_options(invocation, logger))
 
         # Produce list of results
-        if not invocation.reboot_requested:
-            invocation.results += self.extract_results(invocation, logger)
+        invocation.results = self.extract_results(invocation, logger)
 
         invocation.check_results += self.run_checks_after_test(
             invocation=invocation,


### PR DESCRIPTION
These should be the last leftovers from the full test suite which haven't been enabled yet for the pull request testing. Includes also a simple smoke test for provision `connect` implemented in `/tests/execute/reboot/reuse-provision`.

Pull Request Checklist

* [x] extend the test coverage

Relates to #2616.