### PR TITLE
Fix incorrect translation of `cpu.processors` to Beaker

### DIFF
--- a/tests/unit/provision/mrack/test_hw.py
+++ b/tests/unit/provision/mrack/test_hw.py
@@ -105,7 +105,7 @@ def test_maximal_constraint(root_logger: Logger) -> None:
                 'and': [
                     {
                         'cpu': {
-                            'cpu_count': {
+                            'processors': {
                                 '_op': '>',
                                 '_value': '8'
                                 }
@@ -280,7 +280,7 @@ def test_cpu_processors(root_logger: Logger) -> None:
 
     assert result.to_mrack() == {
         'cpu': {
-            'cpu_count': {
+            'processors': {
                 '_op': '==',
                 '_value': '79'
                 }

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -258,7 +258,7 @@ def _transform_cpu_processors(
 
     return MrackHWGroup(
         'cpu',
-        children=[MrackHWBinOp('cpu_count', beaker_operator, actual_value)])
+        children=[MrackHWBinOp('processors', beaker_operator, actual_value)])
 
 
 def _transform_disk_driver(


### PR DESCRIPTION
Pull Request Checklist

* [x] implement the feature