### PR TITLE
Fix normalization of `hardware` key/option

### DIFF
--- a/tests/unit/test_hardware.py
+++ b/tests/unit/test_hardware.py
@@ -89,6 +89,20 @@ def test_constraint_components_pattern(value: str, expected: tuple[Any, Any]) ->
     assert match.groups() == expected
 
 
+def test_normalize_hardware(root_logger) -> None:
+    # All major classes of requirements:
+    spec = (
+        # Simple name.child_name=value
+        'cpu.processors=1',
+        # The same but with cpu.flags which have special handling
+        'cpu.flag!=avc',
+        # name[peer_index].child_name=value
+        'disk[1].size=1'
+        )
+
+    tmt.steps.provision.normalize_hardware('', spec, root_logger)
+
+
 @pytest.mark.parametrize(
     ('spec', 'expected_exc', 'expected_message'),
     [

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -531,7 +531,7 @@ def normalize_hardware(
 
             elif components.name == 'cpu' and components.child_name == 'flag':
                 if components.name not in merged:
-                    merged[components.name] = []
+                    merged[components.name] = {}
 
                 if 'flag' not in merged['cpu']:
                     merged['cpu']['flag'] = []
@@ -540,15 +540,12 @@ def normalize_hardware(
 
             elif components.child_name:
                 if components.name not in merged:
-                    merged[components.name] = []
+                    merged[components.name] = {}
 
                 merged[components.name][components.child_name] = \
                     f'{components.operator} {components.value}'
 
             else:
-                if components.name not in merged:
-                    merged[components.name] = []
-
                 merged[components.name] = f'{components.operator} {components.value}'
 
         # Very crude, we will need something better to handle `and` and


### PR DESCRIPTION
A bug was introduced in the patching adding multiple disks to testcloud plugin, and the test was missing.

Pull Request Checklist

* [x] implement the feature