### PR TITLE
Use Jinja2 and polarion JUnit flavor to generate XUnit in polarion report plugin

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -7,6 +7,11 @@
 tmt-1.37.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The :ref:`/plugins/report/polarion` report plugin now uses Jinja template to
+generate the XUnit file. It doesn't do any extra modifications to the XML tree
+using an ``ElementTree`` anymore. Also the schema is now validated against the
+XSD.
+
 The :ref:`/plugins/report/junit` report plugin now validates all the XML
 flavors against their respective XSD schemas and tries to prettify the final
 XML output. These functionalities are always disabled for ``custom`` flavors.

--- a/tests/report/polarion/test.sh
+++ b/tests/report/polarion/test.sh
@@ -7,14 +7,143 @@ rlJournalStart
         rlRun "set -o pipefail"
     rlPhaseEnd
 
-    rlPhaseStartTest
-        rlRun "tmt run -avr execute report -h polarion --project-id RHELBASEOS --no-upload --planned-in RHEL-9.1.0 --file xunit.xml 2>&1 >/dev/null | tee output" 2
+    rlPhaseStartTest 'Test the properties gets propagated to testsuites correctly'
+        rlRun "tmt run -avr execute report -h polarion --no-upload --project-id RHELBASEOS --template mytemplate --planned-in RHEL-9.1.0 --arch x86_64 --description mydesc --assignee myassignee --pool-team mypoolteam --platform myplatform --build mybuild --sample-image mysampleimage --logs mylogslocation --compose-id mycomposeid --file xunit.xml 2>&1 >/dev/null | tee output" 2
         rlAssertGrep "1 test passed, 1 test failed and 1 error" "output"
-        rlAssertGrep '<testsuite name="/plan" disabled="0" errors="1" failures="1" skipped="0" tests="3"' "xunit.xml"
-        rlAssertGrep '<property name="polarion-project-id" value="RHELBASEOS" />' "xunit.xml"
-        rlAssertGrep '<property name="polarion-testcase-id" value="BASEOS-10914" />' "xunit.xml"
-        rlAssertGrep '<property name="polarion-custom-plannedin" value="RHEL-9.1.0" />' "xunit.xml"
         rlAssertGrep "Maximum test time '2s' exceeded." "xunit.xml"
+
+        # testsuites and testsuite tag attributes
+        rlAssertGrep '<testsuites disabled="0" errors="1" failures="1" tests="3"' "xunit.xml"
+        rlAssertGrep '<testsuite name="/plan" disabled="0" errors="1" failures="1" skipped="0" tests="3"' "xunit.xml"
+        # Main testsuite properties
+        rlAssertGrep '<property name="polarion-project-id" value="RHELBASEOS"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-project-span-ids" value="RHELBASEOS,RHELBASEOS"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-testrun-title" value="plan_[0-9]\+"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-testrun-template-id" value="mytemplate"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-user-id" value="' "xunit.xml"
+
+        # Custom testsuite properties
+        rlAssertGrep '<property name="polarion-custom-description" value="mydesc"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-plannedin" value="RHEL-9.1.0"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-assignee" value="myassignee"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-poolteam" value="mypoolteam"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-arch" value="x86_64"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-platform" value="myplatform"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-build" value="mybuild"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-sampleimage" value="mysampleimage"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-logs" value="mylogslocation"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-composeid" value="mycomposeid"/>' "xunit.xml"
+
+        # The testcase properties
+        rlAssertGrep '<property name="polarion-testcase-id" value="BASEOS-10913"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-testcase-id" value="BASEOS-10914"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-testcase-id" value="BASEOS-10915"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-testcase-project-id" value="RHELBASEOS"/>' "xunit.xml"
+    rlPhaseEnd
+
+    rlPhaseStartTest 'Test the facts properties'
+        rlRun "tmt run -avr execute report -h polarion --no-upload --project-id RHELBASEOS --use-facts --file xunit.xml 2>&1 >/dev/null | tee output" 2
+        rlAssertGrep '<property name="polarion-custom-hostname" value="' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-arch" value="' "xunit.xml"
+    rlPhaseEnd
+
+    rlPhaseStartTest 'The "None" string should never be in a property value'
+        rlRun "tmt run -avr execute report -h polarion --no-upload --project-id RHELBASEOS --template '' --planned-in '' --arch '' --description '' --assignee '' --pool-team '' --platform '' --build '' --sample-image '' --logs '' --compose-id '' --file xunit.xml 2>&1 >/dev/null | tee output" 2
+        rlAssertNotGrep 'value="None"' "xunit.xml"
+
+        rlRun "export \
+        TMT_PLUGIN_REPORT_POLARION_PROJECT_ID= \
+        TMT_PLUGIN_REPORT_POLARION_TITLE= \
+        TMT_PLUGIN_REPORT_POLARION_DESCRIPTION= \
+        TMT_PLUGIN_REPORT_POLARION_TEMPLATE= \
+        TMT_PLUGIN_REPORT_POLARION_PLANNED_IN= \
+        TMT_PLUGIN_REPORT_POLARION_ASSIGNEE= \
+        TMT_PLUGIN_REPORT_POLARION_POOL_TEAM= \
+        TMT_PLUGIN_REPORT_POLARION_ARCH= \
+        TMT_PLUGIN_REPORT_POLARION_PLATFORM= \
+        TMT_PLUGIN_REPORT_POLARION_BUILD= \
+        TMT_PLUGIN_REPORT_POLARION_SAMPLE_IMAGE= \
+        TMT_PLUGIN_REPORT_POLARION_LOGS= \
+        TMT_PLUGIN_REPORT_POLARION_COMPOSE_ID= \
+        "
+        rlRun "tmt run -avr execute report -h polarion --no-upload --project-id RHELBASEOS --file xunit.xml 2>&1 >/dev/null | tee output" 2
+        rlAssertNotGrep 'value="None"' "xunit.xml"
+    rlPhaseEnd
+
+    rlPhaseStartTest 'Check the plugin behavior based on setting ENV variables'
+        rlRun "export \
+        TMT_PLUGIN_REPORT_POLARION_PROJECT_ID=myprojectid \
+        TMT_PLUGIN_REPORT_POLARION_TITLE=mytitle \
+        TMT_PLUGIN_REPORT_POLARION_DESCRIPTION=mydesc \
+        TMT_PLUGIN_REPORT_POLARION_TEMPLATE=mytemplate \
+        TMT_PLUGIN_REPORT_POLARION_PLANNED_IN=myplannedin \
+        TMT_PLUGIN_REPORT_POLARION_ASSIGNEE=myassignee \
+        TMT_PLUGIN_REPORT_POLARION_POOL_TEAM=mypoolteam \
+        TMT_PLUGIN_REPORT_POLARION_ARCH=x86_64 \
+        TMT_PLUGIN_REPORT_POLARION_PLATFORM=myplatform \
+        TMT_PLUGIN_REPORT_POLARION_BUILD=mybuild \
+        TMT_PLUGIN_REPORT_POLARION_SAMPLE_IMAGE=mysampleimage \
+        TMT_PLUGIN_REPORT_POLARION_LOGS=mylogslocation \
+        TMT_PLUGIN_REPORT_POLARION_COMPOSE_ID=mycomposeid \
+        "
+
+        rlRun "tmt run -avr execute report -h polarion --no-upload --file xunit.xml 2>&1 >/dev/null | tee output" 2
+        # Main testsuite properties
+        rlAssertGrep '<property name="polarion-project-id" value="myprojectid"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-project-span-ids" value="myprojectid,RHELBASEOS"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-testrun-title" value="mytitle"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-testrun-template-id" value="mytemplate"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-user-id" value="' "xunit.xml"
+
+        # Custom testsuite properties
+        rlAssertGrep '<property name="polarion-custom-description" value="mydesc"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-plannedin" value="myplannedin"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-assignee" value="myassignee"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-poolteam" value="mypoolteam"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-arch" value="x86_64"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-platform" value="myplatform"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-build" value="mybuild"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-sampleimage" value="mysampleimage"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-logs" value="mylogslocation"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-composeid" value="mycomposeid"/>' "xunit.xml"
+
+        # The testcase properties
+        rlAssertGrep '<property name="polarion-testcase-id" value="BASEOS-10913"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-testcase-id" value="BASEOS-10914"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-testcase-id" value="BASEOS-10915"/>' "xunit.xml"
+        rlAssertGrep '<property name="polarion-testcase-project-id" value="RHELBASEOS"/>' "xunit.xml"
+    rlPhaseEnd
+
+    rlPhaseStartTest 'Check the plugin behavior based on TMT_PLUGIN_REPORT_POLARION_USE_FACTS env variable'
+        # Make sure all ENV variables are unset
+        rlRun "unset \
+        TMT_PLUGIN_REPORT_POLARION_PROJECT_ID \
+        TMT_PLUGIN_REPORT_POLARION_TITLE \
+        TMT_PLUGIN_REPORT_POLARION_DESCRIPTION \
+        TMT_PLUGIN_REPORT_POLARION_TEMPLATE \
+        TMT_PLUGIN_REPORT_POLARION_PLANNED_IN \
+        TMT_PLUGIN_REPORT_POLARION_ASSIGNEE \
+        TMT_PLUGIN_REPORT_POLARION_POOL_TEAM \
+        TMT_PLUGIN_REPORT_POLARION_ARCH \
+        TMT_PLUGIN_REPORT_POLARION_PLATFORM \
+        TMT_PLUGIN_REPORT_POLARION_BUILD \
+        TMT_PLUGIN_REPORT_POLARION_SAMPLE_IMAGE \
+        TMT_PLUGIN_REPORT_POLARION_LOGS \
+        TMT_PLUGIN_REPORT_POLARION_COMPOSE_ID \
+        TMT_PLUGIN_REPORT_POLARION_USE_FACTS \
+        "
+
+        # The facts must not be set
+        rlRun "export TMT_PLUGIN_REPORT_POLARION_USE_FACTS=0"
+        rlRun "tmt run -avr execute report -h polarion --no-upload --project-id RHELBASEOS --file xunit.xml 2>&1 >/dev/null | tee output" 2
+        rlAssertNotGrep '<property name="polarion-custom-arch" value="' "xunit.xml"
+        rlAssertNotGrep '<property name="polarion-custom-hostname" value="' "xunit.xml"
+
+        # The facts must be set
+        rlRun "export TMT_PLUGIN_REPORT_POLARION_USE_FACTS=1"
+        rlRun "tmt run -avr execute report -h polarion --no-upload --project-id RHELBASEOS --file xunit.xml 2>&1 >/dev/null | tee output" 2
+        rlAssertGrep '<property name="polarion-custom-arch" value="' "xunit.xml"
+        rlAssertGrep '<property name="polarion-custom-hostname" value="' "xunit.xml"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/steps/report/junit/schemas/polarion.xsd
+++ b/tmt/steps/report/junit/schemas/polarion.xsd
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+    This schema supports only a subset of the features provided by the
+    `xml-junit` library. Additionally, many attributes are explicitly set as
+    required. This is intentional to limit the currently supported features of
+    the tmt Polarion report plugin .
+
+    The Polarion `xunit.xml` is almost the same as default output of junit
+    report plugin but it must allow definition of `properties` inside of
+    `testsuites` (NOT `testsuite`) and `testcase`.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="time" type="xs:float" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="required"/>
+            <xs:attribute name="errors" type="xs:string" use="required"/>
+            <xs:attribute name="disabled" type="xs:string" use="required"/>
+            <xs:attribute name="skipped" type="xs:string" use="required"/>
+            <xs:attribute name="time" type="xs:float" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="time" type="xs:float" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/tmt/steps/report/junit/templates/_base.xml.j2
+++ b/tmt/steps/report/junit/templates/_base.xml.j2
@@ -21,10 +21,24 @@
                     {% if INCLUDE_OUTPUT_LOG and main_log %}
                         <system-out>{{ main_log | e }}</system-out>
                     {% endif %}
