### PR TITLE
Extend the `duration` for time-demanding tests

### DIFF
--- a/tests/multihost/complete/main.fmf
+++ b/tests/multihost/complete/main.fmf
@@ -1,2 +1,1 @@
 summary: Verify that multihost works
-duration: 15m

--- a/tests/multihost/main.fmf
+++ b/tests/multihost/main.fmf
@@ -1,1 +1,2 @@
 tier: 4
+duration: 15m

--- a/tests/provision/become/main.fmf
+++ b/tests/provision/become/main.fmf
@@ -6,4 +6,3 @@ tag+:
   - provision-only
   - provision-container
   - provision-virtual
-duration: 20m

--- a/tests/provision/main.fmf
+++ b/tests/provision/main.fmf
@@ -1,2 +1,3 @@
 require+: [tmt+provision-container]
 tier: 3
+duration: 20m


### PR DESCRIPTION
Tests related to `provision` and `multihost` often take more time. Let's adjust the `duration` for all of them (doesn't make sense to raise the time one by one in separate pull requests).