### PR TITLE
Add renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,20 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"packageRules": [
+		{
+			"groupName": "CI and devDependencies",
+			"matchManagers": ["github-actions", "pre-commit"]
+		},
+		{
+			"groupName": "Runtime and test",
+			"matchManagers": ["pep621"]
+		}
+	],
+	"separateMajorMinor": false,
+	"extends": [
+		"config:recommended",
+		"schedule:weekly",
+		":enablePreCommit",
+		":semanticCommitTypeAll(chore)"
+	]
+}


### PR DESCRIPTION
Here is a configuration for adding renovate. It's like `dependabot` but it's far less noisy, allowing to update dependencies when ready instead of whenever dependabot pokes you to do so.

The main benefits over dependabot:
- group dependencies. Can even group across different systems, e.g. github-action + pre-commit
- reuse of PR/issues
- flexibility and configurability. This is just a basic configuration file, there are much more that can be configured here.

For an example, you can check my fork where I've enabled this: https://github.com/LecrisUT/tmt/issues/2

To add this the [app](https://github.com/apps/renovate) needs to be installed, and when configuring the [settings](https://developer.mend.io/github/teemtee/tmt/-/settings) (403 page because it points to the not-yet configured url), make sure to set it to `Renovate -> Mode -> Interactive`, otherwise PRs are not created.

Fixes #3504