### PR TITLE
Add `warnings.deprecated`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
           # report-junit
           - "junit_xml>=1.9"
 
-          - "typing-extensions>=4.4.0; python_version < '3.10'" # TypeAlias introduced in 3.10, Self in 3.11
+          - "typing-extensions>=4.9.0; python_version < '3.13'"
           - "pytest"
           - "requre"
           # Do not install *types-click* - it's not recommended with Click 8 & newer,
@@ -92,7 +92,7 @@ repos:
           # report-junit
           - "junit_xml>=1.9"
 
-          - "typing-extensions>=4.4.0; python_version < '3.10'" # TypeAlias introduced in 3.10, Self in 3.11
+          - "typing-extensions>=4.9.0; python_version < '3.13'"
           - "pytest"
           - "requre"
           # Do not install *types-click* - it's not recommended with Click 8 & newer,
@@ -158,6 +158,7 @@ repos:
         # Help installation by reducing the set of inspected botocore release.
         # There is *a lot* of them, and hatch might fetch many of them.
         - "botocore>=1.25.10"      # 1.25.10 is the current one available for RHEL9
+        - "typing-extensions>=4.9.0; python_version < '3.13'"
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:

--- a/docs/code/plugin-introduction.rst
+++ b/docs/code/plugin-introduction.rst
@@ -11,6 +11,11 @@ standard location under ``tmt/steps`` , from all directories
 provided in the ``TMT_PLUGINS`` environment variable and from
 ``tmt.plugin`` entry point.
 
+.. versionchanged:: 1.35
+   ``warnings.deprecated`` is used to advertise deprecated APIs.
+   Consider adding a static type checker (e.g. ``mypy``) in your
+   plugin's CI using the ``main`` branch of ``tmt``.
+
 
 Inheritance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -11,6 +11,13 @@ tmt will now emit a warning when :ref:`custom test results</spec/tests/result>`
 file does not follow the :ref:`result specification</spec/plans/results>`.
 
 
+tmt-1.36
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We have started to use ``warnings.deprecated`` to advertise upcoming
+API deprecations.
+
+
 tmt-1.35
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [              # F39 / PyPI
     "requests>=2.25.1",       # 2.28.2 / 2.31.0
     "ruamel.yaml>=0.16.6",    # 0.17.32 / 0.17.32
     "urllib3>=1.26.5, <3.0",  # 1.26.16 / 2.0.4
+    "typing-extensions>=4.9.0; python_version < '3.13'",
     ]
 
 [project.optional-dependencies]
@@ -115,7 +116,6 @@ platforms = ["linux"]
 [tool.hatch.envs.dev]
 description = "Development environment"
 dependencies = [
-    "typing-extensions>=4.4.0; python_version < '3.10'", # TypeAlias introduced in 3.10, Self in 3.11
     "autopep8",
     "ruff",
     "mypy",
@@ -403,6 +403,7 @@ builtins-ignorelist = ["help", "format", "input", "filter", "copyright", "max"]
 "typing_extensions.Self".msg = "Use tmt._compat.typing.Self instead."
 "pathlib.Path".msg = "Use tmt._compat.pathlib.Path instead."
 "pathlib.PosixPath".msg = "Use tmt._compat.pathlib.Path instead."
+"warnings.deprecated".msg = "Use tmt._compat.warnings.deprecated instead."
 
 [tool.ruff.lint.isort]
 known-first-party = ["tmt"]

--- a/tmt/_compat/warnings.py
+++ b/tmt/_compat/warnings.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
+
+__all__ = [
+    "deprecated",
+    ]

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -31,7 +31,6 @@ import logging
 import logging.handlers
 import os
 import sys
-import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -44,6 +43,8 @@ from typing import (
     )
 
 import click
+
+from tmt._compat.warnings import deprecated
 
 if TYPE_CHECKING:
     import tmt.cli
@@ -823,12 +824,12 @@ class Logger:
                 shift=shift)
             )
 
+    @deprecated("Use Logger.warning instead")
     def warn(
             self,
             message: str,
             shift: int
             ) -> None:
-        warnings.warn("Use `warning` instead", DeprecationWarning, stacklevel=1)
         return self.warning(message, shift)
 
     def fail(


### PR DESCRIPTION
This is used to add both static type-checking deprecations and run-time as well. For now it requires upgrading `typing-extensions` to a required conditional dependency, otherwise the dynamic deprecation would not apply (and would require some trickery to make it `no-op` on non `TYPE_CHECKING`)

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] mention the version
* [x] include a release note

Depends-on #3059, ~~#3117~~ (managed without it), ~~[BGZ#2295924](https://bugzilla.redhat.com/show_bug.cgi?id=2295924)~~