### PR TITLE
Improve fail message when library doesn't exist

### DIFF
--- a/tests/discover/libraries/data/certificate.fmf
+++ b/tests/discover/libraries/data/certificate.fmf
@@ -63,6 +63,13 @@ test: ./certificate.sh
         require:
           - url: https://github.com/psss/try
             type: library
+    /node-metadata:
+        summary: Path exists but node of such name does not
+        require:
+          - url: https://github.com/teemtee/tests
+            type: library
+            name: /dir-without-fmf
+            path: /nested
     /reference:
         summary: Requested reference does not exist
         require:

--- a/tests/discover/libraries/data/plan.fmf
+++ b/tests/discover/libraries/data/plan.fmf
@@ -64,6 +64,11 @@ execute:
             summary: "Missing reference"
             discover+:
                 test: missing/reference
+        /node-metadata:
+            summary: "Missing node with such name, but path exists"
+            discover+:
+                test: missing/node-metadata
+
 
 /querying:
     summary: "Many tests requiring same rpm-only library"

--- a/tests/discover/libraries/test.sh
+++ b/tests/discover/libraries/test.sh
@@ -40,6 +40,9 @@ rlJournalStart
         rlAssertGrep 'Repository .* does not contain fmf metadata.' $rlRun_LOG
         rlRun -s "$tmt missing/reference" 2
         rlAssertGrep 'Reference .* not found.' $rlRun_LOG
+        rlRun -s "$tmt missing/node-metadata" 2
+        rlAssertGrep 'Library with fmf_id=' $rlRun_LOG
+        rlAssertNotGrep 'has no attribute' $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Deep"

--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -330,7 +330,17 @@ class BeakerLib(Library):
                     shutil.copytree(library_path, local_library_path, dirs_exist_ok=True)
 
                     # Remove metadata file(s) and create one with full data
-                    self._merge_metadata(library_path, local_library_path)
+                    # Node with library might not exist, provide usable error message
+                    try:
+                        self._merge_metadata(library_path, local_library_path)
+                    except tmt.utils.MetadataError as error:
+                        fmf_id = ', '.join([s for s in [
+                            f'name: {self.name}' if self.name else None,
+                            f'url: {self.url}' if self.url else None,
+                            f'ref: {self.ref}' if self.ref else None,
+                            f'path: {self.path}' if self.path else None] if s is not None])
+                        raise tmt.utils.SpecificationError(
+                            f"Library with {fmf_id=} doesn't exist.") from error
 
                     # Copy fmf metadata
                     shutil.copytree(clone_dir / '.fmf', directory / '.fmf', dirs_exist_ok=True)

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2580,7 +2580,10 @@ def get_full_metadata(fmf_tree_path: Path, node_path: str) -> Any:
     Go through fmf tree nodes using given relative node path
     and return full data as dictionary.
     """
-    return fmf.Tree(fmf_tree_path).find(node_path).data
+    try:
+        return fmf.Tree(fmf_tree_path).find(node_path).data
+    except AttributeError:
+        raise MetadataError(f"'{node_path}' not found in the '{fmf_tree_path}' Tree.")
 
 
 def filter_paths(directory: Path, searching: list[str], files_only: bool = False) -> list[Path]:


### PR DESCRIPTION
When /foo doesn't exist in the fmf root tmt should provide better error than saying `AttributeError: 'NoneType' object has no attribute 'data'`

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
