### PR TITLE
Switch metaclass to `__init_subclass__` ?

### DIFF
--- a/tmt/checks/__init__.py
+++ b/tmt/checks/__init__.py
@@ -161,7 +161,7 @@ class Check(
         raise tmt.utils.GeneralError(f"Unsupported test check event '{event}'.")
 
 
-class CheckPlugin(tmt.utils._CommonBase, Generic[CheckT]):
+class CheckPlugin(Generic[CheckT], tmt.utils._CommonBase):
     """ Base class for plugins providing extra checks before, during and after tests """
 
     _check_class: type[CheckT]

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -1171,7 +1171,7 @@ def provides_method(
     return _method
 
 
-class BasePlugin(Phase, Generic[StepDataT]):
+class BasePlugin(Generic[StepDataT], Phase):
     """ Common parent of all step plugins """
 
     # Deprecated, use @provides_method(...) instead. left for backward
@@ -2140,7 +2140,7 @@ class ActionTask(tmt.queue.GuestlessTask[None]):
 
 
 @dataclasses.dataclass
-class PluginTask(tmt.queue.MultiGuestTask[None], Generic[StepDataT]):
+class PluginTask(Generic[StepDataT], tmt.queue.MultiGuestTask[None]):
     """ A task to run a phase on a given set of guests """
 
     phase: Plugin[StepDataT]

--- a/tmt/utils.py
+++ b/tmt/utils.py
@@ -1451,28 +1451,7 @@ class _CommonBase:
             super().__init__(**kwargs)
 
 
-class _CommonMeta(type):
-    """
-    A meta class for all :py:class:`Common` classes.
-
-    Takes care of properly resetting :py:attr:`Common.cli_invocation` attribute
-    that cannot be shared among classes.
-    """
-
-    def __init__(cls, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-
-        # TODO: repeat type annotation from `Common` - IIUIC, `cls` should be
-        # the class being created, in our case that would be a subclass of
-        # `Common`. For some reason, mypy is uncapable of detecting annotation
-        # of this attribute in `Common`, and infers its type is `None` because
-        # of the assignment below. That's incomplete, and leads to mypy warning
-        # about assignments of `CliInvocation` instances to this attribute.
-        # Repeating the annotation silences mypy, giving it better picture.
-        cls.cli_invocation: Optional[tmt.cli.CliInvocation] = None
-
-
-class Common(_CommonBase, metaclass=_CommonMeta):
+class Common(_CommonBase):
     """
     Common shared stuff
 
@@ -1607,6 +1586,13 @@ class Common(_CommonBase, metaclass=_CommonMeta):
     # The "later use" means the context is often used when looking for options
     # like --how or --dry, may affect step data from fmf or even spawn new phases.
     cli_invocation: Optional['tmt.cli.CliInvocation'] = None
+
+    def __init_subclass__(cls) -> None:
+        """
+        Take care of properly resetting :py:attr:`Common.cli_invocation` attribute
+        that cannot be shared among classes.
+        """
+        cls.cli_invocation = None
 
     @classmethod
     def store_cli_invocation(
@@ -2185,26 +2171,15 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         return self._clone_dirpath
 
 
-class _MultiInvokableCommonMeta(_CommonMeta):
-    """
-    A meta class for all :py:class:`Common` classes.
-
-    Takes care of properly resetting :py:attr:`Common.cli_invocation` attribute
-    that cannot be shared among classes.
-    """
-
-    # N805: ruff does not recognize this as a metaclass, `cls` is correct
-    def __init__(cls, *args: Any, **kwargs: Any) -> None:  # noqa: N805
-        super().__init__(*args, **kwargs)
-
-        cls.cli_invocations: list[tmt.cli.CliInvocation] = []
-
-
-class MultiInvokableCommon(Common, metaclass=_MultiInvokableCommonMeta):
+class MultiInvokableCommon(Common):
     cli_invocations: list['tmt.cli.CliInvocation']
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
+
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
+        cls.cli_invocations = []
 
     @classmethod
     def store_cli_invocation(


### PR DESCRIPTION
I am mostly considering the comment
```python
        # TODO: repeat type annotation from `Common` - IIUIC, `cls` should be
        # the class being created, in our case that would be a subclass of
        # `Common`. For some reason, mypy is uncapable of detecting annotation
        # of this attribute in `Common`, and infers its type is `None` because
        # of the assignment below. That's incomplete, and leads to mypy warning
        # about assignments of `CliInvocation` instances to this attribute.
        # Repeating the annotation silences mypy, giving it better picture.
```
But not sure I quite understand what is meant with the comment.