### PR TITLE
Improve the design of the checks and phases in HTML report plugin

### DIFF
--- a/tests/report/html/data/faked-subresults-results.yaml
+++ b/tests/report/html/data/faked-subresults-results.yaml
@@ -1,0 +1,91 @@
+  - name: /test/subresults
+    result: pass
+    note:
+    log:
+      - data/guest/default-0/test/subresults-1/output.txt
+    start-time: '2024-08-26T12:12:08.923924+00:00'
+    end-time: '2024-08-26T12:12:08.942201+00:00'
+    duration: 00:00:00
+    serial-number: 1
+    fmf-id:
+        name: /test/subresults
+    context: {}
+    ids:
+        id:
+        extra-nitrate:
+        extra-task:
+    guest:
+        name: default-0
+        role:
+        __class__:
+            module: tmt.result
+            name: ResultGuestData
+    subresult:
+      - name: /test/subresults/good
+        result: pass
+        end-time: "2024-07-17T14:16:28.735039+00:00"
+        __class__:
+            module: tmt.result
+            name: SubResult
+      - name: /test/subresults/fail
+        result: fail
+        end-time: "2024-07-17T14:16:28.739501+00:00"
+        __class__:
+            module: tmt.result
+            name: SubResult
+      - name: /test/subresults/weird
+        result: warn
+        end-time: "2024-07-17T14:16:28.743959+00:00"
+        __class__:
+            module: tmt.result
+            name: SubResult
+        check:
+          - name: dmesg
+            result: skip
+            note:
+            log: []
+            start-time: '2024-07-22T10:34:41.135249+00:00'
+            end-time: '2024-07-22T10:34:41.135279+00:00'
+            duration: 00:00:00
+            event: before-test
+            __class__:
+                module: tmt.result
+                name: CheckSubResult
+          - name: dmesg
+            result: skip
+            note:
+            log: []
+            start-time: '2024-07-22T10:34:41.393797+00:00'
+            end-time: '2024-07-22T10:34:41.393819+00:00'
+            duration: 00:00:00
+            event: after-test
+            __class__:
+                module: tmt.result
+                name: CheckSubResult
+    check:
+      - name: avc
+        result: skip
+        note:
+        log: []
+        start-time: '2024-07-22T10:34:41.135249+00:00'
+        end-time: '2024-07-22T10:34:41.135279+00:00'
+        duration: 00:00:00
+        event: before-test
+        __class__:
+            module: tmt.result
+            name: CheckSubResult
+      - name: avc
+        result: skip
+        note:
+        log: []
+        start-time: '2024-07-22T10:34:41.393797+00:00'
+        end-time: '2024-07-22T10:34:41.393819+00:00'
+        duration: 00:00:00
+        event: after-test
+        __class__:
+            module: tmt.result
+            name: CheckSubResult
+    data-path: data/guest/default-0/test/subresults-1/data
+    __class__:
+        module: tmt.result
+        name: Result

--- a/tests/report/html/data/main.fmf
+++ b/tests/report/html/data/main.fmf
@@ -24,6 +24,9 @@
         summary: Run command 'false' but report pass
         test: 'false'
         result: xfail
+    /subresults:
+        summary: Fake the subresults data and print them into final report
+        test: 'true'
 
 # Special plan to introduce more than one guest, for verification of --display-guest.
 # Disabled by default, but enabled in the corresponding test by a magic of context.

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -2,6 +2,8 @@ import dataclasses
 import webbrowser
 from typing import Optional
 
+from jinja2 import select_autoescape
+
 import tmt
 import tmt.log
 import tmt.options
@@ -66,6 +68,10 @@ class ReportHtml(tmt.steps.report.ReportPlugin[ReportHtmlData]):
 
         # Prepare the template
         environment = tmt.utils.templates.default_template_environment()
+
+        # Explicitly enable the autoescape because it's disabled by default by TMT
+        # (see /teemtee/tmt/issues/2873 for more info.
+        environment.autoescape = select_autoescape(enabled_extensions=('html.j2'))
 
         if self.data.absolute_paths:
             def _linkable_path(path: str) -> str:

