### PR TITLE
Fix disabled LintableCollection lint checks being applied

### DIFF
--- a/tmt/cli.py
+++ b/tmt/cli.py
@@ -635,6 +635,10 @@ def _lint_collection(
         enable_checks=enable_checks or None,
         disable_checks=disable_checks or None)
 
+    # Do not proceed, if there are no enabled linters - teemtee/tmt/issues/3156
+    if not linters:
+        return exit_code
+
     objs: list[tmt.base.Core] = [
         obj for cls in klasses
         for obj in cls.from_tree(context.obj.tree)]


### PR DESCRIPTION
Resolves [#3156](https://github.com/teemtee/tmt/issues/3156)  

The problem was that while `tmt.base.LintableCollection.resolve_enabled_linters()` correctly resolved disabled checks, it proceeds to do the diabled checks anyway. 

@engelmi Could you take a look please? If you have a better fix (and test), it would be appreciated ;)