### PR TITLE
Fix handling of empty set of allowed linters

### DIFF
--- a/tmt/lint.py
+++ b/tmt/lint.py
@@ -296,7 +296,7 @@ class Lintable(Generic[LintableT]):
 
         enforce_checks = enforce_checks or []
 
-        linters = linters or self.resolve_enabled_linters(
+        linters = linters if linters is not None else self.resolve_enabled_linters(
             enable_checks=enable_checks,
             disable_checks=disable_checks)
 


### PR DESCRIPTION
Empty set is not the same as unset, and the test must respect that.

Fixes https://github.com/teemtee/tmt/issues/3156

Pull Request Checklist

* [x] implement the feature