+
+                    {# Optionally add the result properties #}
+                    {% if result.properties is defined %}
+                        {% with properties=result.properties %}
+                            {% include "includes/_properties.xml.j2" %}
+                        {% endwith %}
+                    {% endif %}
                 </testcase>
             {% endfor %}
         {% endblock %}
     </testsuite>
     {% endblock %}
+
+    {# Optionally include the properties section in testsuites tag #}
+    {% if RESULTS.properties is defined %}
+        {% with properties=RESULTS.properties %}
+            {% include "includes/_properties.xml.j2" %}
+        {% endwith %}
+    {% endif %}
 </testsuites>
 {% endblock %}

--- a/tmt/steps/report/junit/templates/includes/_properties.xml.j2
+++ b/tmt/steps/report/junit/templates/includes/_properties.xml.j2
@@ -1,0 +1,7 @@
+{% if properties %}
+<properties>
+    {% for property in properties %}
+    <property name="{{ property.name | e }}" value="{{ property.value | e }}"/>
+    {% endfor %}
+</properties>
+{% endif %}

--- a/tmt/steps/report/junit/templates/polarion.xml.j2
+++ b/tmt/steps/report/junit/templates/polarion.xml.j2
@@ -1,0 +1,1 @@
+{% extends "_base.xml.j2" %}


### PR DESCRIPTION
Do not edit the default JUnit flavor generated by junit report plugin using an `ElementTree`, use the predefined Jinja2 Polarion template. This PR also adds the XSD schema for a Polarion XUnit file. The checking against this schema is done dynamically by lxml in the same way as for the `default` junit flavor.

Related to:
- https://github.com/teemtee/tmt/issues/2826

Depends on:
- https://github.com/teemtee/tmt/pull/3150

## TODOs:
- [x] `testuites` properties should be probably part of `ResultsContext` (as property)
- [x] Test the actual polarion import (done by @KwisatzHaderach )

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [x] include a release note
