### PR TITLE
Add option to skip output log in junit and polarion reports

### DIFF
--- a/tmt/schemas/report/junit.yaml
+++ b/tmt/schemas/report/junit.yaml
@@ -25,7 +25,7 @@ properties:
   file:
     type: string
 
-  output-log:
+  include-output-log:
     type: boolean
 
 required:

--- a/tmt/schemas/report/junit.yaml
+++ b/tmt/schemas/report/junit.yaml
@@ -25,5 +25,8 @@ properties:
   file:
     type: string
 
+  output-log:
+    type: boolean
+
 required:
   - how

--- a/tmt/schemas/report/polarion.yaml
+++ b/tmt/schemas/report/polarion.yaml
@@ -73,7 +73,7 @@ properties:
   fips:
     type: boolean
 
-  output-log:
+  include-output-log:
     type: boolean
 
 required:

--- a/tmt/schemas/report/polarion.yaml
+++ b/tmt/schemas/report/polarion.yaml
@@ -73,6 +73,9 @@ properties:
   fips:
     type: boolean
 
+  output-log:
+    type: boolean
+
 required:
   - how
   - project-id

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -9,6 +9,7 @@ import tmt.steps
 from tmt.options import option
 from tmt.plugins import PluginRegistry
 from tmt.steps import Action
+from tmt.utils import field
 
 if TYPE_CHECKING:
     import tmt.cli
@@ -16,7 +17,12 @@ if TYPE_CHECKING:
 
 @dataclasses.dataclass
 class ReportStepData(tmt.steps.StepData):
-    pass
+    output_log: bool = field(
+        default=True,
+        option=('--output-log / --no-output-log'),
+        is_flag=True,
+        show_default=True,
+        help='Show full output in resulting xml file.')
 
 
 ReportStepDataT = TypeVar('ReportStepDataT', bound=ReportStepData)

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -17,12 +17,12 @@ if TYPE_CHECKING:
 
 @dataclasses.dataclass
 class ReportStepData(tmt.steps.StepData):
-    output_log: bool = field(
+    include_output_log: bool = field(
         default=True,
-        option=('--output-log / --no-output-log'),
+        option=('--include-output-log / --no-include-output-log'),
         is_flag=True,
         show_default=True,
-        help='Show full output in resulting xml file.')
+        help='Include full standard output in resulting xml file.')
 
 
 ReportStepDataT = TypeVar('ReportStepDataT', bound=ReportStepData)

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -9,7 +9,6 @@ import tmt.steps
 from tmt.options import option
 from tmt.plugins import PluginRegistry
 from tmt.steps import Action
-from tmt.utils import field
 
 if TYPE_CHECKING:
     import tmt.cli
@@ -17,12 +16,7 @@ if TYPE_CHECKING:
 
 @dataclasses.dataclass
 class ReportStepData(tmt.steps.StepData):
-    include_output_log: bool = field(
-        default=True,
-        option=('--include-output-log / --no-include-output-log'),
-        is_flag=True,
-        show_default=True,
-        help='Include full standard output in resulting xml file.')
+    pass
 
 
 ReportStepDataT = TypeVar('ReportStepDataT', bound=ReportStepData)

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -73,7 +73,7 @@ def make_junit_xml(report: 'ReportPlugin[ReportStepDataT]') -> 'junit_xml.TestSu
             classname=None,
             elapsed_sec=duration_to_seconds(result.duration))
 
-        if report.data.output_log:
+        if report.data.include_output_log:
             case.stdout = main_log
 
         # Map tmt OUTCOME to JUnit states

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -71,8 +71,11 @@ def make_junit_xml(report: 'ReportPlugin[ReportStepDataT]') -> 'junit_xml.TestSu
         case = junit_xml.TestCase(
             result.name,
             classname=None,
-            elapsed_sec=duration_to_seconds(result.duration),
-            stdout=main_log)
+            elapsed_sec=duration_to_seconds(result.duration))
+
+        if report.data.output_log:
+            case.stdout = main_log
+
         # Map tmt OUTCOME to JUnit states
         if result.result == tmt.result.ResultOutcome.ERROR:
             case.add_error_info(result.result.value, output=result.failures(main_log))

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -15,7 +15,8 @@ from tmt.utils import Path, field
 if TYPE_CHECKING:
     import junit_xml
 
-    from tmt.steps.report import ReportPlugin, ReportStepDataT
+    from tmt.steps.report import ReportPlugin
+    from tmt.steps.report.polarion import ReportPolarionData
 
 DEFAULT_NAME = "junit.xml"
 
@@ -57,7 +58,9 @@ def duration_to_seconds(duration: Optional[str]) -> Optional[int]:
             f"Malformed duration '{duration}' ({error}).")
 
 
-def make_junit_xml(report: 'ReportPlugin[ReportStepDataT]') -> 'junit_xml.TestSuite':
+def make_junit_xml(
+        report: 'ReportPlugin[ReportJUnitData]|ReportPlugin[ReportPolarionData]'
+        ) -> 'junit_xml.TestSuite':
     """ Create junit xml object """
     junit_xml = import_junit_xml()
 
@@ -99,6 +102,13 @@ class ReportJUnitData(tmt.steps.report.ReportStepData):
         metavar='PATH',
         help='Path to the file to store JUnit to.',
         normalize=lambda key_address, raw_value, logger: Path(raw_value) if raw_value else None)
+
+    include_output_log: bool = field(
+        default=True,
+        option=('--include-output-log / --no-include-output-log'),
+        is_flag=True,
+        show_default=True,
+        help='Include full standard output in resulting xml file.')
 
 
 @tmt.steps.provides_method('junit')

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -180,6 +180,13 @@ class ReportPolarionData(tmt.steps.report.ReportStepData):
         help='FIPS mode enabled or disabled for this run.'
         )
 
+    include_output_log: bool = field(
+        default=True,
+        option=('--include-output-log / --no-include-output-log'),
+        is_flag=True,
+        show_default=True,
+        help='Include full standard output in resulting xml file.')
+
 
 @tmt.steps.provides_method('polarion')
 class ReportPolarion(tmt.steps.report.ReportPlugin[ReportPolarionData]):


### PR DESCRIPTION
We need the option to lower the amount of lines in xml files, so this patch adds the ability to skip the standard output and just keep failures if they appear.
The default is kept on showing the standard output.

Pull Request Checklist

* [x] implement the feature
* [x] modify the json schema