### PR TITLE
Fix inability of rpm-ostree to install multiple packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@
 
 # Prepare variables
 TMP = $(CURDIR)/tmp
-UNIT_TESTS_IMAGE_TAG = tmt-unit-tests
 
 # Define special targets
 .DEFAULT_GOAL := help
@@ -83,16 +82,33 @@ images:  ## Build tmt images for podman/docker
 	podman build -t tmt --squash -f ./containers/Containerfile.mini .
 	podman build -t tmt-all --squash -f ./containers/Containerfile.full .
 
-images-unit-tests: image-unit-tests-alpine image-unit-tests-coreos image/tests/fedora/rawhide/unprivileged  ## Build images for unit tests
+TMT_TEST_IMAGES := image/tests/alpine \
+                   image/tests/alpine/upstream \
+                   image/tests/fedora/coreos \
+                   image/tests/fedora/coreos/ostree \
+                   image/tests/fedora/rawhide \
+                   image/tests/fedora/rawhide/unprivileged
 
-image-unit-tests-alpine:  ## Build local alpine image for unit tests
-	podman build -t alpine:$(UNIT_TESTS_IMAGE_TAG) -f ./containers/Containerfile.alpine .
+images-tests: $(TMT_TEST_IMAGES)  ## Build customized images for tests
 
-image-unit-tests-coreos:  ## Build local CoreOS image for unit tests
-	podman build -t fedora-coreos:$(UNIT_TESTS_IMAGE_TAG) -f ./containers/Containerfile.coreos .
+image/tests/alpine:
+	podman build -t tmt/alpine:latest -f ./containers/alpine/Containerfile .
 
-image/tests/fedora/rawhide/unprivileged:  ## Build local Fedora image with unprivileged account and sudo
-	podman build -t fedora/rawhide/unprivileged:$(UNIT_TESTS_IMAGE_TAG) -f ./containers/fedora/rawhide/Containerfile.unprivileged .
+image/tests/alpine/upstream:
+	podman pull docker.io/library/alpine:3.19
+	podman tag docker.io/library/alpine:3.19 tmt/alpine/upstream:latest
+
+image/tests/fedora/coreos:
+	podman build -t tmt/fedora/coreos:stable -f ./containers/fedora/coreos/Containerfile .
+
+image/tests/fedora/coreos/ostree:
+	podman build -t tmt/fedora/coreos/ostree:stable -f ./containers/fedora/coreos/ostree/Containerfile .
+
+image/tests/fedora/rawhide:
+	podman build -t tmt/fedora/rawhide:latest -f ./containers/fedora/rawhide/Containerfile .
+
+image/tests/fedora/rawhide/unprivileged:
+	podman build -t tmt/fedora/rawhide/unprivileged:latest -f ./containers/fedora/rawhide/Containerfile.unprivileged .
 
 ##
 ## Development

--- a/containers/Containerfile.alpine
+++ b/containers/Containerfile.alpine
@@ -1,4 +1,0 @@
-FROM docker.io/library/alpine:latest
-
-# tmt requires `bash` to be installed
-RUN apk add --no-cache bash

--- a/containers/Containerfile.coreos
+++ b/containers/Containerfile.coreos
@@ -1,4 +1,0 @@
-FROM quay.io/fedora/fedora-coreos:stable
-
-# Inject dnf to make things more complicated for rpm-ostree package manager implementation
-RUN rpm-ostree install dnf5

--- a/containers/alpine/Containerfile
+++ b/containers/alpine/Containerfile
@@ -1,0 +1,8 @@
+#
+# An Alpine image tailored for tmt test suite
+#
+
+FROM docker.io/library/alpine:3.19
+
+# Inject `bash` which is unavoidably required by tmt
+RUN apk add --no-cache bash

--- a/containers/fedora/coreos/Containerfile
+++ b/containers/fedora/coreos/Containerfile
@@ -1,0 +1,13 @@
+#
+# A Fedora CoreOS image tailored for tmt test suite
+#
+
+FROM quay.io/fedora/fedora-coreos:stable
+
+    # Inject `dnf` to make things more complicated for `rpm-ostree` package
+    # manager implementation
+RUN rpm-ostree install dnf5 \
+    # Remove diffutils as its used in many package manager tests, and tests
+    # are simpler if all environments lack the same package, we don't have
+    # to parametrize them even more.
+    && dnf5 remove -y diffutils

--- a/containers/fedora/coreos/ostree/Containerfile
+++ b/containers/fedora/coreos/ostree/Containerfile
@@ -1,0 +1,17 @@
+#
+# A Fedora CoreOS image tailored for tmt test suite
+#
+# Similar to `Containerfile.coreos`, but aims to simulate ostree-booted environment
+#
+
+FROM quay.io/fedora/fedora-coreos:stable
+
+    # Inject `dnf` to make things more complicated for `rpm-ostree` package
+    # manager implementation
+RUN rpm-ostree install dnf5 \
+    # Remove diffutils as its used in many package manager tests, and tests
+    # are simpler if all environments lack the same package, we don't have
+    # to parametrize them even more.
+    && dnf5 remove -y diffutils \
+    # Simulate ostree-booted environment
+    && touch /run/ostree-booted

--- a/containers/fedora/rawhide/Containerfile
+++ b/containers/fedora/rawhide/Containerfile
@@ -1,0 +1,9 @@
+#
+# A Fedora rawhide image tailored for tmt test suite
+#
+
+FROM registry.fedoraproject.org/fedora:rawhide
+
+# Inject `dnf5` to make things more complicated for `dnf` family of
+# package manager implementations
+RUN dnf install -y dnf5

--- a/containers/fedora/rawhide/Containerfile.unprivileged
+++ b/containers/fedora/rawhide/Containerfile.unprivileged
@@ -1,5 +1,5 @@
 #
-# A custom Fedora rawhide image, with unprivieged account & password-less sudo
+# A Fedora rawhide image tailored for tmt test suite, with unprivileged account & password-less sudo
 #
 
 FROM quay.io/fedora/fedora:rawhide

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ lint = ["autopep8 {args:.}", "ruff --fix {args:.}"]
 type = ["mypy {args:tmt}"]
 check = ["lint", "type"]
 
