### PR TITLE
Add ability to flush artifacts from before reboot

### DIFF
--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -1,4 +1,5 @@
 import dataclasses
+import functools
 import os
 import subprocess
 import textwrap
@@ -548,7 +549,9 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                     logger.verbose(
                         f"{duration} {test.name} [{progress}]", shift=shift)
                     try:
-                        if invocation.handle_reboot():
+                        if invocation.handle_reboot(
+                                flush_func=functools.partial(guest.pull, source=self.step.plan.data_directory)
+                        ):
                             continue
                     except tmt.utils.RebootTimeoutError:
                         for result in invocation.results:

--- a/tmt/steps/execute/scripts/tmt-reboot
+++ b/tmt/steps/execute/scripts/tmt-reboot
@@ -13,11 +13,13 @@ PATH=/sbin:/usr/sbin:$PATH
 command=""
 timeout=""
 efi=True
-while getopts "c:t:e" flag; do
+flush_artifacts=False
+while getopts "c:t:e:f" flag; do
     case "${flag}" in
         c) command="${OPTARG}";;
         t) timeout="${OPTARG}";;
         e) efi=False;;
+        f) flush_artifacts=True;;
     esac
 done
 
@@ -37,4 +39,4 @@ if [ $efi = True ]; then
     fi
 fi
 
-flock "$TMT_TEST_PIDFILE_LOCK" tmt-reboot-core "$command" "$timeout"
+flock "$TMT_TEST_PIDFILE_LOCK" tmt-reboot-core "$command" "$timeout" "$flush_artifacts"

--- a/tmt/steps/execute/scripts/tmt-reboot-core
+++ b/tmt/steps/execute/scripts/tmt-reboot-core
@@ -11,6 +11,7 @@ fi
 
 command="$1"
 timeout="$2"
+flush_artifacts="$3"
 
 # Thanks to being run while holding the pidfile lock, the file exists and should
 # no go away. It should be safe to read test PID and reboot-request filepath from
@@ -20,5 +21,5 @@ test_reboot_file="$(awk '{print $2}' < "$TMT_TEST_PIDFILE")"
 
 mkdir -p "$(dirname "$test_reboot_file")"
 
-printf '{"command": "%s", "timeout": "%s"}' "$command" "$timeout" > "$test_reboot_file"
+printf '{"command": "%s", "timeout": "%s", "flush_artifacts": "%s"}' "$command" "$timeout" "$flush_artifacts" > "$test_reboot_file"
 kill "$test_pid"


### PR DESCRIPTION
Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note


This feature is important for tests that need system reboot which is part of the test and poses a risk of losing the system if something goes wrong before TMT reestablishes connection to the system. Having logs in such situations is super critical. So far we have workarounded this by printing all the information to the standard output of the test as that is collected continuously but that is not sustainable.

This PR contains 2 commits, the first one is less invasive and makes TMT pull only test data, but is suboptimal as the remaining (plan and other tests) data remain on the host and are risked to be lost. The second PR addresses this, but uses `functools.partial` which may be controversial and I'd like to get feedback if this approach is acceptable for the TMT project or if some other approach should be chosen - I'm open to it and am willing to change the code to whichever approach is acceptable (if it doesn't involve any major redesign of the TMT).