### PR TITLE
Refactor package manager discovery to allow priorities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,10 +83,13 @@ images:  ## Build tmt images for podman/docker
 	podman build -t tmt --squash -f ./containers/Containerfile.mini .
 	podman build -t tmt-all --squash -f ./containers/Containerfile.full .
 
-images-unit-tests: image-alpine  ## Build images for unit tests
+images-unit-tests: image-unit-tests-alpine image-unit-tests-coreos  ## Build images for unit tests
 
-image-alpine:  ## Build local alpine image for unit tests
+image-unit-tests-alpine:  ## Build local alpine image for unit tests
 	podman build -t alpine:$(UNIT_TESTS_IMAGE_TAG) -f ./containers/Containerfile.alpine .
+
+image-unit-tests-coreos:  ## Build local CoreOS image for unit tests
+	podman build -t fedora-coreos:$(UNIT_TESTS_IMAGE_TAG) -f ./containers/Containerfile.coreos .
 
 ##
 ## Development

--- a/containers/Containerfile.coreos
+++ b/containers/Containerfile.coreos
@@ -1,0 +1,4 @@
+FROM quay.io/fedora/fedora-coreos:stable
+
+# Inject dnf to make things more complicated for rpm-ostree package manager implementation
+RUN rpm-ostree install dnf5

--- a/tests/provision/facts/test-runner.sh
+++ b/tests/provision/facts/test-runner.sh
@@ -19,7 +19,7 @@ rlJournalStart
 
         kernel="$(uname -r)"
 
-        package_manager="dnf\|yum"
+	package_manager="\(dnf\|dnf5\|yum\)"
 
         grep "selinuxfs" /proc/filesystems &> /dev/null
         if [ $? -eq 1 ]; then

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -42,8 +42,10 @@ CONTAINER_FEDORA_39 = Container(url='registry.fedoraproject.org/fedora:39')
 CONTAINER_CENTOS_STREAM_8 = Container(url='quay.io/centos/centos:stream8')
 CONTAINER_CENTOS_7 = Container(url='quay.io/centos/centos:7')
 CONTAINER_UBUNTU_2204 = Container(url='docker.io/library/ubuntu:22.04')
-CONTAINER_FEDORA_COREOS = Container(url='quay.io/fedora/fedora-coreos:stable')
-# Local image created via `make image-alpine`, reference to local registry
+# Local image created via `make image-unit-tests-coreos`, reference to local registry
+CONTAINER_FEDORA_COREOS = Container(
+    url='containers-storage:localhost/fedora-coreos:tmt-unit-tests')
+# Local image created via `make image-unit-tests-alpine`, reference to local registry
 CONTAINER_ALPINE = Container(url='containers-storage:localhost/alpine:tmt-unit-tests')
 
 PACKAGE_MANAGER_DNF5 = tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.get_plugin('dnf5')
@@ -55,6 +57,11 @@ PACKAGE_MANAGER_RPMOSTREE = tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTR
 PACKAGE_MANAGER_APK = tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.get_plugin('apk')
 
 
+# Note: keep the list ordered by the most desired packag manager to the
+# least desired one. For most of the tests, the order is not important,
+# but the list is used to generate the discovery tests as well, and the
+# order is used to find out what package manager is expected to be
+# discovered.
 CONTAINER_BASE_MATRIX = [
     # Fedora
     (CONTAINER_FEDORA_RAWHIDE, PACKAGE_MANAGER_DNF5),
@@ -86,6 +93,15 @@ CONTAINER_MATRIX_IDS = [
     f'{container.url} / {package_manager_class.__name__.lower()}'
     for container, package_manager_class in CONTAINER_BASE_MATRIX
     ]
+
+
+CONTAINER_DISCOVERY_MATRIX: dict[str, tuple[Container, PackageManagerClass]] = {}
+
+for container, package_manager_class in CONTAINER_BASE_MATRIX:
+    if container.url in CONTAINER_DISCOVERY_MATRIX:
+        continue
+
+    CONTAINER_DISCOVERY_MATRIX[container.url] = (container, package_manager_class)
 
 
 @pytest.fixture(name='guest')
@@ -147,6 +163,47 @@ def create_package_manager(
         guest.execute(ShellScript('apt update'))
 
     return package_manager_class(guest=guest, logger=logger)
+
+
+def _parametrize_test_discovery() -> Iterator[tuple[ContainerData, PackageManagerClass]]:
+    yield from CONTAINER_DISCOVERY_MATRIX.values()
+
+
+@pytest.mark.containers()
+@pytest.mark.parametrize(('container',
+                          'expected_package_manager'),
+                         list(_parametrize_test_discovery()),
+                         indirect=["container"],
+                         ids=[
+                             container.url
+                             for container, _
+                             in CONTAINER_DISCOVERY_MATRIX.values()
+    ])
+def test_discovery(
+        container: ContainerData,
+        guest: GuestContainer,
+        expected_package_manager: PackageManagerClass,
+        root_logger: tmt.log.Logger,
+        caplog: _pytest.logging.LogCaptureFixture) -> None:
+
+    def _test_discovery(expected: str) -> None:
+        guest.facts.sync(guest)
+
+        assert guest.facts.package_manager == expected
+
+    # Images in which `dnf5`` would be the best possible choice, do not
+    # come with `dnf5`` pe-installed. Therefore run the discovery first,
+    # but expect to find *dnf* instead of `dnf5`. Then install `dnf5`,
+    # re-run the discovery and expect the original outcome.
+    if expected_package_manager is tmt.package_managers.dnf.Dnf5:
+        _test_discovery(tmt.package_managers.dnf.Dnf.NAME)
+
+        guest.execute(ShellScript('dnf install --nogpgcheck -y dnf5'))
+
+        _test_discovery(expected_package_manager.NAME)
+
+    else:
+        _test_discovery(expected_package_manager.NAME)
 
 
 def _parametrize_test_install() -> \

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -144,9 +144,18 @@ class Options:
 class PackageManager(tmt.utils.Common):
     """ A base class for package manager plugins """
 
+    NAME: str
+
     #: A command to run to check whether the package manager is available on
     #: a guest.
     probe_command: Command
+
+    #: Package managers with higher value would be preferred when more
+    #: one package manager is detected on guest. For most of the time,
+    #: the default is sufficient, but some families of package managers
+    #: (looking at you, ``yum``, ``dnf``, ``dnf5``, ``rpm-ostree``!)
+    #: may be installed togethers, and therefore a priority is needed.
+    probe_priority: int = 0
 
     command: Command
     options: Command

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -33,6 +33,8 @@ PACKAGE_PATH: dict[FileSystemPath, str] = {
 
 @provides_package_manager('apk')
 class Apk(tmt.package_managers.PackageManager):
+    NAME = 'apk'
+
     probe_command = Command('apk', '--version')
 
     install_command = Command('add')

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -27,6 +27,8 @@ ReducedPackages = list[Union[Package, PackagePath]]
 
 @provides_package_manager('apt')
 class Apt(tmt.package_managers.PackageManager):
+    NAME = 'apt'
+
     probe_command = Command('apt', '--version')
 
     install_command = Command('install')

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -14,7 +14,13 @@ from tmt.utils import Command, CommandOutput, GeneralError, RunError, ShellScrip
 
 @provides_package_manager('dnf')
 class Dnf(tmt.package_managers.PackageManager):
+    NAME = 'dnf'
+
     probe_command = Command('dnf', '--version')
+    # The priority of preference: `rpm-ostree` > `dnf5` > `dnf` > `yum`.
+    # `rpm-ostree` has its own implementation and its own priority, and
+    # the `dnf` family just stays below it.
+    probe_priority = 50
 
     _base_command = Command('dnf')
 
@@ -149,7 +155,10 @@ class Dnf(tmt.package_managers.PackageManager):
 
 @provides_package_manager('dnf5')
 class Dnf5(Dnf):
-    probe_command = Command('dnf5', '--version')
+    NAME = 'dnf5'
+
+    probe_command = probe_command = Command('dnf5', '--version')
+    probe_priority = 60
 
     _base_command = Command('dnf5')
     skip_missing_option = '--skip-unavailable'
@@ -157,7 +166,10 @@ class Dnf5(Dnf):
 
 @provides_package_manager('yum')
 class Yum(Dnf):
-    probe_command = Command('yum', '--version')
+    NAME = 'yum'
+
+    probe_command = probe_command = Command('yum', '--version')
+    probe_priority = 40
 
     _base_command = Command('yum')
 

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -15,7 +15,11 @@ from tmt.utils import Command, CommandOutput, GeneralError, RunError, ShellScrip
 
 @provides_package_manager('rpm-ostree')
 class RpmOstree(tmt.package_managers.PackageManager):
-    probe_command = Command('stat', '/run/ostree-booted')
+    NAME = 'rpm-ostree'
+
+    probe_command = ShellScript('stat /etc/ostree-booted || type rpm-ostree').to_shell_command()
+    # Needs to be bigger than priorities of `yum`, `dnf` and `dnf5`.
+    probe_priority = 100
 
     def prepare_command(self) -> tuple[Command, Command]:
         """ Prepare installation command for rpm-ostree"""

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -17,7 +17,7 @@ from tmt.utils import Command, CommandOutput, GeneralError, RunError, ShellScrip
 class RpmOstree(tmt.package_managers.PackageManager):
     NAME = 'rpm-ostree'
 
-    probe_command = ShellScript('stat /etc/ostree-booted || type rpm-ostree').to_shell_command()
+    probe_command = Command('stat', '/run/ostree-booted')
     # Needs to be bigger than priorities of `yum`, `dnf` and `dnf5`.
     probe_priority = 100
 


### PR DESCRIPTION
This has been reported in #2858, `dnf` was detected instead of `rpm-ostree` in CoreOS-like image. This was caused by now undefined order of package manager discovery, depending on the order in which plugins were discovered.

Thsi patch adds priorities for package manager families to let them control preferred package manager when multiple were discovered. And a test is added to guard this behavior.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage