### PR TITLE
Extend xfail to F41 for pint and nitrate issues

### DIFF
--- a/tests/pip/install.fmf
+++ b/tests/pip/install.fmf
@@ -6,10 +6,10 @@ require:
     - python3-devel
 tier: null
 adjust:
-    when: distro == fedora-rawhide
+    when: distro == fedora-rawhide or distro == fedora-41
     result: xfail
-    # 'mini' should start passing once https://github.com/hgrecco/pint/issues/1969 is resolved
-    # if/once that happens, the xfail should be moved to 'full' only
+    # Depends on https://github.com/hgrecco/pint/issues/1969
+    # The 'full' dependes on https://github.com/psss/python-nitrate/pull/49
     because: "Un-installable dependencies on Python 3.13"
 
 /mini:

--- a/tests/precommit/main.fmf
+++ b/tests/precommit/main.fmf
@@ -5,8 +5,8 @@ require:
 - tmt
 tier: 4
 adjust:
-    when: distro == fedora-rawhide
+    when: distro == fedora-rawhide or distro == fedora-41
     result: xfail
     # Remove the xfail adjust once it starts passing.
-    # Dependent on https://github.com/crate-py/rpds/issues/72, PyO3 0.22
+    # https://github.com/hgrecco/pint/issues/1969
     because: "Un-installable dependencies on Python 3.13"


### PR DESCRIPTION
So as far as I can tell, the F41 pint and psycopg2 packages are available and patched, so #3168 would only affect PyPA/pip installations and therefore should not be blocking F41 tmt release.  