### PR TITLE
Move deferred user stories into a separate section

### DIFF
--- a/docs/scripts/generate-stories.py
+++ b/docs/scripts/generate-stories.py
@@ -31,6 +31,7 @@ AREA_TITLES = {
     '/stories/cli': 'Command Line',
     '/stories/install': 'Installation',
     '/stories/features': 'Features',
+    '/stories/deferred': 'Deferred',
     '/spec/core': 'Core',
     '/spec/tests': 'Tests',
     '/spec/plans': 'Plans',

--- a/docs/stories.rst
+++ b/docs/stories.rst
@@ -16,6 +16,7 @@ couple of examples demonstrating expected usage.
     stories/docs
     stories/cli
     stories/features
+    stories/deferred
 
 
 It is also possible to list and search stories directly from the

--- a/stories/cli/run.fmf
+++ b/stories/cli/run.fmf
@@ -90,20 +90,6 @@ story: 'As a user I want to execute tests easily'
         example:
             - tmt run --all provision --how=container
 
-/interactive:
-    story: 'Provide way similar to git rebase --interactive'
-    description:
-        Provide users with list of steps and let them edit them.
-        Allow adding commands between, or at least interactive "pause".
-        When user would be finished with single step, just continue recipe.
-        Do not force users to remember all steps when working with them.
-        Make it possible to repeat single step or abort current run.
-        Allow repeating some steps just by repeating lines with task.
-    example:
-        - tmt run --all --interactive
-        - tmt run --continue
-        - tmt run --abort
-
 /shortcuts:
     story: 'Provide shortcuts for common scenarios'
     /container:
@@ -184,21 +170,6 @@ story: 'As a user I want to execute tests easily'
     link:
       - implemented-by: /tmt/steps/execute
       - implemented-by: /tmt/steps/prepare/install.py
-
-/restraint:
-    story:
-        As a tester I want the option to execute tests using the
-        Restraint harness.
-    description:
-        Restraint is the default harness in beaker for RHEL8 and
-        beyond. In order to provide compatibility with beaker
-        style tests, I would like a way to invoke ``tmt`` using
-        the Restaint harness. This would enable Restraint tests to
-        be invoked by ``tmt`` without modification. Some common
-        commands include ``rstrnt-reboot``, ``rstrnt-abort``, and
-        ``rstrnt-report-result``.
-    example:
-        - tmt run --all execute --how restraint
 
 /last:
     story: 'As a user I want to rerun tests easily'

--- a/stories/deferred/gate.fmf
+++ b/stories/deferred/gate.fmf
@@ -1,3 +1,5 @@
+story: As a user I want to easily enable plan for selected gates.
+
 summary: Gates relevant for testing
 
 description: |

--- a/stories/deferred/interactive.fmf
+++ b/stories/deferred/interactive.fmf
@@ -1,0 +1,14 @@
+story: Provide way similar to git rebase --interactive
+
+description:
+    Provide users with list of steps and let them edit them.
+    Allow adding commands between, or at least interactive "pause".
+    When user would be finished with single step, just continue recipe.
+    Do not force users to remember all steps when working with them.
+    Make it possible to repeat single step or abort current run.
+    Allow repeating some steps just by repeating lines with task.
+
+example:
+  - tmt run --all --interactive
+  - tmt run --continue
+  - tmt run --abort

--- a/stories/deferred/main.fmf
+++ b/stories/deferred/main.fmf
@@ -1,0 +1,8 @@
+story:
+    As tmt contributors we want to keep separately some older,
+    postponed but still valuable ideas for possible future use.
+
+description:
+    This section contains user stories which are not planned to be
+    implemented in the near future. They still might be useful for
+    inspiration or even might be later resurrected from the sleep.

--- a/stories/deferred/restraint.fmf
+++ b/stories/deferred/restraint.fmf
@@ -1,0 +1,31 @@
+story:
+    As a tester I want the option to execute tests using the
+    ``restraint`` harness.
+
+description: |
+    Restraint is the default harness in beaker for RHEL8 and
+    beyond. In order to provide compatibility with beaker
+    style tests, I would like a way to invoke ``tmt`` using
+    the Restaint harness. This would enable Restraint tests to
+    be invoked by ``tmt`` without modification. Some common
+    commands include ``rstrnt-reboot``, ``rstrnt-abort``, and
+    ``rstrnt-report-result``.
+
+    Although implementation of the full execute step plugin has
+    been deferred, backward compatiblity scripts have been
+    provided for several most commonly used restraint commands:
+
+    rstrnt-abort
+        :ref:`/stories/features/abort`
+
+    rstrnt-reboot
+        :ref:`/stories/features/reboot`
+
+    rstrnt-report-log
+        :ref:`/stories/features/report-log`
+
+    rstrnt-report-result
+        :ref:`/stories/features/report-result`
+
+example:
+  - tmt run --all execute --how restraint


### PR DESCRIPTION
Some older ideas might be stalled for a longer time, but still, it might make sense to keep them for inspiration or a future wake-up. Remove them from the main documentation to prevent user confusion.

Pull Request Checklist

* [x] write the documentation