### PR TITLE
Pin the `Sphinx` version and update the docs theme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,10 @@ all = [
     ]
 # Needed for readthedocs and man page build. Not being packaged in rpm.
 docs = [
-    "renku-sphinx-theme==0.3.0",
+    "renku-sphinx-theme==0.4.0",
     "readthedocs-sphinx-ext",
     "docutils>=0.18.1",
+    "Sphinx==7.3.7",
     "fmf>=1.3.0",
     ]
 


### PR DESCRIPTION
Seems that the latest `docutils-0.21.2` do not include the `rst2man.py` command any more which broke package and docs building. Let's pin the `sphinx` version which is compatible with our theme.

Pull Request Checklist

* [x] implement the feature