### PR TITLE
Introduce "phase result" for prepare/finish plugins to return [Step results #2]

### DIFF
--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -9,6 +9,7 @@ import tmt
 import tmt.steps
 from tmt.options import option
 from tmt.plugins import PluginRegistry
+from tmt.result import PhaseResult
 from tmt.steps import (
     Action,
     ActionTask,
@@ -32,7 +33,7 @@ class FinishStepData(tmt.steps.WhereableStepData, tmt.steps.StepData):
 FinishStepDataT = TypeVar('FinishStepDataT', bound=FinishStepData)
 
 
-class FinishPlugin(tmt.steps.Plugin[FinishStepDataT, None]):
+class FinishPlugin(tmt.steps.Plugin[FinishStepDataT, list[PhaseResult]]):
     """ Common parent of finish plugins """
 
     # ignore[assignment]: as a base class, FinishStepData is not included in
@@ -71,8 +72,10 @@ class FinishPlugin(tmt.steps.Plugin[FinishStepDataT, None]):
             *,
             guest: 'Guest',
             environment: Optional[tmt.utils.Environment] = None,
-            logger: tmt.log.Logger) -> None:
+            logger: tmt.log.Logger) -> list[PhaseResult]:
         self.go_prolog(logger)
+
+        return []
 
 
 class Finish(tmt.steps.Step):

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -7,6 +7,7 @@ import tmt
 import tmt.steps
 import tmt.steps.finish
 import tmt.utils
+from tmt.result import PhaseResult
 from tmt.steps import safe_filename
 from tmt.steps.provision import Guest
 from tmt.utils import ShellScript, field
@@ -63,9 +64,9 @@ class FinishShell(tmt.steps.finish.FinishPlugin[FinishShellData]):
             *,
             guest: 'Guest',
             environment: Optional[tmt.utils.Environment] = None,
-            logger: tmt.log.Logger) -> None:
+            logger: tmt.log.Logger) -> list[PhaseResult]:
         """ Perform finishing tasks on given guest """
-        super().go(guest=guest, environment=environment, logger=logger)
+        results = super().go(guest=guest, environment=environment, logger=logger)
 
         # Give a short summary
         overview = fmf.utils.listed(self.data.script, 'script')
@@ -96,3 +97,5 @@ class FinishShell(tmt.steps.finish.FinishPlugin[FinishShellData]):
             else:
                 command = tmt.utils.ShellScript(f'{finish_wrapper_path}')
             guest.execute(command, cwd=workdir)
+
+        return results

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -14,6 +14,7 @@ import tmt.steps.provision
 import tmt.utils
 from tmt.options import option
 from tmt.plugins import PluginRegistry
+from tmt.result import PhaseResult
 from tmt.steps import (
     Action,
     ActionTask,
@@ -44,7 +45,7 @@ class _RawPrepareStepData(tmt.steps._RawStepData, tmt.steps.RawWhereableStepData
     pass
 
 
-class PreparePlugin(tmt.steps.Plugin[PrepareStepDataT, None]):
+class PreparePlugin(tmt.steps.Plugin[PrepareStepDataT, list[PhaseResult]]):
     """ Common parent of prepare plugins """
 
     # ignore[assignment]: as a base class, PrepareStepData is not included in
@@ -83,7 +84,7 @@ class PreparePlugin(tmt.steps.Plugin[PrepareStepDataT, None]):
             *,
             guest: 'tmt.steps.provision.Guest',
             environment: Optional[tmt.utils.Environment] = None,
-            logger: tmt.log.Logger) -> None:
+            logger: tmt.log.Logger) -> list[PhaseResult]:
         """ Prepare the guest (common actions) """
 
         self.go_prolog(logger)
@@ -95,6 +96,8 @@ class PreparePlugin(tmt.steps.Plugin[PrepareStepDataT, None]):
         # Show requested role if defined
         if self.data.where:
             logger.info('where', fmf.utils.listed(self.data.where), 'green')
+
+        return []
 
 
 class Prepare(tmt.steps.Step):

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -10,6 +10,7 @@ import tmt.options
 import tmt.steps
 import tmt.steps.prepare
 import tmt.utils
+from tmt.result import PhaseResult
 from tmt.steps.provision import Guest
 from tmt.utils import Path, PrepareError, field, normalize_string_list, retry_session
 
@@ -122,9 +123,9 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
             *,
             guest: 'Guest',
             environment: Optional[tmt.utils.Environment] = None,
-            logger: tmt.log.Logger) -> None:
+            logger: tmt.log.Logger) -> list[PhaseResult]:
         """ Prepare the guests """
-        super().go(guest=guest, environment=environment, logger=logger)
+        results = super().go(guest=guest, environment=environment, logger=logger)
 
         # Apply each playbook on the guest
         for playbook in self.data.playbook:
@@ -165,3 +166,5 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
                 logger.info('playbook-path', playbook_path, 'green')
 
             guest.ansible(playbook_path, extra_args=self.data.extra_args)
+
+        return results

--- a/tmt/steps/prepare/distgit.py
+++ b/tmt/steps/prepare/distgit.py
@@ -8,6 +8,7 @@ import tmt.steps
 import tmt.steps.prepare
 import tmt.utils
 from tmt.package_managers import Package
+from tmt.result import PhaseResult
 from tmt.steps.prepare import PreparePlugin
 from tmt.steps.prepare.install import _RawPrepareInstallStepData
 from tmt.steps.provision import Guest
@@ -173,10 +174,10 @@ class PrepareDistGit(tmt.steps.prepare.PreparePlugin[DistGitData]):
             *,
             guest: 'Guest',
             environment: Optional[tmt.utils.Environment] = None,
-            logger: tmt.log.Logger) -> None:
+            logger: tmt.log.Logger) -> list[PhaseResult]:
         """ Prepare the guests for building rpm sources """
 
-        super().go(guest=guest, environment=environment, logger=logger)
+        results = super().go(guest=guest, environment=environment, logger=logger)
 
         environment = environment or tmt.utils.Environment()
 
@@ -318,3 +319,5 @@ class PrepareDistGit(tmt.steps.prepare.PreparePlugin[DistGitData]):
                 # Inject additional install plugins - recommend
                 if collected_recommends and self.future_recommends:
                     self.future_recommends.data.package = uniq(collected_recommends)
+
+        return results

--- a/tmt/steps/prepare/feature.py
+++ b/tmt/steps/prepare/feature.py
@@ -8,6 +8,7 @@ import tmt.options
 import tmt.steps
 import tmt.steps.prepare
 import tmt.utils
+from tmt.result import PhaseResult
 from tmt.steps.provision import Guest
 from tmt.utils import Path, field
 
@@ -127,13 +128,13 @@ class PrepareFeature(tmt.steps.prepare.PreparePlugin[PrepareFeatureData]):
             *,
             guest: 'Guest',
             environment: Optional[tmt.utils.Environment] = None,
-            logger: tmt.log.Logger) -> None:
+            logger: tmt.log.Logger) -> list[PhaseResult]:
         """ Prepare the guests """
-        super().go(guest=guest, environment=environment, logger=logger)
+        results = super().go(guest=guest, environment=environment, logger=logger)
 
         # Nothing to do in dry mode
         if self.opt('dry'):
-            return
+            return []
 
         # Enable or disable epel
         for feature_key in _FEATURES:
@@ -152,3 +153,5 @@ class PrepareFeature(tmt.steps.prepare.PreparePlugin[PrepareFeatureData]):
                     raise tmt.utils.GeneralError(f"Unknown feature setting '{value}'.")
             else:
                 raise tmt.utils.GeneralError(f"Unsupported feature '{feature_key}'.")
+
+        return results

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -23,6 +23,7 @@ from tmt.package_managers import (
     PackagePath,
     PackageUrl,
     )
+from tmt.result import PhaseResult
 from tmt.steps.provision import Guest
 from tmt.utils import Command, Path, ShellScript, field
 
@@ -648,13 +649,13 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
             *,
             guest: 'Guest',
             environment: Optional[tmt.utils.Environment] = None,
-            logger: tmt.log.Logger) -> None:
+            logger: tmt.log.Logger) -> list[PhaseResult]:
         """ Perform preparation for the guests """
-        super().go(guest=guest, environment=environment, logger=logger)
+        results = super().go(guest=guest, environment=environment, logger=logger)
 
         # Nothing to do in dry mode
         if self.is_dry_run:
-            return
+            return results
 
         # Pick the right implementation
         # TODO: it'd be nice to use a "plugin registry" and make the
@@ -730,3 +731,5 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
 
         # ... and install packages.
         installer.install()
+
+        return results

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -9,6 +9,7 @@ import tmt.log
 import tmt.steps
 import tmt.steps.prepare
 import tmt.utils
+from tmt.result import PhaseResult
 from tmt.steps import safe_filename
 from tmt.steps.provision import Guest
 from tmt.utils import ShellScript, field
@@ -62,9 +63,9 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             *,
             guest: 'Guest',
             environment: Optional[tmt.utils.Environment] = None,
-            logger: tmt.log.Logger) -> None:
+            logger: tmt.log.Logger) -> list[PhaseResult]:
         """ Prepare the guests """
-        super().go(guest=guest, environment=environment, logger=logger)
+        results = super().go(guest=guest, environment=environment, logger=logger)
 
         environment = environment or tmt.utils.Environment()
 
@@ -112,3 +113,5 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
                 command=command,
                 cwd=workdir,
                 env=environment)
+
+        return results


### PR DESCRIPTION
No plugin returns it yet, not any of the results is saved, the patch changes return value types and adds the structure itself.

Depends on https://github.com/teemtee/tmt/pull/2963

Pull Request Checklist

* [x] implement the feature