### PR TITLE
Fix some invalid links in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -306,7 +306,7 @@ man_pages = [
 
 # -- Options for linkcheck builder ----------------------------------------
 linkcheck_ignore = [
-    # Githup "source code line" anchors are apparently too dynamic for linkcheck
+    # Github "source code line" anchors are apparently too dynamic for linkcheck
     # to detect correctly. The link exists, a browser can open it, but linkcheck
     # reports a broken link.
     r'https://github.com/packit/packit/blob/main/packit/utils/logging.py#L10'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -304,6 +304,14 @@ man_pages = [
 # If true, show URL addresses after external links.
 # man_show_urls = False
 
+# -- Options for linkcheck builder ----------------------------------------
+linkcheck_ignore = [
+    # Githup "source code line" anchors are apparently too dynamic for linkcheck
+    # to detect correctly. The link exists, a browser can open it, but linkcheck
+    # reports a broken link.
+    r'https://github.com/packit/packit/blob/main/packit/utils/logging.py#L10'
+    ]
+
 
 def generate_tmt_docs(app: Sphinx) -> None:
     """ Run `make generate` to populate the auto-generated sources """

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -59,7 +59,7 @@ Why should I care?
 
 You can get some more context in the `stackoverflow`__ article.
 
-__ http://stackoverflow.com/questions/2290016/
+__ https://stackoverflow.com/questions/2290016/
 
 .. _develop:
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1315,7 +1315,7 @@ steps for example. This is currently used in the Testing Farm's
 
     tmt run --last login < script.sh
 
-__ https://docs.testing-farm.io/general/0.1/test-results.html#_tmt_reproducer
+__ https://docs.testing-farm.io/Testing%20Farm/0.1/test-results.html#_tmt_reproducer
 
 Have you heard already that using command abbreviation is possible
 as well? It might save you some typing:

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -693,7 +693,7 @@ Git:
 https://github.com/teemtee/tmt
 
 Docs:
-http://tmt.readthedocs.io/
+https://tmt.readthedocs.io/
 
 Stories:
 https://tmt.readthedocs.io/en/stable/stories.html
@@ -714,7 +714,7 @@ Metadata Specification:
 https://tmt.readthedocs.io/en/stable/spec.html
 
 Flexible Metadata Format:
-http://fmf.readthedocs.io/
+https://fmf.readthedocs.io/
 
 Testing Farm:
 https://docs.testing-farm.io/

--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -460,4 +460,4 @@ If you were using ``provision.fmf`` with Testing Farm, check out
 the `Testing Farm docs`__ on this HW requirement for more details
 and how Testing Farm works with tmt metadata.
 
-__ https://docs.testing-farm.io/general/0.1/test-request.html
+__ https://docs.testing-farm.io/Testing%20Farm/0.1/test-request.html

--- a/spec/core/id.fmf
+++ b/spec/core/id.fmf
@@ -25,5 +25,5 @@ example: |
     id: af994876-1c68-49a7-90e8-c8d2b189189d
 
 link:
-  - implemented-by: /tmt/id.py
+  - implemented-by: /tmt/identifier.py
   - verified-by: /tests/unit

--- a/spec/tests/path.fmf
+++ b/spec/tests/path.fmf
@@ -21,4 +21,4 @@ example: |
 link:
   - implemented-by: /tmt/base.py
   - verified-by: /tests/execute/basic
-  - http://fmf.readthedocs.io/en/latest/features.html#virtual
+  - https://fmf.readthedocs.io/en/latest/features.html#virtual

--- a/stories/cli/plan.fmf
+++ b/stories/cli/plan.fmf
@@ -14,7 +14,7 @@ story: 'As a user I want to comfortably work with plans'
     link:
       - implemented-by: /tmt/cli.py
       - documented-by: /docs/examples.rst#explore-plans
-      - verified-by: /tests/plans/select
+      - verified-by: /tests/plan/select
 
 /filter:
     story: 'Filter available plans'
@@ -31,7 +31,7 @@ story: 'As a user I want to comfortably work with plans'
     link:
       - implemented-by: /tmt/base.py
       - documented-by: /docs/examples.rst#explore-plans
-      - verified-by: /tests/plans/select
+      - verified-by: /tests/plan/select
 
 /lint:
     story: 'Check plan against the L2 metadata specification'
@@ -42,7 +42,7 @@ story: 'As a user I want to comfortably work with plans'
     example: tmt plan lint
     link:
       - implemented-by: /tmt/cli.py
-      - verified-by: /tests/plan/lint
+      - verified-by: /tests/lint/plan
 
 /create:
     story: 'As a developer I want to easily enable CI'

--- a/stories/cli/run.fmf
+++ b/stories/cli/run.fmf
@@ -197,7 +197,7 @@ story: 'As a user I want to execute tests easily'
         or investigate what happened after the test is finished.
 
     link:
-      - implemented-by: /tmt/step
+      - implemented-by: /tmt/steps
       - verified-by: /tests/login
       - documented-by: /docs/examples.rst#guest-login
 

--- a/stories/cli/steps.fmf
+++ b/stories/cli/steps.fmf
@@ -34,7 +34,7 @@
         story: 'Use localhost for testing'
         example: tmt run provision --how=local
         link:
-          - implemented-by: /tmt/steps/provision/localhost.py
+          - implemented-by: /tmt/steps/provision/local.py
           - documented-by: /docs/examples.rst#provision-options
           - verified-by: /tests/init/base
 
@@ -58,7 +58,7 @@
             Do not provision a new system. Instead, use provided
             authentication data to connect to a running machine.
         link:
-          - implemented-by: /tmt/steps/provision/vagrant.py
+          - implemented-by: /tmt/steps/provision/connect.py
           - documented-by: /docs/examples.rst#provision-options
         example:
             - tmt run provision --how=connect --guest=name-or-ip --user=login --password=secret

--- a/stories/cli/test.fmf
+++ b/stories/cli/test.fmf
@@ -48,7 +48,7 @@ story: 'As a user I want to comfortably work with tests'
     example: tmt test import
     link:
       - implemented-by: /tmt/convert.py
-      - verified-by: /tests/test_convert
+      - verified-by: /tests/unit/test_convert.py
       - documented-by: /docs/examples.rst#convert-tests
 
 /export:

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -23,7 +23,7 @@ reducing their individual outcomes to one final answer for the whole set (think
 Components of each constraint - dimension, operator, value, units - are
 decoupled from the rest, and made available for inspection.
 
-[1] https://tmt.readthedocs.io/en/latest/spec/plans.html#hardware
+[1] https://tmt.readthedocs.io/en/stable/spec/hardware.html
 """
 
 import dataclasses

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -1960,7 +1960,8 @@ class Topology(SerializableContainer):
         """
         Convert to a mapping.
 
-        See https://tmt.readthedocs.io/en/stable/classes.html#class-conversions for more details.
+        See https://tmt.readthedocs.io/en/stable/code/classes.html#class-conversions
+        for more details.
         """
 
         data = super().to_dict()

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -2984,7 +2984,8 @@ class DataContainer:
         """
         Convert to a mapping.
 
-        See https://tmt.readthedocs.io/en/stable/classes.html#class-conversions for more details.
+        See https://tmt.readthedocs.io/en/stable/code/classes.html#class-conversions
+        for more details.
         """
 
         return dict(self.items())
@@ -2993,7 +2994,8 @@ class DataContainer:
         """
         Convert to a mapping with unset keys omitted.
 
-        See https://tmt.readthedocs.io/en/stable/classes.html#class-conversions for more details.
+        See https://tmt.readthedocs.io/en/stable/code/classes.html#class-conversions
+        for more details.
         """
 
         return {
@@ -3101,7 +3103,8 @@ class SpecBasedContainer(Generic[SpecInT, SpecOutT], DataContainer):
         """
         Convert from a specification file or from a CLI option
 
-        See https://tmt.readthedocs.io/en/stable/classes.html#class-conversions for more details.
+        See https://tmt.readthedocs.io/en/stable/code/classes.html#class-conversions
+        for more details.
 
         See :py:meth:`to_spec` for its counterpart.
         """
@@ -3112,7 +3115,8 @@ class SpecBasedContainer(Generic[SpecInT, SpecOutT], DataContainer):
         """
         Convert to a form suitable for saving in a specification file
 
-        See https://tmt.readthedocs.io/en/stable/classes.html#class-conversions for more details.
+        See https://tmt.readthedocs.io/en/stable/code/classes.html#class-conversions
+        for more details.
 
         See :py:meth:`from_spec` for its counterpart.
         """
@@ -3123,7 +3127,8 @@ class SpecBasedContainer(Generic[SpecInT, SpecOutT], DataContainer):
         """
         Convert to specification, skip default values
 
-        See https://tmt.readthedocs.io/en/stable/classes.html#class-conversions for more details.
+        See https://tmt.readthedocs.io/en/stable/code/classes.html#class-conversions
+        for more details.
 
         See :py:meth:`from_spec` for its counterpart.
         """
@@ -3178,7 +3183,8 @@ class SerializableContainer(DataContainer):
         """
         Convert to a form suitable for saving in a file.
 
-        See https://tmt.readthedocs.io/en/stable/classes.html#class-conversions for more details.
+        See https://tmt.readthedocs.io/en/stable/code/classes.html#class-conversions
+        for more details.
 
         See :py:meth:`from_serialized` for its counterpart.
         """
@@ -3210,7 +3216,8 @@ class SerializableContainer(DataContainer):
         """
         Convert from a serialized form loaded from a file.
 
-        See https://tmt.readthedocs.io/en/stable/classes.html#class-conversions for more details.
+        See https://tmt.readthedocs.io/en/stable/code/classes.html#class-conversions
+        for more details.
 
         See :py:meth:`to_serialized` for its counterpart.
         """
@@ -3264,7 +3271,8 @@ class SerializableContainer(DataContainer):
         Restoring such containers requires inspection of serialized data
         and dynamic imports of modules as needed.
 
-        See https://tmt.readthedocs.io/en/stable/classes.html#class-conversions for more details.
+        See https://tmt.readthedocs.io/en/stable/code/classes.html#class-conversions
+        for more details.
 
         See :py:meth:`to_serialized` for its counterpart.
         """


### PR DESCRIPTION
Related to https://github.com/teemtee/tmt/pull/2489. This PR does not fix all invalid links, but the rest should be caused by incorrect handling of links in template when rendering them; these should be resolved by the work related to
https://github.com/teemtee/tmt/issues/2868.

Pull Request Checklist

* [x] implement the feature