### PR TITLE
Set default formatting of Pint units to use symbols, not names

### DIFF
--- a/tests/provision/virtual.testcloud/test.sh
+++ b/tests/provision/virtual.testcloud/test.sh
@@ -18,12 +18,12 @@ rlJournalStart
         if ! rlRun "tmt run -i $run --scratch"; then
             rlRun "cat $run/log.txt" 0 "Dump log.txt"
         else
-            rlAssertGrep "memory: 2048 megabyte" "$run/log.txt"
-            rlAssertGrep "disk: 10 gigabyte" "$run/log.txt"
-            rlAssertGrep "effective hardware: variant #1: memory: == 2048 megabyte" "$run/log.txt"
-            rlAssertGrep "effective hardware: variant #1: disk.size: == 10 gigabyte" "$run/log.txt"
-            rlAssertGrep "memory: set to '2048 megabyte' because of 'memory: == 2048 megabyte'" "$run/log.txt"
-            rlAssertGrep "disk\\[0\\].size: set to '10 gigabyte' because of 'disk.size: == 10 gigabyte'" "$run/log.txt"
+            rlAssertGrep "memory: 2048 MB" "$run/log.txt"
+            rlAssertGrep "disk: 10 GB" "$run/log.txt"
+            rlAssertGrep "effective hardware: variant #1: memory: == 2048 MB" "$run/log.txt"
+            rlAssertGrep "effective hardware: variant #1: disk.size: == 10 GB" "$run/log.txt"
+            rlAssertGrep "memory: set to '2048 MB' because of 'memory: == 2048 MB'" "$run/log.txt"
+            rlAssertGrep "disk\\[0\\].size: set to '10 GB' because of 'disk.size: == 10 GB'" "$run/log.txt"
             rlAssertGrep "final domain memory: 2048000" "$run/log.txt"
             rlAssertGrep "final domain disk size: 10" "$run/log.txt"
         fi
@@ -40,12 +40,12 @@ rlJournalStart
                                       --connection system" ; then
             rlRun "cat $run/log.txt" 0 "Dump log.txt"
         else
-            rlAssertGrep "memory: 2049 megabyte" "$run/log.txt"
-            rlAssertGrep "disk: 11 gigabyte" "$run/log.txt"
-            rlAssertGrep "effective hardware: variant #1: memory: == 2049 megabyte" "$run/log.txt"
-            rlAssertGrep "effective hardware: variant #1: disk.size: == 11 gigabyte" "$run/log.txt"
-            rlAssertGrep "memory: set to '2049 megabyte' because of 'memory: == 2049 megabyte'" "$run/log.txt"
-            rlAssertGrep "disk\\[0\\].size: set to '11 gigabyte' because of 'disk.size: == 11 gigabyte'" "$run/log.txt"
+            rlAssertGrep "memory: 2049 MB" "$run/log.txt"
+            rlAssertGrep "disk: 11 GB" "$run/log.txt"
+            rlAssertGrep "effective hardware: variant #1: memory: == 2049 MB" "$run/log.txt"
+            rlAssertGrep "effective hardware: variant #1: disk.size: == 11 GB" "$run/log.txt"
+            rlAssertGrep "memory: set to '2049 MB' because of 'memory: == 2049 MB'" "$run/log.txt"
+            rlAssertGrep "disk\\[0\\].size: set to '11 GB' because of 'disk.size: == 11 GB'" "$run/log.txt"
             rlAssertGrep "final domain memory: 2049000" "$run/log.txt"
             rlAssertGrep "final domain disk size: 11" "$run/log.txt"
         fi

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -59,6 +59,9 @@ if TYPE_CHECKING:
 #: Unit registry, used and shared by all code.
 UNITS = pint.UnitRegistry()
 
+# The default formatting should use unit symbols rather than full names.
+UNITS.default_format = '~'
+
 
 # Special type variable, used in `Constraint.from_specification` - we bound this return value to
 # always be a subclass of `Constraint` class, instead of just any class in general.


### PR DESCRIPTION
Instead of the default "79 mebibyte", we want "79 MiB".

Fixes https://github.com/teemtee/tmt/issues/2410

Pull Request Checklist

* [x] implement the feature