### PR TITLE
Allow commands whose output is not logged unless they fail

### DIFF
--- a/tmt/checks/watchdog.py
+++ b/tmt/checks/watchdog.py
@@ -243,6 +243,7 @@ class WatchdogCheck(Check):
                                        '-c',
                                        str(self.ping_packets),
                                        invocation.guest.primary_address) .run(cwd=Path.cwd(),
+                                                                              stream_output=False,
                                                                               logger=logger)
 
             _handle_output(output.stdout or '')
@@ -327,6 +328,7 @@ class WatchdogCheck(Check):
                                        '-zv',
                                        invocation.guest.primary_address,
                                        str(invocation.guest.port or 22)) .run(cwd=Path.cwd(),
+                                                                              stream_output=False,
                                                                               logger=logger)
 
             _success(output.stderr or '')


### PR DESCRIPTION
There is a class of commands whose output is interesting only when they fail. Allow running them, and do not log their output in real-time, but log it if the command exits with non-zero exit code.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage