### PR TITLE
Support Alpine Linux `apk` package manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 
 # Prepare variables
 TMP = $(CURDIR)/tmp
+UNIT_TESTS_IMAGE_TAG = tmt-unit-tests
 
 # Define special targets
 .DEFAULT_GOAL := help
@@ -81,6 +82,11 @@ ver2spec:
 images:  ## Build tmt images for podman/docker
 	podman build -t tmt --squash -f ./containers/Containerfile.mini .
 	podman build -t tmt-all --squash -f ./containers/Containerfile.full .
+
+images-unit-tests: image-alpine  ## Build images for unit tests
+
+image-alpine:  ## Build local alpine image for unit tests
+	podman build -t alpine:$(UNIT_TESTS_IMAGE_TAG) -f ./containers/Containerfile.alpine .
 
 ##
 ## Development

--- a/containers/Containerfile.alpine
+++ b/containers/Containerfile.alpine
@@ -1,0 +1,4 @@
+FROM docker.io/library/alpine:latest
+
+# tmt requires `bash` to be installed
+RUN apk add --no-cache bash

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -28,8 +28,9 @@ Internal implementation of basic package manager actions has been
 refactored. tmt now supports package implementations to be shipped as
 plugins, therefore allowing for tmt to work natively with distributions
 beyond the ecosystem of rpm-based distributions. As a preview, ``apt``,
-the package manager used by Debian and Ubuntu, has been included in this
-release.
+the package manager used by Debian and Ubuntu, ``rpm-ostree``, the
+package manager used by ``rpm-ostree``-based Linux systems and ``apk``,
+the package manager of Alpine Linux have been included in this release.
 
 New environment variable ``TMT_TEST_ITERATION_ID`` has been added to
 :ref:`test-variables`. This variable is a combination of a unique

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ lint = ["autopep8 {args:.}", "ruff --fix {args:.}"]
 type = ["mypy {args:tmt}"]
 check = ["lint", "type"]
 
-unit = "pytest -vvv -ra --showlocals -n 0 tests/unit"
+unit = "make images-unit-tests && pytest -vvv -ra --showlocals -n 0 tests/unit"
 smoke = "pytest -vvv -ra --showlocals -n 0 tests/unit/test_cli.py"
 cov = [
     "coverage run --source=tmt -m pytest -vvv -ra --showlocals -n 0 tests",

--- a/tests/unit/test.sh
+++ b/tests/unit/test.sh
@@ -35,6 +35,8 @@ rlJournalStart
 
         rlLogInfo "pip is $(which pip), $(pip --version)"
         rlLogInfo "hatch is $(which hatch), $(hatch --version)"
+
+        rlRun "make -C $TMT_TREE images-unit-tests"
     rlPhaseEnd
 
     if [ "$WITH_SYSTEM_PACKAGES" = "yes" ]; then

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -1,0 +1,163 @@
+import re
+from typing import Optional, Union
+
+import tmt.package_managers
+import tmt.utils
+from tmt.package_managers import (
+    FileSystemPath,
+    Installable,
+    Options,
+    Package,
+    PackagePath,
+    escape_installables,
+    provides_package_manager,
+    )
+from tmt.utils import (
+    Command,
+    CommandOutput,
+    GeneralError,
+    RunError,
+    ShellScript,
+    )
+
+ReducedPackages = list[Union[Package, PackagePath]]
+
+PACKAGE_PATH: dict[FileSystemPath, str] = {
+    FileSystemPath('/usr/bin/arch'): 'busybox',
+    FileSystemPath('/usr/bin/flock'): 'flock'
+    }
+
+
+@provides_package_manager('apk')
+class Apk(tmt.package_managers.PackageManager):
+    probe_command = Command('apk', '--version')
+
+    install_command = Command('add')
+
+    _sudo_prefix: Command
+
+    def prepare_command(self) -> tuple[Command, Command]:
+        """ Prepare installation command for apk """
+
+        if self.guest.facts.is_superuser is False:
+            self._sudo_prefix = Command('sudo')
+
+        else:
+            self._sudo_prefix = Command()
+
+        command = Command()
+
+        command += self._sudo_prefix
+        command += Command('apk')
+
+        return (command, Command())
+
+    def path_to_package(self, path: FileSystemPath) -> Package:
+        """
+        Find a package providing given filesystem path.
+
+        This is not easily possible in Alpine. There is `apk-file` utility
+        available but it seems unrealiable. Support only a fixed set
+        of mappings until a better solution is available.
+        """
+
+        if path in PACKAGE_PATH:
+            return Package(PACKAGE_PATH[path])
+
+        raise GeneralError(f"Unsupported package path '{path} for Alpine Linux.")
+
+    def _reduce_to_packages(self, *installables: Installable) -> ReducedPackages:
+        packages: ReducedPackages = []
+
+        for installable in installables:
+            if isinstance(installable, (Package, PackagePath)):
+                packages.append(installable)
+
+            elif isinstance(installable, FileSystemPath):
+                packages.append(self.path_to_package(installable))
+
+            else:
+                raise GeneralError(f"Package specification '{installable}' is not supported.")
+
+        return packages
+
+    def _construct_presence_script(
+            self, *installables: Installable) -> tuple[ReducedPackages, ShellScript]:
+        reduced_packages = self._reduce_to_packages(*installables)
+
+        shell_script = ShellScript(
+            f'apk info -e {" ".join(escape_installables(*reduced_packages))}')
+
+        return reduced_packages, shell_script
+
+    def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
+        reduced_packages, presence_script = self._construct_presence_script(*installables)
+
+        try:
+            output = self.guest.execute(presence_script)
+            stdout, stderr = output.stdout, output.stderr
+
+        except RunError as exc:
+            stdout, stderr = exc.stdout, exc.stderr
+
+        if stdout is None or stderr is None:
+            raise GeneralError("apk presence check output provided no output")
+
+        results: dict[Installable, bool] = {}
+
+        for installable, package in zip(installables, reduced_packages):
+            match = re.search(rf'^{re.escape(str(package))}\s', stdout)
+
+            if match is not None:
+                results[installable] = True
+                continue
+
+            results[installable] = False
+
+        return results
+
+    def install(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        options = options or Options()
+
+        packages = self._reduce_to_packages(*installables)
+
+        script = ShellScript(
+            f'{self.command.to_script()} {self.install_command.to_script()} '
+            f'{" ".join(escape_installables(*packages))}')
+
+        if options.check_first:
+            script = self._construct_presence_script(*packages)[1] | script
+
+        if options.skip_missing:
+            script = script | ShellScript('/bin/true')
+
+        return self.guest.execute(script)
+
+    def reinstall(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        options = options or Options()
+
+        packages = self._reduce_to_packages(*installables)
+
+        script = ShellScript(
+            f'{self.command.to_script()} fix '
+            f'{" ".join(escape_installables(*packages))}')
+
+        if options.check_first:
+            script = self._construct_presence_script(*packages)[1] & script
+
+        if options.skip_missing:
+            script = script | ShellScript('/bin/true')
+
+        return self.guest.execute(script)
+
+    def install_debuginfo(
+            self,
+            *installables: Installable,
+            options: Optional[Options] = None) -> CommandOutput:
+        raise tmt.utils.GeneralError("There is no support for debuginfo packages in apk.")


### PR DESCRIPTION
Add support for `apk` package manager from Alpine Linux.

Unsupported debuginfo installation, seems not have a nice `debuginfo-install`-like solution.

Installing by path is limited to certain recognized paths. The existing `apk-file` solution looks flakey, it was randomly hanging and does not have a good machine readable output.

For testing we need to use a locally build alpine image which contains required packages of tmt and the unit tests.

Resolves #2694

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] include a release note
