### PR TITLE
Add support for linking artifacts from the report

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -87,6 +87,14 @@ Enter the environment by running:
 
     hatch -e dev shell
 
+When interacting from within the development environment with
+services with internal certificates, you need to export the
+following environment variable:
+
+.. code-block:: shell
+
+    export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+
 Install the ``pre-commit`` script to run all available checks for
 your commits to the project:
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -449,6 +449,11 @@ TMT_REBOOT_TIMEOUT
     How many seconds to wait for a connection to succeed after
     guest reboot. By default, it is 10 minutes.
 
+TMT_REPORT_ARTIFACTS_URL
+    Link to test artifacts provided for report plugins.
+
+    .. versionadded:: 1.32
+
 .. _step-variables:
 
 Step Variables

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -38,6 +38,10 @@ new test execution.
 
 __ https://pagure.io/testcloud/
 
+New environment variable ``TMT_REPORT_ARTIFACTS_URL`` has been added
+to :ref:`command-variables`. It can be used to provide a link for
+detailed test artifacts for report plugins to pick.
+
 
 tmt-1.31
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/report/reportportal/test.sh
+++ b/tests/report/reportportal/test.sh
@@ -4,7 +4,7 @@
 TOKEN=$TMT_REPORT_REPORTPORTAL_TOKEN
 URL=$TMT_REPORT_REPORTPORTAL_URL
 PROJECT="$(yq -r .report.project 'data/plan.fmf')"
-
+ARTIFACTS=$TMT_REPORT_ARTIFACTS_URL
 
 rlJournalStart
     rlPhaseStartSetup
@@ -41,7 +41,16 @@ rlJournalStart
         rlAssertEquals "Assert the id of launch is correct (id from url)" "$(echo $response | jq -r '.id')" "$launch_id"
         rlAssertEquals "Assert the name of launch is correct" "$(echo $response | jq -r '.name')" "/plan"
         rlAssertEquals "Assert the status of launch is correct" "$(echo $response | jq -r '.status')" "FAILED"
-        rlAssertEquals "Assert the description of launch is correct" "$(echo $response | jq -r '.description')" "$(yq -r '.summary' plan.fmf)"
+        plan_summary=$(yq -r '.summary' plan.fmf)
+	if [[ -z $ARTIFACTS ]]; then
+            rlAssertEquals "Assert the description of launch is correct" "$(echo $response | jq -r '.description')" "$plan_summary"
+	else
+	    if [[ $plan_summary == "null" ]]; then
+	    rlAssertEquals "Assert the description of launch is correct" "$(echo $response | jq -r '.description')" "$ARTIFACTS"
+	    else
+	    rlAssertEquals "Assert the description of launch is correct" "$(echo $response | jq -r '.description')" "$plan_summary, $ARTIFACTS"
+	    fi
+	fi
 
         # Check all the launch attributes
         rl_message="Test attributes of the launch (context)"

--- a/tmt/schemas/report/reportportal.yaml
+++ b/tmt/schemas/report/reportportal.yaml
@@ -52,10 +52,13 @@ properties:
   launch-rerun:
     type: boolean
 
-  defect_type:
+  defect-type:
     type: string
 
   exclude-variables:
+    type: string
+
+  artifacts-url:
     type: string
 
 required:

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -85,6 +85,11 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
              "Parameters in ReportPortal get filtered out by the pattern"
              "to prevent overloading and to preserve the history aggregation"
              "for ReportPortal item if tmt id is not provided")
+    artifacts_url: Optional[str] = field(
+        metavar="ARTIFACTS_URL",
+        option="--artifacts-url",
+        default=os.getenv('TMT_REPORT_ARTIFACTS_URL'),
+        help="Link to test artifacts provided for report plugins.")
 
     launch_url: Optional[str] = None
     launch_uuid: Optional[str] = None
@@ -314,10 +319,14 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
         attributes = [
             {'key': key, 'value': value[0]}
             for key, value in self.step.plan._fmf_context.items()]
-
         launch_attributes = self.construct_launch_attributes(suite_per_plan, attributes)
 
         launch_description = self.data.launch_description or self.step.plan.summary
+        # Check whether artifacts URL has been provided
+        if not launch_description:
+            launch_description = self.data.artifacts_url
+        elif self.data.artifacts_url:
+            launch_description = f"{launch_description}, {self.data.artifacts_url}"
 
         # Communication with RP instance
         with tmt.utils.retry_session() as session:


### PR DESCRIPTION
Fixes #2660 

This takes whatever Testing Farm exports as a `TMT_REPORT_ARTIFACTS_URL` environment variable for the tmt run process and puts it in the launch's description field on ReportPortal.

Would it make sense to store it also in `ReportReportPortalData` dataclass? Something like this? 
```
artifacts_url: Optional[str] = field(
metavar="ARTIFACTS_URL",
default=os.getenv('TMT_REPORT_ARTIFACTS_URL'),
help="Launch artifacts link provided by Testing Farm")
```

I suppose `option="--artifacts-url"` is not necessary, because this variable will be provided by TF before tmt runs and user trying to use the option manually on command line will not know the link beforehand anyway.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] modify the json schema
* [x] mention the version
* [x] include a release note