### PR TITLE
Fix copy/paste issue for `combine_hw_disk_size()`

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -630,7 +630,7 @@ class GuestTestcloud(tmt.GuestSsh):
         self.hardware.and_(memory_constraint)
 
     def _combine_hw_disk_size(self) -> None:
-        """ Combine ``hardware`` with ``--memory`` option """
+        """ Combine ``hardware`` with ``--disk`` option """
 
         if not self.hardware:
             self.hardware = tmt.hardware.Hardware.from_spec({})


### PR DESCRIPTION
In the doc string it seems there is a tiny copy/paste mistake, the _combine_hw_disk_size() deals with the disks but the docstring says
```
Combine ``hardware`` with ``--memory`` option
```
this commit fixes this.
