### PR TITLE
Allow additional, local CSS file for documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -230,7 +230,7 @@ html_favicon = '_static/tmt-small.png'
 html_static_path = ['_static']
 
 # Include custom style.
-html_style = 'custom.css'
+html_style = os.getenv('TMT_DOCS_CUSTOM_HTML_STYLE', 'custom.css')
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -465,6 +465,26 @@ a colon (``:``): theme package name, and theme name.
     # and theme name are *not* the same string:
     TMT_DOCS_THEME="renku_sphinx_theme:renku" make docs
 
+By default, ``docs/_static/custom.css`` provides additional tweaks to
+the documentation theme. Use the ``TMT_DOCS_CUSTOM_HTML_STYLE`` variable
+to include additional file:
+
+.. code-block:: shell
+
+    $ cat docs/_static/custom.local.css
+    /* Make content wider on my wider screen */
+    .wy-nav-content {
+        max-width: 1200px !important;
+    }
+
+    TMT_DOCS_CUSTOM_HTML_STYLE=custom.local.css make docs
+
+.. note::
+
+    The custom CSS file specified by ``TMT_DOCS_CUSTOM_HTML_STYLE``
+    is included **before** the built-in ``custom.css``, therefore to
+    override theme CSS, it is recommended to add ``!important`` flag.
+
 
 Pull Requests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Intended as addition to built-in ``custom.css`, to allow local tweaks.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation