### PR TITLE
Add initial release-drafter workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Highlights'
+    labels:
+      - 'release note'
+  - title: '🔧 Other changes'
+    labels:
+      - '*'
+exclude-labels:
+  - 'ignore-for-release'
+change-template: '- $TITLE by @$AUTHOR (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  [TODO: Update the version number in the URL below. (usually `x.y.z` -> `x-y-z`)]
+  See the [release notes](https://tmt.readthedocs.io/en/stable/releases.html#tmt-$RESOLVED_VERSION) for the list of interesting changes.
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,0 +1,36 @@
+# Based on https://github.com/release-drafter/release-drafter/blob/master/README.md
+name: Release Drafter
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+  # pull_request event is required only for autolabeler
+  #pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+  #  types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v6
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To further automate the release process, I've been looking into github releases. After evaluating various options, like `.github/release.yml`, I'm proposing [release-drafter](https://github.com/release-drafter/release-drafter) , which seems to be the most popular tool specifically for this.

The initial template aims to keep everything as is, but could be a base to further improve the release notes (see available [configuration options](https://github.com/release-drafter/release-drafter?tab=readme-ov-file#configuration-options))

Note I've added:
```
exclude-labels:
  - 'ignore-for-release'
```
this, or some similarly named label could be used for merges that should be omitted from release notes, e.g. single-line typo fix that blocks release :)

TODO:
- [ ] use `replacers` for tmt rtd link 