### PR TITLE
Switch to furo sphinx docs theme

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -12,6 +12,7 @@ issue_repository: https://github.com/teemtee/tmt
 srpm_build_deps:
   - hatch
   - python3-hatch-vcs
+  - make
 
 jobs:
 

--- a/docs/_static/tmt-custom.css
+++ b/docs/_static/tmt-custom.css
@@ -1,4 +1,5 @@
 @import 'css/theme.css';
+@import 'custom.css';
 
 /* Used for HW requirement support matrix */
 .supported   { color: green; }

--- a/docs/_static/tmt-custom.js
+++ b/docs/_static/tmt-custom.js
@@ -1,0 +1,13 @@
+// Respect browsers with light color scheme preference
+// Wait for the DOM to be fully loaded before running the script
+document.addEventListener('DOMContentLoaded', (event) => {
+    // Check if the browser supports the matchMedia method
+    // and if the user has set a preference for light mode
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+        // If the user prefers light mode, set the theme to light
+        // This overrides the default dark theme set in conf.py
+        document.documentElement.dataset.theme = 'light';
+    }
+    // If the user hasn't set a preference or prefers dark mode,
+    // the theme will remain dark as set in conf.py
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,10 +24,8 @@ if TYPE_CHECKING:
 import tmt.utils
 
 _POSSIBLE_THEMES: list[tuple[Optional[str], str]] = [
-    # Use renku as the default theme
-    ('renku_sphinx_theme', 'renku'),
-    # Fall back to sphinx_rtd_theme if available
-    ('sphinx_rtd_theme', 'sphinx_rtd_theme'),
+    # Use furo as the default theme
+    ('furo', 'furo'),
     # The default theme
     (None, 'default')
     ]
@@ -108,7 +106,6 @@ sys.path.insert(0, os.path.abspath('../'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autodoc.typehints',
-    'sphinx_rtd_theme',
     ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -297,9 +297,10 @@ htmlhelp_basename = 'doc'
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_man, '', 'tmt Documentation',
+    ('man', 'tmt', 'tmt Documentation',
      [author], 1)
     ]
+
 
 # If true, show URL addresses after external links.
 # man_show_urls = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -203,7 +203,16 @@ html_theme = HTML_THEME
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+
+# Dark by default
+html_theme_options = {
+    "light_css_variables": {
+        "color-scheme": "dark",
+        },
+    "dark_css_variables": {
+        "color-scheme": "dark",
+        },
+    }
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -227,7 +236,7 @@ html_favicon = 'https://raw.githubusercontent.com/teemtee/docs/main/logo/tmt-fav
 html_static_path = ['_static']
 
 # Include custom style.
-html_style = os.getenv('TMT_DOCS_CUSTOM_HTML_STYLE', 'tmt-custom.css')
+# html_style = os.getenv('TMT_DOCS_CUSTOM_HTML_STYLE', 'tmt-custom.css') TODO missing @include?
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -288,6 +297,10 @@ html_style = os.getenv('TMT_DOCS_CUSTOM_HTML_STYLE', 'tmt-custom.css')
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
 # html_search_scorer = 'scorer.js'
+
+html_js_files = [
+    'tmt-custom.js',
+    ]
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'doc'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -214,12 +214,12 @@ html_theme = HTML_THEME
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-# html_logo = None
+html_logo = 'https://raw.githubusercontent.com/teemtee/docs/main/logo/tmt-transparent-175x175.png'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = '_static/tmt-small.png'
+html_favicon = 'https://raw.githubusercontent.com/teemtee/docs/main/logo/tmt-favicon.ico'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -230,7 +230,7 @@ html_favicon = '_static/tmt-small.png'
 html_static_path = ['_static']
 
 # Include custom style.
-html_style = os.getenv('TMT_DOCS_CUSTOM_HTML_STYLE', 'custom.css')
+html_style = os.getenv('TMT_DOCS_CUSTOM_HTML_STYLE', 'tmt-custom.css')
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -465,9 +465,9 @@ a colon (``:``): theme package name, and theme name.
     # and theme name are *not* the same string:
     TMT_DOCS_THEME="renku_sphinx_theme:renku" make docs
 
-By default, ``docs/_static/custom.css`` provides additional tweaks to
-the documentation theme. Use the ``TMT_DOCS_CUSTOM_HTML_STYLE`` variable
-to include additional file:
+By default, ``docs/_static/tmt-custom.css`` provides additional tweaks
+to the documentation theme. Use the ``TMT_DOCS_CUSTOM_HTML_STYLE``
+variable to include additional file:
 
 .. code-block:: shell
 
@@ -482,7 +482,7 @@ to include additional file:
 .. note::
 
     The custom CSS file specified by ``TMT_DOCS_CUSTOM_HTML_STYLE``
-    is included **before** the built-in ``custom.css``, therefore to
+    is included **before** the built-in ``tmt-custom.css``, therefore to
     override theme CSS, it is recommended to add ``!important`` flag.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,12 +178,10 @@ dependencies = ["tmt[docs]"]
 # files below, but it may be providing additional metadata for RTD to index.
 html = "sphinx-build -b html {root}/docs {root}/docs/_build {args}"
 man = [
-    "cp {root}/docs/header.txt {root}/man.rst",
-    "tail -n+8 docs/overview.rst >> {root}/man.rst",
-    # TODO rst2man cannot process this directive, removed for now
-    "sed '/versionadded::/d' -i {root}/man.rst",
-    "rst2man.py {root}/man.rst > {root}/tmt.1",
-    "rm -f {root}/man.rst",
+    "(cat {root}/docs/header.txt; echo; tail -n+8 {root}/docs/overview.rst) > {root}/docs/man.rst",
+    "sed '/versionadded::/d' -i {root}/docs/man.rst",
+    "sphinx-build -b man {root}/docs/ {root}",
+    "rm -f {root}/docs/man.rst",
     ]
 
 [dirs.env]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,10 +76,8 @@ all = [
     ]
 # Needed for readthedocs and man page build. Not being packaged in rpm.
 docs = [
-    "renku-sphinx-theme==0.4.0",
+    "furo",
     "readthedocs-sphinx-ext",
-    "docutils>=0.18.1",
-    "Sphinx==7.3.7",
     "fmf>=1.3.0",
     ]
 


### PR DESCRIPTION
The currently used theme is not being updated and it's dependencies are causing issues, like https://github.com/teemtee/tmt/pull/3087

This is a proof of concept of using the Furo theme, which is being used, among others, by [pip](https://pip.pypa.io/), [Python Developer’s Guide](https://devguide.python.org/) and [black](https://black.readthedocs.io/en/stable/).  

https://github.com/pradyunsg/furo
https://pradyunsg.me/furo/

Removing usage of rst2man and relying on sphinx builder to create manpage. This would be also a good opportunity to improve the man page, perhaps with additional pages and such.

We could also introduce sphinx-design, for which furo is the showpiece theme:https://sphinx-design.readthedocs.io/en/furo-theme/

Having markdown support would be a boon as well: https://myst-parser.readthedocs.io/en/latest/

Perhaps we could add https://github.com/executablebooks/sphinx-copybutton

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
