### PR TITLE
Move `/tests/run/shell` to `/plans/provision/local`

### DIFF
--- a/tests/run/shell/main.fmf
+++ b/tests/run/shell/main.fmf
@@ -1,10 +1,8 @@
 summary: Use bash regardless users' login shell or /bin/sh value
-test: ./test.sh
-framework: beakerlib
 require:
   - zsh
   - tmt
 tag+:
   - as_root
   - provision-only
-  - provision-virtual
+  - provision-local

--- a/tests/run/shell/test.sh
+++ b/tests/run/shell/test.sh
@@ -6,7 +6,6 @@ USER=test_user$$
 
 rlJournalStart
     rlPhaseStartSetup
-
         [[ $(id -u) -eq 0 ]] || rlDie "Test has to run as root"
 
         rlRun "set -o pipefail"


### PR DESCRIPTION
As for now, the test actually exercises the `local` provision method. Let's move it under the right plan.