### PR TITLE
Update the `reportportal` plugin

### DIFF
--- a/tmt/schemas/report/reportportal.yaml
+++ b/tmt/schemas/report/reportportal.yaml
@@ -61,6 +61,9 @@ properties:
   artifacts-url:
     type: string
 
+  api-version:
+    type: string
+
 required:
   - how
   - project


### PR DESCRIPTION
Features:
* support of environment variables `TMT_PLUGIN_REPORT_REPORTPORTAL_<option>` also for report step set via fmf
* launch-description option modified to append an existing description instead of overwriting it
* option to specify api-version

Pull Request Checklist

* [x] implement the feature 
* [x] write the documentation
* [x] modify the json schema

Plan for additional PR:
* rerun of failed report for older ReportPortal version
* test coverage