### PR TITLE
Fix ansible `playbook` normalization

### DIFF
--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -53,9 +53,13 @@ class PrepareAnsibleData(tmt.steps.prepare.PrepareStepData):
 
         # Perform `playbook` normalization here, so we could merge `playbooks` to it.
         playbook = raw_data.pop('playbook', [])
-        raw_data['playbook'] = [playbook] if isinstance(playbook, str) else playbook
+        if isinstance(playbook, str):
+            playbook = [playbook]
+        elif isinstance(playbook, tuple):
+            playbook = list(playbook)
+        assert isinstance(playbook, list)
+        raw_data['playbook'] = playbook
 
-        assert isinstance(raw_data['playbook'], list)
         raw_data['playbook'] += raw_data.pop('playbooks', [])
 
 


### PR DESCRIPTION
Playbook can be not only list and string, it can also be a tuple, when the preparation is specified on CLI.

Fixes #3051

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
