### PR TITLE
Use `attrs`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     ]
 dependencies = [              # F39 / PyPI
+    "attrs",
     "click>=8.0.3,!=8.1.4",   # 8.1.3 / 8.1.6 TODO type annotations tmt.cli.Context -> click.core.Context click/issues/2558
     "docutils>=0.16",         # 0.16 is the current one available for RHEL9
     "fmf>=1.3.0",

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -1,7 +1,7 @@
 import copy
-import dataclasses
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, Union, cast
 
+import attrs
 import click
 import fmf
 
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     import tmt.cli
 
 
-@dataclasses.dataclass
+@attrs.define
 class FinishStepData(tmt.steps.WhereableStepData, tmt.steps.StepData):
     pass
 


### PR DESCRIPTION
Testing out how hard it would be to replace `dataclass` with `attrs`

- Replace standalone `dataclass`: Trivial
- `attrs.define` subclassing `dataclasses.dataclass`:
  - `__init__` kwargs are not inheritted
- Converting `tmt.utils.field`: unknown
  - How to simplify type-checking and forward all kwargs to `click`/`metadata`/`attrs.field` 
- Converting `tmt.utils.FieldMetadata`: unknown
- Converting `tmt.utils.DataContainer`: unknown

---

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
