### PR TITLE
Add template helper for raising errors

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -317,7 +317,7 @@ def generate_tmt_docs(app: Sphinx, config: Any) -> None:
     """ Run `make generate` to populate the auto-generated sources """
 
     conf_dir = Path(app.confdir)
-    subprocess.run(["make", "generate"], cwd=conf_dir)
+    subprocess.run(["make", "generate"], cwd=conf_dir, check=True)
 
 
 def setup(app: Sphinx) -> None:

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -100,17 +100,10 @@
 {% elif link.target.startswith('/plans') %}
   {% set objects = STORY.tree.plans(names=["^" + link.target + "(/|$)"]) %}
 {% else %}
-  {#
-    TODO: capture `emit_tmt_object_links` being called for anything but
-    plans and tests.
-  #}
-  {{ 0/0 }}
+  {{ raise_error("Cannot use emit_tmt_object_links for target '" + link.target + "'.") }}
 {% endif %}
 {% if not objects %}
-  {#
-    TODO: capture pointing to a test/plan that cannot be found.
-  #}
-  {{ 0/0 }}
+  {{ raise_error("No test or plan was found for target '" + link.target + "'.") }}
 {% endif %}
 {% for object in objects %}
 {{ _emit_remote_link(link, object.name, object.web_link()) }}

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -7023,6 +7023,14 @@ def render_template(
 
     environment = environment or default_template_environment()
 
+    def raise_error(message: str) -> None:
+        """ An in-template helper for raising exceptions """
+
+        raise Exception(message)
+
+    if 'raise_error' not in variables:
+        variables['raise_error'] = raise_error
+
     try:
         return environment.from_string(template).render(**variables).strip()
 


### PR DESCRIPTION
When template runs into an error, there is no built-in support for exceptions. The recommended workaround is a division by zero, `{{ 0/0 }}`. Adding a simple function template may use to report an error and quit.

Fixing our story template to use it.

Pull Request Checklist

* [x] implement the feature