### PR TITLE
Improve rendering of story links in our docs

### DIFF
--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -54,7 +54,7 @@
     :param tmt.base.Link link: link to render.
 #}
 {% macro emit_tmt_repo_link(link) %}
-{{ _emit_remote_link(link, link.target, "https://github.com/teemtee/tmt/tree/main/" + link.target.lstrip('/')) }}
+{{ _emit_remote_link(link, link.target, "https://github.com/teemtee/tmt/tree/" + (STORY.fmf_id.ref or 'main') + "/" + link.target.lstrip('/')) }}
 {% endmacro %}
 
 {#
@@ -78,7 +78,7 @@
 {% elif plugin_name == "provision/testcloud" %}
     {% set plugin_name = "provision/virtual" %}
 {% endif %}
-{{ _emit_remote_link(link, plugin_name, "https://github.com/teemtee/tmt/tree/main/" + link.target) }}
+{{ _emit_remote_link(link, plugin_name, "https://github.com/teemtee/tmt/tree/" + (STORY.fmf_id.ref or 'main') + "/" + link.target) }}
 {% endmacro %}
 
 {#

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -101,7 +101,7 @@
   {% set objects = STORY.tree.plans(names=["^" + link.target + "(/|$)"]) %}
 {% else %}
   {#
-    TODO: capture `emit_tmt_object_links` beign called for anything but
+    TODO: capture `emit_tmt_object_links` being called for anything but
     plans and tests.
   #}
   {{ 0/0 }}

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -45,7 +45,7 @@
     :param url: URL to point at.
 #}
 {% macro _emit_remote_link(link, label, url) %}
-* {{ printable_relation(link) }} `{{ label }} <{{ url }}>`__ {% if link.note %}({{ link.note }}){% endif %}
+* {{ printable_relation(link) }} `{{ label }} <{{ url }}>`_ {% if link.note %}({{ link.note }}){% endif %}
 {% endmacro %}
 
 {#

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -100,8 +100,17 @@
 {% elif link.target.startswith('/plans') %}
   {% set objects = STORY.tree.plans(names=["^" + link.target + "(/|$)"]) %}
 {% else %}
+  {#
+    TODO: capture `emit_tmt_object_links` beign called for anything but
+    plans and tests.
+  #}
   {{ 0/0 }}
-  {% set objects = [] %}
+{% endif %}
+{% if not objects %}
+  {#
+    TODO: capture pointing to a test/plan that cannot be found.
+  #}
+  {{ 0/0 }}
 {% endif %}
 {% for object in objects %}
 {{ _emit_remote_link(link, object.name, object.web_link()) }}
@@ -210,7 +219,7 @@
 
 {# Links pointing to websites #}
 {% elif link.target | match('^https?://') %}
-* {{ printable_relation(link) }} `{{ link.target}} <{{ link.target }}>`__
+* {{ printable_relation(link) }} `{{ link.target}} <{{ link.target }}>`_
 
 {# Links pointing to anything else #}
 {% else %}

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -9,6 +9,12 @@
     links.
 #}
 
+{#
+    Render a given example as a `code-block`.
+
+    :param str example: the example to render. May contain syntax
+        token to use for highlighting instead of the default ``yaml``.
+#}
 {% macro render_example(example) %}
     {% set example = example.strip() %}
     {% set syntax = example | regex_search('^# syntax: ([a-z]+)') %}
@@ -27,37 +33,34 @@
 {#
     Convert link relation into a nicely formatted string.
 
-    :param link: tmt.base.Link instance.
+    :param tmt.base.Link link: instance.
 #}
 {% macro printable_relation(link) %}{{ link.relation.replace('relates', 'relates-to').replace('-', ' ').capitalize() }}{% endmacro %}
 
 {#
     Emit a remote link.
 
-    :param link: tmt.base.Link instance.
-    :param label: HTML link label.
-    :param url: HTML link URL.
+    :param tmt.base.Link link: link to render.
+    :param str label: label of the link.
+    :param url: URL to point at.
 #}
 {% macro _emit_remote_link(link, label, url) %}
-* {{ printable_relation(link) }} `{{ label }} <{{ url }}>`_ {% if link.note %}({{ link.note }}){% endif %}
+* {{ printable_relation(link) }} `{{ label }} <{{ url }}>`__ {% if link.note %}({{ link.note }}){% endif %}
 {% endmacro %}
 
 {#
-    Emit a link leading to tmt's upstream repository.
+    Emit a link leading to something in tmt upstream repository.
 
-    :param link: tmt.base.Link instance.
-    :param pattern: used to extract link label from its target. It shall include
-        one capturing group, representing the label.
-    :param suffix: optional suffix to attach to link's target.
+    :param tmt.base.Link link: link to render.
 #}
-{% macro emit_tmt_repo_link(link, pattern, suffix) %}
-{{ _emit_remote_link(link, link.target, "https://github.com/teemtee/tmt/tree/main/" + link.target.lstrip('/') + (suffix or '')) }}
+{% macro emit_tmt_repo_link(link) %}
+{{ _emit_remote_link(link, link.target, "https://github.com/teemtee/tmt/tree/main/" + link.target.lstrip('/')) }}
 {% endmacro %}
 
 {#
-    Emit a link leading to tmt's plugin.
+    Emit a link leading to tmt plugin sources.
 
-    :param link: tmt.base.Link instance.
+    :param tmt.base.Link link: link to render.
 #}
 {% macro emit_tmt_plugin_link(link) %}
 {% set matched = link.target | match('^/tmt/steps/([a-z_]+/[a-z_]+)\\.py$') %}
@@ -79,32 +82,30 @@
 {% endmacro %}
 
 {#
-    Emit a link leading to an object in tmt's upstream repository - a test,
-    story, source file.
+    Emit a link leading to fmf object in tmt upstream repository.
 
-    If we're able to identify the object in story's tree, we will use its
-    :py:meth:`Core.web_link` method to get the proper URL. Otherwise, a URL
-    would be constructed from link's target.
+    Since a link can point to a root of hierarchy of fmf objects, we
+    render all of them, with their names instead of labeling them all
+    with ``link.target``.
 
-    :param link: tmt.base.Link instance.
-    :param pattern: used to extract link label from its target. It shall include
-        one capturing group, representing the label.
-    :param suffix: optional suffix to attach to link's target.
+    We are ignoring stories on purpose: stories are rendered as docs,
+    therefore links pointing to stores are rendered as in-doc references
+    by the template.
+
+    :param tmt.base.Link link: link to render.
 #}
-{% macro emit_tmt_object_link(link, suffix) %}
+{% macro emit_tmt_object_links(link) %}
 {% if link.target.startswith('/tests') %}
-  {% set objects = STORY.tree.tests(names=["^" + link.target + "$"]) %}
+  {% set objects = STORY.tree.tests(names=["^" + link.target + "(/|$)"]) %}
 {% elif link.target.startswith('/plans') %}
-  {% set objects = STORY.tree.plans(names=["^" + link.target + "$"]) %}
+  {% set objects = STORY.tree.plans(names=["^" + link.target + "(/|$)"]) %}
 {% else %}
+  {{ 0/0 }}
   {% set objects = [] %}
 {% endif %}
-{% if objects %}
-  {% set url = objects[0].web_link() %}
-{% else %}
-  {% set url = "https://github.com/teemtee/tmt/tree/main/" + link.target.lstrip('/') + (suffix or default('')) %}
-{% endif %}
-{{ _emit_remote_link(link, link.target, url) }}
+{% for object in objects %}
+{{ _emit_remote_link(link, object.name, object.web_link()) }}
+{% endfor %}
 {% endmacro %}
 
 {#
@@ -181,11 +182,11 @@
 
 {# Links pointing to step core implementation #}
 {% elif link.target | match('^/tmt/steps(?:/__init__.py)?$') %}
-{{ emit_tmt_repo_link(link, '/tmt/(steps)(?:/__init__.py)?') }}
+{{ emit_tmt_repo_link(link) }}
 
 {# Links pointing to step implementations #}
 {% elif link.target | match('^/tmt/steps/([a-z_]+)(?:$|(?:/__init__.py))$') %}
-{{ emit_tmt_repo_link(link, '/tmt/steps/([a-z_]+)(?:$|(?:/__init__.py))') }}
+{{ emit_tmt_repo_link(link) }}
 
 {# Links pointing to step plugins #}
 {% elif link.target | match('^/tmt/steps/([a-z_]+/[a-z_]+)\\.py$') %}
@@ -193,7 +194,7 @@
 
 {# Links pointing to other tmt code #}
 {% elif link.target.startswith('/tmt') %}
-{{ emit_tmt_repo_link(link, '/(.*)') }}
+{{ emit_tmt_repo_link(link) }}
 
 {# Links pointing to stories #}
 {% elif link.target | match('^/stories') %}
@@ -201,15 +202,15 @@
 
 {# Links pointing to tests #}
 {% elif link.target | match ('^/tests') %}
-{{ emit_tmt_object_link(link, '.fmf') }}
+{{ emit_tmt_object_links(link) }}
 
 {# Links pointing to plans #}
 {% elif link.target | match ('^/plans') %}
-{{ emit_tmt_object_link(link, '.fmf') }}
+{{ emit_tmt_object_links(link) }}
 
 {# Links pointing to websites #}
 {% elif link.target | match('^https?://') %}
-* {{ printable_relation(link) }} `{{ link.target}} <{{ link.target }}>`_
+* {{ printable_relation(link) }} `{{ link.target}} <{{ link.target }}>`__
 
 {# Links pointing to anything else #}
 {% else %}

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -89,7 +89,7 @@
     with ``link.target``.
 
     We are ignoring stories on purpose: stories are rendered as docs,
-    therefore links pointing to stores are rendered as in-doc references
+    therefore links pointing to stories are rendered as in-doc references
     by the template.
 
     :param tmt.base.Link link: link to render.

--- a/spec/core/id.fmf
+++ b/spec/core/id.fmf
@@ -26,4 +26,4 @@ example: |
 
 link:
   - implemented-by: /tmt/identifier.py
-  - verified-by: /tests/unit
+  - verified-by: /tests/unit/.*/basic

--- a/spec/tests/result.fmf
+++ b/spec/tests/result.fmf
@@ -37,4 +37,4 @@ example:
 link:
   - implemented-by: /tmt/base.py
   - verified-by: /tests/execute/result
-  - verified-by: /tests/execute/results-custom
+  - verified-by: /tests/execute/result/custom

--- a/stories/cli/init.fmf
+++ b/stories/cli/init.fmf
@@ -2,7 +2,7 @@ story: As a user I want to start using tmt in my git repository.
 summary: Initialize a new metadata tree
 link:
   - implemented-by: /tmt/cli.py
-  - verified-by: /tests/unit
+  - verified-by: /tests/unit/.*/basic
 
 /empty:
     summary: Create an empty metadata tree

--- a/stories/cli/test.fmf
+++ b/stories/cli/test.fmf
@@ -48,7 +48,7 @@ story: 'As a user I want to comfortably work with tests'
     example: tmt test import
     link:
       - implemented-by: /tmt/convert.py
-      - verified-by: /tests/unit/test_convert.py
+      - verified-by: /tests/unit/.*/basic
       - documented-by: /docs/examples.rst#convert-tests
 
 /export:

--- a/stories/features/report-result.fmf
+++ b/stories/features/report-result.fmf
@@ -29,4 +29,4 @@ example: |
 
 link:
   - implemented-by: /tmt/steps/execute/internal.py
-  - verified-by: /tests/execute/restraint/report_result
+  - verified-by: /tests/execute/restraint/report-result


### PR DESCRIPTION
There were several broken links, caused by links being misrendered. I added several comments and removed unused parameters in the process, but the important bit is the chaneg to rendering of plan/test links, usualy pointed to by `verified-by` links. No longer adding suffixes or composing URLs, we rely on `web_link` completely, and if a link points to multiple objects, like a hierarchy of multiple tests with the same prefix, we render all of them. It turns out to be hard to get web link correctly for such a root node, and it provides nice list of all related links to the user.

Related to https://github.com/teemtee/tmt/issues/2868

Pull Request Checklist

* [x] implement the feature