### PR TITLE
Fix pre-commit typing python version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,4 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      with:
+        python-version: |
+          3.9
+          3.x
     - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
     rev: "v1.9.0"
     hooks:
       - id: mypy
+        language_version: "3.9"
         # TODO: find out how to amend mypy, pyright, pre-commit and package requirements.
         # Apparently, there is no easy way to avoid some level of duplication of
         # information when the package is *not* installed, which is the case of tmt
@@ -68,6 +69,7 @@ repos:
     rev: v1.1.357
     hooks:
       - id: pyright
+        language_version: "3.9"
         # TODO: find out how to amend mypy, pyright, pre-commit and package requirements.
         # Apparently, there is no easy way to avoid some level of duplication of
         # information when the package is *not* installed, which is the case of tmt

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1028,9 +1028,9 @@ def test_import_member(root_logger):
 
 def test_import_member_no_such_module(root_logger):
     with pytest.raises(
-            SystemExit,
-            match=rf"Failed to import the 'tmt\.steps\.nope_does_not_exist'"
-                  rf" module from '{Path.cwd()}'."):
+        SystemExit,
+        match=rf"Failed to import the 'tmt\.steps\.nope_does_not_exist'"
+            rf" module from '{Path.cwd()}'."):
         tmt.plugins.import_member(
             module='tmt.steps.nope_does_not_exist',
             member='Discover',


### PR DESCRIPTION
Just figured out, when `language_version` is not specified, the `python_version` in `additional_dependencies` is ignored, although the configuration in `pyproject.toml` is still respected.

@happz, you might want to pull this one early for the typing fixes