### PR TITLE
base: Honor `.gitignore` for rsync

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1828,7 +1828,6 @@ class Plan(
             # Make sure ignored paths are saved before telling rsync to use them.
             # With Python 3.12, we could use `delete_on_false=False` and call `close()`.
             excludes_tempfile.flush()
-            os.fsync(excludes_tempfile.fileno())
 
             # Note: rsync doesn't use reflinks right now, so in the future it'd be even better to
             # use e.g. `cp` but filtering out the above.

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -4524,6 +4524,31 @@ def git_add(*, path: Path, logger: tmt.log.Logger) -> None:
         raise GeneralError(f"Failed to add path '{path}' to git index.") from error
 
 
+def git_ignore(*, root: Path, logger: tmt.log.Logger) -> list[Path]:
+    """
+    Collect effective paths ignored by git.
+
+    :param root: path to the root of git repository.
+    :param logger: used for logging.
+    :returns: list of actual paths tah would be ignored by git based on
+        its ``.gitignore`` files. If a whole directory is to be ignored,
+        its listed as a directory path, not listing its content.
+    """
+
+    output = Command(
+        'git',
+        'ls-files',
+        # Consider standard git exclusion files
+        '--exclude-standard',
+        # List untracked files matching exclusion patterns
+        '-oi',
+        # If a whole directory is to be ignored, list only its name with a trailing slash
+        '--directory') \
+        .run(cwd=root, logger=logger)
+
+    return [Path(line.strip()) for line in output.stdout.splitlines()] if output.stdout else []
+
+
 def default_branch(
         *,
         repository: Path,

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -4530,9 +4530,9 @@ def git_ignore(*, root: Path, logger: tmt.log.Logger) -> list[Path]:
 
     :param root: path to the root of git repository.
     :param logger: used for logging.
-    :returns: list of actual paths tah would be ignored by git based on
+    :returns: list of actual paths that would be ignored by git based on
         its ``.gitignore`` files. If a whole directory is to be ignored,
-        its listed as a directory path, not listing its content.
+        it is listed as a directory path, not listing its content.
     """
 
     output = Command(


### PR DESCRIPTION

I am guessing I may be one of the first people to try using tmt
with a Rust project. The default for the `cargo` toolchain
is to keep a *lot* of cached incremental data in `target/`.
In my case with bootc, it's currently 20G.

A plain rsync() of this is *incredibly* inefficient. rsync doesn't
even use reflinks if available, though that's a distinct bug.

Use `git ls-files` to honor `.gitignore`.

Signed-off-by: Colin Walters <walters@verbum.org>
