### PR TITLE
Use the default branch for polarion tests

### DIFF
--- a/plans/remote/polarion.fmf
+++ b/plans/remote/polarion.fmf
@@ -4,4 +4,3 @@ plan:
     import:
         url: https://github.com/teemtee/tests
         name: /plans/polarion
-        ref: update_polarion_tests


### PR DESCRIPTION
The test suite change has been [merged](https://github.com/teemtee/tests/pull/8) in the `tests` repo. Time to use content from the default branch.