### PR TITLE
Add `_compat` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,6 +393,8 @@ builtins-ignorelist = ["help", "format", "input", "filter", "copyright", "max"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "typing.TypeAlias".msg = "Use tmt._compat.typing.TypeAlias instead."
+"pathlib.Path".msg = "Use tmt._compat.pathlib.Path instead."
+"pathlib.PosixPath".msg = "Use tmt._compat.pathlib.Path instead."
 
 [tool.ruff.lint.isort]
 known-first-party = ["tmt"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -362,6 +362,7 @@ lint.ignore = [
     ]
 
 lint.logger-objects = ["tmt.log.Logger"]
+lint.typing-modules = ["tmt._compat.typing"]
 
 [tool.ruff.lint.per-file-ignores]
 # Less strict security checks in tests
@@ -371,6 +372,9 @@ lint.logger-objects = ["tmt.log.Logger"]
     "S318",  # Using xml to parse untrusted data is known to be vulnerable to XML attacks
     "S108",  # Probable insecure usage of temporary file or directory: "{}"
     ]
+# The purpose of tmt/_compat is to be used with TID251 (banned imports)
+"tmt/_compat/**.py" = ["TID251"]
+"docs/conf.py" = ["TID251"]
 
 [tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["tmt.utils.field"]
@@ -386,6 +390,9 @@ convention = "pep257"
 
 [tool.ruff.lint.flake8-builtins]
 builtins-ignorelist = ["help", "format", "input", "filter", "copyright", "max"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.TypeAlias".msg = "Use tmt._compat.typing.TypeAlias instead."
 
 [tool.ruff.lint.isort]
 known-first-party = ["tmt"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -393,6 +393,9 @@ builtins-ignorelist = ["help", "format", "input", "filter", "copyright", "max"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "typing.TypeAlias".msg = "Use tmt._compat.typing.TypeAlias instead."
+"typing_extensions.TypeAlias".msg = "Use tmt._compat.typing.TypeAlias instead."
+"typing.Self".msg = "Use tmt._compat.typing.Self instead."
+"typing_extensions.Self".msg = "Use tmt._compat.typing.Self instead."
 "pathlib.Path".msg = "Use tmt._compat.pathlib.Path instead."
 "pathlib.PosixPath".msg = "Use tmt._compat.pathlib.Path instead."
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -59,7 +59,7 @@ try:
         return TempPathFactory(tmp_path_factory)
 
     @pytest.fixture()
-    def tmppath(tmp_path: pathlib.Path) -> Path:
+    def tmppath(tmp_path: pathlib.Path) -> Path:  # noqa: TID251
         return Path(str(tmp_path))
 
 except ImportError:

--- a/tmt/_compat/pathlib.py
+++ b/tmt/_compat/pathlib.py
@@ -1,0 +1,45 @@
+import os
+import pathlib
+from typing import Union
+
+
+class Path(pathlib.PosixPath):
+    # Apparently, `pathlib`` does not offer `relpath` transition between
+    # parallel trees, instead, a `ValueError`` is raised when `self` does not
+    # lie under `other`. Overriding the original implementation with one based
+    # on `os.path.relpath()`, which is more suited to tmt code base needs.
+    #
+    # ignore[override]: does not match the signature on purpose, our use is
+    # slightly less generic that what pathlib supports, to be usable with
+    # os.path.relpath.
+    def relative_to(self, other: Union[str, "Path"]) -> "Path":  # type: ignore[override]
+        return Path(os.path.relpath(self, other))
+
+    # * `Path.is_relative_to()`` has been added in 3.9
+    # https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.is_relative_to
+    #
+    # * The original implementation calls `relative_to()`, which we just made
+    # to return a relative path for all possible inputs, even those the original
+    # implementation considers to not be relative to each other. Therefore, we
+    # need to override `is_relative_to()` even for other Python versions, to not
+    # depend on `ValueError` raised by the original `relative_to()`.
+    def is_relative_to(self, other: "Path") -> bool:  # type: ignore[override]
+        # NOTE: the following is not perfect, but it should be enough for
+        # what tmt needs to know about its paths.
+
+        # Acquire the relative path from the one we're given and the other...
+        relpath = os.path.relpath(str(self), str(other))
+
+        # ... and if the relative path starts with `..`, it means we had to
+        # walk *up* from `other` and descend to `path`, therefore `path` cannot
+        # be a subtree of `other`.
+
+        return not relpath.startswith("..")
+
+    def unrooted(self) -> "Path":
+        """Return the path as if it was not starting in file system root"""
+
+        if self.is_absolute():
+            return self.relative_to("/")
+
+        return self

--- a/tmt/_compat/typing.py
+++ b/tmt/_compat/typing.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+__all__ = [
+    "TypeAlias",
+    ]

--- a/tmt/_compat/typing.py
+++ b/tmt/_compat/typing.py
@@ -3,10 +3,18 @@ from __future__ import annotations
 import sys
 
 if sys.version_info >= (3, 10):
-    from typing import TypeAlias
+    from typing import Concatenate, ParamSpec, TypeAlias
 else:
-    from typing_extensions import TypeAlias
+    from typing_extensions import Concatenate, ParamSpec, TypeAlias
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 __all__ = [
+    "Concatenate",
+    "ParamSpec",
+    "Self",
     "TypeAlias",
     ]

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -31,14 +31,13 @@ from tmt.options import Deprecated, create_options_decorator, option
 from tmt.utils import Command, Path
 
 if TYPE_CHECKING:
-    from typing_extensions import Concatenate, ParamSpec
-
     import tmt.steps.discover
     import tmt.steps.execute
     import tmt.steps.finish
     import tmt.steps.prepare
     import tmt.steps.provision
     import tmt.steps.report
+    from tmt._compat.typing import Concatenate, ParamSpec
 
     P = ParamSpec('P')
     R = TypeVar('R')

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -32,7 +32,6 @@ import functools
 import itertools
 import operator
 import re
-import sys
 from collections.abc import Iterable, Iterator
 from typing import (
     TYPE_CHECKING,
@@ -55,13 +54,7 @@ from tmt.utils import SpecBasedContainer, SpecificationError
 if TYPE_CHECKING:
     from pint import Quantity
 
-    # Using TypeAlias and typing-extensions under the guard of TYPE_CHECKING,
-    # to avoid the necessity of requiring the package in runtime. This way,
-    # we can deal with it in build time and when running tests.
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
+    from tmt._compat.typing import TypeAlias
 
     #: A type of values describing sizes of things like storage or RAM.
     # Note: type-hinting is a bit wonky with pyright

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -1,6 +1,5 @@
 import dataclasses
 import shlex
-import sys
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
@@ -11,15 +10,8 @@ import tmt.utils
 from tmt.utils import Command, CommandOutput, Path
 
 if TYPE_CHECKING:
+    from tmt._compat.typing import TypeAlias
     from tmt.steps.provision import Guest
-
-    # Using TypeAlias and typing-extensions under the guard of TYPE_CHECKING,
-    # to avoid the necessity of requiring the package in runtime. This way,
-    # we can deal with it in build time and when running tests.
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
 
     #: A type of package manager names.
     GuestPackageManager: TypeAlias = str

--- a/tmt/queue.py
+++ b/tmt/queue.py
@@ -7,8 +7,7 @@ from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
 from tmt.log import Logger
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
-
+    from tmt._compat.typing import Self
     from tmt.steps.provision import Guest
 
 

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -77,14 +77,7 @@ if TYPE_CHECKING:
     import tmt.cli
     import tmt.options
     import tmt.steps
-
-    # Using TypeAlias and typing-extensions under the guard of TYPE_CHECKING,
-    # to avoid the necessity of requiring the package in runtime. This way,
-    # we can deal with it in build time and when running tests.
-    if sys.version_info >= (3, 10):
-        from typing import TypeAlias
-    else:
-        from typing_extensions import TypeAlias
+    from tmt._compat.typing import TypeAlias
 
 
 class Path(pathlib.PosixPath):

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -67,6 +67,7 @@ from ruamel.yaml.parser import ParserError
 from ruamel.yaml.representer import Representer
 
 import tmt.log
+from tmt._compat.pathlib import Path
 from tmt.log import LoggableValue, Logger
 
 if TYPE_CHECKING:
@@ -78,48 +79,6 @@ if TYPE_CHECKING:
     import tmt.options
     import tmt.steps
     from tmt._compat.typing import TypeAlias
-
-
-class Path(pathlib.PosixPath):
-    # Apparently, `pathlib`` does not offer `relpath` transition between
-    # parallel trees, instead, a `ValueError`` is raised when `self` does not
-    # lie under `other`. Overriding the original implementation with one based
-    # on `os.path.relpath()`, which is more suited to tmt code base needs.
-    #
-    # ignore[override]: does not match the signature on purpose, our use is
-    # slightly less generic that what pathlib supports, to be usable with
-    # os.path.relpath.
-    def relative_to(self, other: Union[str, 'Path']) -> 'Path':  # type: ignore[override]
-        return Path(os.path.relpath(self, other))
-
-    # * `Path.is_relative_to()`` has been added in 3.9
-    # https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.is_relative_to
-    #
-    # * The original implementation calls `relative_to()`, which we just made
-    # to return a relative path for all possible inputs, even those the original
-    # implementation considers to not be relative to each other. Therefore, we
-    # need to override `is_relative_to()` even for other Python versions, to not
-    # depend on `ValueError` raised by the original `relative_to()`.
-    def is_relative_to(self, other: 'Path') -> bool:  # type: ignore[override]
-        # NOTE: the following is not perfect, but it should be enough for
-        # what tmt needs to know about its paths.
-
-        # Acquire the relative path from the one we're given and the other...
-        relpath = os.path.relpath(str(self), str(other))
-
-        # ... and if the relative path starts with `..`, it means we had to
-        # walk *up* from `other` and descend to `path`, therefore `path` cannot
-        # be a subtree of `other`.
-
-        return not relpath.startswith('..')
-
-    def unrooted(self) -> 'Path':
-        """ Return the path as if it was not starting in file system root """
-
-        if self.is_absolute():
-            return self.relative_to('/')
-
-        return self
 
 
 def configure_optional_constant(default: Optional[int], envvar: str) -> Optional[int]:
@@ -2686,8 +2645,8 @@ def dict_to_yaml(
     def _represent_path(representer: Representer, data: Path) -> Any:
         return representer.represent_scalar('tag:yaml.org,2002:str', str(data))
 
-    yaml.representer.add_representer(pathlib.Path, _represent_path)
-    yaml.representer.add_representer(pathlib.PosixPath, _represent_path)
+    yaml.representer.add_representer(pathlib.Path, _represent_path)  # noqa: TID251
+    yaml.representer.add_representer(pathlib.PosixPath, _represent_path)  # noqa: TID251
     yaml.representer.add_representer(Path, _represent_path)
 
     def _represent_environment(representer: Representer, data: Environment) -> Any:

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -72,13 +72,12 @@ from tmt.log import LoggableValue, Logger
 
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
-    from typing_extensions import Self
 
     import tmt.base
     import tmt.cli
     import tmt.options
     import tmt.steps
-    from tmt._compat.typing import TypeAlias
+    from tmt._compat.typing import Self, TypeAlias
 
 
 def configure_optional_constant(default: Optional[int], envvar: str) -> Optional[int]:


### PR DESCRIPTION
The purpose of this package is to consolidate and make it easier to track custom classes and custom import calls due to differences in python version or a package's version. This uses `TID251` which detects if any effective `from ... import ...` is used and triggers a warning to use the compatibility package

Right now I've moved the `typing_extension` and `pathlib.Path` calls to that. Other contenders would be `click`, and `dataclass.field` (this would also help experiment with `attrs` later)

(Credit: scikit-build-core project)