### PR TITLE
Select no tests if `modified-only` returns nothing

### DIFF
--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -169,6 +169,14 @@ execute:
             modified-only: true
             modified-ref: 8329db0^
 
+    /empty-modified:
+        discover:
+            how: fmf
+            path: ../../..
+            ref: 8329db0
+            modified-only: true
+            modified-ref: 8329db0
+
     /distgit:
         summary: Extract distgit sources
         discover:

--- a/tests/discover/modified.sh
+++ b/tests/discover/modified.sh
@@ -8,21 +8,23 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest 'Command-line'
-        rlRun 'tmt run -rdv discover --how fmf --ref 8329db0 \
+        rlRun -s 'tmt run -rdv discover --how fmf --ref 8329db0 \
             --modified-only --modified-ref 8329db0^ \
-            plan -n features/core finish 2>&1 >/dev/null | tee output'
-        rlAssertGrep 'summary: 1 test selected' output
-        rlAssertGrep '/tests/core/adjust' output
+            plan -n features/core finish >/dev/null'
+        rlAssertGrep 'summary: 1 test selected' "$rlRun_LOG"
+        rlAssertGrep '/tests/core/adjust' "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartTest 'Plan'
-        rlRun 'env -C data tmt run -rdv discover \
-            plan -n fmf/modified finish 2>&1 >/dev/null | tee output'
-        rlAssertGrep 'summary: 1 test selected' output
-        rlAssertGrep '/tests/core/adjust' output
+        rlRun -s 'env -C data tmt run -rdv discover \
+            plan -n fmf/modified finish >/dev/null'
+        rlAssertGrep 'summary: 1 test selected' "$rlRun_LOG"
+        rlAssertGrep '/tests/core/adjust' "$rlRun_LOG"
     rlPhaseEnd
 
-    rlPhaseStartCleanup
-        rlRun 'rm -f output' 0 'Remove tmp file'
+    rlPhaseStartTest 'No changes'
+        rlRun -s 'env -C data tmt run -rdv discover \
+            plan -n fmf/empty-modified >/dev/null'
+        rlAssertGrep 'summary: 0 tests selected' "$rlRun_LOG"
     rlPhaseEnd
 rlJournalEnd

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -566,17 +566,19 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 Command(
                     'git', 'log', '--format=', '--stat', '--name-only', f"{modified_ref}..HEAD"
                     ), cwd=self.testdir)
+            self._tests: list['tmt.Test'] = []
             if output.stdout:
                 directories = [os.path.dirname(name) for name in output.stdout.split('\n')]
                 modified = {f"^/{re.escape(name)}" for name in directories if name}
                 if not modified:
                     # Nothing was modified, do not select anything
-                    self._tests: list['tmt.Test'] = []
                     return
                 self.debug(f"Limit to modified test dirs: {modified}", level=3)
                 names.extend(modified)
             else:
                 self.debug(f"No modified directories between '{modified_ref}..HEAD' found.")
+                # Nothing was modified, do not select anything
+                return
 
         # Initialize the metadata tree, search for available tests
         self.debug(f"Check metadata tree in '{tree_path}'.")

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -569,6 +569,10 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             if output.stdout:
                 directories = [os.path.dirname(name) for name in output.stdout.split('\n')]
                 modified = {f"^/{re.escape(name)}" for name in directories if name}
+                if not modified:
+                    # Nothing was modified, do not select anything
+                    self._tests: list['tmt.Test'] = []
+                    return
                 self.debug(f"Limit to modified test dirs: {modified}", level=3)
                 names.extend(modified)
             else:


### PR DESCRIPTION
Previously it selected all tests. Now it respects that if nothing is modified then nothing is selected.

Fix: #2449

Is this worth of release note? 

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
