### PR TITLE
Fix the operator to be not equal in string values

### DIFF
--- a/spec/hardware/main.fmf
+++ b/spec/hardware/main.fmf
@@ -41,7 +41,7 @@ description: |
         Only ``=`` and ``!=`` operators are accepted for flag-like requirements,
         e.g. :ref:`virtualization.is-virtualized </spec/hardware/virtualization>`.
 
-        Only ``=``, ``!``, ``~`` and ``!~`` operators are accepted for
+        Only ``=``, ``!=``, ``~`` and ``!~`` operators are accepted for
         requirements that accept string values, e.g.
         :ref:`cpu.model-name </spec/hardware/cpu>` or
         :ref:`virtualization.hypervisor </spec/hardware/virtualization>`.


### PR DESCRIPTION
As the document explains in the introduction, `!` is not an available operator, so logically it should be `!=`

Pull Request Checklist

* [ ] implement the feature
* [x] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
