### PR TITLE
Add HW requirement support matrix to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/plugins/prepare.rst
 docs/plugins/provision.rst
 docs/plugins/report.rst
 docs/plugins/test-checks.rst
+docs/plugins/hardware-matrix.rst
 docs/_build
 docs/spec
 docs/stories

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -108,7 +108,7 @@ plugins/report.rst: $(call plugins-dependencies)
 plugins/test-checks.rst: $(call plugins-checks-dependencies)
 	$(call build-plugins)
 
-spec/hardware-matrix.rst: $(SCRIPTSDIR)/generate-hardware-matrix.py \
+plugins/hardware-matrix.rst: $(SCRIPTSDIR)/generate-hardware-matrix.py \
                           $(TEMPLATESDIR)/hardware-matrix.rst.j2 \
                           $(shell find $(REPODIR)/spec/hardware -name '*.fmf')
 	$(SCRIPTSDIR)/generate-hardware-matrix.py $(TEMPLATESDIR)/hardware-matrix.rst.j2 $@
@@ -126,17 +126,17 @@ generate-autodocs:  ## Generate autodocs from source docstrings
 
 generate-lint-checks: spec spec/lint.rst  ## Generate documentation sources for lint checks
 
-generate-plugins: $(PLUGIN_TARGETS)  ## Generate documentation sources for plugins
+generate-plugins: $(PLUGIN_TARGETS) generate-hardware-matrix  ## Generate documentation sources for plugins
 
-generate-hardware-matrix: spec/hardware-matrix.rst  ## Generate HW requirement support matrix
+generate-hardware-matrix: plugins/hardware-matrix.rst  ## Generate HW requirement support matrix
 
-generate-stories: stories $(TEMPLATESDIR)/story.rst.j2 generate-hardware-matrix  ## Generate documentation sources for stories
+generate-stories: stories $(TEMPLATESDIR)/story.rst.j2  ## Generate documentation sources for stories
 	$(SCRIPTSDIR)/generate-stories.py $(TEMPLATESDIR)/story.rst.j2
 
 generate-template-filters: code/template-filters.rst  ## Generate documentation sources for Jinja2 template filters
 
 clean:  ## Remove all generated content
-	rm -rf _build $(GENERATED_DIRECTORIES) code/autodocs/*.rst code/template-filters.rst $(PLUGIN_TARGETS) $(LOGO_DST)
+	rm -rf _build $(GENERATED_DIRECTORIES) code/autodocs/*.rst code/template-filters.rst plugins/hardware-matrix.rst $(PLUGIN_TARGETS) $(LOGO_DST)
 
 ##
 ## Help!

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -108,6 +108,11 @@ plugins/report.rst: $(call plugins-dependencies)
 plugins/test-checks.rst: $(call plugins-checks-dependencies)
 	$(call build-plugins)
 
+spec/hardware-matrix.rst: $(SCRIPTSDIR)/generate-hardware-matrix.py \
+                          $(TEMPLATESDIR)/hardware-matrix.rst.j2 \
+                          $(shell find $(REPODIR)/spec/hardware -name '*.fmf')
+	$(SCRIPTSDIR)/generate-hardware-matrix.py $(TEMPLATESDIR)/hardware-matrix.rst.j2 $@
+
 spec/lint.rst: $(SCRIPTSDIR)/generate-lint-checks.py \
                $(TEMPLATESDIR)/lint-checks.rst.j2 \
                $(TMTDIR)/base.py
@@ -123,7 +128,9 @@ generate-lint-checks: spec spec/lint.rst  ## Generate documentation sources for 
 
 generate-plugins: $(PLUGIN_TARGETS)  ## Generate documentation sources for plugins
 
-generate-stories: stories $(TEMPLATESDIR)/story.rst.j2  ## Generate documentation sources for stories
+generate-hardware-matrix: spec/hardware-matrix.rst  ## Generate HW requirement support matrix
+
+generate-stories: stories $(TEMPLATESDIR)/story.rst.j2 generate-hardware-matrix  ## Generate documentation sources for stories
 	$(SCRIPTSDIR)/generate-stories.py $(TEMPLATESDIR)/story.rst.j2
 
 generate-template-filters: code/template-filters.rst  ## Generate documentation sources for Jinja2 template filters

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,5 @@
+@import 'css/theme.css';
+
+/* Used for HW requirement support matrix */
+.supported   { color: green; }
+.unsupported { color: red; }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -229,6 +229,9 @@ html_favicon = '_static/tmt-small.png'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# Include custom style.
+html_style = 'custom.css'
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -155,7 +155,7 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', '**/*.inc.rst']
+exclude_patterns = ['_build', '**/*.inc.rst', 'plugins/hardware-matrix.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/plugins/provision-header.inc.rst
+++ b/docs/plugins/provision-header.inc.rst
@@ -16,3 +16,5 @@ Following plugins fully implement hard reboot:
 * :ref:`plugins/provision/beaker`
 * :ref:`plugins/provision/container`
 * :ref:`virtual<plugins/provision/virtual.testcloud>`
+
+.. include:: hardware-matrix.rst

--- a/docs/scripts/generate-hardware-matrix.py
+++ b/docs/scripts/generate-hardware-matrix.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import sys
+import textwrap
+
+import tmt.plugins
+import tmt.steps.provision
+from tmt.utils import Path, render_template_file
+
+HELP = textwrap.dedent("""
+Usage: generate-hardware-matrix.py <TEMPLATE-PATH> <OUTPUT-PATH>
+
+Generate page with HW requirement support matrix from stories.
+""").strip()
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print(HELP)
+
+        sys.exit(1)
+
+    template_filepath = Path(sys.argv[1])
+    output_filepath = Path(sys.argv[2])
+
+    # We will need a logger...
+    logger = tmt.Logger.create()
+    logger.add_console_handler()
+
+    # Explore available *export* plugins - do not import other plugins, we don't need them.
+    tmt.plugins._explore_packages(logger)
+
+    known_methods = sorted(
+        tmt.steps.provision.ProvisionPlugin._supported_methods.iter_plugin_ids())
+
+    tree = tmt.Tree(logger=logger, path=Path.cwd())
+
+    logger.info('Generating reST file for HW requirement support matrix')
+
+    matrix: dict[str, dict[str, tuple[bool, str]]] = {}
+    notes: list[str] = []
+
+    for story in tree.stories(logger=logger, names=['^/spec/hardware/.*'], whole=True):
+        hw_requirement = story.name.replace('/spec/hardware/', '')
+
+        if hw_requirement == 'arch':
+            continue
+
+        matrix[hw_requirement] = {
+            method: (False, int) for method in known_methods
+            }
+
+        if not story.link:
+            pass
+
+        for link in story.link.get(relation='implemented-by'):
+            implemented_by_method = Path(link.target).stem
+
+            if implemented_by_method == 'mrack':
+                implemented_by_method = 'beaker'
+
+            elif implemented_by_method == 'testcloud':
+                implemented_by_method = 'virtual.testcloud'
+
+            if implemented_by_method not in matrix[hw_requirement]:
+                raise Exception(f'{implemented_by_method} unknown')
+
+            if link.note:
+                notes.append(f'``{hw_requirement}`` with ``{implemented_by_method}``: {link.note}')
+
+                matrix[hw_requirement][implemented_by_method] = (True, len(notes))
+
+            else:
+                matrix[hw_requirement][implemented_by_method] = (True, None)
+
+    output_filepath.write_text(render_template_file(
+        template_filepath,
+        LOGGER=logger,
+        MATRIX=matrix,
+        NOTES=notes))
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/templates/hardware-matrix.rst.j2
+++ b/docs/templates/hardware-matrix.rst.j2
@@ -1,0 +1,42 @@
+{#
+    A Jinja2 template for rendering HW requirement support matrix in tmt's own docs.
+#}
+
+Support matrix
+^^^^^^^^^^^^^^
+
+Below you can find a matrix documenting which hardware requirement are
+supported by plugins bundled with tmt.
+
+.. role:: supported
+
+.. role:: unsupported
+
+.. list-table::
+   :header-rows: 1
+
+   * - Requirement
+    {% for plugin in MATRIX['memory'].keys() %}
+        {% if plugin == 'virtual.testcloud' %}
+     - ``virtual``
+         {% else %}
+     - ``{{ plugin }}``
+         {% endif %}
+    {% endfor %}
+
+{% for requirement, plugins in MATRIX.items() %}
+   * - :ref:`{{ requirement }}</spec/hardware/{{ requirement }}>`
+    {% for plugin, (enabled, note_id) in plugins.items() %}
+        {% if enabled %}
+     - :supported:`yes`{% if note_id %} [{{ note_id }}]_{% endif %}
+
+        {% else %}
+     - :unsupported:`no`
+
+        {% endif %}
+    {% endfor %}
+{% endfor %}
+
+{% for note in NOTES %}
+.. [{{ loop.index}}] {{ note }}
+{% endfor %}

--- a/docs/templates/hardware-matrix.rst.j2
+++ b/docs/templates/hardware-matrix.rst.j2
@@ -25,7 +25,7 @@ supported by plugins bundled with tmt.
     {% endfor %}
 
 {% for requirement, plugins in MATRIX.items() %}
-   * - :ref:`{{ requirement }}</spec/hardware/{{ requirement }}>`
+   * - :ref:`{{ requirement }}{# djlint:off #}</spec/hardware/{# djlint:on H025 #}{{ requirement }}>`
     {% for plugin, (enabled, note_id) in plugins.items() %}
         {% if enabled %}
      - :supported:`yes`{% if note_id %} [{{ note_id }}]_{% endif %}
@@ -38,5 +38,5 @@ supported by plugins bundled with tmt.
 {% endfor %}
 
 {% for note in NOTES %}
-.. [{{ loop.index}}] {{ note }}
+.. [{{ loop.index }}] {{ note }}
 {% endfor %}

--- a/docs/templates/hardware-matrix.rst.j2
+++ b/docs/templates/hardware-matrix.rst.j2
@@ -2,8 +2,10 @@
     A Jinja2 template for rendering HW requirement support matrix in tmt's own docs.
 #}
 
-Support matrix
-^^^^^^^^^^^^^^
+.. _/plugins/provision/hardware-requirement-support-matrix:
+
+Hardware requirement support
+----------------------------
 
 Below you can find a matrix documenting which hardware requirement are
 supported by plugins bundled with tmt.

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -219,3 +219,8 @@
 * {{ printable_relation(link) }} ``{{ link.target }}``
 {% endif %}
 {% endfor %}
+
+{# Include HW requirement matrix when generating the main HW story #}
+{% if STORY.name == '/spec/hardware'%}
+.. include:: hardware-matrix.rst
+{% endif %}

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -221,6 +221,6 @@
 {% endfor %}
 
 {# Include HW requirement matrix when generating the main HW story #}
-{% if STORY.name == '/spec/hardware'%}
+{% if STORY.name == '/spec/hardware' %}
 .. include:: hardware-matrix.rst
 {% endif %}

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -219,8 +219,3 @@
 * {{ printable_relation(link) }} ``{{ link.target }}``
 {% endif %}
 {% endfor %}
-
-{# Include HW requirement matrix when generating the main HW story #}
-{% if STORY.name == '/spec/hardware' %}
-.. include:: hardware-matrix.rst
-{% endif %}

--- a/spec/hardware/main.fmf
+++ b/spec/hardware/main.fmf
@@ -10,6 +10,10 @@ description: |
     requirements. For example one consistent way how to specify
     `at least 2 GB of RAM` for all supported provisioners.
 
+    The current state of support of HW requirements among plugins
+    bundled with tmt is available at
+    :ref:`/plugins/provision/hardware-requirement-support-matrix`.
+
     Introduction
     ^^^^^^^^^^^^
 


### PR DESCRIPTION
Generated from HW requriement stories and their links, it should be the most up-to-date picture of what's supported by plugins shipped with tmt.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation