### PR TITLE
Do not enable epel on EL 10

### DIFF
--- a/tmt/steps/prepare/feature/epel-enable.yaml
+++ b/tmt/steps/prepare/feature/epel-enable.yaml
@@ -20,8 +20,12 @@
           register: output
           changed_when: output.rc != 0
 
-    - name: Enable EPEL and EPEL-Next repos on RHEL 8+
-      when: ansible_distribution == "RedHat" and ansible_distribution_major_version | int >= 8
+    - name: Enable EPEL and EPEL-Next repos on RHEL 8, 9
+      when:
+        - ansible_distribution == "RedHat"
+        - ansible_distribution_major_version | int >= 8
+        # Drop the following line once EPEL10 becomes available 
+        - ansible_distribution_major_version | int < 10
       block:
         - name: Install package 'epel-release'
           ansible.builtin.dnf:
@@ -72,8 +76,12 @@
           register: output
           changed_when: output.rc != 0
 
-    - name: Enable EPEL and EPEL-Next repos on CentOS Stream 8+
-      when: ansible_distribution == "CentOS" and ansible_distribution_major_version | int >= 8
+    - name: Enable EPEL and EPEL-Next repos on CentOS Stream 8, 9
+      when:
+        - ansible_distribution == "CentOS"
+        - ansible_distribution_major_version | int >= 8
+        # Drop the following line once EPEL10 becomes available 
+        - ansible_distribution_major_version | int < 10
       block:
         - name: Install package 'epel-release'
           ansible.builtin.dnf:

--- a/tmt/steps/prepare/feature/epel-enable.yaml
+++ b/tmt/steps/prepare/feature/epel-enable.yaml
@@ -24,7 +24,7 @@
       when:
         - ansible_distribution == "RedHat"
         - ansible_distribution_major_version | int >= 8
-        # Drop the following line once EPEL10 becomes available 
+        # Drop the following line once EPEL10 becomes available
         - ansible_distribution_major_version | int < 10
       block:
         - name: Install package 'epel-release'
@@ -80,7 +80,7 @@
       when:
         - ansible_distribution == "CentOS"
         - ansible_distribution_major_version | int >= 8
-        # Drop the following line once EPEL10 becomes available 
+        # Drop the following line once EPEL10 becomes available
         - ansible_distribution_major_version | int < 10
       block:
         - name: Install package 'epel-release'


### PR DESCRIPTION
prepare:, how: feature, epel: enabled fails on EL 10.
prepare's `feature` does not provide a way to avoid running on a specific platform.
Hence, my `prepare` passes on all platforms but fails on EL 10 because EL 10 doesn't have epel-release available:

```
fatal: [root@10.0.187.147]: FAILED! => {"changed": false, "failures":
["No package epel-release available."], "msg": "Failed to install some
of the specified packages", "rc": 1, "results": []}
```

For now, avoid enabling epel on EL 10.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
