### PR TITLE
Display locals in traceback when requested

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -398,6 +398,8 @@ TMT_SHOW_TRACEBACK
     By default, when tmt reports an error, the corresponding
     traceback is not printed out. When ``TMT_SHOW_TRACEBACK`` is
     set to any string except ``0``, traceback would be printed out.
+    When set to ``full``, traceback would list also local variables
+    in each stack frame.
 
 TMT_OUTPUT_WIDTH
     By default, the output width of commands like ``tmt * show`` is constrained

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2468,6 +2468,8 @@ def render_run_exception(exception: RunError) -> Iterator[str]:
 
 
 def render_exception_stack(exception: BaseException) -> Iterator[str]:
+    """ Render traceback of the given exception """
+
     exception_traceback = traceback.TracebackException(
         type(exception),
         exception,


### PR DESCRIPTION
By setting `TMT_SHOW_TRACEBACK` to `full`, tmt would dump locals for each frame.

Pull Request Checklist

* [x] implement the feature