### PR TITLE
Override test metada from plan using `adjust-tests`

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -18,10 +18,6 @@ option or with the environment variable ``TMT_FEELING_SAFE`` set
 to ``True``. See the :ref:`/stories/features/feeling-safe` section
 for more details and motivation behind this change.
 
-When plan discovers tests using :ref:`/plugins/discover/fmf` plugin
-it is possible to modify metadata of such discovered tests with the
-``adjust-tests`` option specified in the plan itself.
-
 The :ref:`/plugins/discover/fmf` discover plugin now supports
 a new ``adjust-tests`` key which allows modifying metadata of all
 discovered tests. This can be useful especially when fetching

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -22,6 +22,12 @@ When plan discovers tests using :ref:`/plugins/discover/fmf` plugin
 it is possible to modify metadata of such discovered tests with the
 ``adjust-tests`` option specified in the plan itself.
 
+The :ref:`/plugins/discover/fmf` discover plugin now supports
+a new ``adjust-tests`` key which allows modifying metadata of all
+discovered tests. This can be useful especially when fetching
+tests from remote repositories where the user does not have write
+access.
+
 
 tmt-1.37.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -18,6 +18,10 @@ option or with the environment variable ``TMT_FEELING_SAFE`` set
 to ``True``. See the :ref:`/stories/features/feeling-safe` section
 for more details and motivation behind this change.
 
+When plan discovers tests using :ref:`/plugins/discover/fmf` plugin
+it is possible to modify metadata of such discovered tests with the
+``adjust-tests`` option specified in the plan itself.
+
 
 tmt-1.37.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 dependencies = [              # F39 / PyPI
     "click>=8.0.3,!=8.1.4",   # 8.1.3 / 8.1.6 TODO type annotations tmt.cli.Context -> click.core.Context click/issues/2558
     "docutils>=0.16",         # 0.16 is the current one available for RHEL9
-    "fmf>=1.3.0",
+    "fmf>=1.4.0",
     "jinja2>=2.11.3",         # 3.1.2 / 3.1.2
     "packaging>=20",          # 20 seems to be available with RHEL8
     "pint>=0.16.1",           # 0.16.1
@@ -87,7 +87,7 @@ docs = [
     "readthedocs-sphinx-ext",
     "docutils>=0.18.1",
     "Sphinx==7.3.7",
-    "fmf>=1.3.0",
+    "fmf>=1.4.0",
     ]
 
 [project.scripts]

--- a/tests/discover/adjust-tests.sh
+++ b/tests/discover/adjust-tests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "pushd data"
+        rlRun "run=\$(mktemp -d)"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun -s "tmt run -i $run discover plans --name /fmf/adjust-tests"
+        # If we ever change the path...
+        tests_yaml="$(find $run -name tests.yaml)"
+        rlAssertExits "$tests_yaml"
+        rlRun -s "yq '.[].require' < $tests_yaml"
+        rlAssertGrep "foo" "$rlRun_LOG"
+        rlRun -s "yq '.[].duration' < $tests_yaml"
+        # Note the space before 10.. duration is adjusted to the raw input ' 10h'
+        rlAssertGrep " 10h" "$rlRun_LOG"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "rm -rf $run"
+        rlRun "popd"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/discover/adjust-tests.sh
+++ b/tests/discover/adjust-tests.sh
@@ -15,8 +15,11 @@ rlJournalStart
         rlRun -s "yq '.[].require' < $tests_yaml"
         rlAssertGrep "foo" "$rlRun_LOG"
         rlRun -s "yq '.[].duration' < $tests_yaml"
-        # Note the space before 10.. duration is adjusted to the raw input ' 10h'
-        rlAssertGrep " 10h" "$rlRun_LOG"
+        # 'duration_to_seconds' takes care of injection the default '5m' as the base
+        rlAssertGrep "*2" "$rlRun_LOG"
+        # check added
+        rlRun -s "yq '.[].check' < $tests_yaml"
+        rlAssertGrep "avc" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/discover/adjust-tests.sh
+++ b/tests/discover/adjust-tests.sh
@@ -8,7 +8,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun -s "tmt run -i $run discover plans --name /fmf/adjust-tests"
+        rlRun -s "tmt -c trigger=commit run -i $run discover plans --name /fmf/adjust-tests"
         # If we ever change the path...
         tests_yaml="$(find $run -name tests.yaml)"
         rlAssertExits "$tests_yaml"
@@ -20,6 +20,9 @@ rlJournalStart
         # check added
         rlRun -s "yq '.[].check' < $tests_yaml"
         rlAssertGrep "avc" $rlRun_LOG
+        # recommend should not contain FAILURE
+        rlRun -s "yq '.[].recommend' < $tests_yaml"
+        rlAssertNotGrep "FAILURE" "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -203,3 +203,11 @@ execute:
                 url: https://github.com/teemtee/tmt
                 how: fmf
                 ref: "@tests/discover/data/dynamic-ref.fmf"
+    /adjust-tests:
+        discover:
+            how: fmf
+            test: /tests/discover1
+            adjust-tests:
+            - duration+: " 10h"
+            - require+:
+                - foo

--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -208,6 +208,8 @@ execute:
             how: fmf
             test: /tests/discover1
             adjust-tests:
-            - duration+: " 10h"
+            - duration+: "*2"
             - require+:
                 - foo
+            - check+:
+                - how: avc

--- a/tests/discover/data/plans.fmf
+++ b/tests/discover/data/plans.fmf
@@ -209,7 +209,13 @@ execute:
             test: /tests/discover1
             adjust-tests:
             - duration+: "*2"
+            - recommend:
+                - FAILURE
+              when: trigger is not defined
+              because: check if context is evaluated
             - require+:
                 - foo
+              when: trigger == commit
+              because: check if context is evaluated
             - check+:
                 - how: avc

--- a/tests/discover/main.fmf
+++ b/tests/discover/main.fmf
@@ -72,3 +72,7 @@ tier: 3
 /exception:
     summary: Verify no color when throwing an exception if '--no-color' is specified
     test: ./exception.sh
+
+/adjust-tests:
+    summary: Change test metadata within discover phase
+    test: ./adjust-tests.sh

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -341,6 +341,11 @@ def test_duration_to_seconds():
     assert duration_to_seconds('*2 *3 1m4') == 384
     # Round up
     assert duration_to_seconds('1s *3.3') == 4
+    # Value might by just the multiplication
+    #   without the default it thus equals zero
+    assert duration_to_seconds('*2') == 0
+    #   however the supplied "default" can be used: (1m * 2)
+    assert duration_to_seconds('*2', injected_default="1m") == 120
 
 
 @pytest.mark.parametrize("duration", [

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -341,7 +341,7 @@ def test_duration_to_seconds():
     assert duration_to_seconds('*2 *3 1m4') == 384
     # Round up
     assert duration_to_seconds('1s *3.3') == 4
-    # Value might by just the multiplication
+    # Value might be just the multiplication
     #   without the default it thus equals zero
     assert duration_to_seconds('*2') == 0
     #   however the supplied "default" can be used: (1m * 2)

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2857,6 +2857,7 @@ class Tree(tmt.utils.Common):
                  path: Optional[Path] = None,
                  tree: Optional[fmf.Tree] = None,
                  fmf_context: Optional[FmfContext] = None,
+                 additional_rules: Optional[list[Any]] = None,
                  logger: tmt.log.Logger) -> None:
         """ Initialize tmt tree from directory path or given fmf tree """
 
@@ -2866,6 +2867,7 @@ class Tree(tmt.utils.Common):
         self._path = path or Path.cwd()
         self._tree = tree
         self._custom_fmf_context = fmf_context or FmfContext()
+        self._additional_rules = additional_rules
 
     @classmethod
     def grow(
@@ -2980,7 +2982,8 @@ class Tree(tmt.utils.Common):
             self._tree.adjust(
                 fmf.context.Context(**self._fmf_context),
                 case_sensitive=False,
-                decision_callback=create_adjust_callback(self._logger))
+                decision_callback=create_adjust_callback(self._logger),
+                additional_rules=self._additional_rules)
         return self._tree
 
     @tree.setter

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2857,7 +2857,7 @@ class Tree(tmt.utils.Common):
                  path: Optional[Path] = None,
                  tree: Optional[fmf.Tree] = None,
                  fmf_context: Optional[FmfContext] = None,
-                 additional_rules: Optional[list[Any]] = None,
+                 additional_rules: Optional[list[_RawAdjustRule]] = None,
                  logger: tmt.log.Logger) -> None:
         """ Initialize tmt tree from directory path or given fmf tree """
 

--- a/tmt/schemas/discover/fmf.yaml
+++ b/tmt/schemas/discover/fmf.yaml
@@ -95,5 +95,10 @@ properties:
   where:
     $ref: "/schemas/common#/definitions/where"
 
+  adjust-tests:
+    type: array
+    items:
+      type: object
+
 required:
   - how

--- a/tmt/schemas/discover/fmf.yaml
+++ b/tmt/schemas/discover/fmf.yaml
@@ -96,9 +96,7 @@ properties:
     $ref: "/schemas/common#/definitions/where"
 
   adjust-tests:
-    type: array
-    items:
-      type: object
+    $ref: "/schemas/core#/definitions/adjust"
 
 required:
   - how

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -162,7 +162,8 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
     adjust_tests: Optional[list[_RawAdjustRule]] = field(
         default_factory=list,
         normalize=lambda key_address, raw_value, logger: [] if raw_value is None
-        else ([raw_value] if not isinstance(raw_value, list) else raw_value))
+        else ([raw_value] if not isinstance(raw_value, list) else raw_value),
+        help="Modify metadata of discovered tests from the plan itself.")
 
     # Upgrade plan path so the plan is not pruned
     upgrade_path: Optional[str] = None
@@ -267,6 +268,25 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
     Note that internally the modified tests are appended to the list
     specified via ``test``, so those tests will also be selected even if
     not modified.
+
+    To modify the discovered tests' metadata directly from the plan (for example if
+    it is an yet-to-be added package, special HW, or missing permissions to modify the tests repo),
+    you can use the ``adjust-tests``. Its value is the list of actions to do, each action is the
+    "merging" operation of fmf (similar form as is used in the adjust rules)
+
+    Following example adds an 'avc' check for each discovered test, doubles its duration and
+    replaces each occurrence of the word 'python3.11' in the list of required packages.
+
+    .. code-block:: yaml
+
+        discover:
+            how: fmf
+            adjust-tests:
+            - check+:
+                - how: avc
+            - duration+: '*2'
+            - require~:
+                - '/python3.11/python3.12/'
     """
 
     _data_class = DiscoverFmfStepData

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -270,13 +270,13 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
     Note that internally the modified tests are appended to the list
     specified via ``test``, so those tests will also be selected even if
     not modified.
-    \b
+
     Use the ``adjust-tests`` key to modify the discovered tests'
     metadata directly from the plan. For example, extend the test
     duration for slow hardware or modify the list of required packages
     when you do not have write access to the remote test repository.
     The value should follow the ``adjust`` rules syntax.
-    \b
+
     The following example adds an ``avc`` check for each discovered
     test, doubles its duration and replaces each occurrence of the word
     ``python3.11`` in the list of required packages.

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -157,6 +157,12 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
         show_default=True,
         help="Copy only immediate directories of executed tests and their required files.")
 
+    # Edit discovered tests
+    adjust_tests: list[Any] = field(
+        multiple=True,
+        default_factory=list
+        )
+
     # Upgrade plan path so the plan is not pruned
     upgrade_path: Optional[str] = None
 
@@ -564,7 +570,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
         tree = tmt.Tree(
             logger=self._logger,
             path=tree_path,
-            fmf_context=self.step.plan._fmf_context)
+            fmf_context=self.step.plan._fmf_context,
+            additional_rules=self.get('adjust-tests'))
         self._tests = tree.tests(
             filters=filters,
             names=names,

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -161,9 +161,11 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
     # Edit discovered tests
     adjust_tests: Optional[list[_RawAdjustRule]] = field(
         default_factory=list,
-        normalize=lambda key_address, raw_value, logger: [] if raw_value is None
-        else ([raw_value] if not isinstance(raw_value, list) else raw_value),
-        help="Modify metadata of discovered tests from the plan itself.")
+        normalize=tmt.utils.normalize_adjust,
+        help="""
+             Modify metadata of discovered tests from the plan itself. Use the
+             same format as for adjust rules.
+             """)
 
     # Upgrade plan path so the plan is not pruned
     upgrade_path: Optional[str] = None
@@ -268,13 +270,13 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
     Note that internally the modified tests are appended to the list
     specified via ``test``, so those tests will also be selected even if
     not modified.
-
+    \b
     Use the ``adjust-tests`` key to modify the discovered tests'
     metadata directly from the plan. For example, extend the test
     duration for slow hardware or modify the list of required packages
     when you do not have write access to the remote test repository.
     The value should follow the ``adjust`` rules syntax.
-
+    \b
     The following example adds an ``avc`` check for each discovered
     test, doubles its duration and replaces each occurrence of the word
     ``python3.11`` in the list of required packages.

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -271,8 +271,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
 
     To modify the discovered tests' metadata directly from the plan (for example if
     it is an yet-to-be added package, special HW, or missing permissions to modify the tests repo),
-    you can use the ``adjust-tests``. Its value is the list of actions to do, each action is the
-    "merging" operation of fmf (similar form as is used in the adjust rules)
+    you can use the ``adjust-tests``. Values are in the same form as the adjust rules, you can use
+    same functionality.
 
     Following example adds an 'avc' check for each discovered test, doubles its duration and
     replaces each occurrence of the word 'python3.11' in the list of required packages.
@@ -285,6 +285,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             - check+:
                 - how: avc
             - duration+: '*2'
+              because: Slow system under test
+              when: arch == i286
             - require~:
                 - '/python3.11/python3.12/'
     """

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -269,26 +269,28 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
     specified via ``test``, so those tests will also be selected even if
     not modified.
 
-    To modify the discovered tests' metadata directly from the plan (for example if
-    it is an yet-to-be added package, special HW, or missing permissions to modify the tests repo),
-    you can use the ``adjust-tests``. Values are in the same form as the adjust rules, you can use
-    same functionality.
+    Use the ``adjust-tests`` key to modify the discovered tests'
+    metadata directly from the plan. For example, extend the test
+    duration for slow hardware or modify the list of required packages
+    when you do not have write access to the remote test repository.
+    The value should follow the ``adjust`` rules syntax.
 
-    Following example adds an 'avc' check for each discovered test, doubles its duration and
-    replaces each occurrence of the word 'python3.11' in the list of required packages.
+    The following example adds an ``avc`` check for each discovered
+    test, doubles its duration and replaces each occurrence of the word
+    ``python3.11`` in the list of required packages.
 
     .. code-block:: yaml
 
         discover:
             how: fmf
             adjust-tests:
-            - check+:
-                - how: avc
-            - duration+: '*2'
-              because: Slow system under test
-              when: arch == i286
-            - require~:
-                - '/python3.11/python3.12/'
+              - check+:
+                  - how: avc
+              - duration+: '*2'
+                because: Slow system under test
+                when: arch == i286
+              - require~:
+                  - '/python3.11/python3.12/'
     """
 
     _data_class = DiscoverFmfStepData

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -18,6 +18,7 @@ import tmt.steps
 import tmt.steps.discover
 import tmt.utils
 import tmt.utils.git
+from tmt.base import _RawAdjustRule
 from tmt.steps.prepare.distgit import insert_to_prepare_step
 from tmt.utils import Command, Environment, EnvVarValue, Path, field
 
@@ -158,10 +159,10 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
         help="Copy only immediate directories of executed tests and their required files.")
 
     # Edit discovered tests
-    adjust_tests: list[Any] = field(
-        multiple=True,
-        default_factory=list
-        )
+    adjust_tests: Optional[list[_RawAdjustRule]] = field(
+        default_factory=list,
+        normalize=lambda key_address, raw_value, logger: [] if raw_value is None
+        else ([raw_value] if not isinstance(raw_value, list) else raw_value))
 
     # Upgrade plan path so the plan is not pruned
     upgrade_path: Optional[str] = None
@@ -571,7 +572,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             logger=self._logger,
             path=tree_path,
             fmf_context=self.step.plan._fmf_context,
-            additional_rules=self.get('adjust-tests'))
+            additional_rules=self.data.adjust_tests)
         self._tests = tree.tests(
             filters=filters,
             names=names,

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -401,7 +401,8 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                 timeout = None
 
             else:
-                timeout = tmt.utils.duration_to_seconds(test.duration)
+                timeout = tmt.utils.duration_to_seconds(
+                    test.duration, tmt.base.DEFAULT_TEST_DURATION_L1)
 
             try:
                 output = guest.execute(

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -3344,7 +3344,7 @@ def shell_variables(
     return [f"{key}={shlex.quote(str(value))}" for key, value in data.items()]
 
 
-def duration_to_seconds(duration: str) -> int:
+def duration_to_seconds(duration: str, magic: Optional[str] = None) -> int:
     """ Convert extended sleep time format into seconds """
     units = {
         's': 1,
@@ -3389,6 +3389,9 @@ def duration_to_seconds(duration: str) -> int:
             multiply_by *= float(match['float'])
         else:
             total_time += int(match['digit']) * units.get(match['suffix'], 1)
+    # Inject value so we have something to multiply
+    if magic and total_time == 0:
+        total_time = duration_to_seconds(magic)
     # Multiply in the end and round up
     return ceil(total_time * multiply_by)
 

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -3344,8 +3344,13 @@ def shell_variables(
     return [f"{key}={shlex.quote(str(value))}" for key, value in data.items()]
 
 
-def duration_to_seconds(duration: str, magic: Optional[str] = None) -> int:
-    """ Convert extended sleep time format into seconds """
+def duration_to_seconds(duration: str, injected_default: Optional[str] = None) -> int:
+    """
+    Convert extended sleep time format into seconds
+
+    Optional 'injected_default' argument to evaluate 'duration' when
+    it contains only multiplication.
+    """
     units = {
         's': 1,
         'm': 60,
@@ -3390,8 +3395,8 @@ def duration_to_seconds(duration: str, magic: Optional[str] = None) -> int:
         else:
             total_time += int(match['digit']) * units.get(match['suffix'], 1)
     # Inject value so we have something to multiply
-    if magic and total_time == 0:
-        total_time = duration_to_seconds(magic)
+    if injected_default and total_time == 0:
+        total_time = duration_to_seconds(injected_default)
     # Multiply in the end and round up
     return ceil(total_time * multiply_by)
 

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -5413,6 +5413,18 @@ def normalize_shell_script(
     raise NormalizationError(key_address, value, 'a string')
 
 
+def normalize_adjust(
+        key_address: str,
+        raw_value: Any,
+        logger: tmt.log.Logger) -> Optional[list['tmt.base._RawAdjustRule']]:
+
+    if raw_value is None:
+        return []
+    if isinstance(raw_value, list):
+        return raw_value
+    return [raw_value]
+
+
 def normalize_string_dict(
         key_address: str,
         raw_value: Any,


### PR DESCRIPTION
New option for discover -h fmf to adjust discovered tests

I went with 'adjust-tests' keyword proposed in https://github.com/teemtee/tmt/discussions/2430#discussioncomment-7870532

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] update the specification
* [x] adjust plugin docstring
* [x] modify the json schema
* [x] include a release note

I'm not able to set the `versionadded` into the discover/fmf.py so I'll omit that.