### PR TITLE
Fix path to watchdog log

### DIFF
--- a/tests/test/check/test-watchdog.sh
+++ b/tests/test/check/test-watchdog.sh
@@ -25,7 +25,7 @@ rlJournalStart
         rlRun "test_dir=$run/plan/execute/data/guest/default-0/watchdog/ping-1"
         rlRun "log=$run/log.txt"
         rlRun "test_log=$test_dir/output.txt"
-        rlRun "watchdog_log=$test_dir/tmt-watchdog.txt"
+        rlRun "watchdog_log=$test_dir/checks/tmt-watchdog.txt"
 
         if [ "$PROVISION_HOW" = "container" ]; then
             rlRun "tmt -c provision_method=$PROVISION_HOW run --id $run --scratch -a -vv provision -h $PROVISION_HOW                     test -n /watchdog" 1

--- a/tmt/checks/watchdog.py
+++ b/tmt/checks/watchdog.py
@@ -50,7 +50,7 @@ REPORT_FILENAME = 'tmt-watchdog.txt'
 def render_report_path(invocation: 'TestInvocation') -> Path:
     """ Render path to a watchdog report file from necessary components """
 
-    return invocation.path / REPORT_FILENAME
+    return invocation.check_files_path / REPORT_FILENAME
 
 
 def report_progress(
@@ -479,9 +479,10 @@ class Watchdog(CheckPlugin[WatchdogCheck]):
 
             guest_context.thread = None
 
+        assert invocation.phase.step.workdir is not None  # narrow type
+
         return [
             CheckResult(
                 name='watchdog',
                 result=ResultOutcome.PASS,
-                log=[render_report_path(invocation)]
-                )]
+                log=[render_report_path(invocation).relative_to(invocation.phase.step.workdir)])]


### PR DESCRIPTION
It needs to be relative to step workdir, and it belongs to the directory dedicated to check logs.

Pull Request Checklist

* [x] implement the feature