### PR TITLE
Add support for multiple disks to testcloud plugin

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -12,6 +12,11 @@ The :ref:`/spec/tests/duration` now supports multiplication.
 Added option ``--failed-only`` to the test attributes,
 enabling rerunning failed tests from previous runs.
 
+The :ref:`virtual<plugins/provision/virtual.testcloud>` provision
+plugin gains support for adding multiple disks to guests, by adding
+the corresponding ``disk[N].size``
+:ref:`HW requirements</spec/hardware/disk>`.
+
 
 tmt-1.33
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/provision/virtual.testcloud/test.sh
+++ b/tests/provision/virtual.testcloud/test.sh
@@ -21,11 +21,11 @@ rlJournalStart
             rlAssertGrep "memory: 2048 MB" "$run/log.txt"
             rlAssertGrep "disk: 10 GB" "$run/log.txt"
             rlAssertGrep "effective hardware: variant #1: memory: == 2048 MB" "$run/log.txt"
-            rlAssertGrep "effective hardware: variant #1: disk.size: == 10 GB" "$run/log.txt"
+            rlAssertGrep "effective hardware: variant #1: disk\\[0\\].size: == 10 GB" "$run/log.txt"
             rlAssertGrep "memory: set to '2048 MB' because of 'memory: == 2048 MB'" "$run/log.txt"
-            rlAssertGrep "disk\\[0\\].size: set to '10 GB' because of 'disk.size: == 10 GB'" "$run/log.txt"
+            rlAssertGrep "disk\\[0\\].size: set to '10 GB' because of 'disk\\[0\\].size: == 10 GB'" "$run/log.txt"
             rlAssertGrep "final domain memory: 2048000" "$run/log.txt"
-            rlAssertGrep "final domain disk size: 10" "$run/log.txt"
+            rlAssertGrep "final domain root disk size: 10" "$run/log.txt"
         fi
     rlPhaseEnd
 
@@ -43,11 +43,11 @@ rlJournalStart
             rlAssertGrep "memory: 2049 MB" "$run/log.txt"
             rlAssertGrep "disk: 11 GB" "$run/log.txt"
             rlAssertGrep "effective hardware: variant #1: memory: == 2049 MB" "$run/log.txt"
-            rlAssertGrep "effective hardware: variant #1: disk.size: == 11 GB" "$run/log.txt"
+            rlAssertGrep "effective hardware: variant #1: disk\\[0\\].size: == 11 GB" "$run/log.txt"
             rlAssertGrep "memory: set to '2049 MB' because of 'memory: == 2049 MB'" "$run/log.txt"
-            rlAssertGrep "disk\\[0\\].size: set to '11 GB' because of 'disk.size: == 11 GB'" "$run/log.txt"
+            rlAssertGrep "disk\\[0\\].size: set to '11 GB' because of 'disk\\[0\\].size: == 11 GB'" "$run/log.txt"
             rlAssertGrep "final domain memory: 2049000" "$run/log.txt"
-            rlAssertGrep "final domain disk size: 11" "$run/log.txt"
+            rlAssertGrep "final domain root disk size: 11" "$run/log.txt"
         fi
     rlPhaseEnd
 
@@ -57,6 +57,31 @@ rlJournalStart
           provision -h virtual.testcloud --image fedora-coreos"; then
          rlRun "cat $run/log.txt" 0 "Dump log.txt"
       fi
+    rlPhaseEnd
+
+    rlPhaseStartTest "Provision a guest with multiple disks"
+        rlRun "cp $SRC_PLAN ."
+
+        if ! rlRun "tmt run -i $run --scratch --all \
+                        provision -h virtual.testcloud \
+                                  --hardware disk[1].size=22GB \
+                                  --hardware disk[2].size=33GB \
+                                  --connection system"; then
+            rlRun "cat $run/log.txt" 0 "Dump log.txt"
+        else
+            rlAssertGrep "effective hardware: variant #1: disk\\[0\\].size: == 10 GB" "$run/log.txt"
+            rlAssertGrep "effective hardware: variant #1: disk\\[1\\].size: == 22 GB" "$run/log.txt"
+            rlAssertGrep "effective hardware: variant #1: disk\\[2\\].size: == 33 GB" "$run/log.txt"
+
+            rlAssertGrep "disk\\[0\\].size: set to '10 GB' because of 'disk\\[0\\].size: == 10 GB'" "$run/log.txt"
+            rlAssertGrep "disk\\[1\\].size: set to '22 GB' because of 'disk\\[1\\].size: == 22 GB'" "$run/log.txt"
+            rlAssertGrep "disk\\[2\\].size: set to '33 GB' because of 'disk\\[2\\].size: == 33 GB'" "$run/log.txt"
+
+            rlAssertGrep "final domain root disk size: 10" "$run/log.txt"
+            rlAssertGrep "final domain disk #0 size: 10" "$run/log.txt"
+            rlAssertGrep "final domain disk #1 size: 22" "$run/log.txt"
+            rlAssertGrep "final domain disk #2 size: 33" "$run/log.txt"
+        fi
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -595,7 +595,7 @@ class Constraint(BaseConstraint, Generic[ConstraintValueT]):
 
         names: list[str] = []
 
-        if components.peer_index:
+        if components.peer_index is not None:
             names.append(f'{components.name.replace("_", "-")}[{components.peer_index}]')
 
         else:

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -161,7 +161,7 @@ INDEXABLE_CONSTRAINTS: tuple[str, ...] = (
     'network'
     )
 
-#: A list oc constraint names that do not have child properties.
+#: A list of constraint names that do not have child properties.
 CHILDLESS_CONSTRAINTS: tuple[str, ...] = (
     'arch',
     'memory',

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -154,6 +154,21 @@ CONSTRAINT_COMPONENTS_PATTERN = re.compile(rf"""
     $                                   # must match the whole string
     """, re.VERBOSE)
 
+
+#: A list of constraint names that operate over sequence of entities.
+INDEXABLE_CONSTRAINTS: tuple[str, ...] = (
+    'disk',
+    'network'
+    )
+
+#: A list oc constraint names that do not have child properties.
+CHILDLESS_CONSTRAINTS: tuple[str, ...] = (
+    'arch',
+    'memory',
+    'hostname'
+    )
+
+
 # Type of the operator callable. The operators accept two arguments, and return
 # a boolean evaluation of relationship of their two inputs.
 OperatorHandlerType = Callable[[Any, Any], bool]

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -521,7 +521,7 @@ def normalize_hardware(
 
                 # Calculate the number of placeholders needed.
                 placeholders = components.peer_index - len(merged[components.name]) + 1
-                
+
                 # Fill in empty spots between the existing ones and the
                 # one we're adding with placeholders.
                 if placeholders > 0:

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -563,7 +563,14 @@ def normalize_hardware(
 
             return new_data
 
-        return tmt.hardware.Hardware.from_spec(_drop_placeholders(merged))
+        # TODO: if the index matters - and it does, because `disk[0]` is
+        # often a "root disk" - we need sparse list. Cannot prune
+        # placeholders now, because it would turn `disk[1]` into `disk[0]`,
+        # overriding whatever was set for the root disk.
+        # https://github.com/teemtee/tmt/issues/3004 for tracking.
+        # merged = _drop_placeholders(merged)
+
+        return tmt.hardware.Hardware.from_spec(merged)
 
     # From fmf
     return tmt.hardware.Hardware.from_spec(raw_hardware)

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1,5 +1,4 @@
 import ast
-import collections
 import dataclasses
 import datetime
 import enum
@@ -493,7 +492,7 @@ def normalize_hardware(
 
     # From command line
     if isinstance(raw_hardware, (list, tuple)):
-        merged: collections.defaultdict[str, Any] = collections.defaultdict(dict)
+        merged: dict[str, Any] = {}
 
         for raw_datum in raw_hardware:
             components = tmt.hardware.ConstraintComponents.from_spec(raw_datum)
@@ -531,16 +530,25 @@ def normalize_hardware(
                     f'{components.operator} {components.value}'
 
             elif components.name == 'cpu' and components.child_name == 'flag':
+                if components.name not in merged:
+                    merged[components.name] = []
+
                 if 'flag' not in merged['cpu']:
                     merged['cpu']['flag'] = []
 
                 merged['cpu']['flag'].append(f'{components.operator} {components.value}')
 
             elif components.child_name:
+                if components.name not in merged:
+                    merged[components.name] = []
+
                 merged[components.name][components.child_name] = \
                     f'{components.operator} {components.value}'
 
             else:
+                if components.name not in merged:
+                    merged[components.name] = []
+
                 merged[components.name] = f'{components.operator} {components.value}'
 
         # Very crude, we will need something better to handle `and` and

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -519,12 +519,13 @@ def normalize_hardware(
                 if components.name not in merged:
                     merged[components.name] = []
 
+                # Calculate the number of placeholders needed.
+                placeholders = components.peer_index - len(merged[components.name]) + 1
+                
                 # Fill in empty spots between the existing ones and the
                 # one we're adding with placeholders.
-                if len(merged[components.name]) <= components.peer_index:
-                    merged[components.name] += [
-                        {} for _ in range(components.peer_index - len(merged[components.name]) + 1)
-                        ]
+                if placeholders > 0:
+                    merged[components.name].extend([{} for _ in range(placeholders)])
 
                 merged[components.name][components.peer_index][components.child_name] = \
                     f'{components.operator} {components.value}'

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -498,7 +498,24 @@ def normalize_hardware(
         for raw_datum in raw_hardware:
             components = tmt.hardware.ConstraintComponents.from_spec(raw_datum)
 
-            if components.name == 'cpu' and components.child_name == 'flag':
+            if components.peer_index is not None:
+                if components.child_name is None:
+                    raise tmt.utils.SpecificationError(
+                        f"Hardware requirement '{raw_datum}' lacks child property.")
+
+                if components.name not in merged:
+                    merged[components.name] = []
+
+                # Fill in empty spots between the existing ones and the one we're adding.
+                if len(merged[components.name]) <= components.peer_index:
+                    merged[components.name] += [
+                        {} for _ in range(components.peer_index - len(merged[components.name]) + 1)
+                        ]
+
+                merged[components.name][components.peer_index][components.child_name] = \
+                    f'{components.operator} {components.value}'
+
+            elif components.name == 'cpu' and components.child_name == 'flag':
                 if 'flag' not in merged['cpu']:
                     merged['cpu']['flag'] = []
 

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -1,11 +1,14 @@
 
+import collections
 import dataclasses
 import datetime
+import itertools
 import os
 import platform
 import re
 import threading
 import types
+from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import click
@@ -690,10 +693,22 @@ class GuestTestcloud(tmt.GuestSsh):
 
             domain.memory_size = int(constraint.value.to('kB').magnitude)
 
-    def _apply_hw_disk_size(self, domain: 'DomainConfiguration') -> 'QCow2StorageDevice':
+    def _apply_hw_disk_size(self, domain: 'DomainConfiguration') -> None:
         """ Apply ``disk`` constraint to given VM domain """
 
         final_size: 'Size' = DEFAULT_DISK
+
+        def _generate_disk_filepaths() -> Iterator[Path]:
+            """ Generate paths to use for files representing VM storage """
+
+            # Start with the path already decided by testcloud...
+            yield Path(domain.local_disk)
+
+            # ... and use it as a basis for remaining paths.
+            for i in itertools.count(1, 1):
+                yield Path(f'{domain.local_disk}.{i}')
+
+        disk_filepath_generator = _generate_disk_filepaths()
 
         if not self.hardware or not self.hardware.constraint:
             self.debug(
@@ -701,10 +716,17 @@ class GuestTestcloud(tmt.GuestSsh):
                 f"set to '{final_size}' because of no constraints",
                 level=4)
 
-            return QCow2StorageDevice(domain.local_disk, int(final_size.to('GB').magnitude))
+            domain.storage_devices = [
+                QCow2StorageDevice(
+                    str(next(disk_filepath_generator)),
+                    int(final_size.to('GB').magnitude))
+                ]
+
+            return
 
         variant = self.hardware.constraint.variant()
 
+        # Collect all `disk.size` constraints, ignore the rest.
         disk_size_constraints = [
             constraint
             for constraint in variant
@@ -718,7 +740,17 @@ class GuestTestcloud(tmt.GuestSsh):
                 f"set to '{final_size}' because of no 'disk.size' constraints",
                 level=4)
 
-            return QCow2StorageDevice(domain.local_disk, int(final_size.to('GB').magnitude))
+            domain.storage_devices = [
+                QCow2StorageDevice(
+                    str(next(disk_filepath_generator)),
+                    int(final_size.to('GB').magnitude))
+                ]
+
+            return
+
+        # Now sort them into groups by their `peer_index`, i.e. `disk[0]`,
+        # `disk[1]` and so on.
+        by_peer_index: dict[int, list[tmt.hardware.SizeConstraint]] = collections.defaultdict(list)
 
         for constraint in disk_size_constraints:
             if constraint.operator not in (
@@ -728,14 +760,31 @@ class GuestTestcloud(tmt.GuestSsh):
                 raise ProvisionError(
                     f"Cannot apply hardware requirement '{constraint}', operator not supported.")
 
-            self.debug(
-                'disk[0].size',
-                f"set to '{constraint.value}' because of '{constraint}'",
-                level=4)
+            components = constraint.expand_name()
 
-            final_size = constraint.value
+            assert components.peer_index is not None  # narrow type
 
-        return QCow2StorageDevice(domain.local_disk, int(final_size.to('GB').magnitude))
+            by_peer_index[components.peer_index].append(constraint)
+
+        # Process each disk and its constraints, construct the
+        # corresponding storage device, and the last constraint wins
+        # & sets its size.
+        for peer_index in sorted(by_peer_index.keys()):
+            final_size = DEFAULT_DISK
+
+            for constraint in by_peer_index[peer_index]:
+                self.debug(
+                    f'disk[{peer_index}].size',
+                    f"set to '{constraint.value}' because of '{constraint}'",
+                    level=4)
+
+                final_size = constraint.value
+
+            domain.storage_devices.append(
+                QCow2StorageDevice(
+                    str(next(disk_filepath_generator)),
+                    int(final_size.to('GB').magnitude))
+                )
 
     def _apply_hw_arch(self, domain: 'DomainConfiguration', kvm: bool, legacy_os: bool) -> None:
         if self.arch == "x86_64":
@@ -826,11 +875,14 @@ class GuestTestcloud(tmt.GuestSsh):
                 self._logger.debug('effective hardware', line, level=4)
 
         self._apply_hw_memory(self._domain)
-        storage_image = self._apply_hw_disk_size(self._domain)
+        self._apply_hw_disk_size(self._domain)
         _apply_hw_tpm(self.hardware, self._domain, self._logger)
 
         self.debug('final domain memory', str(self._domain.memory_size))
-        self.debug('final domain disk size', str(storage_image.size))
+        self.debug('final domain root disk size', str(self._domain.storage_devices[0].size))
+
+        for i, device in enumerate(self._domain.storage_devices):
+            self.debug(f'final domain disk #{i} size', str(device.size))
 
         # Is this a CoreOS?
         self._domain.coreos = self.is_coreos
@@ -851,8 +903,6 @@ class GuestTestcloud(tmt.GuestSsh):
                 device_type=device_type)
         else:
             raise tmt.utils.ProvisionError("Only system, or session connection is supported.")
-
-        self._domain.storage_devices.append(storage_image)
 
         if not self._domain.coreos:
             seed_disk = RawStorageDevice(self._domain.seed_path)


### PR DESCRIPTION
```
TMT_SHOW_TRACEBACK=1 tmt -vv run plans --default \
    provision --how virtual --image fedora-39 \
              --hardware 'disk[1].size=20GB' \
              --hardware 'disk[0].size=15GB' \
    login -s provision \
    finish
```

Fixes https://github.com/teemtee/tmt/issues/2765

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [x] mention the version
* [x] include a release note
