### PR TITLE
Use /usr/sbin/sestatus instead of /usr/bin/sestatus

### DIFF
--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -300,7 +300,7 @@ class AvcDenials(CheckPlugin[Check]):
         import tmt.base
 
         return [
-            tmt.base.DependencySimple('/usr/bin/sestatus'),
+            tmt.base.DependencySimple('/usr/sbin/sestatus'),
             tmt.base.DependencySimple('/usr/sbin/ausearch')
             ]
 


### PR DESCRIPTION
On a RHEL-8.9 compose, there's no /usr/bin/sestatus file, only /usr/sbin/sestatus,

which made the test preparation failed.

Command 'rpm -q --whatprovides /usr/bin/dmesg /usr/bin/sestatus /usr/sbin/ausearch /usr/bin/flock || dnf install -y /usr/bin/dmesg /usr/bin/sestatus /usr/sbin/ausearch /usr/bin/flock' returned 1,

so changing /usr/bin/sestatus to /usr/sbin/sestatus.

$ rpm -ql policycoreutils-2.9-25.el8.x86_64 | grep bin/sestatus
/usr/sbin/sestatus

On a RHEL-9.4 compose:
$ rpm -ql policycoreutils-3.6-1.el9.x86_64 | grep bin/sestatus
/usr/bin/sestatus
/usr/sbin/sestatus


Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