--- a/tmt/steps/report/html/template.html.j2
+++ b/tmt/steps/report/html/template.html.j2
@@ -45,6 +45,13 @@
             margin: 30px 7px 0px 7px;
         }
 
+        #results table.check,
+        #results table.subresult-check,
+        #results table.subresult {
+            width: 100%;
+            background: #dadada;
+        }
+
         #results, #filters {
             border-spacing: 7px;
         }
@@ -89,15 +96,22 @@
             color: #c00;
         }
 
-        #results tr.check {
+        #results tr.check,
+        /* #results tr.subresult-check, // Do not hide subresult checks by default */
+        #results tr.subresult {
             font-size: 90%;
+            display: none;
         }
 
-        #results tr.check td.result {
+        #results tr.check td.result,
+        #results tr.subresult-check td.result,
+        #results tr.subresult td.result {
             width: 5ex;
         }
 
-        #results tr.check td.name {
+        #results tr.check td.name,
+        #results tr.subresult-check td.name,
+        #results tr.subresult td.name {
             color: #888;
             padding-left: 5ex;
             width: 22ex;
@@ -171,6 +185,18 @@
             filter_values["note"] = e.value;
             update_rows();
         }
+
+        // toggle the visibility of a given table row
+        function toggle_row_visibility(button, e) {
+            const element = document.getElementById(e);
+            if (element.style.display === 'none' || element.style.display === '') {
+                element.style.display = 'table-row';
+                button.textContent = button.textContent.replace('+', '-');
+            } else {
+                element.style.display = 'none';
+                button.textContent = button.textContent.replace('-', '+');
+            }
+        }
     </script>
 </head>
 
@@ -218,11 +244,13 @@ Context:
         <tr>
             <th>Result</th>
             <th>Test</th>
-{% if display_guest %}
+            {% if display_guest %}
             <th>Guest</th>
-{% endif %}
+            {% endif %}
             <th>Logs</th>
             <th>Data</th>
+            <th>Note</th>
+            <th>Actions</th>
         </tr>
     </thead>
     {% for result in results %}
@@ -238,14 +266,28 @@ Context:
         {% endfor %}
         </td>
         <td class="data"><a href="{{ base_dir | linkable_path | urlencode }}/{{ result.data_path | urlencode }}">data</a></td>
-        {% if result.note %}
-        <td class="note">{{ result.note | e }}</td>
-        {% endif %}
+        <td class="note">{% if result.note %}{{ result.note | e }}{% else %}-{% endif %}</td>
+        <td class="action">
+            {% if result.check %}
+            <button onclick="toggle_row_visibility(this, 'check-{{ loop.index }}')" title="Show / hide checks">checks&nbsp;[+]</button>
+            {% endif %}
+            {% if result.subresult %}
+            <button onclick="toggle_row_visibility(this, 'subresult-{{ loop.index }}')" title="Show / hide subresults">subresults&nbsp;[+]</button>
+            {% endif %}
+        </td>
     </tr>
     {% if result.check %}
-    <tr class="check">
-        <td colspan="4">
-            <table>
+    <tr class="check" id="check-{{ loop.index }}">
+        <td colspan="{% if display_guest %}7{% else %}6{% endif %}">
+            <h3>Checks</h3>
+            <table class="check">
+                <thead>
+                    <tr>
+                        <th>Result</th>
+                        <th>Name</th>
+                        <th>Logs</th>
+                    </tr>
+                </thead>
                 {% for check in result.check %}
                 <tr>
                     <td class="result {{ check.result.value | e }}">{{ check.result.value | e }}</td>
@@ -253,9 +295,69 @@ Context:
                     <td class="log">
                         {% for log in check.log %}
                         <a href="{{ base_dir | linkable_path | urlencode }}/{{ log | urlencode }}">{{ log | basename }}</a>
+                        {% else %}
+                        -
                         {% endfor %}
                     </td>
                 </tr>
+                {% endfor %}
+            </table>
+        </td>
+    </tr>
+    {% endif %}
+    {% if result.subresult %}
+    <tr class="subresult" id="subresult-{{ loop.index }}">
+        <td colspan="{% if display_guest %}7{% else %}6{% endif %}">
+            <h3>Subresults</h3>
+            <table class="subresult">
+                <thead>
+                    <tr>
+                        <th>Result</th>
+                        <th>Name</th>
+                        <th>Logs</th>
+                    </tr>
+                </thead>
+                {% for subresult in result.subresult %}
+                <tr>
+                    <td class="result {{ subresult.result.value | e }}">{{ subresult.result.value | e }}</td>
+                    <td class="name">{{ subresult.name | e }}</td>
+                    <td class="log">
+                        {% for log in subresult.log %}
+                        <a href="{{ base_dir | linkable_path | urlencode }}/{{ log | urlencode }}">{{ log | basename }}</a>
+                        {% else %}
+                        -
+                        {% endfor %}
+                    </td>
+                </tr>
+                {% if subresult.check %}
+                <tr class="subresult-check" id="subresult-check-{{ loop.index }}">
+                    <td colspan="3">
+                        <h3>Subresult checks</h3>
+                        <table class="check">
+                            <thead>
+                                <tr>
+                                    <th>Result</th>
+                                    <th>Name</th>
+                                    <th>Logs</th>
+                                </tr>
+                            </thead>
+                            {% for check in subresult.check %}
+                            <tr>
+                                <td class="result {{ check.result.value | e }}">{{ check.result.value | e }}</td>
+                                <td class="name">{{ check.name | e }} ({{ check.event.value }})</td>
+                                <td class="log">
+                                    {% for log in check.log %}
+                                    <a href="{{ base_dir | linkable_path | urlencode }}/{{ log | urlencode }}">{{ log | basename }}</a>
+                                    {% else %}
+                                    -
+                                    {% endfor %}
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </table>
+                    </td>
+                </tr>
+                {% endif %}
                 {% endfor %}
             </table>
         </td>


### PR DESCRIPTION
I tried to fix the colspan of the main table, added a new column "Actions" into the table, and added the possibility to show/hide the checks and subresults row for each result using the toggle buttons.

The https://github.com/teemtee/tmt/pull/3094 is a prerequisite to test the code in this PR. To generate the subresults in the attached screenshots, I have for now faked the `subresult` data in the `plans/example/execute/results.yaml` as following:

```
...
    phase:
      - name: /tests/mine-rep-multi/test/good
        result: pass
        end-time: "2024-07-17T14:16:28.735039+00:00"
        __class__:
            module: tmt.result
            name: PhaseResult
      - name: /tests/mine-rep-multi/test/fail
        result: fail
        end-time: "2024-07-17T14:16:28.739501+00:00"
        __class__:
            module: tmt.result
            name: PhaseResult
      - name: /tests/mine-rep-multi/test/weird
        result: warn
        end-time: "2024-07-17T14:16:28.743959+00:00"
        __class__:
            module: tmt.result
            name: PhaseResult

    check:
      - name: dmesg
        result: skip
        note:
        log: []
        start-time: '2024-07-18T12:18:06.339547+00:00'
        end-time: '2024-07-18T12:18:06.339574+00:00'
        duration: 00:00:00
        event: before-test
        __class__:
            module: tmt.result
            name: CheckResult
...
```

Related to:
- https://github.com/teemtee/tmt/issues/2826

Blocked by:
- https://github.com/teemtee/tmt/pull/3106

TODOs:
- [x] Somehow also show the phase checks.
- [x] Fix old tests
- [ ] Add new test for subresults and checks

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note

## Example screenshots:

![3](https://github.com/user-attachments/assets/83ddf44e-0d20-4233-822c-4cdd041d6d40)
![4](https://github.com/user-attachments/assets/847e4c4d-832d-4564-9f1e-34f605d89eeb)


