### PR TITLE
Clarify the `trigger` context dimension values

### DIFF
--- a/spec/context/trigger.fmf
+++ b/spec/context/trigger.fmf
@@ -11,11 +11,13 @@ description: |
 
     commit
         Project source code has changed. This can be either a
-        pull/merge request or a new commit pushed to a branch.
+        pull/merge request creation or update, new branch created
+        or a new commit pushed to an existing branch.
 
     build
-        There has been a new package built in koji or brew and is
-        available for testing.
+        There has been a new official package built in koji or
+        brew. It can be a non-scratch build created directly or a
+        `draft build`__ which has been promoted to non-draft.
 
     update
         A new bodhi update or errata advisory with one or more
@@ -26,6 +28,8 @@ description: |
 
     This context dimension will usually be provided from the
     command line.
+
+    __ https://docs.pagure.org/koji/draft_builds/
 
 example: |
     summary: Full test coverage (takes three days)


### PR DESCRIPTION
Provide a bit more precise definitions of the `commit` and `build` trigger values, especially to make it clear that `build` could be used for the event of promoting draft builds as well.

Related issue: https://issues.redhat.com/browse/OSCI-4586

Pull Request Checklist

* [x] update the specification