### PR TITLE
Move timestamp/duration formatting to utils [Step results #5]

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1176,9 +1176,9 @@ def test_flatten(lists: list[list[Any]], unique: bool, expected: list[Any]) -> N
         ]
     )
 def test_format_duration(duration, expected):
-    from tmt.steps.execute import ExecutePlugin
+    from tmt.utils import format_duration
 
-    assert ExecutePlugin.format_duration(duration) == expected
+    assert format_duration(duration) == expected
 
 
 def test_filter_paths(source_dir):

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -8,7 +8,13 @@ import tmt.steps.provision
 import tmt.utils
 from tmt.checks import Check, CheckPlugin, provides_check
 from tmt.result import CheckResult, ResultOutcome
-from tmt.utils import CommandOutput, Path, ShellScript, render_run_exception_streams
+from tmt.utils import (
+    CommandOutput,
+    Path,
+    ShellScript,
+    format_timestamp,
+    render_run_exception_streams,
+    )
 
 if TYPE_CHECKING:
     import tmt.base
@@ -48,12 +54,10 @@ def _save_report(
     :returns: path to the report file.
     """
 
-    from tmt.steps.execute import ExecutePlugin
-
     report_filepath = invocation.check_files_path / TEST_POST_AVC_FILENAME
 
     report = [
-        f'# Reported at {ExecutePlugin.format_timestamp(timestamp)}',
+        f'# Reported at {format_timestamp(timestamp)}',
         *report
         ]
 

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -11,7 +11,7 @@ import tmt.utils
 from tmt.checks import Check, CheckEvent, CheckPlugin, _RawCheck, provides_check
 from tmt.result import CheckResult, ResultOutcome
 from tmt.steps.provision import GuestCapability
-from tmt.utils import Path, field, render_run_exception_streams
+from tmt.utils import Path, field, format_timestamp, render_run_exception_streams
 
 if TYPE_CHECKING:
     import tmt.base
@@ -95,11 +95,9 @@ class DmesgCheck(Check):
             event: CheckEvent,
             logger: tmt.log.Logger) -> tuple[ResultOutcome, Path]:
 
-        from tmt.steps.execute import ExecutePlugin
-
         assert invocation.phase.step.workdir is not None  # narrow type
 
-        timestamp = ExecutePlugin.format_timestamp(datetime.datetime.now(datetime.timezone.utc))
+        timestamp = format_timestamp(datetime.datetime.now(datetime.timezone.utc))
 
         path = invocation.check_files_path / TEST_POST_DMESG_FILENAME.format(event=event.value)
 

--- a/tmt/checks/watchdog.py
+++ b/tmt/checks/watchdog.py
@@ -18,7 +18,7 @@ import tmt.steps.provision.testcloud
 import tmt.utils
 from tmt.checks import Check, CheckPlugin, provides_check
 from tmt.result import CheckResult, ResultOutcome
-from tmt.utils import Path, field, render_run_exception_streams
+from tmt.utils import Path, field, format_timestamp, render_run_exception_streams
 
 if TYPE_CHECKING:
     from tmt.steps.execute import TestInvocation
@@ -68,8 +68,7 @@ def report_progress(
         ``report`` lines are written into it.
     """
 
-    timestamp = tmt.steps.execute.ExecutePlugin.format_timestamp(
-        datetime.datetime.now(datetime.timezone.utc))
+    timestamp = format_timestamp(datetime.datetime.now(datetime.timezone.utc))
 
     with open(log, mode='a') as f:
         f.write(f'# {check_name} reported at {timestamp}\n')

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1,6 +1,5 @@
 import copy
 import dataclasses
-import datetime
 import functools
 import json
 import os
@@ -27,7 +26,14 @@ from tmt.result import CheckResult, Result, ResultGuestData, ResultOutcome
 from tmt.steps import Action, ActionTask, PhaseQueue, PluginTask, Step
 from tmt.steps.discover import Discover, DiscoverPlugin, DiscoverStepData
 from tmt.steps.provision import Guest
-from tmt.utils import Path, ShellScript, Stopwatch, field
+from tmt.utils import (
+    Path,
+    ShellScript,
+    Stopwatch,
+    field,
+    format_duration,
+    format_timestamp,
+    )
 
 if TYPE_CHECKING:
     import tmt.cli
@@ -904,23 +910,13 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
 
         return invocation.test.test_framework.extract_results(invocation, logger)
 
-    @staticmethod
-    def format_timestamp(timestamp: datetime.datetime) -> str:
-        """ Convert timestamp to a human readable format """
+    def check_abort_file(self, invocation: TestInvocation) -> bool:
+        """
+        Check for an abort file created by tmt-abort
 
-        return timestamp.isoformat()
-
-    @staticmethod
-    def format_duration(duration: datetime.timedelta) -> str:
-        """ Convert duration to a human readable format """
-
-        # A helper variable to hold the duration while we cut away days, hours and seconds.
-        counter = int(duration.total_seconds())
-
-        hours, counter = divmod(counter, 3600)
-        minutes, seconds = divmod(counter, 60)
-
-        return f'{hours:02}:{minutes:02}:{seconds:02}'
+        Returns whether an abort file is present (i.e. abort occurred).
+        """
+        return (invocation.test_data_path / TMT_ABORT_SCRIPT.created_file).exists()
 
     def timeout_hint(self, invocation: TestInvocation) -> None:
         """ Append a duration increase hint to the test output """
@@ -957,9 +953,9 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
             for result in check_results:
                 result.event = event
 
-                result.start_time = self.format_timestamp(timer.start_time)
-                result.end_time = self.format_timestamp(timer.end_time)
-                result.duration = self.format_duration(timer.duration)
+                result.start_time = format_timestamp(timer.start_time)
+                result.end_time = format_timestamp(timer.end_time)
+                result.duration = format_duration(timer.duration)
 
             results += check_results
 

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -26,6 +26,8 @@ from tmt.utils import (
     ShellScript,
     Stopwatch,
     field,
+    format_duration,
+    format_timestamp,
     )
 
 TEST_PIDFILE_FILENAME = 'tmt-test.pid'
@@ -387,7 +389,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
 
         # Execute the test, save the output and return code
         with Stopwatch() as timer:
-            invocation.start_time = self.format_timestamp(timer.start_time)
+            invocation.start_time = format_timestamp(timer.start_time)
 
             timeout: Optional[int]
 
@@ -429,8 +431,8 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         with invocation.process_lock:
             invocation.process = None
 
-        invocation.end_time = self.format_timestamp(timer.end_time)
-        invocation.real_duration = self.format_duration(timer.duration)
+        invocation.end_time = format_timestamp(timer.end_time)
+        invocation.real_duration = format_duration(timer.duration)
 
         # Save the captured output. Do not let the follow-up pulls
         # overwrite it.

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -6375,6 +6375,24 @@ class Stopwatch(contextlib.AbstractContextManager['Stopwatch']):
         return self.end_time - self.start_time
 
 
+def format_timestamp(timestamp: datetime.datetime) -> str:
+    """ Convert timestamp to a human readable format """
+
+    return timestamp.isoformat()
+
+
+def format_duration(duration: datetime.timedelta) -> str:
+    """ Convert duration to a human readable format """
+
+    # A helper variable to hold the duration while we cut away days, hours and seconds.
+    counter = int(duration.total_seconds())
+
+    hours, counter = divmod(counter, 3600)
+    minutes, seconds = divmod(counter, 60)
+
+    return f'{hours:02}:{minutes:02}:{seconds:02}'
+
+
 def retry(
         func: Callable[..., T],
         attempts: int,


### PR DESCRIPTION
We will need them from other places, it's not longer just `execute` who will be dealign with times.

Depends on https://github.com/teemtee/tmt/pull/2979

Pull Request Checklist

* [x] implement the feature