### PR TITLE
Fix multiple rules `adjust` example in `duration` spec

### DIFF
--- a/spec/tests/duration.fmf
+++ b/spec/tests/duration.fmf
@@ -49,9 +49,9 @@ example:
     # Use context adjust to scale duration for given arch
     duration: 5m
     adjust:
-        duration+: *2
+      - duration+: *2
         when: arch == aarch64
-        duration+: *0.9
+      - duration+: *0.9
         when: arch == s390x
 
 


### PR DESCRIPTION
There are multiple rules so `list` should be used instead.

Pull Request Checklist

* [x] write the documentation