### PR TITLE
Correctly show the `--provision-timeout` default

### DIFF
--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -573,7 +573,7 @@ class BeakerGuestData(tmt.steps.provision.GuestSshData):
         default=DEFAULT_PROVISION_TIMEOUT,
         option='--provision-timeout',
         metavar='SECONDS',
-        help="""
+        help=f"""
              How long to wait for provisioning to complete,
              {DEFAULT_PROVISION_TIMEOUT} seconds by default.
              """,


### PR DESCRIPTION
Add forgotten f-string to properly render the default value in the `--help` message.