### PR TITLE
Support `virtiofs` in the `virtual` provision step

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -54,6 +54,7 @@ UserNetworkConfiguration: Any
 QCow2StorageDevice: Any
 RawStorageDevice: Any
 TPMConfiguration: Any
+VIRTIOFSConfiguration: Any
 
 
 def import_testcloud() -> None:
@@ -71,6 +72,7 @@ def import_testcloud() -> None:
     global QCow2StorageDevice
     global RawStorageDevice
     global TPMConfiguration
+    global VIRTIOFSConfiguration
     try:
         import libvirt
         import testcloud.image
@@ -86,6 +88,7 @@ def import_testcloud() -> None:
             SystemNetworkConfiguration,
             TPMConfiguration,
             UserNetworkConfiguration,
+            VIRTIOFSConfiguration,
             X86_64ArchitectureConfiguration,
             )
         from testcloud.workarounds import Workarounds
@@ -342,6 +345,11 @@ class TestcloudGuestData(tmt.steps.provision.GuestSshData):
         option=('-a', '--arch'),
         choices=['x86_64', 'aarch64', 's390x', 'ppc64le'],
         help="What architecture to virtualize, host arch by default.")
+    virtiofs: str = field(
+        default="",
+        option=('-s', '--virtiofs'),
+        help="What directory to mount where, eg."
+             "'<host path>:<guest path>'")
 
     list_local_images: bool = field(
         default=False,
@@ -615,6 +623,7 @@ class GuestTestcloud(tmt.GuestSsh):
         memory ..... memory size for vm
         disk ....... disk size for vm
         connection . either session (default) or system, to be passed to qemu
+        virtiofs ... What directory to mount where, eg. <host path>:<guest path>
         arch ....... architecture for the VM, host arch is the default
     """
 
@@ -626,6 +635,7 @@ class GuestTestcloud(tmt.GuestSsh):
     memory: Optional['Size']
     disk: Optional['Size']
     connection: str
+    virtiofs: str
     arch: str
 
     # Not to be saved, recreated from image_url/instance_name/... every
@@ -909,6 +919,7 @@ class GuestTestcloud(tmt.GuestSsh):
 
         # Initialize and prepare testcloud image
         assert testcloud is not None
+        assert libvirt is not None
         self._image = testcloud.image.Image(self.image_url)
         self.verbose('qcow', self._image.name, 'green')
         if not Path(self._image.local_path).exists():
@@ -971,6 +982,22 @@ class GuestTestcloud(tmt.GuestSsh):
         self._domain.coreos = self.is_coreos
 
         self._apply_hw_arch(self._domain, self.is_kvm, self.is_legacy_os)
+
+        # Do we have virtiofs to handle?
+        if self.virtiofs:
+            if (f"qemu:///{self.connection}" == "qemu:///session" and
+                    libvirt.getVersion() < 10000000):
+                raise tmt.utils.ProvisionError("Only system connection is supported"
+                                               " for virtiofs on libvirt < 10.0.")
+
+            virtiofs_split = self.virtiofs.split(":")
+            if len(virtiofs_split) != 2:
+                raise tmt.utils.ProvisionError("virtiofs specified in a bad format, use "
+                                               "<host path>:<guest path>")
+
+            self._domain.virtiofs_configuration = [
+                VIRTIOFSConfiguration(
+                    virtiofs_split[0], virtiofs_split[1], 0)]
 
         mac_address = testcloud.util.generate_mac_address()
         if f"qemu:///{self.connection}" == "qemu:///system":


### PR DESCRIPTION
Fixes https://github.com/teemtee/tmt/issues/2348

This wires up the virtiofs mounting support that testcloud gained. It now works even with user sessions with libvirt >= 10.0 . If I could get some pointers on how to make it (arg parsing wise), It could also support passing multiple desired mounts.

As a possible future enhancement, this could get wired up to be automatically used for runs which include file copying to the VM.

@cgwalters fyi, we finally have all the necessary pieces!

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
