### PR TITLE
Fix running of Ansible playbooks shipped with tmt

### DIFF
--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -166,7 +166,10 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
 
                 logger.info('playbook-path', playbook_path, 'green')
 
-            guest.ansible(playbook_path, extra_args=self.data.extra_args)
+            guest.ansible(
+                playbook_path,
+                playbook_root=self.step.plan.fmf_root,
+                extra_args=self.data.extra_args)
 
         return results
 

--- a/tmt/steps/prepare/feature.py
+++ b/tmt/steps/prepare/feature.py
@@ -41,17 +41,6 @@ class Feature(tmt.utils.Common):
 
 
 class ToggleableFeature(Feature):
-    # def get_root_path(self) -> Path:
-    #     """ Get the root path for getting the path of a playbook"""
-    #     assert self.parent is not None  # narrow type
-    #     assert self.parent.parent is not None  # narrow type
-    #     assert self.parent.parent.parent is not None  # narrow type
-    #     plan = cast(tmt.base.Plan, self.parent.parent.parent)
-    #     assert plan.my_run is not None  # narrow type
-    #     assert plan.my_run.tree is not None  # narrow type
-    #     assert plan.my_run.tree.root is not None  # narrow type
-    #     return plan.my_run.tree.root
-
     def _run_playbook(self, op: str, playbook_filename: str) -> None:
         playbook_path = self._find_playbook(playbook_filename)
         if not playbook_path:

--- a/tmt/steps/prepare/feature.py
+++ b/tmt/steps/prepare/feature.py
@@ -41,16 +41,16 @@ class Feature(tmt.utils.Common):
 
 
 class ToggleableFeature(Feature):
-    def get_root_path(self) -> Path:
-        """ Get the root path for getting the path of a playbook"""
-        assert self.parent is not None  # narrow type
-        assert self.parent.parent is not None  # narrow type
-        assert self.parent.parent.parent is not None  # narrow type
-        plan = cast(tmt.base.Plan, self.parent.parent.parent)
-        assert plan.my_run is not None  # narrow type
-        assert plan.my_run.tree is not None  # narrow type
-        assert plan.my_run.tree.root is not None  # narrow type
-        return plan.my_run.tree.root
+    # def get_root_path(self) -> Path:
+    #     """ Get the root path for getting the path of a playbook"""
+    #     assert self.parent is not None  # narrow type
+    #     assert self.parent.parent is not None  # narrow type
+    #     assert self.parent.parent.parent is not None  # narrow type
+    #     plan = cast(tmt.base.Plan, self.parent.parent.parent)
+    #     assert plan.my_run is not None  # narrow type
+    #     assert plan.my_run.tree is not None  # narrow type
+    #     assert plan.my_run.tree.root is not None  # narrow type
+    #     return plan.my_run.tree.root
 
     def _run_playbook(self, op: str, playbook_filename: str) -> None:
         playbook_path = self._find_playbook(playbook_filename)
@@ -59,7 +59,7 @@ class ToggleableFeature(Feature):
                 f"{op.capitalize()} {self.NAME.upper()} is not supported on this guest.")
 
         self.info(f'{op.capitalize()} {self.NAME.upper()}')
-        self.guest.ansible(playbook_path.relative_to(self.get_root_path()))
+        self.guest.ansible(playbook_path)
 
     def _enable(self, playbook_filename: str) -> None:
         self._run_playbook('enable', playbook_filename)

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -952,18 +952,36 @@ class Guest(tmt.utils.Common):
                 tasks = fmf.utils.listed(matched.group(1), 'task')
                 self.verbose(key, tasks, 'green')
 
-    def _ansible_playbook_path(self, playbook: Path, playbook_root: Path) -> Path:
-        """ Prepare full ansible playbook path """
-        # self.debug(f"Applying playbook '{playbook}' on guest '{self.primary_address}'.")
-        # FIXME: cast() - https://github.com/teemtee/tmt/issues/1372
-        # parent = cast(Provision, self.parent)
-        # assert parent.plan.fmf_root is not None  # narrow type
-        # Playbook paths should be relative to the metadata tree root
-        playbook = playbook_root / playbook.unrooted()
-        if not playbook.exists() or not playbook.is_relative_to(playbook_root):
-            raise tmt.utils.GeneralError(f"{playbook} is not relative to the metadata tree root.")
+    def _sanitize_ansible_playbook_path(
+            self,
+            playbook: Path,
+            playbook_root: Optional[Path]) -> Path:
+        """
+        Prepare full ansible playbook path.
+
+        :param playbook: path to the playbook to run.
+        :param playbook_root: if set, ``playbook`` path must be located
+            under the given root path.
+        :returns: an absolute path to a playbook.
+        :raises GeneralError: when ``playbook_root`` is set, but
+            ``playbook`` is not located in this filesystem tree, or when
+            the eventual playbook path is not absolute.
+        """
+
+        # Some playbooks must be under playbook root, which is often
+        # a metadata tree root.
+        if playbook_root is not None:
+            playbook = playbook_root / playbook.unrooted()
+
+            if not playbook.is_relative_to(playbook_root):
+                raise tmt.utils.GeneralError(
+                    f"'{playbook}' is not relative to the expected root '{playbook_root}'.")
+
+        if not playbook.exists():
+            raise tmt.utils.FileError(f"Playbook '{playbook}' does not exist.")
 
         self.debug(f"Playbook full path: '{playbook}'", level=2)
+
         return playbook
 
     def _prepare_environment(
@@ -1056,6 +1074,8 @@ class Guest(tmt.utils.Common):
         playbook in whatever way is fitting for the guest and infrastructure.
 
         :param playbook: path to the playbook to run.
+        :param playbook_root: if set, ``playbook`` path must be located
+            under the given root path.
         :param extra_args: additional arguments to be passed to ``ansible-playbook``
             via ``--extra-args``.
         :param friendly_command: if set, it would be logged instead of the
@@ -1083,7 +1103,8 @@ class Guest(tmt.utils.Common):
         the playbook while this method makes sure our logging is consistent.
 
         :param playbook: path to the playbook to run.
-        :param playbook_root: TODO fill doc
+        :param playbook_root: if set, ``playbook`` path must be located
+            under the given root path.
         :param extra_args: additional arguments to be passed to ``ansible-playbook``
             via ``--extra-args``.
         :param friendly_command: if set, it would be logged instead of the
@@ -1540,6 +1561,8 @@ class GuestSsh(Guest):
         playbook in whatever way is fitting for the guest and infrastructure.
 
         :param playbook: path to the playbook to run.
+        :param playbook_root: if set, ``playbook`` path must be located
+            under the given root path.
         :param extra_args: additional arguments to be passed to ``ansible-playbook``
             via ``--extra-args``.
         :param friendly_command: if set, it would be logged instead of the
@@ -1549,8 +1572,8 @@ class GuestSsh(Guest):
         :param silent: if set, logging of steps taken by this function would be
             reduced.
         """
-        if playbook_root:
-            playbook = self._ansible_playbook_path(playbook, playbook_root)
+
+        playbook = self._sanitize_ansible_playbook_path(playbook, playbook_root)
 
         ansible_command = Command('ansible-playbook', *self._ansible_verbosity())
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -29,6 +29,7 @@ class GuestLocal(tmt.Guest):
     def _run_ansible(
             self,
             playbook: Path,
+            playbook_root: Optional[Path] = None,
             extra_args: Optional[str] = None,
             friendly_command: Optional[str] = None,
             log: Optional[tmt.log.LoggingFunction] = None,
@@ -50,7 +51,8 @@ class GuestLocal(tmt.Guest):
             reduced.
         """
 
-        playbook = self._ansible_playbook_path(playbook)
+        if playbook_root:
+            playbook = self._ansible_playbook_path(playbook, playbook_root)
 
         return self._run_guest_command(
             Command(

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -41,6 +41,8 @@ class GuestLocal(tmt.Guest):
         playbook in whatever way is fitting for the guest and infrastructure.
 
         :param playbook: path to the playbook to run.
+        :param playbook_root: if set, ``playbook`` path must be located
+            under the given root path.
         :param extra_args: additional arguments to be passed to ``ansible-playbook``
             via ``--extra-args``.
         :param friendly_command: if set, it would be logged instead of the
@@ -51,8 +53,7 @@ class GuestLocal(tmt.Guest):
             reduced.
         """
 
-        if playbook_root:
-            playbook = self._ansible_playbook_path(playbook, playbook_root)
+        playbook = self._sanitize_ansible_playbook_path(playbook, playbook_root)
 
         return self._run_guest_command(
             Command(

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -234,6 +234,7 @@ class GuestContainer(tmt.Guest):
     def _run_ansible(
             self,
             playbook: Path,
+            playbook_root: Optional[Path] = None,
             extra_args: Optional[str] = None,
             friendly_command: Optional[str] = None,
             log: Optional[tmt.log.LoggingFunction] = None,
@@ -254,7 +255,8 @@ class GuestContainer(tmt.Guest):
         :param silent: if set, logging of steps taken by this function would be
             reduced.
         """
-        playbook = self._ansible_playbook_path(playbook)
+        if playbook_root:
+            playbook = self._ansible_playbook_path(playbook, playbook_root)
 
         # As non-root we must run with podman unshare
         podman_command = Command()

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -246,6 +246,8 @@ class GuestContainer(tmt.Guest):
         playbook in whatever way is fitting for the guest and infrastructure.
 
         :param playbook: path to the playbook to run.
+        :param playbook_root: if set, ``playbook`` path must be located
+            under the given root path.
         :param extra_args: additional arguments to be passed to ``ansible-playbook``
             via ``--extra-args``.
         :param friendly_command: if set, it would be logged instead of the
@@ -255,8 +257,8 @@ class GuestContainer(tmt.Guest):
         :param silent: if set, logging of steps taken by this function would be
             reduced.
         """
-        if playbook_root:
-            playbook = self._ansible_playbook_path(playbook, playbook_root)
+
+        playbook = self._sanitize_ansible_playbook_path(playbook, playbook_root)
 
         # As non-root we must run with podman unshare
         podman_command = Command()


### PR DESCRIPTION
Plugins have to mangle playbook paths to appease a piece of code that
expected paths to always be relative and under the fmf root. This is not
true for playbooks shipped with plugins that are bundled with tmt, like
`prepare/feature`. Therefore changing the code to support plugins that
may never be under the fmf root.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] mention the version
* [ ] include a release note