-unit = "make images-unit-tests && pytest -vvv -ra --showlocals -n 0 tests/unit"
+unit = "make images-tests && pytest -vvv -ra --showlocals -n 0 tests/unit"
 smoke = "pytest -vvv -ra --showlocals -n 0 tests/unit/test_cli.py"
 cov = [
     "coverage run --source=tmt -m pytest -vvv -ra --showlocals -n 0 tests",

--- a/tests/prepare/install/data/debuginfo.fmf
+++ b/tests/prepare/install/data/debuginfo.fmf
@@ -1,23 +1,15 @@
 summary: Install debuginfo packages
 
 prepare:
-    how: install
+  - how: install
     package: grep-debuginfo
 
 execute:
-    script: rpm -q grep-debuginfo grep-debugsource
+    script: rpm -q grep-debuginfo
 
-/fedora:
-    summary+: " on Fedora"
-
-/ubi8:
-    summary+: " on Red Hat Universal Base Image 8"
-    provision+:
-        image: ubi8
-
-/centos-stream-9:
-    summary+: " on CentOS Stream 9"
-    provision+:
-        image: centos:stream9
-    # FIXME: Disabled because of missing `flock` on the guest
-    enabled: false
+adjust+:
+  - because: "On CentOS Stream 8, debuginfo-install does not seem to enable debug repos"
+    when: distro == centos-stream-8
+    prepare+<:
+      - how: shell
+        script: sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/CentOS-Stream-Debuginfo.repo

--- a/tests/prepare/install/data/empty.fmf
+++ b/tests/prepare/install/data/empty.fmf
@@ -1,0 +1,8 @@
+summary: Do nothing in prepare, CLI will provide inputs
+prepare: []
+
+adjust:
+  - when: distro == ubuntu
+    prepare+:
+      - how: shell
+        script: apt-get update

--- a/tests/prepare/install/data/epel7.fmf
+++ b/tests/prepare/install/data/epel7.fmf
@@ -1,5 +1,3 @@
-provision+:
-    image: centos:7
 prepare:
     how: install
     copr: '@oamg/convert2rhel'

--- a/tests/prepare/install/data/epel8-remote.fmf
+++ b/tests/prepare/install/data/epel8-remote.fmf
@@ -1,5 +1,3 @@
-provision+:
-    image: centos:stream8
 prepare:
     how: install
     package:

--- a/tests/prepare/install/data/existing.fmf
+++ b/tests/prepare/install/data/existing.fmf
@@ -1,6 +1,12 @@
-summary: Install an existing package
+summary: Install existing packages
 prepare:
-    how: install
-    package: tree
-execute:
-    script: rpm -q tree
+  - how: install
+    package:
+      - tree
+      - diffutils
+
+adjust:
+  - when: distro == ubuntu
+    prepare+<:
+      - how: shell
+        script: apt-get update

--- a/tests/prepare/install/data/main.fmf
+++ b/tests/prepare/install/data/main.fmf
@@ -1,2 +1,3 @@
-provision:
-    how: container
+execute:
+    how: tmt
+    script: /bin/true

--- a/tests/prepare/install/data/missing.fmf
+++ b/tests/prepare/install/data/missing.fmf
@@ -1,6 +1,12 @@
-summary: Report a missing package
+summary: Install existing and invalid packages
 prepare:
-    how: install
-    package: forest
-execute:
-    script: we should not get here
+  - how: install
+    package:
+      - tree-but-spelled-wrong
+      - diffutils
+
+adjust:
+  - when: distro == ubuntu
+    prepare+<:
+      - how: shell
+        script: apt-get update

--- a/tests/prepare/install/main.fmf
+++ b/tests/prepare/install/main.fmf
@@ -1,11 +1,14 @@
-summary: Various package installation options
-description:
-    Check basic installation of an existing and missing package.
-    Make sure that special characters are correctly escaped.
-    Verify that installation from copr works for epel7. Exercises
-    all provision methods in full mode, container only by default.
+summary: Exercise prepare/install plugin
+description: |
+    Check basic installation of required and recommended packages, both
+    valid and invalid ones.
+    Also verify special characters are correctly escaped, and copr
+    functionality.
+duration: 120m
 tag+:
   - provision-only
   - provision-container
-  - provision-local
   - provision-virtual
+
+# TODO: what test cases are safe enough to be executed against the localhost?
+#  - provision-local

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -1,9 +1,112 @@
 #!/bin/bash
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
+# TODO: should these variables exist outside of this test, for all tests
+# to share?
+CONTAINER_IMAGES="${CONTAINER_IMAGES:-localhost/tmt/fedora/rawhide:latest
+registry.fedoraproject.org/fedora:39
+quay.io/centos/centos:stream8
+quay.io/centos/centos:7
+docker.io/library/ubuntu:22.04
+ubi8
+localhost/tmt/alpine:latest
+localhost/tmt/fedora/coreos:stable
+localhost/tmt/fedora/coreos/ostree:stable}"
+
+# TODO: enable Ubuntu
+VIRTUAL_IMAGES="${VIRTUAL_IMAGES:-fedora-rawhide
+fedora-39
+centos-stream-8
+centos-7
+fedora-coreos}"
+
+# A couple of "is image this?" helpers, to simplify conditions.
+function is_fedora_rawhide () {
+    [[ "$1" =~ ^.*fedora/rawhide:.* ]] && return 0
+    [[ "$1" = "fedora-rawhide" ]] && return 0
+
+    return 1
+}
+
+function is_fedora_39 () {
+    [[ "$1" =~ ^.*fedora:39 ]] && return 0
+    [[ "$1" = "fedora-39" ]] && return 0
+
+    return 1
+}
+
+function is_centos_stream_8 () {
+    [[ "$1" =~ ^.*centos:stream8 ]] && return 0
+    [[ "$1" = "centos-stream-8" ]] && return 0
+
+    return 1
+}
+
+function is_centos_7 () {
+    [[ "$1" =~ ^.*centos:7 ]] && return 0
+    [[ "$1" = "centos-7" ]] && return 0
+
+    return 1
+}
+
+function is_ubuntu () {
+    [[ "$1" =~ ^.*ubuntu:22.04 ]] && return 0
+    [[ "$1" = "ubuntu" ]] && return 0
+
+    return 1
+}
+
+function is_ostree () {
+    [[ "$1" =~ ^.*fedora/coreos/ostree:stable ]] && return 0
+    [[ "$1" = "fedora-coreos" && "$PROVISION_HOW" = "virtual" ]] && return 0
+
+    return 1
+}
+
+function is_fedora_coreos () {
+    [[ "$1" =~ ^.*fedora/coreos(/ostree)?:stable ]] && return 0
+    [[ "$1" = "fedora-coreos" ]] && return 0
+
+    return 1
+}
+
+function is_fedora () {
+    [[ "$1" =~ ^.*fedora.* ]] && return 0 || return 1
+}
+
+function is_centos () {
+    [[ "$1" =~ ^.*centos.* ]] && return 0 || return 1
+}
+
+function is_rhel () {
+    is_ubi "$1" && return 0 || return 1
+}
+
+function is_alpine () {
+    [[ "$1" =~ ^.*alpine.* ]] && return 0 || return 1
+}
+
+function is_ubi () {
+    [[ "$1" =~ ^.*ubi.* ]] && return 0 || return 1
+}
+
+
 rlJournalStart
     rlPhaseStartSetup
         rlRun "PROVISION_HOW=${PROVISION_HOW:-container}"
