### PR TITLE
Do not install epel-next-release on RHEL-8-like guests

### DIFF
--- a/tests/prepare/install/data/epel8-remote.fmf
+++ b/tests/prepare/install/data/epel8-remote.fmf
@@ -2,7 +2,6 @@ prepare:
     how: install
     package:
       - https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-      - https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-8.noarch.rpm
 execute:
     how: tmt
-    script: rpm -q epel-release epel-next-release
+    script: rpm -q epel-release

--- a/tmt/steps/prepare/feature/epel-enable.yaml
+++ b/tmt/steps/prepare/feature/epel-enable.yaml
@@ -34,6 +34,8 @@
             name: "https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
             disable_gpg_check: true
             state: present
+          # EPEL Next is available for CentOS Stream 9 and newer only
+          when: ansible_distribution_major_version | int >= 9
 
         - name: Install 'dnf config-manager'
           ansible.builtin.command: dnf -y install 'dnf-command(config-manager)'
@@ -49,6 +51,8 @@
           ansible.builtin.command: dnf config-manager --enable epel-next epel-next-debuginfo epel-next-source
           register: output
           changed_when: output.rc != 0
+          # EPEL Next is available for CentOS Stream 9 and newer only
+          when: ansible_distribution_major_version | int >= 9
 
     - name: Enable EPEL repos on CentOS 7
       when: ansible_distribution == "CentOS" and ansible_distribution_major_version | int == 7
@@ -80,6 +84,8 @@
           ansible.builtin.dnf:
             name: epel-next-release
             state: present
+          # EPEL Next is available for CentOS Stream 9 and newer only
+          when: ansible_distribution_major_version | int >= 9
 
         - name: Install 'dnf config-manager'
           ansible.builtin.command: dnf -y install 'dnf-command(config-manager)'
@@ -95,3 +101,5 @@
           ansible.builtin.command: dnf config-manager --enable epel-next epel-next-debuginfo epel-next-source
           register: output
           changed_when: output.rc != 0
+          # EPEL Next is available for CentOS Stream 9 and newer only
+          when: ansible_distribution_major_version | int >= 9


### PR DESCRIPTION
See [1]:

> EPEL packages are built against RHEL. EPEL Next is an additional
> repository that allows package maintainers to alternatively build
> against CentOS Stream.

Since CentOS Stream 8 is now EOL, it's understandable `epel-next-release` repository is no longer available for CentOS Stream 8.

1. https://docs.fedoraproject.org/en-US/epel/epel-about-next/

Pull Request Checklist

* [x] implement the feature