### PR TITLE
Fix handling of installation of packages from subdirectory

### DIFF
--- a/tests/prepare/install/data/downloaded.fmf
+++ b/tests/prepare/install/data/downloaded.fmf
@@ -1,6 +1,21 @@
-summary: Install downloaded packages
-prepare:
-  - how: install
-    package:
-      - tree.rpm
-      - diffutils.rpm
+/in-cwd:
+  summary: Install downloaded packages
+  prepare:
+    - how: install
+      package:
+        - tree.rpm
+        - diffutils.rpm
+
+/in-subdirectory:
+  summary: Install downloaded packages from a subdirectory
+  prepare:
+    - how: install
+      package:
+        - downloaded-rpms/tree.rpm
+        - downloaded-rpms/diffutils.rpm
+
+/as-directory:
+  summary: Install downloaded packages from a subdirectory
+  prepare:
+    - how: install
+      directory: downloaded-rpms

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -256,7 +256,7 @@ class InstallDnf(InstallBase, Copr):
 
         # Use both dnf install/reinstall to get all packages refreshed
         # FIXME Simplify this once BZ#1831022 is fixed/implemented.
-        filelist = [PackagePath(self.package_directory / filename)
+        filelist = [PackagePath(self.package_directory / filename.name)
                     for filename in self.local_packages]
 
         self.guest.package_manager.install(


### PR DESCRIPTION
A egression was introduced, when processing `directory`/`-D` key `prepare/install` was looking for incorrect paths when attempting to install packages provided in a directory.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
