### PR TITLE
Removing /var/tmp workdir from rpm packaging

### DIFF
--- a/examples/redis/test.sh
+++ b/examples/redis/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 
 set -eux
 

--- a/tmt.spec
+++ b/tmt.spec
@@ -20,8 +20,6 @@ Obsoletes:      tmt-report-reportportal < %{version}-%{release}
 
 Recommends:     bash-completion
 
-%define workdir_root /var/tmp/tmt
-
 %py_provides    python3-tmt
 
 %description
@@ -126,7 +124,6 @@ mkdir -p %{buildroot}%{_mandir}/man1
 install -pm 644 tmt.1 %{buildroot}%{_mandir}/man1
 mkdir -p %{buildroot}%{_datadir}/bash-completion/completions
 install -pm 644 completions/bash/%{name} %{buildroot}%{_datadir}/bash-completion/completions/%{name}
-mkdir -pm 1777 %{buildroot}%{workdir_root}
 mkdir -p %{buildroot}/etc/%{name}/
 install -pm 644 %{name}/steps/provision/mrack/mrack* %{buildroot}/etc/%{name}/
 
@@ -137,7 +134,6 @@ install -pm 644 %{name}/steps/provision/mrack/mrack* %{buildroot}/etc/%{name}/
 %doc README.rst examples
 %{_bindir}/tmt
 %{_mandir}/man1/tmt.1.gz
-%dir %{workdir_root}
 %{_datadir}/bash-completion/completions/%{name}
 
 %files -n tmt+provision-container -f %{_pyproject_ghost_distinfo}


### PR DESCRIPTION
Addressing #2803

tmt is creating the workdir by itself and as such does not need to have the directory being packaged as part of the rpm.  
This change is in sync with Fedora Python packaging guidelines, harmonizing the rpm package with the PyPI package.
It also fixes the issue of the current implementation not using [tmpfiles.d](https://docs.fedoraproject.org/en-US/packaging-guidelines/Tmpfiles.d/) and as such is marked as forbidden by rpmlint Fedora configs.  