### PR TITLE
Use ansible playbook from worktree

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -956,11 +956,9 @@ class Guest(tmt.utils.Common):
         self.debug(f"Applying playbook '{playbook}' on guest '{self.primary_address}'.")
         # FIXME: cast() - https://github.com/teemtee/tmt/issues/1372
         parent = cast(Provision, self.parent)
-        assert parent.plan.my_run is not None  # narrow type
-        assert parent.plan.my_run.tree is not None  # narrow type
-        assert parent.plan.my_run.tree.root is not None  # narrow type
+        assert parent.plan.fmf_root is not None  # narrow type
         # Playbook paths should be relative to the metadata tree root
-        playbook = parent.plan.my_run.tree.root / playbook.unrooted()
+        playbook = parent.plan.fmf_root / playbook.unrooted()
         self.debug(f"Playbook full path: '{playbook}'", level=2)
         return playbook
 


### PR DESCRIPTION
During `tmt run` execution there are two copies of the playbook
available:
- One in the original repository with tmt plan
- Second in the `worktree` under /var/tmp/tmt...

`_ansible_playbook_path` uses the second one instead the first one now.

Resolves: https://github.com/teemtee/tmt/issues/2935

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
