### PR TITLE
Fix error message if no supported package manager found

### DIFF
--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -704,9 +704,13 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
                 exclude=self.data.exclude,
                 guest=guest)
 
+        elif guest.facts.package_manager is None:
+            raise tmt.utils.PrepareError('Unrecognized package manager.')
+
         else:
             raise tmt.utils.PrepareError(
-                f'Package manager "{guest.facts.package_manager}" is not supported.')
+                f"Package manager '{guest.facts.package_manager}' "
+                "is not supported by 'prepare/install'.")
 
         # Enable copr repositories...
         if isinstance(installer, Copr):


### PR DESCRIPTION
```
Unrecognized package manager.
```

Or:

```
Package manager 'foo' is not supported by 'prepare/install'.
```

when the package manager has been detected, but is not supported by
`prepare/install`.

I like this error more than:

```
Package manager "None" is not supported.
```

Pull Request Checklist

* [x] implement the feature
