### PR TITLE
Add `Environment` and `FmfContext` among loggable types

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1472,7 +1472,21 @@ _test_format_value_big_list = list(range(1, 20))
             """
             '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18' and '19'
             """  # noqa: E501
-            )
+            ),
+        # environment
+        (
+            tmt.utils.Environment.from_dict({'FOO': 'BAR'}),
+            None,
+            'FOO: BAR'),
+        # fmf context
+        (
+            tmt.utils.FmfContext({'foo': ['bar', 'baz']}),
+            None,
+            """
+            foo:
+              - bar
+              - baz
+            """)
         ],
     ids=(
         'true',
@@ -1491,6 +1505,8 @@ _test_format_value_big_list = list(range(1, 20))
         'long list',
         'long list within small window',
         'long list within huge window',
+        'environment',
+        'fmf context'
         )
     )
 def test_format_value(value: Any, window_size: Optional[int], expected: str) -> None:

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -68,7 +68,6 @@ from tmt.utils import (
     container_field,
     dict_to_yaml,
     field,
-    format_value,
     git_clone,
     normalize_shell_script,
     verdict,
@@ -2249,8 +2248,8 @@ class Plan(
         # Additional debug info like plan environment
         self.debug('info', color='cyan', shift=0, level=3)
         # TODO: something better than str()?
-        self.debug('environment', format_value(self.environment), 'magenta', level=3)
-        self.debug('context', format_value(self._fmf_context), 'magenta', level=3)
+        self.debug('environment', self.environment, 'magenta', level=3)
+        self.debug('context', self._fmf_context, 'magenta', level=3)
 
         # Wake up all steps
         self.wake()

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -76,6 +76,8 @@ LoggableValue = Union[
     int,
     bool,
     float,
+    'tmt.utils.Environment',
+    'tmt.utils.FmfContext',
     'tmt.utils.Path',
     'tmt.utils.Command',
     'tmt.utils.ShellScript']

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1225,7 +1225,7 @@ class Command:
             actual_env = Environment.from_environ()
             actual_env.update(env)
 
-        logger.debug('environment', format_value(actual_env), level=4)
+        logger.debug('environment', actual_env, level=4)
 
         # Set special executable only when shell was requested
         executable = DEFAULT_SHELL if shell else None


### PR DESCRIPTION
They are just fancy dictionaries, and since our logging subsystem supports dictionaries out of the box, we can let developers pass these two to logging methods without formatting them first.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage