### PR TITLE
Remove support for junit-xml, use Jinja2 instead

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
           - "urllib3>=1.26.5, <2.0"  # 1.26.16 / 2.0.4
 
           # report-junit
-          - "junit_xml>=1.9"
+          - "lxml>=4.6.5"
 
           - "typing-extensions>=4.9.0; python_version < '3.13'"
           - "pytest"
@@ -62,6 +62,7 @@ repos:
           - "types-jinja2"
           - "types-babel"
           - "types-docutils"
+          - "types-lxml"
 
         pass_filenames: false
         args: [--config-file=pyproject.toml]
@@ -90,7 +91,7 @@ repos:
           - "urllib3>=1.26.5, <2.0"  # 1.26.16 / 2.0.4
 
           # report-junit
-          - "junit_xml>=1.9"
+          - "lxml>=4.6.5"
 
           - "typing-extensions>=4.9.0; python_version < '3.13'"
           - "pytest"
@@ -108,6 +109,7 @@ repos:
           - "types-jinja2"
           - "types-babel"
           - "types-docutils"
+          - "types-lxml"
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: "0.29.2"

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,22 @@
     Releases
 ======================
 
+tmt-1.37
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`/plugins/report/junit` report plugin now validates all the XML
+flavors against their respective XSD schemas and tries to prettify the final
+XML output. These functionalities are always disabled for ``custom`` flavors.
+The prettify functionality can be controlled for non-custom templates by
+``--prettify`` and ``--no-prettify`` arguments.
+
+The :ref:`/plugins/report/junit` report plugin now uses Jinja instead of
+``junit-xml`` library to generate the JUnit XMLs. It also adds support for a
+new ``--flavor`` argument. Using this argument the user can choose between a
+``default`` flavor, which keeps the current behavior untouched, and a
+``custom`` flavor where user must provide a custom template using a
+``--template-path`` argument.
+
 
 tmt-1.37.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ provision-virtual = [
     ]
 provision-container = []
 report-junit = [
-    "junit_xml>=1.9",
+    # Required to support XML parsing and checking the XSD schemas.
+    "lxml>=4.6.5",
     ]
 report-polarion = [
     "tmt[report-junit]",
@@ -139,6 +140,7 @@ dependencies = [
     "types-jinja2",
     "types-babel",
     "types-docutils",
+    "types-lxml",
     ]
 features = ["all"]
 
@@ -216,7 +218,7 @@ module = [
     "guestfs.*",
     "html2text.*",
     "fmf.*",
-    "junit_xml.*",
+    "lxml.*",
     "libvirt.*",
     "nitrate.*",
     "pylero.*",

--- a/tests/report/junit/data/custom.xml.j2
+++ b/tests/report/junit/data/custom.xml.j2
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<tests>
+    {% for result in RESULTS %}
+        <test name="{{ result.name | e }}" value="{{ result.result.value | e }}"/>
+    {% endfor %}
+</tests>

--- a/tests/report/junit/data/main.fmf
+++ b/tests/report/junit/data/main.fmf
@@ -27,3 +27,5 @@
         /timeout:
             test: sleep 10
             duration: 2s
+        /escape"<speci&l>_chars:
+            test: "echo '<speci&l>\"chars'"

--- a/tests/report/junit/data/non-xml-custom.j2
+++ b/tests/report/junit/data/non-xml-custom.j2
@@ -1,0 +1,3 @@
+{% for result in RESULTS %}
+name='{{ result.name | e }}',value='{{ result.result.value | e }}'
+{% endfor %}

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -8,16 +8,60 @@ rlJournalStart
     rlPhaseEnd
 
     for method in tmt; do
-        rlPhaseStartTest "$method"
+        rlPhaseStartTest "[$method] Basic format checks"
             rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml 2>&1 >/dev/null | tee output" 2
-            rlAssertGrep "2 tests passed, 2 tests failed and 2 errors" "output"
-            rlAssertGrep '<testsuite disabled="0" errors="2" failures="2" name="/plan" skipped="0" tests="6"' "junit.xml"
+            rlAssertGrep "3 tests passed, 2 tests failed and 2 errors" "output"
+            rlAssertGrep '00:00:00 pass /test/shell/escape"<speci&l>_chars (on default-0)' "output"
+            rlAssertGrep '<testsuite name="/plan" disabled="0" errors="2" failures="2" skipped="0" tests="7"' "junit.xml"
             rlAssertGrep 'fail</failure>' "junit.xml"
+
+            # Test the escape of special characters
+            rlAssertGrep '<testcase name="/test/shell/escape&quot;&lt;speci&amp;l&gt;_chars">' "junit.xml"
+            rlAssertGrep '<system-out>&lt;speci&amp;l&gt;"chars' "junit.xml"
+
+            # Check there is no schema problem reported
+            rlAssertNotGrep 'The generated XML output is not a valid XML file or it is not valid against the XSD schema\.' "output"
+        rlPhaseEnd
+
+        rlPhaseStartTest "[$method] Check the flavor argument is working"
+            rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml --flavor default 2>&1 >/dev/null | tee output" 2
+            rlAssertGrep "3 tests passed, 2 tests failed and 2 errors" "output"
+
+            # Check there is no schema problem reported
+            rlAssertNotGrep 'The generated XML output is not a valid XML file or it is not valid against the XSD schema\.' "output"
+        rlPhaseEnd
+
+        rlPhaseStartTest "[$method] Check the mutually exclusive arguments"
+            rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml --flavor custom 2>&1 >/dev/null | tee output" 2
+            rlAssertGrep "The 'custom' flavor requires the '--template-path' argument." "output"
+
+            rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml --template-path custom.xml.j2 2>&1 >/dev/null | tee output" 2
+            rlAssertGrep "The '--template-path' can be used only with '--flavor=custom'." "output"
+
+        rlPhaseEnd
+
+        rlPhaseStartTest "[$method] Check the 'custom' flavor with a custom XML template"
+            rlRun "tmt run -avr execute -h $method report -h junit --file custom-template-out.xml --template-path custom.xml.j2 --flavor custom 2>&1 >/dev/null | tee output" 2
+
+            # There must not be a schema check when using a custom flavor
+            rlAssertGrep "The 'custom' JUnit flavor is used, you are solely responsible for the validity of the XML schema\." "output"
+
+            rlAssertGrep '<test name="/test/beakerlib/fail" value="fail"/>' "custom-template-out.xml"
+            rlAssertGrep '<test name="/test/beakerlib/pass" value="pass"/>' "custom-template-out.xml"
+            rlAssertGrep '<test name="/test/shell/pass" value="pass"/>' "custom-template-out.xml"
+            rlAssertGrep '<test name="/test/shell/timeout" value="error"/>' "custom-template-out.xml"
+            rlAssertGrep '<test name="/test/shell/escape&quot;&lt;speci&amp;l&gt;_chars" value="pass"/>' "custom-template-out.xml"
+        rlPhaseEnd
+
+        rlPhaseStartTest "[$method] The 'custom' flavor with a custom **non-XML** template must not work"
+            rlRun "tmt run -avr execute -h $method report -h junit --file custom-template-out.xml --template-path non-xml-custom.j2 --flavor custom 2>&1 >/dev/null | tee output" 2
+
+            rlAssertGrep 'The generated XML output is not a valid XML file.' "output"
         rlPhaseEnd
     done
 
     rlPhaseStartCleanup
-        rlRun "rm output junit.xml"
+        rlRun "rm output junit.xml custom-template-out.xml"
         rlRun "popd"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/report/polarion/test.sh
+++ b/tests/report/polarion/test.sh
@@ -10,10 +10,11 @@ rlJournalStart
     rlPhaseStartTest
         rlRun "tmt run -avr execute report -h polarion --project-id RHELBASEOS --no-upload --planned-in RHEL-9.1.0 --file xunit.xml 2>&1 >/dev/null | tee output" 2
         rlAssertGrep "1 test passed, 1 test failed and 1 error" "output"
-        rlAssertGrep '<testsuite disabled="0" errors="1" failures="1" name="/plan" skipped="0" tests="3"' "xunit.xml"
+        rlAssertGrep '<testsuite name="/plan" disabled="0" errors="1" failures="1" skipped="0" tests="3"' "xunit.xml"
         rlAssertGrep '<property name="polarion-project-id" value="RHELBASEOS" />' "xunit.xml"
         rlAssertGrep '<property name="polarion-testcase-id" value="BASEOS-10914" />' "xunit.xml"
         rlAssertGrep '<property name="polarion-custom-plannedin" value="RHEL-9.1.0" />' "xunit.xml"
+        rlAssertGrep "Maximum test time '2s' exceeded." "xunit.xml"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/unit/test_report_junit.py
+++ b/tests/unit/test_report_junit.py
@@ -19,7 +19,7 @@ def report_fix(tmppath: Path, root_logger):
     type(plan_mock).name = name_property
     type(step_mock).plan = plan_mock
 
-    out_file_path = str(tmppath / "out.xml")
+    out_file_path = Path(tmppath / "out.xml")
 
     report = ReportJUnit(
         logger=root_logger,
@@ -120,11 +120,14 @@ class TestStateMapping:
 
         report.go()
 
-        assert_xml(out_file_path, """<?xml version="1.0" ?>
+        assert_xml(out_file_path, """<?xml version='1.0' encoding='utf-8'?>
 <testsuites disabled="0" errors="0" failures="0" tests="1" time="0.0">
-    <testsuite disabled="0" errors="0" failures="0" name="name" skipped="0" tests="1" time="0">
-        <testcase name="/pass"/>
-    </testsuite>
+  <testsuite name="name" disabled="0" errors="0" failures="0" skipped="0" tests="1" time="0.0">
+    <testcase name="/pass">
+
+
+                </testcase>
+  </testsuite>
 </testsuites>
 """)
 
@@ -133,13 +136,13 @@ class TestStateMapping:
         results.append(Result(result=ResultOutcome.INFO, name="/info", serial_number=1))
         report.go()
 
-        assert_xml(out_file_path, """<?xml version="1.0" ?>
+        assert_xml(out_file_path, """<?xml version='1.0' encoding='utf-8'?>
 <testsuites disabled="0" errors="0" failures="0" tests="1" time="0.0">
-    <testsuite disabled="0" errors="0" failures="0" name="name" skipped="1" tests="1" time="0">
-        <testcase name="/info">
-            <skipped type="skipped" message="info"/>
-        </testcase>
-    </testsuite>
+  <testsuite name="name" disabled="0" errors="0" failures="0" skipped="1" tests="1" time="0.0">
+    <testcase name="/info">
+      <skipped type="skipped" message="info"/>
+    </testcase>
+  </testsuite>
 </testsuites>
 """)
 
@@ -148,13 +151,13 @@ class TestStateMapping:
         results.append(Result(result=ResultOutcome.WARN, name="/warn", serial_number=1))
         report.go()
 
-        assert_xml(out_file_path, """<?xml version="1.0" ?>
+        assert_xml(out_file_path, """<?xml version='1.0' encoding='utf-8'?>
 <testsuites disabled="0" errors="1" failures="0" tests="1" time="0.0">
-    <testsuite disabled="0" errors="1" failures="0" name="name" skipped="0" tests="1" time="0">
-        <testcase name="/warn">
-            <error type="error" message="warn"/>
-        </testcase>
-    </testsuite>
+  <testsuite name="name" disabled="0" errors="1" failures="0" skipped="0" tests="1" time="0.0">
+    <testcase name="/warn">
+      <error type="error" message="warn"/>
+    </testcase>
+  </testsuite>
 </testsuites>
 """)
 
@@ -163,13 +166,13 @@ class TestStateMapping:
         results.append(Result(result=ResultOutcome.ERROR, name="/error", serial_number=1))
         report.go()
 
-        assert_xml(out_file_path, """<?xml version="1.0" ?>
+        assert_xml(out_file_path, """<?xml version='1.0' encoding='utf-8'?>
 <testsuites disabled="0" errors="1" failures="0" tests="1" time="0.0">
-    <testsuite disabled="0" errors="1" failures="0" name="name" skipped="0" tests="1" time="0">
-        <testcase name="/error">
-            <error type="error" message="error"/>
-        </testcase>
-    </testsuite>
+  <testsuite name="name" disabled="0" errors="1" failures="0" skipped="0" tests="1" time="0.0">
+    <testcase name="/error">
+      <error type="error" message="error"/>
+    </testcase>
+  </testsuite>
 </testsuites>
 """)
 
@@ -178,12 +181,12 @@ class TestStateMapping:
         results.append(Result(result=ResultOutcome.FAIL, name="/fail", serial_number=1))
         report.go()
 
-        assert_xml(out_file_path, """<?xml version="1.0" ?>
+        assert_xml(out_file_path, """<?xml version='1.0' encoding='utf-8'?>
 <testsuites disabled="0" errors="0" failures="1" tests="1" time="0.0">
-    <testsuite disabled="0" errors="0" failures="1" name="name" skipped="0" tests="1" time="0">
-        <testcase name="/fail">
-            <failure type="failure" message="fail"/>
-        </testcase>
-    </testsuite>
+  <testsuite name="name" disabled="0" errors="0" failures="1" skipped="0" tests="1" time="0.0">
+    <testcase name="/fail">
+      <failure type="failure" message="fail"/>
+    </testcase>
+  </testsuite>
 </testsuites>
 """)

--- a/tmt/steps/report/junit/schemas/default.xsd
+++ b/tmt/steps/report/junit/schemas/default.xsd
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+    This schema supports only a subset of the features provided by the
+    `xml-junit` library. Additionally, many attributes are explicitly set as
+    required. This is intentional to limit the currently supported features of
+    the tmt JUnit report plugin.
+
+    For example, tmt always creates only one `testsuite` within a `testsuites`,
+    and this schema enforces that constraint. Also the properties tags in
+    testsuites and testcases are explicitly disallowed in a `default` flavor.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="time" type="xs:float" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="required"/>
+            <xs:attribute name="errors" type="xs:string" use="required"/>
+            <xs:attribute name="disabled" type="xs:string" use="required"/>
+            <xs:attribute name="skipped" type="xs:string" use="required"/>
+            <xs:attribute name="time" type="xs:float" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="1" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="time" type="xs:float" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/tmt/steps/report/junit/templates/_base.xml.j2
+++ b/tmt/steps/report/junit/templates/_base.xml.j2
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+{% block content %}
+<testsuites disabled="0" errors="{{ RESULTS.errored | length }}" failures="{{ RESULTS.failed | length }}" tests="{{ RESULTS | length }}" time="{{ RESULTS.duration | float }}">
+    {% block testsuites %}
+    <testsuite name="{{ PLAN.name | trim | e }}" disabled="0" errors="{{ RESULTS.errored | length }}" failures="{{ RESULTS.failed | length }}" skipped="{{ RESULTS.skipped | length }}" tests="{{ RESULTS | length }}" time="{{ RESULTS.duration | float }}">
+        {% block testcases %}
+            {% for result in RESULTS %}
+                {% set main_log = result.log | first | read_log %}
+                {% set log_failures = main_log | failures | e %}
+                {% set test_duration = result.duration | duration_to_seconds | float %}
+
+                <testcase name="{{ result.name | e }}" {% if test_duration %}time="{{ test_duration }}"{% endif %}>
+                    {% if result.result.value == 'error' or result.result.value == 'warn' %}
+                        <error type="error" message="{{ result.result.value | e }}">{{ log_failures }}</error>
+                    {% elif result.result.value == 'fail' %}
+                        <failure type="failure" message="{{ result.result.value | e }}">{{ log_failures }}</failure>
+                    {% elif result.result.value == 'info' %}
+                        <skipped type="skipped" message="{{ result.result.value | e }}">{{ log_failures }}</skipped>
+                    {% endif %}
+
+                    {% if INCLUDE_OUTPUT_LOG and main_log %}
+                        <system-out>{{ main_log | e }}</system-out>
+                    {% endif %}
+                </testcase>
+            {% endfor %}
+        {% endblock %}
+    </testsuite>
+    {% endblock %}
+</testsuites>
+{% endblock %}

--- a/tmt/steps/report/junit/templates/default.xml.j2
+++ b/tmt/steps/report/junit/templates/default.xml.j2
@@ -1,0 +1,1 @@
+{% extends "_base.xml.j2" %}


### PR DESCRIPTION
This PR removes support for the deprecated `junit-xml` library and uses the Jinja2 to generate JUnit XML instead.

It also prepares support for various junit flavors (`--flavor`) and adds the possibility to specify user-defined JUnit Jinja templates using the `--template-path` and `--flavor=custom` options. These options are mutually exclusive.

The current implementation requires that custom templates must be valid XML files. If we want to allow users use non-XML custom templates, we would probably go with something like [template report plugin](https://github.com/teemtee/tmt/pull/3150#discussion_r1724853623) for results.

```
/plans/example<br>
    report
        how: junit
        warn: The 'custom' JUnit flavor is used, you are solely responsible for the validity of the XML schema.
        warn: The pretty print is always disabled for 'custom' JUnit flavor
        warn: The generated XML output is not valid XML file or it is not valid against the XSD schema.
        warn: <string>:1:1:FATAL:PARSER:ERR_DOCUMENT_EMPTY: Start tag expected, '<' not found
        warn: Start tag expected, '<' not found, line 1, column 1 (<string>, line 1)

plan failed

The exception was caused by 1 earlier exceptions

Cause number 1:

    The generated XML output is not a valid XML file.
```


The implementation of the `polarion` flavor and its support in the Polarion report plugin will be addressed in a separate PR. In this PR, the Polarion report plugin just calls the `junit.make_junit_xml` function in nearly the same way as before, aiming to keep the Polarion `xunit.xml` file unchanged.

### TODOs:
- [x] Probably divide the changes into multiple PRs (polarion and junit separately)
- [x] Define XSD JUnit for `default` flavor and validate the XML output against this schema. Warn user if there are any problems.
- ~~[ ] Possibility to specify template variables directly from cmdline as key-values (e.g. `--var <key> <value>`) for a `custom` flavor / user-defined template?~~ - This could be a part of "template" report plugin in the future.
- [x] The difference between junit-xml generated files and the new junit files is that the quotes `"` are not escaped to `&quot;` inside of tag data (they **are** correctly escaped inside attributes). According to my knowledge, this should be OK and the XML is also valid.
- [x] Add tests
- [x] Add test which checks there is no schema/XML warning in the tmt logs when running non-custom flavor `The generated XML output is not a valid XML file or it is not valid against the XSD schema`.
- [x] The `duration` should be probably converted to `float` and propagated to XML `time="<val>"` attributes as float, not an integer. If this gets changed, is it possible to enforce float attributes in XSD schema? - tmt works with seconds, let's just convert them to floats using a jinja filter.

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [x] include a release note
