### PR TITLE
Re-use "become" image to fix sudo-related trouble in /tests/provision/user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,13 +83,16 @@ images:  ## Build tmt images for podman/docker
 	podman build -t tmt --squash -f ./containers/Containerfile.mini .
 	podman build -t tmt-all --squash -f ./containers/Containerfile.full .
 
-images-unit-tests: image-unit-tests-alpine image-unit-tests-coreos  ## Build images for unit tests
+images-unit-tests: image-unit-tests-alpine image-unit-tests-coreos image-tests-fedora-become  ## Build images for unit tests
 
 image-unit-tests-alpine:  ## Build local alpine image for unit tests
 	podman build -t alpine:$(UNIT_TESTS_IMAGE_TAG) -f ./containers/Containerfile.alpine .
 
 image-unit-tests-coreos:  ## Build local CoreOS image for unit tests
 	podman build -t fedora-coreos:$(UNIT_TESTS_IMAGE_TAG) -f ./containers/Containerfile.coreos .
+
+image/tests/fedora/rawhide/unprivileged:  ## Build local Fedora image with unprivileged account and sudo
+	podman build -t fedora/rawhide/unprivileged:$(UNIT_TESTS_IMAGE_TAG) -f ./containers/fedora/rawhide/Containerfile.unprivileged .
 
 ##
 ## Development

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ images:  ## Build tmt images for podman/docker
 	podman build -t tmt --squash -f ./containers/Containerfile.mini .
 	podman build -t tmt-all --squash -f ./containers/Containerfile.full .
 
-images-unit-tests: image-unit-tests-alpine image-unit-tests-coreos image-tests-fedora-become  ## Build images for unit tests
+images-unit-tests: image-unit-tests-alpine image-unit-tests-coreos image/tests/fedora/rawhide/unprivileged  ## Build images for unit tests
 
 image-unit-tests-alpine:  ## Build local alpine image for unit tests
 	podman build -t alpine:$(UNIT_TESTS_IMAGE_TAG) -f ./containers/Containerfile.alpine .

--- a/containers/fedora/rawhide/Containerfile.unprivileged
+++ b/containers/fedora/rawhide/Containerfile.unprivileged
@@ -1,0 +1,11 @@
+#
+# A custom Fedora rawhide image, with unprivieged account & password-less sudo
+#
+
+FROM quay.io/fedora/fedora:rawhide
+
+RUN    useradd fedora \
+    && usermod -aG wheel fedora \
+    && echo -e 'fedora\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
+
+USER fedora

--- a/tests/provision/become/data/main.fmf
+++ b/tests/provision/become/data/main.fmf
@@ -8,7 +8,7 @@ adjust:
     - when: provisiontest == container
       provision+:
         how: container
-        image: localhost/become-container-test:latest
+        image: localhost/fedora/rawhide/unprivileged:tmt-unit-tests
 
 execute:
     how: tmt

--- a/tests/provision/become/test.sh
+++ b/tests/provision/become/test.sh
@@ -4,13 +4,13 @@
 rlJournalStart
     rlPhaseStartSetup
         rlRun "PROVISION_HOW=${PROVISION_HOW:-container}"
-        rlRun "pushd data"
         if [[ "$PROVISION_HOW" == "container" ]]; then
             # Try several times to build the container
             # https://github.com/teemtee/tmt/issues/2063
-            build="podman build -t become-container-test:latest ."
+            build="make -C ../../../ image/tests/fedora/rawhide/unprivileged"
             rlRun "rlWaitForCmd '$build' -m 5 -d 5" || rlDie "Unable to prepare the image"
         fi
+        rlRun "pushd data"
     rlPhaseEnd
 
     rlPhaseStartTest "$PROVISION_HOW, test with become=true"
@@ -45,8 +45,5 @@ rlJournalStart
 
     rlPhaseStartCleanup
         rlRun "popd"
-        if [[ "$PROVISION_HOW" == "container" ]]; then
-            rlRun "podman image rm -f localhost/become-container-test:latest" 0 "Remove custom image"
-        fi
     rlPhaseEnd
 rlJournalEnd

--- a/tests/provision/user/test.sh
+++ b/tests/provision/user/test.sh
@@ -14,16 +14,14 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "$PROVISION_HOW, set specific user"
-        if [ "$PROVISION_HOW" = "virtual" ]; then
-            user="fedora"
-            ids="1000"
-        else
-            user="nobody"
-            ids="65534"
+        image=""
+
+        if [ "$PROVISION_HOW" = "container" ]; then
+            image="--image localhost/fedora/rawhide/unprivileged:tmt-unit-tests"
         fi
 
-        rlRun -s "tmt run --scratch -i $run -a provision --how $PROVISION_HOW --user $user report -vvv"
-        rlAssertGrep "uid=$ids($user) gid=$ids($user) groups=$ids($user)" $rlRun_LOG
+        rlRun -s "tmt run --scratch -i $run -a provision --how $PROVISION_HOW $image --user fedora report -vvv"
+        rlAssertGrep "uid=1000(fedora) gid=1000(fedora) groups=1000(fedora)" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
The test started to fail because `/usr/bin/flock` is not preinstalled and the default Fedora image does not come with password-less `sudo` enabled out of the box. Therefore we use the image we build for `/tests/provision/become`, give a nice name other images will follow Soon(TM), and use it in a test that exercises a non-privileged access.

Pull Request Checklist

* [x] implement the feature