### PR TITLE
User per-guest SSH master sockets to prevent re-use

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1392,7 +1392,7 @@ class GuestSsh(Guest):
         # Use '/run/user/uid' if it exists, 'temp dir' otherwise.
         run_dir = Path(f"/run/user/{os.getuid()}")
         socket_dir = run_dir if run_dir.is_dir() else Path(tempfile.mkdtemp())
-        return socket_dir / "tmt"
+        return socket_dir / f'tmt-{self.pathless_safe_name}'
 
     @property
     def _ssh_options(self) -> Command:


### PR DESCRIPTION
It seems that under some conditions, using same socket path for SSH master processes may lead to SSH commands to operate over incorrect and unexpected guest without noticing. Using per-guest paths should prevent such a race condition.

Pull Request Checklist

* [x] implement the feature