+
+        if [ "$PROVISION_HOW" = "container" ]; then
+            rlRun "IMAGES='$CONTAINER_IMAGES'"
+
+            rlRun "make -C ../../../ images-tests"
+
+        elif [ "$PROVISION_HOW" = "virtual" ]; then
+            rlRun "IMAGES='$VIRTUAL_IMAGES'"
+
+        else
+            rlRun "IMAGES="
+        fi
+
         rlRun "run=\$(mktemp -d)" 0 "Create run directory"
         rlRun "pushd data"
 
@@ -11,68 +114,195 @@ rlJournalStart
         rlRun "export TMT_CONNECT_TIMEOUT=300"
     rlPhaseEnd
 
-    # Prepare the common tmt command
-    tmt="tmt run --all --id $run --scratch -vvv"
+    while IFS= read -r image; do
+        phase_prefix="[$PROVISION_HOW / $image]"
 
-    # Run basic tests against the given provision method
-    provision="provision --how $PROVISION_HOW"
+        rlPhaseStartTest "$phase_prefix Prepare runtime"
+            [ "$PROVISION_HOW" = "container" ] && rlRun "podman images $image"
 
-    rlPhaseStartTest "Install an existing package ($PROVISION_HOW)"
-        rlRun "$tmt $provision plan --name existing"
-    rlPhaseEnd
+            if is_fedora_rawhide "$image"; then
+                rlRun "distro=fedora-rawhide"
 
-    rlPhaseStartTest "Report a missing package ($PROVISION_HOW)"
-        rlRun "$tmt $provision plan --name missing" 2
-    rlPhaseEnd
+                if [ "$PROVISION_HOW" = "virtual" ]; then
+                    rlRun "package_manager=dnf"
+                else
+                    rlRun "package_manager=dnf5"
+                fi
 
-    # Add one extra CoreOS run for virtual provision
-    if [[ "$PROVISION_HOW" == "virtual" ]]; then
-        provision="provision --how $PROVISION_HOW --image fedora-coreos"
+            elif is_fedora_39 "$image"; then
+                rlRun "distro=fedora-39"
+                rlRun "package_manager=dnf"
 
-        rlPhaseStartTest "Install an existing package ($PROVISION_HOW, CoreOS)"
-            rlRun "$tmt $provision plan --name existing"
-            rlAssertGrep "rpm-ostree install.*tree" $run/log.txt
-            rlAssertNotGrep "rpm-ostree install.*/usr/bin/flock" $run/log.txt
+            elif is_centos_stream_8 "$image"; then
+                rlRun "distro=centos-stream-8"
+                rlRun "package_manager=dnf"
+
+            elif is_centos_7 "$image"; then
+                rlRun "distro=centos-7"
+                rlRun "package_manager=yum"
+
+            elif is_ubuntu "$image"; then
+                rlRun "distro=ubuntu"
+                rlRun "package_manager=apt"
+
+            elif is_fedora_coreos "$image"; then
+                rlRun "distro=fedora-coreos"
+
+                if is_ostree "$image"; then
+                    rlRun "package_manager=rpm-ostree"
+
+                elif [ "$PROVISION_HOW" = "virtual" ]; then
+                    rlRun "package_manager=dnf"
+
+                else
+                    rlRun "package_manager=dnf5"
+
+                fi
+
+            elif is_ubi "$image"; then
+                rlRun "distro=rhel-8"
+                rlRun "package_manager=dnf"
+
+            elif is_alpine "$image"; then
+                rlRun "distro=alpine"
+                rlRun "package_manager=apk"
+
+            else
+                rlFail "Cannot infer distro for image $image"
+            fi
+
+            tmt="tmt -vvv -c distro=$distro run --id $run --scratch finish discover provision --how $PROVISION_HOW --image $image prepare"
         rlPhaseEnd
 
-        rlPhaseStartTest "Report a missing package ($PROVISION_HOW, CoreOS)"
-            rlRun "$tmt $provision plan --name missing" 2
-        rlPhaseEnd
-    fi
+        # TODO: find out whether all those exceptions can be simplified and parametrized...
 
-    # And a couple of additional tests with container provision
-    if [[ "$PROVISION_HOW" == "container" ]]; then
-        rlPhaseStartTest "Provide package on the command line"
-            rlRun "tmt run -vvvr plan --default \
-                provision --how container \
-                prepare --how install --package tree \
-                finish"
+        # TODO: cannot *successfully* install on ubi without subscribing first?
+        if ! is_ubi "$image"; then
+            rlPhaseStartTest "$phase_prefix Install existing packages (plan)"
+                rlRun -s "$tmt plan --name /existing"
+
+                rlAssertGrep "package manager: $package_manager" $rlRun_LOG
+
+                if is_ubuntu "$image"; then
+                    # Runs 1 extra phase, to populate local caches.
+                    rlAssertGrep "summary: 3 preparations applied" $rlRun_LOG
+                else
+                    rlAssertGrep "summary: 2 preparations applied" $rlRun_LOG
+                fi
+            rlPhaseEnd
+
+            rlPhaseStartTest "$phase_prefix Install existing packages (CLI)"
+                rlRun -s "$tmt --insert --how install --package tree --package diffutils plan --name /empty"
+
+                rlAssertGrep "package manager: $package_manager" $rlRun_LOG
+
+                if is_ubuntu "$image"; then
+                    # Runs 1 extra phase, to populate local caches.
+                    rlAssertGrep "summary: 3 preparations applied" $rlRun_LOG
+                else
+                    rlAssertGrep "summary: 2 preparations applied" $rlRun_LOG
+                fi
+            rlPhaseEnd
+        fi
+
+        rlPhaseStartTest "$phase_prefix Install existing and invalid packages (plan)"
+            rlRun -s "$tmt plan --name /missing" 2
+
+            rlAssertGrep "package manager: $package_manager" $rlRun_LOG
+
+            if is_centos_7 "$image"; then
+                rlAssertGrep "out: no package provides tree-but-spelled-wrong" $rlRun_LOG
+
+            elif is_ostree "$image"; then
+                rlAssertGrep "err: error: Packages not found: tree-but-spelled-wrong" $rlRun_LOG
+
+            elif is_fedora_coreos "$image"; then
+                rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG
+
+            elif is_fedora_rawhide "$image"; then
+                if [ "$PROVISION_HOW" = "virtual" ]; then
+                    rlAssertGrep "err: Error: Unable to find a match: tree-but-spelled-wrong" $rlRun_LOG
+                else
+                    rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG
+                fi
+
+            elif is_ubuntu "$image"; then
+                rlAssertGrep "err: E: Unable to locate package tree-but-spelled-wrong" $rlRun_LOG
+
+            elif is_alpine "$image"; then
+                rlAssertGrep "err:   tree-but-spelled-wrong (no such package)" $rlRun_LOG
+
+            else
+                rlAssertGrep "err: Error: Unable to find a match: tree-but-spelled-wrong" $rlRun_LOG
+            fi
         rlPhaseEnd
 
