### PR TITLE
Use checkmark and cross for hardware support matrix

### DIFF
--- a/docs/templates/hardware-matrix.rst.j2
+++ b/docs/templates/hardware-matrix.rst.j2
@@ -30,10 +30,10 @@ supported by plugins bundled with tmt.
    * - :ref:`{{ requirement }}{# djlint:off #}</spec/hardware/{# djlint:on H025 #}{{ requirement }}>`
     {% for plugin, (enabled, note_id) in plugins.items() %}
         {% if enabled %}
-     - :supported:`yes`{% if note_id %} [{{ note_id }}]_{% endif %}
+     - ✅{% if note_id %} [{{ note_id }}]_{% endif %}
 
         {% else %}
-     - :unsupported:`no`
+     - ❌
 
         {% endif %}
     {% endfor %}


### PR DESCRIPTION
The color scheme is rather confusing as it clashes with the hyperlink text right next to it (from https://github.com/teemtee/tmt/pull/3121)

![Screenshot_20240730_133159](https://github.com/user-attachments/assets/066399e2-83f4-4d36-82fe-a64f2741b3a7)

Proposing to use emojis instead ✅❌

@happz do you want to cherry-pick this one into #3121? There is not much value to it as standalone

---

Pull Request Checklist

* [x] implement the feature
