### PR TITLE
Include an example template for creating `tmt` tests

### DIFF
--- a/examples/template/README.rst
+++ b/examples/template/README.rst
@@ -1,0 +1,12 @@
+
+==================================================================
+                        tmt test template
+==================================================================
+
+When creating a new ``tmt`` test it is recommended to use the test
+template provided in this directory. In order to be able to use it
+directly from the ``tmt test create`` command you might want to
+symlink it to your configuration::
+
+    ln -sr test.sh ~/.config/tmt/templates/script/tmt.j2
+    ln -sr main.fmf ~/.config/tmt/templates/test/tmt.j2

--- a/examples/template/main.fmf
+++ b/examples/template/main.fmf
@@ -1,0 +1,4 @@
+summary: Verify that this and that works like this
+description:
+    Include a bit longer description which would help a stranger
+    or your future self to quickly grasp the purpose of the test.

--- a/examples/template/test.sh
+++ b/examples/template/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "run=\$(mktemp -d)" 0 "Create a run directory"
+        rlRun "pushd data"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun "tmt run --id $run"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlGetTestState || rlFileSubmit "$run/log.txt"
+        rlRun "rm -r $run" 0 "Remove the run directory"
+    rlPhaseEnd
+rlJournalEnd


### PR DESCRIPTION
Vast majority of tests verifying the `tmt` features shares a similar outline of the `beakerlib` skeleton. Let's make it super easy to start writing a new `tmt` test. The skeleton also covers submitting `log.txt` when something goes wrong during the test execution so that a detailed investigation is possible later.

Pull Request Checklist

* [ ] write the documentation
* [ ] include a release note
