### PR TITLE
Enforce "one blank line after class docstring" rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,6 +310,7 @@ lint.select = [
     "PLR04",
     "PLR1",
     "RUF",  # ruff
+    "D",    # pydocstyle
     ]
 lint.ignore = [
     "B904",  # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -325,7 +325,11 @@ lint.ignore = [
     "RUF013",  # PEP 484 prohibits implicit `Optional`
 
     # pydocstyle
-    # TODO: some of these will be enabled in their own patches
+    # TODO: the permanent list (drop this comment once the temporary list
+    # below gets to zero items...)
+    "D203",  # 1 blank line required before class docstring
+    # TODO: the temporary list - some of these will be enabled in their
+    # own patches
     "D100",  # Missing docstring in public module
     "D101",  # Missing docstring in public class
     "D102",  # Missing docstring in public method
@@ -335,8 +339,6 @@ lint.ignore = [
     "D106",  # Missing docstring in public nested class
     "D107",  # Missing docstring in __init__
     "D202",  # No blank lines allowed after function docstring
-    "D203",  # 1 blank line required before class docstring
-    "D204",  # 1 blank line required after class docstring
     "D205",  # 1 blank line required between summary line and description
     "D210",  # No whitespaces allowed surrounding docstring text
     "D212",  # Multi-line docstring summary should start at the first line

--- a/tests/discover/data/distgit_test_plugin.py
+++ b/tests/discover/data/distgit_test_plugin.py
@@ -13,6 +13,7 @@ class TestDistGit(DistGitHandler):
     each line in MOCK_SOURCES_FILENAME contains
     filename to serve and optional (after single space a custom filename)
     """
+
     usage_name = "TESTING"
     server = f"http://localhost:{SERVER_PORT}"
 

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 @dataclasses.dataclass(frozen=True)
 class Deprecated:
     """ Version information and hint for obsolete options """
+
     since: str
     hint: Optional[str] = None
 

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -54,6 +54,7 @@ SCRIPTS_SRC_DIR = tmt.utils.resource_files('steps/execute/scripts')
 @dataclass
 class Script:
     """ Represents a script provided by the internal executor """
+
     path: Path
     aliases: list[Path]
     related_variables: list[str]
@@ -62,6 +63,7 @@ class Script:
 @dataclass
 class ScriptCreatingFile(Script):
     """ Represents a script which creates a file """
+
     created_file: str
 
 

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -732,6 +732,7 @@ class BeakerAPI:
 
 class GuestBeaker(tmt.steps.provision.GuestSsh):
     """ Beaker guest instance """
+
     _data_class = BeakerGuestData
 
     # Guest request properties

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -5112,6 +5112,7 @@ class StructuredField:
 
 class DistGitHandler:
     """ Common functionality for DistGit handlers """
+
     sources_file_name = 'sources'
     uri = "/rpms/{name}/{filename}/{hashtype}/{hash}/{filename}"
 
@@ -5165,6 +5166,7 @@ class DistGitHandler:
 
 class FedoraDistGit(DistGitHandler):
     """ Fedora Handler """
+
     usage_name = "fedora"
     re_source = re.compile(r"^(\w+) \(([^)]+)\) = ([0-9a-fA-F]+)$")
     lookaside_server = "https://src.fedoraproject.org/repo/pkgs"
@@ -5173,6 +5175,7 @@ class FedoraDistGit(DistGitHandler):
 
 class CentOSDistGit(DistGitHandler):
     """ CentOS Handler """
+
     usage_name = "centos"
     re_source = re.compile(r"^(\w+) \(([^)]+)\) = ([0-9a-fA-F]+)$")
     lookaside_server = "https://sources.stream.centos.org/sources"
@@ -5181,6 +5184,7 @@ class CentOSDistGit(DistGitHandler):
 
 class RedHatGitlab(DistGitHandler):
     """ Red Hat on Gitlab """
+
     usage_name = "redhatgitlab"
     re_source = re.compile(r"^(\w+) \(([^)]+)\) = ([0-9a-fA-F]+)$")
     # Location already public (standard-test-roles)


### PR DESCRIPTION
We already enforce "no blank line before class docstring" rule, and "no blank line after class docstring" is put on ignore list.

Pull Request Checklist

* [x] implement the feature