### PR TITLE
Add descriptions to well-known process exit codes

### DIFF
--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -244,9 +244,6 @@ class ProcessExitCodes(enum.IntEnum):
         if member is None:
             return 'unrecognized'
 
-        if member in (cls.SUCCESS, cls.FAILURE, cls.TIMEOUT):
-            return member.name.lower()
-
         if member.name.startswith('SIG'):
             return member.name
 


### PR DESCRIPTION
And log them:

```
# Old:
Command returned '1'.
Command returned '127'.
Command returned '143'.

# New:
Command returned '1' (failure).
Command returned '127' (not found).
Command returned '143' (SIGTERM).
```

This should provide more hints when investigating what commands did, why they finished and how.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation