### PR TITLE
Allow `duration` in the `execute` schema

### DIFF
--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -159,6 +159,7 @@ definitions:
 
   # https://tmt.readthedocs.io/en/stable/spec/tests.html#duration
   # https://tmt.readthedocs.io/en/stable/spec/plans.html#shell
+  # https://tmt.readthedocs.io/en/stable/spec/plans.html#script
   duration:
     type: string
     pattern: "^[0-9]+[smhd]?$"

--- a/tmt/schemas/execute/tmt.yaml
+++ b/tmt/schemas/execute/tmt.yaml
@@ -34,5 +34,8 @@ properties:
   where:
     $ref: "/schemas/common#/definitions/where"
 
+  duration:
+    $ref: "/schemas/common#/definitions/duration"
+
 required:
   - how

--- a/tmt/schemas/execute/upgrade.yaml
+++ b/tmt/schemas/execute/upgrade.yaml
@@ -50,5 +50,8 @@ properties:
   where:
     $ref: "/schemas/common#/definitions/where"
 
+  duration:
+    $ref: "/schemas/common#/definitions/duration"
+
 required:
   - how

--- a/tmt/schemas/test.yaml
+++ b/tmt/schemas/test.yaml
@@ -32,8 +32,7 @@ properties:
 
   # https://tmt.readthedocs.io/en/stable/spec/tests.html#duration
   duration:
-    type: string
-    pattern: "^([0-9]+ *?[smhd]? *)+$"
+    $ref: "/schemas/common#/definitions/duration"
 
   # https://tmt.readthedocs.io/en/stable/spec/core.html#enabled
   enabled:


### PR DESCRIPTION
This attribute is accepted and tested, schema validation needs to respect that.

Pull Request Checklist

* [x] modify the json schema
