### PR TITLE
Add a linter for Jinja2 templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -165,4 +165,18 @@ repos:
   - repo: https://github.com/djlint/djLint
     rev: v1.34.1
     hooks:
-      - id: djlint-jinja
+      - id: djlint
+        files: "\\.j2"
+        types_or: ['jinja']
+
+  - repo: https://github.com/aristanetworks/j2lint.git
+    rev: v1.1.0
+    hooks:
+      - id: j2lint
+        args:
+          # j2lint does not consume pyproject.toml
+          - "--ignore"
+          - jinja-statements-indentation
+          - jinja-variable-lower-case
+          - single-statement-per-line
+          - "--"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -161,3 +161,8 @@ repos:
       - id: codespell
         additional_dependencies:
           - tomli  # Required for python < 3.11
+
+  - repo: https://github.com/djlint/djLint
+    rev: v1.34.1
+    hooks:
+      - id: djlint-jinja

--- a/docs/templates/lint-checks.rst.j2
+++ b/docs/templates/lint-checks.rst.j2
@@ -34,7 +34,7 @@ Below you can find the list of available checks. See the
      - {{ linter.help }}
 
 {% endfor %}
-{% endmacro%}
+{% endmacro %}
 
 {{ emit_table('Test checks', TEST_LINTERS) }}
 {{ emit_table('Plan checks', PLAN_LINTERS) }}

--- a/docs/templates/plugins.rst.j2
+++ b/docs/templates/plugins.rst.j2
@@ -10,7 +10,7 @@
 .. _plugins/{{ STEP }}/{{ PLUGIN_ID | trim }}:
 
 {{ PLUGIN_ID }}
-{{ '-' * (PLUGIN_ID | length)}}
+{{ '-' * (PLUGIN_ID | length) }}
 
 {# Emit the warning only for plugins that have not been reviewed yet. #}
 {% set plugin_full_id = STEP + "/" + PLUGIN_ID %}
@@ -65,7 +65,7 @@ Configuration
     Default: *could not render default value correctly*
         {% endif %}
     {% endif %}
-{%endmacro %}
+{% endmacro %}
 
 {% set ignored_fields = container_ignored_fields(PLUGIN_DATA_CLASS) %}
 {% set inherited_fields = container_inherited_fields(PLUGIN_DATA_CLASS) | sort %}

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -219,7 +219,7 @@
 
 {# Links pointing to websites #}
 {% elif link.target | match('^https?://') %}
-* {{ printable_relation(link) }} `{{ link.target}} <{{ link.target }}>`_
+* {{ printable_relation(link) }} `{{ link.target }} <{{ link.target }}>`_
 
 {# Links pointing to anything else #}
 {% else %}

--- a/docs/templates/template-filters.rst.j2
+++ b/docs/templates/template-filters.rst.j2
@@ -25,7 +25,7 @@ __ https://jinja.palletsprojects.com/en/3.1.x/templates/#filters
     {% set filter_callable = TEMPLATES[filter_name] %}
 
 {{ filter_name }}
-{{ '-' * (filter_name | length)}}
+{{ '-' * (filter_name | length) }}
 
 {% if filter_callable.__doc__ %}
 {{ filter_callable.__doc__ | dedent | trim }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -400,3 +400,7 @@ markers = [
 ignore-words = "docs/codespell.dic"
 exclude-file = "docs/codespell.ignore"
 skip = "tests/execute/weird/data/weird.txt,tests/lint/plan/data/invalid_attr.fmf,tests/lint/plan/test.sh"
+
+[tool.djlint]
+use_gitignore=true
+ignore="H005,H030,H031"

--- a/tmt/steps/report/html/template.html.j2
+++ b/tmt/steps/report/html/template.html.j2
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html>
 <head>
     <title>Test results of {{ plan.name }}</title>
     <style>

--- a/tmt/steps/report/html/template.html.j2
+++ b/tmt/steps/report/html/template.html.j2
@@ -227,8 +227,8 @@ Context:
     </thead>
     {% for result in results %}
     <tr class="result">
-        <td class="result {{ result.result.value|e }}">{{ result.result.value|e }}</td>
-        <td class="name">{{ result.name|e }}</td>
+        <td class="result {{ result.result.value | e }}">{{ result.result.value | e }}</td>
+        <td class="name">{{ result.name | e }}</td>
 {% if display_guest %}
         <td class="guest">{{ emit_guest(result.guest) | trim | e }}</td>
 {% endif %}
@@ -239,7 +239,7 @@ Context:
         </td>
         <td class="data"><a href="{{ base_dir | linkable_path | urlencode }}/{{ result.data_path | urlencode }}">data</a></td>
         {% if result.note %}
-        <td class="note">{{ result.note|e }}</td>
+        <td class="note">{{ result.note | e }}</td>
         {% endif %}
     </tr>
     {% if result.check %}


### PR DESCRIPTION
Maybe we would add also a formatter (same tool, different check and options), but starting small with linters. Few very minor issues reported, plus a genuine one.

Pull Request Checklist

* [x] implement the feature