### PR TITLE
Workaround for pip test installation on py3.13

### DIFF
--- a/tests/pip/install.fmf
+++ b/tests/pip/install.fmf
@@ -5,6 +5,12 @@ require:
     - python3
     - python3-devel
 tier: null
+adjust:
+    when: distro == fedora-rawhide
+    result: xfail
+    # 'mini' should start passing once https://github.com/hgrecco/pint/issues/1969 is resolved
+    # if/once that happens, the xfail should be moved to 'full' only
+    because: "Un-installable dependencies on Python 3.13"
 
 /mini:
     summary: Ensure the minimal pip install works

--- a/tests/precommit/main.fmf
+++ b/tests/precommit/main.fmf
@@ -4,3 +4,9 @@ require:
 - git-core
 - tmt
 tier: 4
+adjust:
+    when: distro == fedora-rawhide
+    result: xfail
+    # Remove the xfail adjust once it starts passing.
+    # Dependent on https://github.com/crate-py/rpds/issues/72, PyO3 0.22
+    because: "Un-installable dependencies on Python 3.13"


### PR DESCRIPTION
Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
