### PR TITLE
Make `mypy` happy about the `error.schema` content

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -933,7 +933,7 @@ class Core(
                     return
 
                 for bad_property in match.group(1).replace("'", '').replace(' ', '').split(','):
-                    if '$id' in error.schema:
+                    if isinstance(error.schema, dict) and '$id' in error.schema:
                         yield LinterOutcome.WARN, \
                             f'key "{bad_property}" not recognized by schema {error.schema["$id"]}'
                     else:


### PR DESCRIPTION
For for some reason `mypy` started to complain about the `error.schema` type:

    error: Unsupported right operand type for in
    ("Union[Mapping[str, Any], bool, Unset]")  [operator]

Let's make it happy! :)