### PR TITLE
Fix loose ends in documentation after renaming plugin hrefs

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -362,17 +362,17 @@ parts, to highlight important points, or to provide helpful examples.
 A couple of best practices when updating documentation:
 
 * When referring to a plugin, its options or documentation, prefer
-  reference to ``plugins/STEP/PLUGIN`` rather than to older
+  reference to ``/plugins/STEP/PLUGIN`` rather than to older
   ``/spec/plans/STEP/PLUGIN``:
 
   .. code-block:: rest
 
     # This is good:
-    :ref:`plugins/prepare/ansible`
+    :ref:`/plugins/prepare/ansible`
 
     # If the user-facing plugin name differs from the Python one,
     # or if you need capitalize the first letter:
-    :ref:`Beaker<plugins/provision/beaker>`
+    :ref:`Beaker</plugins/provision/beaker>`
 
     # This should be avoided:
     :ref:`/spec/plans/prepare/ansible`

--- a/docs/plugins/provision-header.inc.rst
+++ b/docs/plugins/provision-header.inc.rst
@@ -1,4 +1,4 @@
-.. _plugins/provision/hard-reboot:
+.. _/plugins/provision/hard-reboot:
 
 Hard reboot
 -----------

--- a/spec/tests/restart.fmf
+++ b/spec/tests/restart.fmf
@@ -40,7 +40,7 @@ description: |
 
             Be aware that this feature may be limited depending on how
             the guest was provisioned. See
-            :ref:`plugins/provision/hard-reboot`.
+            :ref:`/plugins/provision/hard-reboot`.
 
     .. versionadded:: 1.33
 

--- a/tmt/checks/watchdog.py
+++ b/tmt/checks/watchdog.py
@@ -370,7 +370,7 @@ class Watchdog(CheckPlugin[WatchdogCheck]):
     .. warning::
 
         Be aware that this feature may be limited depending on how the
-        guest was provisioned. See :ref:`plugins/provision/hard-reboot`.
+        guest was provisioned. See :ref:`/plugins/provision/hard-reboot`.
 
     Each probe has a "budget" of allowed failures, and when it runs out,
     the action is taken. A successful probe replenishes its budget to


### PR DESCRIPTION
Hopefully a wrap up of https://github.com/teemtee/tmt/pull/3104

Pull Request Checklist

* [x] implement the feature