### PR TITLE
Fix collection of know keys for test, plan and story T001 linter

### DIFF
--- a/tests/lint/test/data/bad-attribute.fmf
+++ b/tests/lint/test/data/bad-attribute.fmf
@@ -1,2 +1,5 @@
 test: /bin/true
 requires: "typo, should be require"
+
+# Internal keys should be reported as well
+serial_number: 123

--- a/tests/lint/test/test.sh
+++ b/tests/lint/test/test.sh
@@ -54,6 +54,7 @@ rlJournalStart
         done
         rlRun -s "tmt test lint bad-attribute" 1
         rlAssertGrep "fail T001 unknown key \"requires\" is used" $rlRun_LOG
+        rlAssertGrep "fail T001 unknown key \"serial_number\" is used" $rlRun_LOG
         rlRun -s "tmt test lint coverage" 1
         rlAssertGrep "fail T006 the 'coverage' field has been obsoleted by 'link'" $rlRun_LOG
     rlPhaseEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -65,6 +65,7 @@ from tmt.utils import (
     SpecBasedContainer,
     WorkdirArgumentType,
     container_field,
+    container_fields,
     dict_to_yaml,
     field,
     git_clone,
@@ -896,7 +897,19 @@ class Core(
 
     def _lint_keys(self, additional_keys: list[str]) -> list[str]:
         """ Return list of invalid keys used, empty when all good """
-        known_keys = additional_keys + self._keys()
+
+        known_keys: list[str] = []
+
+        for field_ in container_fields(self):
+            _, key, _, _, metadata = container_field(self, field_.name)
+
+            if metadata.internal:
+                continue
+
+            known_keys.append(key)
+
+        known_keys.extend(additional_keys)
+
         return [key for key in self.node.get() if key not in known_keys]
 
     def lint_validate(self) -> LinterReturn:


### PR DESCRIPTION
The original code did not handle fields with dashes (`restart-max-count`) and internal fields (`serial-number`).

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
