### PR TITLE
Show subresults and their checks in report display plugin

### DIFF
--- a/tests/report/display/data/faked-subresults-results.yaml
+++ b/tests/report/display/data/faked-subresults-results.yaml
@@ -1,0 +1,69 @@
+  - name: /test
+    result: pass
+    note:
+    log:
+      - data/guest/default-0/test-1/output.txt
+    start-time: '2024-08-15T13:15:06.556611+00:00'
+    end-time: '2024-08-15T13:15:06.574717+00:00'
+    duration: 00:00:00
+    serial-number: 1
+    fmf-id:
+        name: /test
+    context: {}
+    ids:
+        id:
+        extra-nitrate:
+        extra-task:
+    guest:
+        name: default-0
+        role:
+        __class__:
+            module: tmt.result
+            name: ResultGuestData
+    subresult:
+      - name: /test/good
+        result: pass
+        end-time: "2024-07-17T14:16:28.735039+00:00"
+        __class__:
+            module: tmt.result
+            name: SubResult
+      - name: /test/fail
+        result: fail
+        end-time: "2024-07-17T14:16:28.739501+00:00"
+        __class__:
+            module: tmt.result
+            name: SubResult
+      - name: /test/weird
+        result: warn
+        end-time: "2024-07-17T14:16:28.743959+00:00"
+        __class__:
+            module: tmt.result
+            name: SubResult
+        check:
+          - name: dmesg
+            result: skip
+            note:
+            log: []
+            start-time: '2024-07-22T10:34:41.135249+00:00'
+            end-time: '2024-07-22T10:34:41.135279+00:00'
+            duration: 00:00:00
+            event: before-test
+            __class__:
+                module: tmt.result
+                name: CheckSubResult
+          - name: dmesg
+            result: skip
+            note:
+            log: []
+            start-time: '2024-07-22T10:34:41.393797+00:00'
+            end-time: '2024-07-22T10:34:41.393819+00:00'
+            duration: 00:00:00
+            event: after-test
+            __class__:
+                module: tmt.result
+                name: CheckSubResult
+    check: []
+    data-path: data/guest/default-0/test-1/data
+    __class__:
+        module: tmt.result
+        name: Result

--- a/tests/report/display/data/main.fmf
+++ b/tests/report/display/data/main.fmf
@@ -20,3 +20,11 @@
           how: container
     execute:
         how: tmt
+
+/subresults:
+    discover:
+        how: fmf
+    provision:
+        how: local
+    execute:
+        how: tmt

--- a/tests/report/display/test.sh
+++ b/tests/report/display/test.sh
@@ -25,6 +25,17 @@ rlJournalStart
         rlRun -s "tmt run -av --scratch --id $tmp plan -n multihost report -h display --display-guest never"
         rlAssertGrep "pass /test$" "$rlRun_LOG"
         rlAssertGrep "pass /test$" "$rlRun_LOG"
+
+        # Check the subresults and their checks using a faked results.yaml data
+        rlRun -s "tmt run -av --scratch --id $tmp plan -n subresults report -h display"
+        rlRun "cp -r faked-subresults-results.yaml $tmp/subresults/execute/results.yaml" 0 "Faking the execute/results.yaml with subresult data"
+        rlRun -s "tmt run --last --id $tmp plan -n subresults report -h display -v"
+        rlAssertGrep "pass /test$" "$rlRun_LOG"
+        rlAssertGrep "pass /test/good$" "$rlRun_LOG"
+        rlAssertGrep "fail /test/fail$" "$rlRun_LOG"
+        rlAssertGrep "warn /test/weird$" "$rlRun_LOG"
+        rlAssertGrep "skip dmesg (before-test check)$" "$rlRun_LOG"
+        rlAssertGrep "summary: 1 test passed$" "$rlRun_LOG"
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
This is a proposal to show the result phases (aka subresults) and their checks in the display report plugin.

Related to:
- https://github.com/teemtee/tmt/issues/2826

Depends on:
- https://github.com/teemtee/tmt/pull/3094

Blocked by:
- https://github.com/teemtee/tmt/pull/3106

The code uses faked `subresult` data in `plans/example/execute/results.yaml` for testing purposes.

```
$ python -m tmt -r ~/tmt-learning/13 run --last report --how display --force -v 
/var/tmp/tmt/run-001

/plans/example
    report
        how: display
            pass /tests/call-dmesg
                skip dmesg (before-test check)
                skip dmesg (after-test check)
            fail /tests/mine-rep-multi
                skip dmesg (before-test check)
                skip dmesg (after-test check)
                pass /tests/mine-rep-multi/test/good
                fail /tests/mine-rep-multi/test/fail
                warn /tests/mine-rep-multi/test/weird
                    skip dmesg (before-test check)
                    skip dmesg (after-test check)
            pass /tests/mine-rep-pass
        summary: 2 tests passed and 1 test failed

total: 2 tests passed and 1 test failed
```

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
