### PR TITLE
Log hash of the beakerlib library repo

### DIFF
--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -220,13 +220,16 @@ class BeakerLib(Library):
                         raise LibraryError
                     with TemporaryDirectory() as tmp:
                         assert self.url is not None  # narrow type
+                        destination = Path(tmp)
                         try:
                             tmt.utils.git_clone(
                                 url=self.url,
-                                destination=Path(tmp),
+                                destination=destination,
                                 shallow=True,
                                 env=Environment({"GIT_ASKPASS": EnvVarValue("echo")}),
                                 logger=self._logger)
+                            self.parent.debug('hash', tmt.utils.git_hash(
+                                directory=destination, logger=self._logger))
                         except (tmt.utils.RunError, tmt.utils.RetryError):
                             self.parent.debug(f"Repository '{self.url}' not found.")
                             self._nonexistent_url.add(self.url)
@@ -312,6 +315,10 @@ class BeakerLib(Library):
                         self.parent.fail(
                             f"Reference '{self.ref}' for library '{self}' not found.")
                         raise
+
+                    # Log what HEAD really is
+                    self.parent.debug('hash', tmt.utils.git_hash(
+                        directory=clone_dir, logger=self._logger))
 
                     # Copy only the required library
                     library_path: Path = clone_dir / str(self.fmf_node_path).strip('/')

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -1,3 +1,4 @@
+import contextlib
 import dataclasses
 import glob
 import os
@@ -431,13 +432,12 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
 
         # Show current commit hash if inside a git repository
         if self.testdir.is_dir():
-            try:
-                output = self.run(Command("git", "rev-parse", "--short", "HEAD"),
-                                  cwd=self.testdir)
-                if output.stdout is not None:
-                    self.verbose('hash', output.stdout.strip(), 'green')
-            except (tmt.utils.RunError, AttributeError):
-                pass
+            with contextlib.suppress(tmt.utils.RunError, AttributeError):
+                self.verbose(
+                    'hash',
+                    tmt.utils.git_hash(directory=self.testdir, logger=self._logger),
+                    'green'
+                    )
 
         # Dist-git source processing during discover step
         if dist_git_source:

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -308,6 +308,12 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin[DiscoverShellData]):
             self.debug(f"Checkout ref '{ref}'.")
             self.run(Command('git', 'checkout', '-f', ref), cwd=testdir)
 
+        # Log where HEAD leads to
+        self.debug('hash', tmt.utils.git_hash(
+            directory=testdir,
+            logger=self._logger
+            ))
+
         # Remove .git so that it's not copied to the SUT
         # if 'keep-git-metadata' option is not specified
         if not keep_git_metadata:

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -4426,6 +4426,26 @@ def remove_color(text: str) -> str:
     return re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', '', text)
 
 
+def git_hash(*, directory: Path, logger: tmt.log.Logger) -> Optional[str]:
+    """
+    Return short hash of current HEAD in the git repo in directory.
+
+    :param directory: path to a local git repository.
+    :param logger: used for logging.
+    :returns: short hash as string
+    """
+    cmd = Command("git", "rev-parse", "--short", "HEAD")
+    result = cmd.run(cwd=directory, logger=logger)
+
+    if result.stdout is None:
+        raise RunError(message="No output from 'git' when looking for the hash of HEAD.",
+                       command=cmd,
+                       returncode=0,
+                       stderr=result.stderr)
+
+    return result.stdout.strip()
+
+
 def git_root(*, fmf_root: Path, logger: tmt.log.Logger) -> Optional[Path]:
     """
     Find a path to the root of git repository containing an fmf root.


### PR DESCRIPTION
Make common tmt.utils.git_hash function to have single way of getting this information

Pull Request Checklist

* [x] implement the feature
