### PR TITLE
Improve version comparison in `--feeling-safe` check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,7 @@ repos:
           - "docutils>=0.16"         # 0.16 is the current one available for RHEL9
           - "fmf>=1.3.0"
           - "jinja2>=2.11.3"         # 3.1.2 / 3.1.2
+          - "packaging>=20"          # 20 seems to be available with RHEL8
           - "pint>=0.16.1"           # 0.16.1
           - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
           - "requests>=2.25.1"       # 2.28.2 / 2.31.0
@@ -81,6 +82,7 @@ repos:
           - "docutils>=0.16"         # 0.16 is the current one available for RHEL9
           - "fmf>=1.3.0"
           - "jinja2>=2.11.3"         # 3.1.2 / 3.1.2
+          - "packaging>=20"          # 20 seems to be available with RHEL8
           - "pint>=0.16.1"           # 0.16.1 / 0.19.x  TODO: Pint 0.20 requires larger changes to tmt.hardware
           - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
           - "requests>=2.25.1"       # 2.28.2 / 2.31.0
@@ -150,6 +152,7 @@ repos:
     - id: tmt-lint
       additional_dependencies:
         - "docutils>=0.16"         # 0.16 is the current one available for RHEL9
+        - "packaging>=20"          # 20 seems to be available with RHEL8
         - "pint<0.20"
         - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
         # Help installation by reducing the set of inspected botocore release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [              # F39 / PyPI
     "docutils>=0.16",         # 0.16 is the current one available for RHEL9
     "fmf>=1.3.0",
     "jinja2>=2.11.3",         # 3.1.2 / 3.1.2
+    "packaging>=20",          # 20 seems to be available with RHEL8
     "pint>=0.16.1",           # 0.16.1
     "pygments>=2.7.4",        # 2.7.4 is the current one available for RHEL9
     "requests>=2.25.1",       # 2.28.2 / 2.31.0

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -14,11 +14,20 @@ class TestPhaseAssertFeelingSafe:
         self.phase = Phase(logger=self.mock_logger)
 
     @pytest.mark.parametrize(
-        ("tmt_version", "deprecated_version", "expect_warn", "expect_exception"), [
+        ("tmt_version", "deprecated_version", "expect_warn", "expect_exception"),
+        [
             ('1.30', '1.38', True, False),  # warn for older version
+            ('1.4.0.dev1595+ga35d7140.d20240806', '1.38', True, False),  # warn for older version
             ('1.40', '1.38', False, True),  # raise exception for newer version
-            ('1.38', '1.38', False, True)  # raise exception for same version
-            ])
+            ('1.38', '1.38', False, True),  # raise exception for same version
+            ],
+        ids=(
+            'warn for older version',
+            'warn for older version with commit ID',
+            'raise exception for newer version',
+            'raise exception for same version',
+            )
+        )
     def test_assert_feeling_safe(
             self,
             tmt_version,

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -25,6 +25,7 @@ from typing import (
 
 import click
 import fmf.utils
+import packaging.version
 from click import echo
 from click.core import ParameterSource
 
@@ -216,7 +217,8 @@ class Phase(tmt.utils.Common):
         if self.is_feeling_safe:
             return
 
-        if tmt.__version__ < deprecated_in_version:
+        if packaging.version.Version(tmt.__version__) \
+                < packaging.version.Version(deprecated_in_version):
             self.warn(f"{subject} will require '--feeling-safe' option "
                       f"from version {deprecated_in_version}.")
 


### PR DESCRIPTION
Simple string comparion will fail for versions like `1.4.0.dev1595+ga35d7140.d20240806` vs `1.38` - the former is clearly older, but the comparison will yield false-ish result.

`packaging.version.Version` should provide smarter and correct comparison for these corner cases.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage