### PR TITLE
Cleanup from EPEL8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -383,7 +383,6 @@ extend-immutable-calls = ["tmt.utils.field"]
 # See https://docs.astral.sh/ruff/faq/#does-ruff-support-numpy-or-google-style-docstrings for
 # the most up-to-date info.
 convention = "pep257"
-property-decorators = ["tmt.utils.cached_property"]
 
 [tool.ruff.lint.flake8-builtins]
 builtins-ignorelist = ["help", "format", "input", "filter", "copyright", "max"]

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -64,7 +64,6 @@ from tmt.utils import (
     ShellScript,
     SpecBasedContainer,
     WorkdirArgumentType,
-    cached_property,
     container_field,
     dict_to_yaml,
     field,
@@ -796,7 +795,7 @@ class Core(
             always_get_ref=True,
             logger=self._logger)
 
-    @cached_property
+    @functools.cached_property
     def fmf_sources(self) -> list[Path]:
         return [Path(source) for source in self.node.sources]
 
@@ -1810,7 +1809,7 @@ class Plan(
             f"Create the data directory '{self.data_directory}'.", level=2)
         self.data_directory.mkdir(exist_ok=True, parents=True)
 
-    @tmt.utils.cached_property
+    @functools.cached_property
     def plan_environment_file(self) -> Path:
         assert self.data_directory is not None  # narrow type
 
@@ -3239,7 +3238,7 @@ class Run(tmt.utils.Common):
         self.remove = self.opt('remove')
         self.unique_id = str(time.time()).split('.')[0]
 
-    @tmt.utils.cached_property
+    @functools.cached_property
     def runner(self) -> 'tmt.steps.provision.local.GuestLocal':
         import tmt.steps.provision.local
 

--- a/tmt/checks/__init__.py
+++ b/tmt/checks/__init__.py
@@ -1,5 +1,6 @@
 import dataclasses
 import enum
+import functools
 from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, TypedDict, TypeVar, cast
 
 import tmt.log
@@ -10,7 +11,6 @@ from tmt.utils import (
     NormalizeKeysMixin,
     SerializableContainer,
     SpecBasedContainer,
-    cached_property,
     field,
     )
 
@@ -101,7 +101,7 @@ class Check(
         is_flag=True,
         help='Whether the check is enabled or not.')
 
-    @cached_property
+    @functools.cached_property
     def plugin(self) -> 'CheckPluginClass':
         return find_plugin(self.how)
 

--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -4,6 +4,7 @@
 import collections
 import dataclasses
 import enum
+import functools
 import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
@@ -27,7 +28,7 @@ import tmt.templates
 import tmt.trying
 import tmt.utils
 from tmt.options import Deprecated, create_options_decorator, option
-from tmt.utils import Command, Path, cached_property
+from tmt.utils import Command, Path
 
 if TYPE_CHECKING:
     from typing_extensions import Concatenate, ParamSpec
@@ -181,7 +182,7 @@ class CliInvocation:
             }
         return invocation
 
-    @cached_property
+    @functools.cached_property
     def option_sources(self) -> dict[str, click.core.ParameterSource]:
         if not self.context:
             return {}

--- a/tmt/queue.py
+++ b/tmt/queue.py
@@ -1,9 +1,9 @@
 import dataclasses
+import functools
 from collections.abc import Iterator
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
 
-import tmt.utils
 from tmt.log import Logger
 
 if TYPE_CHECKING:
@@ -193,7 +193,7 @@ class MultiGuestTask(Task[TaskResultT]):
 
         self.guests = guests
 
-    @tmt.utils.cached_property
+    @functools.cached_property
     def guest_ids(self) -> list[str]:
         return sorted([guest.multihost_name for guest in self.guests])
 

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -43,7 +43,6 @@ from tmt.utils import (
     RunError,
     SerializableContainer,
     SpecBasedContainer,
-    cached_property,
     container_field,
     container_keys,
     field,
@@ -544,7 +543,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
 
         return self.name in self.plan.my_run._cli_context_object.steps
 
-    @cached_property
+    @functools.cached_property
     def allowed_methods_pattern(self) -> Pattern[str]:
         """ Return a pattern allowed methods must match """
 
@@ -1227,7 +1226,7 @@ class BasePlugin(Phase, Generic[StepDataT, PluginReturnValueT]):
         self.data = data
         self.step = step
 
-    @cached_property
+    @functools.cached_property
     def safe_name(self) -> str:
         """
         A safe variant of the name which does not contain special characters.

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 import datetime
+import functools
 import json
 import os
 import signal as _signal
@@ -25,7 +26,7 @@ from tmt.result import CheckResult, Result, ResultGuestData, ResultOutcome
 from tmt.steps import Action, ActionTask, PhaseQueue, PluginTask, Step
 from tmt.steps.discover import Discover, DiscoverPlugin, DiscoverStepData
 from tmt.steps.provision import Guest
-from tmt.utils import Path, ShellScript, Stopwatch, cached_property, field
+from tmt.utils import Path, ShellScript, Stopwatch, field
 
 if TYPE_CHECKING:
     import tmt.cli
@@ -179,7 +180,7 @@ class TestInvocation:
     #: Number of times the guest has been rebooted.
     _reboot_count: int = 0
 
-    @cached_property
+    @functools.cached_property
     def path(self) -> Path:
         """ Absolute path to invocation directory """
 
@@ -200,7 +201,7 @@ class TestInvocation:
 
         return path
 
-    @cached_property
+    @functools.cached_property
     def relative_path(self) -> Path:
         """ Invocation directory path relative to step workdir """
 
@@ -208,25 +209,25 @@ class TestInvocation:
 
         return self.path.relative_to(self.phase.step.workdir)
 
-    @cached_property
+    @functools.cached_property
     def test_data_path(self) -> Path:
         """ Absolute path to test data directory """
 
         return self.path / TEST_DATA
 
-    @cached_property
+    @functools.cached_property
     def relative_test_data_path(self) -> Path:
         """ Test data path relative to step workdir """
 
         return self.relative_path / TEST_DATA
 
-    @tmt.utils.cached_property
+    @functools.cached_property
     def check_files_path(self) -> Path:
         """ Construct a directory path for check files needed by tmt """
 
         return self.path / CHECK_DATA
 
-    @tmt.utils.cached_property
+    @functools.cached_property
     def reboot_request_path(self) -> Path:
         """ A path to the reboot request file """
         return self.test_data_path / TMT_REBOOT_SCRIPT.created_file

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -2,6 +2,7 @@ import ast
 import dataclasses
 import datetime
 import enum
+import functools
 import os
 import re
 import secrets
@@ -49,7 +50,6 @@ from tmt.utils import (
     Path,
     SerializableContainer,
     ShellScript,
-    cached_property,
     configure_constant,
     effective_workdir_root,
     field,
@@ -792,7 +792,7 @@ class Guest(tmt.utils.Common):
         run_id = parent.plan.my_run.workdir.name
         return self._random_name(prefix=f"tmt-{run_id[-3:]}-")
 
-    @cached_property
+    @functools.cached_property
     def multihost_name(self) -> str:
         """ Return guest's multihost name, i.e. name and its role """
 
@@ -804,7 +804,7 @@ class Guest(tmt.utils.Common):
 
         raise NotImplementedError
 
-    @cached_property
+    @functools.cached_property
     def package_manager(self) -> 'tmt.package_managers.PackageManager':
         if not self.facts.package_manager:
             raise tmt.utils.GeneralError(
@@ -1380,12 +1380,12 @@ class GuestSsh(Guest):
 
         super().__init__(data=data, logger=logger, parent=parent, name=name)
 
-    @tmt.utils.cached_property
+    @functools.cached_property
     def _ssh_guest(self) -> str:
         """ Return user@guest """
         return f'{self.user}@{self.primary_address}'
 
-    @tmt.utils.cached_property
+    @functools.cached_property
     def _ssh_master_socket_path(self) -> Path:
         """ Return path to the SSH master socket """
 

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -1,5 +1,6 @@
 import dataclasses
 import datetime
+import functools
 from typing import Any, Optional, TypedDict, cast
 
 import requests
@@ -14,7 +15,6 @@ import tmt.utils
 from tmt.utils import (
     ProvisionError,
     UpdatableMessage,
-    cached_property,
     dict_to_yaml,
     field,
     retry_session,
@@ -486,7 +486,7 @@ class GuestArtemis(tmt.GuestSsh):
     watchdog_dispatch_delay: Optional[int]
     watchdog_period_delay: Optional[int]
 
-    @cached_property
+    @functools.cached_property
     def api(self) -> ArtemisAPI:
         return ArtemisAPI(self)
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -201,10 +201,6 @@ class GuestContainer(tmt.Guest):
 
         additional_args = []
 
-        # FIXME: Workaround for BZ#1900021 (f34 container on centos-8)
-        workaround = ['--security-opt', 'seccomp=unconfined']
-        additional_args.extend(workaround)
-
         additional_args.extend(self._setup_network())
 
         # Run the container

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -2,6 +2,7 @@
 import collections
 import dataclasses
 import datetime
+import functools
 import itertools
 import os
 import platform
@@ -27,7 +28,6 @@ from tmt.utils import (
     Path,
     ProvisionError,
     ShellScript,
-    cached_property,
     configure_constant,
     field,
     retry_session,
@@ -585,12 +585,12 @@ class GuestTestcloud(tmt.GuestSsh):
         except libvirt.libvirtError:
             return False
 
-    @cached_property
+    @functools.cached_property
     def is_kvm(self) -> bool:
         # Is the combination of host-requested architecture kvm capable?
         return bool(self.arch == platform.machine() and os.path.exists("/dev/kvm"))
 
-    @cached_property
+    @functools.cached_property
     def is_legacy_os(self) -> bool:
         assert testcloud is not None  # narrow post-import type
         assert self._image is not None  # narrow type
@@ -598,7 +598,7 @@ class GuestTestcloud(tmt.GuestSsh):
         # Is this el <= 7?
         return cast(bool, testcloud.util.needs_legacy_net(self._image.name))
 
-    @cached_property
+    @functools.cached_property
     def is_coreos(self) -> bool:
         # Is this a CoreOS?
         return bool(re.search('coreos|rhcos', self.image.lower()))

--- a/tmt/templates/__init__.py
+++ b/tmt/templates/__init__.py
@@ -1,8 +1,9 @@
+import functools
 from typing import Any, Optional
 
 import tmt
 import tmt.utils
-from tmt.utils import Path, cached_property
+from tmt.utils import Path
 
 DEFAULT_CUSTOM_TEMPLATES_PATH = tmt.utils.Config().path / 'templates'
 DEFAULT_PLAN_NAME = "/default/plan"
@@ -70,12 +71,12 @@ class TemplateManager:
         self._init_custom_templates_folder()
         self._environment = tmt.utils.default_template_environment()
 
-    @cached_property
+    @functools.cached_property
     def templates(self) -> TemplatesType:
         """ Return all available templates (default and optional). """
         return _combine(self.default_templates, self.custom_templates)
 
-    @cached_property
+    @functools.cached_property
     def default_templates(self) -> TemplatesType:
         """ Return all default templates. """
         templates_dir = tmt.utils.resource_files('templates/')
@@ -84,7 +85,7 @@ class TemplateManager:
             raise tmt.utils.GeneralError(f"Could not find default templates in '{templates_dir}'.")
         return templates
 
-    @cached_property
+    @functools.cached_property
     def custom_templates(self) -> TemplatesType:
         """ Return all custom templates. """
         return _get_templates(self.custom_template_path)

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -299,28 +299,6 @@ def effective_workdir_root() -> Path:
     return WORKDIR_ROOT
 
 
-# TODO: yes, cached_property is available since Python 3.8, but 1. we still need
-# to support Python 3.6, and 2. the type annotations are not perfect, depending
-# on what's in typing_extensions available in RPMs. Therefore adding a simplified
-# cached_property we would remove with Python 3.6 support.
-class cached_property(Generic[T]):  # noqa: N801
-    def __init__(self, fn: Callable[[Any], T]) -> None:
-        self.__doc__ = fn.__doc__
-        self.fn = fn
-
-    def __get__(self, obj: Any, cls: Any) -> T:
-        if obj is None:
-            # ignore[return-value]: special case, when `obj` is unset, operates
-            # as a class-level property, but that is not supported by cached
-            # property from stdlib.
-            return self  # type: ignore[return-value]
-
-        value = self.fn(obj)
-        obj.__dict__[self.fn.__name__] = value
-
-        return value
-
-
 class FmfContext(dict[str, list[str]]):
     """
     Represents an fmf context.
@@ -967,7 +945,7 @@ class Config:
             raise GeneralError(
                 f"Unable to save last run '{self.path}'.\n{error}")
 
-    @cached_property
+    @functools.cached_property
     def fmf_tree(self) -> fmf.Tree:
         """ Return the configuration tree """
         try:
@@ -1598,7 +1576,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         if 'safe_name' in self.__dict__:
             delattr(self, 'safe_name')
 
-    @cached_property
+    @functools.cached_property
     def safe_name(self) -> str:
         """
         A safe variant of the name which does not contain special characters.
@@ -1612,7 +1590,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
 
         return sanitize_name(self.name)
 
-    @cached_property
+    @functools.cached_property
     def pathless_safe_name(self) -> str:
         """
         A safe variant of the name which does not contain any special characters.
@@ -2900,7 +2878,7 @@ class FieldMetadata(Generic[T]):
     #: A :py:func:`click.option` decorator defining a corresponding CLI option.
     _option: Optional['tmt.options.ClickOptionDecoratorType'] = None
 
-    @cached_property
+    @functools.cached_property
     def choices(self) -> Optional[Sequence[str]]:
         """ A list of allowed values the field can take """
 
@@ -2912,7 +2890,7 @@ class FieldMetadata(Generic[T]):
 
         return None
 
-    @cached_property
+    @functools.cached_property
     def metavar(self) -> Optional[str]:
         """ Placeholder for field's value in documentation and help """
 


### PR DESCRIPTION
Was looking through the todo comments, and the comments seemed like these can be addressed now that EPEL8 is dropped?
- use `functools.chaced_property`
- drop the fix introduced in #751. Let's see if it's still needed for other reasons?