### PR TITLE
Extend coverage of prepare/finish ansible plugin with more images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,9 @@ TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX = tmt/tests/container
 
 TMT_TEST_CONTAINER_IMAGES := $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/alpine:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/alpine/upstream:latest \
+                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/centos/7:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/centos/7/upstream:latest \
+                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/centos/stream9:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/centos/stream9/upstream:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/coreos:stable \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/coreos/ostree:stable \
@@ -128,8 +130,14 @@ $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/alpine\:
 $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/alpine/upstream\:latest:
 	$(call build-test-container-image,$@,alpine/Containerfile.upstream)
 
+$(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/centos/7\:latest:
+	$(call build-test-container-image,$@,centos/7/Containerfile)
+
 $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/centos/7/upstream\:latest:
 	$(call build-test-container-image,$@,centos/7/Containerfile.upstream)
+
+$(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/centos/stream9\:latest:
+	$(call build-test-container-image,$@,centos/stream9/Containerfile)
 
 $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/centos/stream9/upstream\:latest:
 	$(call build-test-container-image,$@,centos/stream9/Containerfile.upstream)

--- a/containers/centos/7/Containerfile
+++ b/containers/centos/7/Containerfile
@@ -1,0 +1,15 @@
+#
+# A CentOS 7 image tailored for tmt test suite
+#
+# tmt/tests/centos/7/upstream:latest
+#
+
+FROM quay.io/centos/centos:7
+
+# Use latest vault repos, mirrors are gone after centos EOL
+RUN cd /etc/yum.repos.d/ \
+    && sed '/mirrorlist/d' -i *repo \
+    && sed 's|#baseurl=http://mirror.centos.org/centos/$releasever|baseurl=https://vault.centos.org/7.9.2009|' -i *repo
+
+    # Populate yum cache
+RUN yum makecache

--- a/containers/centos/stream9/Containerfile
+++ b/containers/centos/stream9/Containerfile
@@ -1,0 +1,10 @@
+#
+# A CentOS Stream 9 image tailored for tmt test suite
+#
+# tmt/tests/centos/stream9/upstream:latest
+#
+
+FROM quay.io/centos/centos:stream9
+
+    # Populate dnf cache
+RUN dnf makecache

--- a/tests/finish/ansible/data/plan.fmf
+++ b/tests/finish/ansible/data/plan.fmf
@@ -1,24 +1,31 @@
-environment:
-    SIMPLE: word
-    SPACES: several words with spaces
 provision:
     how: container
-finish:
-    - name: State before is valid (no file)
-      order: 20
-      how: shell
-      script: bash -xc "! [ -f /tmp/finished ]"
-    - name: Ansible we want to test
-      how: ansible
-      playbook: playbook.yml
-    - name: State after is as expected (file created)
-      order: 70
-      how: shell
-      script: bash -xc "[ -f /tmp/finished ]"
-    - name: Create a file that is pulled during the finish stage
-      order: 80
-      how: shell
-      script: touch $TMT_PLAN_DATA/my_file.txt
 execute:
     how: tmt
     script: echo fake
+
+environment:
+    SIMPLE: word
+    SPACES: several words with spaces
+
+finish:
+    - name: State before is valid (no file)
+      order: 80
+      how: shell
+      script: bash -xc "! [ -f /tmp/finished ]"
+
+    - name: Ansible we want to test
+      order: 85
+      how: ansible
+      playbook: playbook.yml
+      extra-args: '-e ansible_remote_tmp=/tmp'
+
+    - name: State after is as expected (file created)
+      order: 90
+      how: shell
+      script: bash -xc "[ -f /tmp/finished ]"
+
+    - name: Create a file that is pulled during the finish stage
+      order: 95
+      how: shell
+      script: touch $TMT_PLAN_DATA/my_file.txt

--- a/tests/finish/ansible/main.fmf
+++ b/tests/finish/ansible/main.fmf
@@ -10,3 +10,4 @@ tag+:
   - provision-container
   - provision-local
   - provision-virtual
+duration: 30m

--- a/tests/images.sh
+++ b/tests/images.sh
@@ -15,7 +15,121 @@ TEST_IMAGE_PREFIX="localhost/tmt/tests/container"
 # "Source" of this script -> its absolute path -> dirname -> one level above `tests/`
 _MAKEFILE_DIR="$(dirname $(readlink -f ${BASH_SOURCE[0]}))/.."
 
+# Basic set of container images to test on
+#
+# It does not contain "unprivileged" images.
+TEST_CONTAINER_IMAGES="${TEST_CONTAINER_IMAGES:-$TEST_IMAGE_PREFIX/alpine:latest
+$TEST_IMAGE_PREFIX/centos/7/upstream:latest
+$TEST_IMAGE_PREFIX/centos/stream9/upstream:latest
+$TEST_IMAGE_PREFIX/fedora/39/upstream:latest
+$TEST_IMAGE_PREFIX/fedora/40/upstream:latest
+$TEST_IMAGE_PREFIX/fedora/rawhide/upstream:latest
+$TEST_IMAGE_PREFIX/fedora/coreos:stable
+$TEST_IMAGE_PREFIX/fedora/coreos/ostree:stable
+$TEST_IMAGE_PREFIX/ubi/8/upstream:latest
+$TEST_IMAGE_PREFIX/ubuntu/22.04/upstream:latest}"
 
+# Basic set of virtual images to test on.
+#
+# Enable Alpine
+# TODO: enable Ubuntu
+# TODO: enable centos-7 again with modified repo files
+TEST_VIRTUAL_IMAGES="${TEST_VIRTUAL_IMAGES:-centos-stream-9
+fedora-39
+fedora-40
+fedora-rawhide
+fedora-coreos}"
+
+# A couple of "is image this?" helpers, to simplify conditions.
+function is_fedora_rawhide () {
+    [[ "$1" =~ ^.*fedora/rawhide[:/].* ]] && return 0
+    [[ "$1" = "fedora-rawhide" ]] && return 0
+
+    return 1
+}
+
+function is_fedora_40 () {
+    [[ "$1" =~ ^.*fedora/40[:/].* ]] && return 0
+    [[ "$1" = "fedora-40" ]] && return 0
+
+    return 1
+}
+
+function is_fedora_39 () {
+    [[ "$1" =~ ^.*fedora/39[:/].* ]] && return 0
+    [[ "$1" = "fedora-39" ]] && return 0
+
+    return 1
+}
+
+function is_centos_stream_9 () {
+    [[ "$1" =~ ^.*centos/stream9[:/].* ]] && return 0
+    [[ "$1" = "centos-stream-9" ]] && return 0
+
+    return 1
+}
+
+function is_centos_7 () {
+    [[ "$1" =~ ^.*centos/7[:/].* ]] && return 0
+    [[ "$1" = "centos-7" ]] && return 0
+
+    return 1
+}
+
+function is_ubuntu () {
+    [[ "$1" =~ ^.*ubuntu/.* ]] && return 0
+    [[ "$1" = "ubuntu" ]] && return 0
+
+    return 1
+}
+
+function is_ostree () {
+    [[ "$1" =~ ^.*fedora/coreos/ostree:stable ]] && return 0
+    [[ "$1" = "fedora-coreos" && "$PROVISION_HOW" = "virtual" ]] && return 0
+
+    return 1
+}
+
+function is_fedora_coreos () {
+    [[ "$1" =~ ^.*fedora/coreos(/ostree)?:stable ]] && return 0
+    [[ "$1" = "fedora-coreos" ]] && return 0
+
+    return 1
+}
+
+function is_fedora () {
+    [[ "$1" =~ ^.*fedora.* ]] && return 0 || return 1
+}
+
+function is_centos () {
+    [[ "$1" =~ ^.*centos.* ]] && return 0 || return 1
+}
+
+function is_rhel () {
+    is_ubi "$1" && return 0 || return 1
+}
+
+function is_alpine () {
+    [[ "$1" =~ ^.*alpine.* ]] && return 0 || return 1
+}
+
+function is_ubi () {
+    [[ "$1" =~ ^.*ubi.* ]] && return 0 || return 1
+}
+
+function is_ubi_8 () {
+    [[ "$1" =~ ^.*ubi/8.* ]] && return 0 || return 1
+}
+
+function test_phase_prefix () {
+    if [ "$PROVISION_HOW" = "local" ]; then
+        echo "[$PROVISION_HOW]"
+    else
+        echo "[$PROVISION_HOW / $(echo $1 | sed "s|$TEST_IMAGE_PREFIX/||")]"
+    fi
+}
+
+# Building of container images
 function build_container_image () {
     if [ "$PROVISION_HOW" != "container" ]; then
         rlLogInfo "Skipping the build of $1 container image because of PROVISION_HOW=$PROVISION_HOW"

--- a/tests/prepare/ansible/data/plan.fmf
+++ b/tests/prepare/ansible/data/plan.fmf
@@ -1,22 +1,37 @@
-discover:
-    how: fmf
-environment:
-    SIMPLE: word
-    SPACES: several words with spaces
 provision:
     how: container
 execute:
     how: tmt
+    script: echo fake
+
+environment:
+    SIMPLE: word
+    SPACES: several words with spaces
+
+prepare:
+  - name: State before is valid (no file)
+    order: 80
+    how: shell
+    script: bash -xc "! [ -f /tmp/prepared ]"
+
+  - name: State after is as expected (file created)
+    order: 90
+    how: shell
+    script: bash -xc "[ -f /tmp/prepared ]"
 
 /local:
-    prepare:
+    prepare+:
+      - name: Ansible we want to test
+        order: 85
         how: ansible
         playbook: playbook.yml
-        extra-args: '-vvv'
+        extra-args: '-vvv -e ansible_remote_tmp=/tmp'
 
 /remote:
-    prepare:
+    prepare+:
+      - name: Ansible we want to test
+        order: 85
         how: ansible
         # This is the very same playbook as the local one, just living in tmt's repository.
         playbook: https://raw.githubusercontent.com/teemtee/tmt/main/tests/prepare/ansible/data/playbook.yml
-        extra-args: '-vvv'
+        extra-args: '-vvv -e ansible_remote_tmp=/tmp'

--- a/tests/prepare/ansible/data/test.fmf
+++ b/tests/prepare/ansible/data/test.fmf
@@ -1,2 +1,0 @@
-summary: Verify that the test file was prepared
-test: grep pass /tmp/prepared

--- a/tests/prepare/ansible/main.fmf
+++ b/tests/prepare/ansible/main.fmf
@@ -9,3 +9,4 @@ tag+:
   - provision-container
   - provision-local
   - provision-virtual
+duration: 30m

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -2,107 +2,6 @@
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 . ../../images.sh || exit 1
 
-# TODO: should these variables exist outside of this test, for all tests
-# to share?
-CONTAINER_IMAGES="${CONTAINER_IMAGES:-$TEST_IMAGE_PREFIX/fedora/rawhide/upstream:latest
-$TEST_IMAGE_PREFIX/fedora/40/upstream:latest
-$TEST_IMAGE_PREFIX/fedora/39/upstream:latest
-$TEST_IMAGE_PREFIX/centos/stream9/upstream:latest
-$TEST_IMAGE_PREFIX/centos/7/upstream:latest
-$TEST_IMAGE_PREFIX/ubi/8/upstream:latest
-$TEST_IMAGE_PREFIX/ubuntu/22.04/upstream:latest
-$TEST_IMAGE_PREFIX/alpine:latest
-$TEST_IMAGE_PREFIX/fedora/coreos:stable
-$TEST_IMAGE_PREFIX/fedora/coreos/ostree:stable}"
-
-# TODO: enable Ubuntu
-# TODO: enable centos-7 again with modified repo files)
-VIRTUAL_IMAGES="${VIRTUAL_IMAGES:-fedora-rawhide
-fedora-39
-centos-stream-9
-fedora-coreos}"
-
-# A couple of "is image this?" helpers, to simplify conditions.
-function is_fedora_rawhide () {
-    [[ "$1" =~ ^.*fedora/rawhide[:/].* ]] && return 0
-    [[ "$1" = "fedora-rawhide" ]] && return 0
-
-    return 1
-}
-
-function is_fedora_40 () {
-    [[ "$1" =~ ^.*fedora/40[:/].* ]] && return 0
-    [[ "$1" = "fedora-40" ]] && return 0
-
-    return 1
-}
-
-function is_fedora_39 () {
-    [[ "$1" =~ ^.*fedora/39[:/].* ]] && return 0
-    [[ "$1" = "fedora-39" ]] && return 0
-
-    return 1
-}
-
-function is_centos_stream_9 () {
-    [[ "$1" =~ ^.*centos/stream9[:/].* ]] && return 0
-    [[ "$1" = "centos-stream-9" ]] && return 0
-
-    return 1
-}
-
-function is_centos_7 () {
-    [[ "$1" =~ ^.*centos/7[:/].* ]] && return 0
-    [[ "$1" = "centos-7" ]] && return 0
-
-    return 1
-}
-
-function is_ubuntu () {
-    [[ "$1" =~ ^.*ubuntu/.* ]] && return 0
-    [[ "$1" = "ubuntu" ]] && return 0
-
-    return 1
-}
-
-function is_ostree () {
-    [[ "$1" =~ ^.*fedora/coreos/ostree:stable ]] && return 0
-    [[ "$1" = "fedora-coreos" && "$PROVISION_HOW" = "virtual" ]] && return 0
-
-    return 1
-}
-
-function is_fedora_coreos () {
-    [[ "$1" =~ ^.*fedora/coreos(/ostree)?:stable ]] && return 0
-    [[ "$1" = "fedora-coreos" ]] && return 0
-
-    return 1
-}
-
-function is_fedora () {
-    [[ "$1" =~ ^.*fedora.* ]] && return 0 || return 1
-}
-
-function is_centos () {
-    [[ "$1" =~ ^.*centos.* ]] && return 0 || return 1
-}
-
-function is_rhel () {
-    is_ubi "$1" && return 0 || return 1
-}
-
-function is_alpine () {
-    [[ "$1" =~ ^.*alpine.* ]] && return 0 || return 1
-}
-
-function is_ubi () {
-    [[ "$1" =~ ^.*ubi.* ]] && return 0 || return 1
-}
-
-function is_ubi_8 () {
-    [[ "$1" =~ ^.*ubi/8.* ]] && return 0 || return 1
-}
-
 function fetch_downloaded_packages () {
     in_subdirectory="$2"
 
@@ -136,12 +35,12 @@ rlJournalStart
         rlRun "PROVISION_HOW=${PROVISION_HOW:-container}"
 
         if [ "$PROVISION_HOW" = "container" ]; then
-            rlRun "IMAGES='$CONTAINER_IMAGES'"
+            rlRun "IMAGES='$TEST_CONTAINER_IMAGES'"
 
             build_container_images
 
         elif [ "$PROVISION_HOW" = "virtual" ]; then
-            rlRun "IMAGES='$VIRTUAL_IMAGES'"
+            rlRun "IMAGES='$TEST_VIRTUAL_IMAGES'"
 
         else
             rlRun "IMAGES="
@@ -156,7 +55,7 @@ rlJournalStart
     rlPhaseEnd
 
     while IFS= read -r image; do
-        phase_prefix="[$PROVISION_HOW / $image]"
+        phase_prefix="$(test_phase_prefix $image)"
 
         rlPhaseStartTest "$phase_prefix Prepare runtime"
             [ "$PROVISION_HOW" = "container" ] && rlRun "podman images $image"

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -25,6 +25,7 @@ ReducedPackages = list[Union[Package, PackagePath]]
 PACKAGE_PATH: dict[FileSystemPath, str] = {
     FileSystemPath('/usr/bin/arch'): 'busybox',
     FileSystemPath('/usr/bin/flock'): 'flock',
+    FileSystemPath('/usr/bin/python3'): 'python3',
     # Note: not used for anything serious, serves for unit tests as
     # an installable path.
     FileSystemPath('/usr/bin/dos2unix'): 'dos2unix'

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 import requests
 
 import tmt
+import tmt.base
 import tmt.log
 import tmt.options
 import tmt.steps
@@ -168,3 +169,17 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
             guest.ansible(playbook_path, extra_args=self.data.extra_args)
 
         return results
+
+    def essential_requires(self) -> list[tmt.base.Dependency]:
+        """
+        Collect all essential requirements of the plugin.
+
+        Essential requirements of a plugin are necessary for the plugin to
+        perform its basic functionality.
+
+        :returns: a list of requirements.
+        """
+
+        return [
+            tmt.base.DependencySimple('/usr/bin/python3')
+            ]


### PR DESCRIPTION
The coverage now matches what `prepare/install` is tested with. This change required refactoring of some bits of `prepare/install` test:

* moving generic helpers into `tests/install.sh`,
* changing tests for `ansible` plugin to use `tests/images.sh` instead of its original one-shot use of images.

This gives us:

* the same coverage for both plugins,
* one place where new environment needs to be added,
* less code duplication, more re-use of "image testing" helpers,
* and, the best, it actually discovers a genuine bug: `ansible` plugins did not report Python interpreter as their essential requirement, therefore playbooks were impossible to run in some environments.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage