### PR TITLE
Check JUnit and XUnit against the XSD schemas

### DIFF
--- a/tests/report/junit/data/main.fmf
+++ b/tests/report/junit/data/main.fmf
@@ -17,6 +17,15 @@
         /timeout:
             test: ./runtest.sh timeout
             duration: 2s
+        /skip:
+            test: ./runtest.sh pass
+            result: skip
+        /info:
+            test: ./runtest.sh pass
+            result: info
+        /warn:
+            test: ./runtest.sh pass
+            result: warn
 
     /shell:
         framework: shell
@@ -27,3 +36,12 @@
         /timeout:
             test: sleep 10
             duration: 2s
+        /skip:
+            test: "true"
+            result: skip
+        /info:
+            test: "true"
+            result: info
+        /warn:
+            test: "false"
+            result: warn

--- a/tests/report/junit/data/tmt-report-junit.xsd
+++ b/tests/report/junit/data/tmt-report-junit.xsd
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+    This schema supports only a subset of the features provided by the
+    `xml-junit` library. Additionally, many attributes are explicitly set as
+    required. This is intentional to limit the currently supported features of
+    the TMT JUnit report plugin.
+
+    For example, TMT always creates only one `testsuite` within a `testsuites`,
+    and this schema enforces that constraint.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="required"/>
+            <xs:attribute name="errors" type="xs:string" use="required"/>
+            <xs:attribute name="disabled" type="xs:string" use="required"/>
+            <xs:attribute name="skipped" type="xs:string" use="required"/>
+            <xs:attribute name="time" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="1" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="time" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/tests/report/junit/main.fmf
+++ b/tests/report/junit/main.fmf
@@ -1,1 +1,4 @@
 summary: Check for JUnit output
+require+:
+  # To support xmllint tool
+  - libxml2

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -10,9 +10,11 @@ rlJournalStart
     for method in tmt; do
         rlPhaseStartTest "$method"
             rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml 2>&1 >/dev/null | tee output" 2
-            rlAssertGrep "2 tests passed, 2 tests failed and 2 errors" "output"
-            rlAssertGrep '<testsuite disabled="0" errors="2" failures="2" name="/plan" skipped="0" tests="6"' "junit.xml"
+            rlAssertGrep "2 tests passed, 2 tests failed, 2 tests skipped, 2 infos, 2 warns and 2 errors" "output"
+            rlAssertGrep '<testsuite disabled="0" errors="4" failures="2" name="/plan" skipped="2" tests="12"' "junit.xml"
             rlAssertGrep 'fail</failure>' "junit.xml"
+
+            rlRun "xmllint --noout --schema 'tmt-report-junit.xsd' 'junit.xml'" 0 "Checking generated JUnit against the XSD schema"
         rlPhaseEnd
     done
 

--- a/tests/report/polarion/data/tmt-report-polarion.xsd
+++ b/tests/report/polarion/data/tmt-report-polarion.xsd
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+    This schema supports only a subset of the features provided by the
+    `xml-junit` library. Additionally, many attributes are explicitly set as
+    required. This is intentional to limit the currently supported features of
+    the TMT Polarion report plugin .
+
+    The Polarion `xunit.xml` is almost the same as default output of junit
+    report plugin but it must allow definition of `properties` inside of
+    `testsuites` (NOT `testsuite`) and `testcase`.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="required"/>
+            <xs:attribute name="errors" type="xs:string" use="required"/>
+            <xs:attribute name="disabled" type="xs:string" use="required"/>
+            <xs:attribute name="skipped" type="xs:string" use="required"/>
+            <xs:attribute name="time" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="time" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/tests/report/polarion/main.fmf
+++ b/tests/report/polarion/main.fmf
@@ -1,2 +1,5 @@
 summary: Check for xUnit output
 enabled: false # needs pylero, so just for local testing
+require+:
+  # To support xmllint tool
+  - libxml2

--- a/tests/report/polarion/test.sh
+++ b/tests/report/polarion/test.sh
@@ -14,6 +14,8 @@ rlJournalStart
         rlAssertGrep '<property name="polarion-project-id" value="RHELBASEOS" />' "xunit.xml"
         rlAssertGrep '<property name="polarion-testcase-id" value="BASEOS-10914" />' "xunit.xml"
         rlAssertGrep '<property name="polarion-custom-plannedin" value="RHEL-9.1.0" />' "xunit.xml"
+
+        rlRun "xmllint --noout --schema 'tmt-report-polarion.xsd' 'xunit.xml'" 0 "Checking generated XUnit against the XSD schema"
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
This PR adds tests for checking XML schemas of JUnit and XUnit generated by `junit` and `polarion` report plugins. The XSD schemas are purposely limited only to currently supported features (tags/attributes) by these report plugins.

The plan is probably to [check these schemas dynamically directly by TMT](https://github.com/teemtee/tmt/pull/3150#issuecomment-2296017256) for every supported junit flavor in the future.

This PR is highly related to #3150 because I need better test coverage, especially for the `xunit.xml` (output of the Polarion report plugin) - probably this will be obsoleted by tests in #3150 - Schema check is done directly in tmt.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
