### PR TITLE
Add (custom) result file validation, schema-based

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,12 @@
     Releases
 ======================
 
+tmt-1.36
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+tmt will now emit a warning when :ref:`custom test results</spec/tests/result>`
+file does not follow the :ref:`result specification</spec/plans/results>`.
+
 
 tmt-1.35
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -14,6 +14,7 @@ rlJournalStart
     testName="/test/custom-results"
     rlPhaseStartTest "${testName}"
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 1 "Test provides 'results.yaml' file by itself"
+        rlAssertGrep "warn: Result format violation: :3.name - 'without-leading-slash' does not match '^/.*'" $rlRun_LOG
         rlAssertGrep "00:11:22 pass /test/custom-results/test/passing" $rlRun_LOG
         rlAssertGrep "00:22:33 fail /test/custom-results/test/failing" $rlRun_LOG
         rlAssertGrep "00:00:00 skip /test/custom-results/test/skipped" $rlRun_LOG
@@ -94,6 +95,7 @@ rlJournalStart
     rlPhaseStartTest "${testName}"
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test provides partial result with wrong value"
         rlAssertGrep "Invalid partial custom result 'errrrrr'." $rlRun_LOG
+        rlAssertGrep "warn: Result format violation: :0.result - 'errrrrr' is not one of \\['pass', 'fail', 'info', 'warn', 'error', 'skip'\\]" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -14,7 +14,7 @@ rlJournalStart
     testName="/test/custom-results"
     rlPhaseStartTest "${testName}"
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 1 "Test provides 'results.yaml' file by itself"
-        rlAssertGrep "warn: Result format violation: :3.name - 'without-leading-slash' does not match '^/.*'" $rlRun_LOG
+        rlAssertGrep "warn: Result format violation: 3.name - 'without-leading-slash' does not match '^/.*'" $rlRun_LOG
         rlAssertGrep "00:11:22 pass /test/custom-results/test/passing" $rlRun_LOG
         rlAssertGrep "00:22:33 fail /test/custom-results/test/failing" $rlRun_LOG
         rlAssertGrep "00:00:00 skip /test/custom-results/test/skipped" $rlRun_LOG
@@ -95,7 +95,7 @@ rlJournalStart
     rlPhaseStartTest "${testName}"
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test provides partial result with wrong value"
         rlAssertGrep "Invalid partial custom result 'errrrrr'." $rlRun_LOG
-        rlAssertGrep "warn: Result format violation: :0.result - 'errrrrr' is not one of \\['pass', 'fail', 'info', 'warn', 'error', 'skip'\\]" $rlRun_LOG
+        rlAssertGrep "warn: Result format violation: 0.result - 'errrrrr' is not one of \\['pass', 'fail', 'info', 'warn', 'error', 'skip'\\]" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -464,6 +464,7 @@ definitions:
       - info
       - warn
       - error
+      - skip
 
   # https://tmt.readthedocs.io/en/stable/spec/tests.html#result
   result_interpret:
@@ -477,6 +478,7 @@ definitions:
       - warn
       - error
       - fail
+      - skip
       - custom
       - restraint
 

--- a/tmt/schemas/results.yaml
+++ b/tmt/schemas/results.yaml
@@ -42,7 +42,7 @@ definitions:
         $ref: "/schemas/common#/definitions/timestamp"
 
       duration:
-        $ref: "/definitions/duration"
+        $ref: "#/definitions/duration"
 
     required:
       - name
@@ -76,7 +76,7 @@ definitions:
         $ref: "/schemas/common#/definitions/timestamp"
 
       duration:
-        $ref: "/definitions/duration"
+        $ref: "#/definitions/duration"
 
       check:
         $ref: "/definitions/check_results"
@@ -84,6 +84,11 @@ definitions:
     required:
       - name
       - result
+
+  subresults:
+    type: array
+    items:
+      $ref: "/definitions/subresult"
 
 type: array
 items:
@@ -128,7 +133,7 @@ items:
       $ref: "/schemas/common#/definitions/timestamp"
 
     duration:
-      $ref: "/definitions/duration"
+      $ref: "#/definitions/duration"
 
     ids:
       type: object
@@ -143,7 +148,7 @@ items:
       $ref: "/definitions/check_results"
 
     subresult:
-      $ref: "/definitions/subresult"
+      $ref: "/definitions/subresults"
 
   required:
     - name

--- a/tmt/schemas/results.yaml
+++ b/tmt/schemas/results.yaml
@@ -52,7 +52,7 @@ definitions:
   check_results:
     type: array
     items:
-      $ref: "/definitions/check_result"
+      $ref: "#/definitions/check_result"
 
   subresult:
     type: object
@@ -79,7 +79,7 @@ definitions:
         $ref: "#/definitions/duration"
 
       check:
-        $ref: "/definitions/check_results"
+        $ref: "#/definitions/check_results"
 
     required:
       - name
@@ -88,7 +88,7 @@ definitions:
   subresults:
     type: array
     items:
-      $ref: "/definitions/subresult"
+      $ref: "#/definitions/subresult"
 
 type: array
 items:
@@ -145,10 +145,10 @@ items:
       $ref: "/schemas/common#/definitions/result_log"
 
     check:
-      $ref: "/definitions/check_results"
+      $ref: "#/definitions/check_results"
 
     subresult:
-      $ref: "/definitions/subresults"
+      $ref: "#/definitions/subresults"
 
   required:
     - name

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -5326,7 +5326,7 @@ def preformat_jsonschema_validation_errors(
     errors: list[tuple[jsonschema.ValidationError, str]] = []
 
     for error in raw_errors:
-        path = f'{prefix}:{".".join(str(p) for p in error.path)}'
+        path = f'{prefix}{".".join(str(p) for p in error.path)}'
 
         errors.append((error, f'{path} - {error.message}'))
 

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -5311,15 +5311,23 @@ def _prenormalize_fmf_node(node: fmf.Tree, schema_name: str, logger: tmt.log.Log
 
 
 def preformat_jsonschema_validation_errors(
-        raw_errors: list[Any],
+        raw_errors: list[jsonschema.ValidationError],
         prefix: Optional[str] = None) -> list[tuple[jsonschema.ValidationError, str]]:
     """
-    A bit of error formatting for JSON schema validation.
+    A helper to preformat JSON schema validation errors.
 
-    It is possible to use str(error), but the result is a bit too
-    JSON-ish. Let's present an error message in a way that helps users
-    to point finger on each and every issue. But don't throw the
-    original errors away!
+    Raw errors can be converted to strings with a simple ``str()`` call,
+    but resulting string is very JSON-ish. This helper provides
+    simplified string representation consisting of error message and
+    element path.
+
+    :param raw_error: raw validation errors as provided by
+        :py:mod:`jsonschema`.
+    :param prefix: if specified, it is added at the beginning of each
+        stringified error.
+    :returns: a list of two-item tuples, the first item being the
+        original validation error, the second item being its simplified
+        string rendering.
     """
 
     prefix = f'{prefix}:' if prefix else ''


### PR DESCRIPTION
And fix some of the issues reported by this simple addition:

* results schema was defining subresults as a single result,
* some broken references,
* `skip` was missing from the list of allowed outcomes.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] update the specification
* [x] include a release note
