### PR TITLE
Run `/plans/install/docs` in core `packit` jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -41,12 +41,12 @@ jobs:
     identifier: core
     trigger: pull_request
     targets:
-      - fedora-all
+      - fedora-latest-stable
       - epel-9
     tf_extra_params:
         test:
             tmt:
-                name: /plans/features/(core|basic)
+                name: /plans/(features/core|features/basic|install/docs)
 
   # Test pull requests (full)
   # Do not run extended unit tests, that plan gets its own job because

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -309,7 +309,8 @@ created pull request and its updates to verify basic sanity of the
 change. Once the pull request content is ready for a thorough
 testing add the ``full test`` label and make sure that the
 ``discuss`` label is not present. All future changes of the pull
-request will be tested with the full test coverage.
+request will be tested with the full test coverage. For changes
+related to documentation only the full test suite is not required.
 
 
 Merging


### PR DESCRIPTION
In order to ensure that docs can be successfully built and the full test execution is not needed for documentation-only changes let's enable `/plans/install/docs` for the core packit jobs.

Also, I propose to use the `fedora-latest-stable` target for the core jobs as it should cover the basic functionality just fine.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation