### PR TITLE
Make `junit_xml` more visible to linters

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1023,18 +1023,19 @@ def test_wait_success_but_too_late(root_logger):
 
 def test_import_member(root_logger):
     klass = tmt.plugins.import_member(
-        module_name='tmt.steps.discover', member_name='Discover', logger=root_logger)
+        module='tmt.steps.discover', member='Discover', logger=root_logger)[1]
 
     assert klass is tmt.steps.discover.Discover
 
 
 def test_import_member_no_such_module(root_logger):
     with pytest.raises(
-            tmt.utils.GeneralError,
-            match=r"Failed to import module 'tmt\.steps\.nope_does_not_exist'."):
+            SystemExit,
+            match=rf"Failed to import the 'tmt\.steps\.nope_does_not_exist'"
+                  rf" module from '{Path.cwd()}'."):
         tmt.plugins.import_member(
-            module_name='tmt.steps.nope_does_not_exist',
-            member_name='Discover',
+            module='tmt.steps.nope_does_not_exist',
+            member='Discover',
             logger=root_logger)
 
 
@@ -1043,8 +1044,8 @@ def test_import_member_no_such_class(root_logger):
             tmt.utils.GeneralError,
             match=r"No such member 'NopeDoesNotExist' in module 'tmt\.steps\.discover'."):
         tmt.plugins.import_member(
-            module_name='tmt.steps.discover',
-            member_name='NopeDoesNotExist',
+            module='tmt.steps.discover',
+            member='NopeDoesNotExist',
             logger=root_logger)
 
 

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -3278,9 +3278,9 @@ class SerializableContainer(DataContainer):
 
         klass_info = serialized.pop('__class__')
         klass = import_member(
-            module_name=klass_info['module'],
-            member_name=klass_info['name'],
-            logger=logger)
+            module=klass_info['module'],
+            member=klass_info['name'],
+            logger=logger)[1]
 
         # Stay away from classes that are not derived from this one, to
         # honor promise given by return value annotation.
@@ -5650,9 +5650,9 @@ def _prenormalize_fmf_node(node: fmf.Tree, schema_name: str, logger: tmt.log.Log
         step_class_name = step_name.capitalize()
 
         step_class = import_member(
-            module_name=step_module_name,
-            member_name=step_class_name,
-            logger=logger)
+            module=step_module_name,
+            member=step_class_name,
+            logger=logger)[1]
 
         if not issubclass(step_class, tmt.steps.Step):
             raise GeneralError(


### PR DESCRIPTION
With a bit of module import refactoring, `junit_xml` is now imported and annotated enough for it to be recognized correctly by both type checkers, mypy and pyright.

Pull Request Checklist

* [x] implement the feature