### PR TITLE
Correct the description for `where` under `finish`

### DIFF
--- a/spec/plans/finish.fmf
+++ b/spec/plans/finish.fmf
@@ -58,7 +58,7 @@ example: |
     summary: Perform finishing tasks on selected guests
     description: |
         In the :ref:`/spec/plans/provision/multihost` scenarios it
-        is often necessary to perform different preparation tasks
+        is often necessary to perform different completion tasks
         on individual guests. The ``where`` key allows to select
         guests where the finishing tasks should be applied by
         providing their ``name`` or the ``role`` they play in the


### PR DESCRIPTION
finish,where: corrects the spec description

The first sentence of the description is identical
to the one from prepare > where. Adjust the verb to
make sense.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [x] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
