### PR TITLE
Update interaction with Fedora rawhide

### DIFF
--- a/containers/fedora/rawhide/Containerfile.unprivileged
+++ b/containers/fedora/rawhide/Containerfile.unprivileged
@@ -4,7 +4,8 @@
 
 FROM quay.io/fedora/fedora:rawhide
 
-RUN    useradd fedora \
+RUN    dnf install -y /usr/sbin/useradd \
+    && useradd fedora \
     && usermod -aG wheel fedora \
     && echo -e 'fedora\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
 

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -262,11 +262,7 @@ rlJournalStart
                 rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG
 
             elif is_fedora_rawhide "$image"; then
-                if [ "$PROVISION_HOW" = "virtual" ]; then
-                    rlAssertGrep "err: Error: Unable to find a match: tree-but-spelled-wrong" $rlRun_LOG
-                else
-                    rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG
-                fi
+                rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG
 
             elif is_ubuntu "$image"; then
                 rlAssertGrep "err: E: Unable to locate package tree-but-spelled-wrong" $rlRun_LOG
@@ -294,11 +290,7 @@ rlJournalStart
                 rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG
 
             elif is_fedora_rawhide "$image"; then
-                if [ "$PROVISION_HOW" = "virtual" ]; then
-                    rlAssertGrep "err: Error: Unable to find a match: tree-but-spelled-wrong" $rlRun_LOG
-                else
-                    rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG
-                fi
+                rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG
 
             elif is_ubuntu "$image"; then
                 rlAssertGrep "err: E: Unable to locate package tree-but-spelled-wrong" $rlRun_LOG

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -16,7 +16,10 @@ from tmt.utils import Command, CommandOutput, GeneralError, RunError, ShellScrip
 class Dnf(tmt.package_managers.PackageManager):
     NAME = 'dnf'
 
-    probe_command = Command('dnf', '--version')
+    probe_command = ShellScript(
+        """
+        type dnf && ((dnf --version | grep -E 'dnf5 version') && exit 1 || exit 0)
+        """).to_shell_command()
     # The priority of preference: `rpm-ostree` > `dnf5` > `dnf` > `yum`.
     # `rpm-ostree` has its own implementation and its own priority, and
     # the `dnf` family just stays below it.
@@ -168,7 +171,10 @@ class Dnf5(Dnf):
 class Yum(Dnf):
     NAME = 'yum'
 
-    probe_command = probe_command = Command('yum', '--version')
+    probe_command = ShellScript(
+        """
+        type yum && ((yum --version | grep -E 'dnf5 version') && exit 1 || exit 0)
+        """).to_shell_command()
     probe_priority = 40
 
     _base_command = Command('yum')


### PR DESCRIPTION
* `dnf` and `yum` are no longer standalone, legacy tools, they are now
  symlinks to `dnf5`, and as such we cannot detect them as distinct
  package managers. Fixing the probe commands to not detect `dnf` or `yum`
  when they report `dnf5` version.
* fix build of unprivileged rawhide test container, `useradd` is no longer
  pre-installed, request it.

Pull Request Checklist

* [x] implement the feature