### PR TITLE
Switch testcloud plugin to the Workarounds API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ provision-beaker = [
     "mrack>=1.15.1",
     ]
 provision-virtual = [
-    "testcloud>=0.9.10",
+    "testcloud>=0.9.13",
     ]
 provision-container = []
 report-junit = [

--- a/tmt.spec
+++ b/tmt.spec
@@ -74,7 +74,7 @@ Provides:       tmt-provision-virtual == %{version}-%{release}
 Obsoletes:      tmt-provision-virtual < %{version}-%{release}
 %endif
 Requires:       tmt == %{version}-%{release}
-Requires:       python3-testcloud >= 0.9.10
+Requires:       python3-testcloud >= 0.9.13
 Requires:       libvirt-daemon-config-network
 Requires:       openssh-clients
 Requires:       (ansible or ansible-core)


### PR DESCRIPTION
This will allow to:
- expose a proper API to share commands to be executed during boot/cloud-init between tmt and testcloud, and customize them tmt-side
- open way to address https://github.com/teemtee/tmt/issues/2687 in an atomic way
- open way to address https://github.com/teemtee/tmt/issues/2348

Requires https://pagure.io/testcloud/pull-request/173 ; built in https://copr.fedorainfracloud.org/coprs/frantisekz/testcloud-wip/build/7630902/

Known issues so far:
- el9 host doesn't work - resolved
- TBD

This is meant also as a RFC for the api itself, source and available methods can be seen at https://pagure.io/testcloud/blob/284f136fcbca4e9166d687e90f0108962c1bc8f1/f/testcloud/workarounds.py