-        rlPhaseStartTest "Just enable copr"
-            rlRun "$tmt plan --name copr"
+        rlPhaseStartTest "$phase_prefix Install existing and invalid packages (CLI)"
+            rlRun -s "$tmt --insert --how install --package tree-but-spelled-wrong --package diffutils plan --name /empty" 2
+
+            rlAssertGrep "package manager: $package_manager" $rlRun_LOG
+
+            if is_centos_7 "$image"; then
+                rlAssertGrep "out: no package provides tree-but-spelled-wrong" $rlRun_LOG
+
+            elif is_ostree "$image"; then
+                rlAssertGrep "err: error: Packages not found: tree-but-spelled-wrong" $rlRun_LOG
+
+            elif is_fedora_coreos "$image"; then
+                rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG
+
+            elif is_fedora_rawhide "$image"; then
+                if [ "$PROVISION_HOW" = "virtual" ]; then
+                    rlAssertGrep "err: Error: Unable to find a match: tree-but-spelled-wrong" $rlRun_LOG
+                else
+                    rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG
+                fi
+
+            elif is_ubuntu "$image"; then
+                rlAssertGrep "err: E: Unable to locate package tree-but-spelled-wrong" $rlRun_LOG
+
+            elif is_alpine "$image"; then
+                rlAssertGrep "err:   tree-but-spelled-wrong (no such package)" $rlRun_LOG
+
+            else
+                rlAssertGrep "err: Error: Unable to find a match: tree-but-spelled-wrong" $rlRun_LOG
+            fi
         rlPhaseEnd
 
-        rlPhaseStartTest "Escape package names"
-            rlRun "$tmt plan --name escape"
-        rlPhaseEnd
+        # TODO: at least copr is RH-specific, but package name escaping and debuginfo should be
+        # possible to extend to other distros.
+        if (is_fedora "$image" && ! is_fedora_coreos "$image") || is_centos "$image" || is_ubi "$image"; then
+            if ! is_centos_7 "$image"; then
+                rlPhaseStartTest "$phase_prefix Just enable copr"
+                    rlRun "$tmt execute plan --name copr"
+                rlPhaseEnd
 
-        rlPhaseStartTest "Exclude selected packages"
-            rlRun "$tmt plan --name exclude"
-        rlPhaseEnd
+                rlPhaseStartTest "$phase_prefix Exclude selected packages"
+                    rlRun "$tmt execute plan --name exclude"
+                rlPhaseEnd
+            fi
 
-        rlPhaseStartTest "Install from epel7 copr"
-            rlRun "$tmt plan --name epel7"
-        rlPhaseEnd
+            rlPhaseStartTest "$phase_prefix Escape package names"
+                rlRun "$tmt execute plan --name escape"
+            rlPhaseEnd
 
-        rlPhaseStartTest "Install remote packages"
-            rlRun "$tmt plan --name epel8-remote"
-        rlPhaseEnd
+            if is_centos_7 "$image"; then
+                rlPhaseStartTest "$phase_prefix Install from epel7 copr"
+                    rlRun "$tmt execute plan --name epel7"
+                rlPhaseEnd
+            fi
 
-        rlPhaseStartTest "Install debuginfo packages"
-            rlRun "$tmt plan --name debuginfo"
-        rlPhaseEnd
-    fi
+            if is_centos_stream_8 "$image"; then
+                rlPhaseStartTest "$phase_prefix Install remote packages"
+                    rlRun "$tmt execute plan --name epel8-remote"
+                rlPhaseEnd
+            fi
+
+            rlPhaseStartTest "$phase_prefix Install debuginfo packages"
+                rlRun "$tmt execute plan --name debuginfo"
+            rlPhaseEnd
+        fi
+    done <<< "$IMAGES"
 
     rlPhaseStartCleanup
         rlRun "popd"

--- a/tests/provision/become/data/main.fmf
+++ b/tests/provision/become/data/main.fmf
@@ -8,7 +8,7 @@ adjust:
     - when: provisiontest == container
       provision+:
         how: container
-        image: localhost/fedora/rawhide/unprivileged:tmt-unit-tests
+        image: localhost/tmt/fedora/rawhide/unprivileged:latest
 
 execute:
     how: tmt

--- a/tests/provision/container/alpine/test.sh
+++ b/tests/provision/container/alpine/test.sh
@@ -5,7 +5,7 @@ USER="tester"
 
 rlJournalStart
     rlPhaseStartSetup
-        rlRun "make -C ../../../../ image-unit-tests-alpine"
+        rlRun "make -C ../../../../ image/tests/alpine image/tests/alpine/upstream"
 
         # Directories
         rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
@@ -15,14 +15,14 @@ rlJournalStart
 
     rlPhaseStartTest "Test vanilla alpine without bash"
         rlRun -s "tmt run --all --id $run --verbose --scratch \
-            provision --how container --image docker.io/alpine \
+            provision --how container --image localhost/tmt/alpine/upstream:latest \
             execute --how tmt --script whoami" 2
         rlAssertGrep "fail: /bin/bash is required on the guest." $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Test alpine with bash"
         rlRun -s "tmt run -vv --all --id $run --verbose --scratch \
-            provision --how container --image localhost/alpine:tmt-unit-tests \
+            provision --how container --image localhost/tmt/alpine:latest \
             execute --how tmt --script whoami" 0
         rlAssertGrep "out: root" $rlRun_LOG
     rlPhaseEnd

--- a/tests/provision/user/test.sh
+++ b/tests/provision/user/test.sh
@@ -17,7 +17,7 @@ rlJournalStart
         image=""
 
         if [ "$PROVISION_HOW" = "container" ]; then
-            image="--image localhost/fedora/rawhide/unprivileged:tmt-unit-tests"
+            image="--image localhost/tmt/fedora/rawhide/unprivileged:latest"
         fi
 
         rlRun -s "tmt run --scratch -i $run -a provision --how $PROVISION_HOW $image --user fedora report -vvv"

--- a/tests/unit/test.sh
+++ b/tests/unit/test.sh
@@ -36,7 +36,7 @@ rlJournalStart
         rlLogInfo "pip is $(which pip), $(pip --version)"
         rlLogInfo "hatch is $(which hatch), $(hatch --version)"
 
-        rlRun "make -C $TMT_TREE images-unit-tests"
+        rlRun "make -C $TMT_TREE images-tests"
     rlPhaseEnd
 
     if [ "$WITH_SYSTEM_PACKAGES" = "yes" ]; then

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -104,10 +104,6 @@ class RpmOstree(tmt.package_managers.PackageManager):
             self,
             *installables: Installable,
             options: Optional[Options] = None) -> CommandOutput:
-        if len(installables) != 1:
-            raise GeneralError(
-                "rpm-ostree package manager does not support installation of multiple packages.")
-
         options = options or Options()
 
         extra_options = self._extra_options(options)


### PR DESCRIPTION
That's 3 lines removed. The rest of 800+ lines of the patch consist of various improvements to related tests:

* new unit test, uses package managers directly to install multiple packages,
* `prepare/install` test refactored and extended to cover more distros when testing the basic operations, through parametrization,
* added new custom images to make tests cover "ostree" scenario
* plenty of `TODO` comments that should be resolved later.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage