### PR TITLE
Mark test check tests with more fitting provision tags

### DIFF
--- a/tests/test/check/main.fmf
+++ b/tests/test/check/main.fmf
@@ -1,6 +1,5 @@
 summary: Test test checks
 tier: 2
-tag+: [provision-virtual]
 
 /dmesg:
     test: ./test-dmesg.sh
@@ -8,6 +7,10 @@ tag+: [provision-virtual]
       - provision-only
       - provision-container
       - provision-local
+      - provision-virtual
 
 /avc:
     test: ./test-avc.sh
+    tag+:
+      - provision-local
+      - provision-virtual


### PR DESCRIPTION
* add `provision-virtual` explicitly - there will be more checks, more tests, it's easir to find which check supports which plugins
* AVC test supports `local`

Pull Request Checklist

* [x] implement the feature