### PR TITLE
Add support for `subresults` flavor to `junit` report plugin

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,7 +4,8 @@
     Releases
 ======================
 
-tmt-1.XX.0
+
+tmt-1.46.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :ref:`/plugins/report/junit` report plugin now supports a new

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,16 @@
     Releases
 ======================
 
+tmt-1.XX.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`/plugins/report/junit` report plugin now supports a new
+``subresults`` JUnit flavor. This flavor adds support for tmt subresults and
+changes the level of ``<testsuite>`` and ``<testcase>`` tags. By using this
+flavor, the ``tmt.Result`` tags become ``<testsuite>`` tags with one
+``<testcase>`` tag representing the parent result, and possible additional
+``<testcase>`` tags for each ``tmt.result.SubResult``.
+
 
 tmt-1.45.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -8,11 +8,12 @@ tmt-1.XX.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :ref:`/plugins/report/junit` report plugin now supports a new
-``subresults`` JUnit flavor. This flavor adds support for tmt subresults and
-changes the level of ``<testsuite>`` and ``<testcase>`` tags. By using this
-flavor, the ``tmt.Result`` tags become ``<testsuite>`` tags with one
-``<testcase>`` tag representing the parent result, and possible additional
-``<testcase>`` tags for each ``tmt.result.SubResult``.
+experimental ``subresults`` JUnit flavor. This flavor introduces
+support for tmt subresults and adjusts the hierarchy of
+``<testsuite>`` and ``<testcase>`` tags. With this flavor, test
+results are represented as ``<testsuite>`` tags, each containing a
+``<testcase>`` tag for the main result, along with additional
+``<testcase>`` tags for any subresults.
 
 
 tmt-1.45.0

--- a/tests/report/junit/data/custom-subresults.xml.j2
+++ b/tests/report/junit/data/custom-subresults.xml.j2
@@ -9,6 +9,5 @@
                 <subresult name="{{ subresult.name | e }}" {% if subresult_test_duration %}time="{{ subresult_test_duration }}"{% endif %} outcome="{{ subresult.result.value }}"></subresult>
             {% endfor %}
         </result>
-
     {% endfor %}
 </tests>

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -116,7 +116,7 @@ rlJournalStart
             rlAssertGrep '<testcase name="/pass-subtest/good1">' "subresults-out.xml"
             rlAssertGrep '<testcase name="/pass-subtest/good2">' "subresults-out.xml"
 
-            rlAssertGrep '<testsuite name="/test/beakerlib/subresults" disabled="0" errors="1" failures="3" skipped="2" tests="10"' "subresults-out.xml"
+            rlAssertGrep '<testsuite name="/test/beakerlib/subresults" disabled="0" errors="1" failures="3" skipped="1" tests="10"' "subresults-out.xml"
             rlAssertGrep '<testcase name="/test/beakerlib/subresults">' "subresults-out.xml"
             rlAssertGrep '<testcase name="/phase-setup">' "subresults-out.xml"
             rlAssertGrep '<testcase name="/phase-test-pass">' "subresults-out.xml"
@@ -127,8 +127,6 @@ rlJournalStart
             rlAssertGrep '<testcase name="/extra-tmt-report-result/skip">' "subresults-out.xml"
             rlAssertGrep '<testcase name="/phase-test-multiple-tmt-report-result">' "subresults-out.xml"
             rlAssertGrep '<testcase name="/phase-cleanup">' "subresults-out.xml"
-
-
         rlPhaseEnd
     done
 

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -93,17 +93,42 @@ rlJournalStart
         rlPhaseStartTest "[$method] Check the 'subresults' flavor"
             rlRun "tmt run -avr execute -h $method report -h junit --file subresults-out.xml --flavor subresults 2>&1 >/dev/null | tee output" 2
 
-            # Parent result recorded in testuite tag
-            rlAssertGrep '<testsuite name="/test/beakerlib/fail" disabled="0" errors="1" failures="0" skipped="0" tests="1"' "subresults-out.xml"
-            rlAssertGrep '<testsuite name="/test/beakerlib/pass" disabled="0" errors="0" failures="0" skipped="0" tests="1" ' "subresults-out.xml"
-            rlAssertGrep '<testsuite name="/test/shell/fail" disabled="0" errors="1" failures="0" skipped="0" tests="1"'
+            rlAssertGrep '<testsuites disabled="0" errors="2" failures="5" tests="13"' "subresults-out.xml"
 
-            # Parent result testsuite must have its respective testcase tag
+            # Parent result recorded in testuite tag
+            rlAssertGrep '<testsuite name="/test/beakerlib/fail" disabled="0" errors="0" failures="2" skipped="0" tests="2"' "subresults-out.xml"
+
+            # Parent result testsuite must have its respective testcase tag with the same name
             rlAssertGrep '<testcase name="/test/beakerlib/fail">' "subresults-out.xml"
+
+            rlAssertGrep '<testsuite name="/test/beakerlib/pass" disabled="0" errors="0" failures="0" skipped="0" tests="2" ' "subresults-out.xml"
             rlAssertGrep '<testcase name="/test/beakerlib/pass">' "subresults-out.xml"
 
-            # TODO: Add check for additional subresults as soon as they get saved by:
-            # - https://github.com/teemtee/tmt/pull/3200
+            rlAssertGrep '<testsuite name="/test/shell/big-output" disabled="0" errors="0" failures="0" skipped="0" tests="1"' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/test/shell/big-output">' "subresults-out.xml"
+
+            rlAssertGrep '<testsuite name="/test/shell/fail" disabled="0" errors="0" failures="1" skipped="0" tests="1"' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/test/shell/fail">' "subresults-out.xml"
+
+            rlAssertGrep '<testsuite name="/test/shell/subresults/pass" disabled="0" errors="0" failures="0" skipped="0" tests="4"' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/test/shell/subresults/pass">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/pass-subtest/good0">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/pass-subtest/good1">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/pass-subtest/good2">' "subresults-out.xml"
+
+            rlAssertGrep '<testsuite name="/test/beakerlib/subresults" disabled="0" errors="1" failures="3" skipped="2" tests="10"' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/test/beakerlib/subresults">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/phase-setup">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/phase-test-pass">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/phase-test-fail">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/extra-tmt-report-result/good">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/extra-tmt-report-result/bad">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/extra-tmt-report-result/weird">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/extra-tmt-report-result/skip">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/phase-test-multiple-tmt-report-result">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/phase-cleanup">' "subresults-out.xml"
+
+
         rlPhaseEnd
     done
 

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -88,8 +88,22 @@ rlJournalStart
             rlAssertGrep '<subresult name="/skip-subtest/extra-skip" outcome="skip"/>' "custom-subresults-template-out.xml"
             rlAssertGrep '<result name="/test/shell/subresults/skip" disabled="0" errors="0" failures="0" skipped="1" tests="2" time="0" outcome="pass"' "custom-subresults-template-out.xml"
             rlAssertGrep '<result name="/test/shell/subresults/sleep" disabled="0" errors="0" failures="1" skipped="0" tests="2" time="5"' "custom-subresults-template-out.xml"
+        rlPhaseEnd
 
-            rlAssertGrep '<subresult name="/fail-subtest/good" outcome="pass"/>' "custom-subresults-template-out.xml"
+        rlPhaseStartTest "[$method] Check the 'subresults' flavor"
+            rlRun "tmt run -avr execute -h $method report -h junit --file subresults-out.xml --flavor subresults 2>&1 >/dev/null | tee output" 2
+
+            # Parent result recorded in testuite tag
+            rlAssertGrep '<testsuite name="/test/beakerlib/fail" disabled="0" errors="1" failures="0" skipped="0" tests="1"' "subresults-out.xml"
+            rlAssertGrep '<testsuite name="/test/beakerlib/pass" disabled="0" errors="0" failures="0" skipped="0" tests="1" ' "subresults-out.xml"
+            rlAssertGrep '<testsuite name="/test/shell/fail" disabled="0" errors="1" failures="0" skipped="0" tests="1"'
+
+            # Parent result testsuite must have its respective testcase tag
+            rlAssertGrep '<testcase name="/test/beakerlib/fail">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/test/beakerlib/pass">' "subresults-out.xml"
+
+            # TODO: Add check for additional subresults as soon as they get saved by:
+            # - https://github.com/teemtee/tmt/pull/3200
         rlPhaseEnd
     done
 

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -429,7 +429,7 @@ class ReportJUnitData(tmt.steps.report.ReportStepData):
     flavor: str = field(
         default=DEFAULT_FLAVOR_NAME,
         option='--flavor',
-        choices=[DEFAULT_FLAVOR_NAME, CUSTOM_FLAVOR_NAME],
+        choices=[DEFAULT_FLAVOR_NAME, CUSTOM_FLAVOR_NAME, 'subresults'],
         help='Name of a JUnit flavor to generate.',
     )
 

--- a/tmt/steps/report/junit/schemas/subresults.xsd
+++ b/tmt/steps/report/junit/schemas/subresults.xsd
@@ -68,11 +68,6 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
-
-                <!-- TODO: These should not be probably allowed
-                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
-                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
-                -->
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="required"/>
             <xs:attribute name="tests" type="xs:string" use="required"/>

--- a/tmt/steps/report/junit/schemas/subresults.xsd
+++ b/tmt/steps/report/junit/schemas/subresults.xsd
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+    This schema extends the `default` flavor and adds support for tmt
+    subresults. It allows multiple occurrences of testsuite elements inside a
+    <testsuites>.
+
+    The <testsuite> is mapped to `tmt.Result` and the <testcase> is mapped to
+    `tmt.SubResult`.
+-->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="required"/>
+            <xs:attribute name="message" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="time" type="xs:float" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+
+                <!-- TODO: These should not be probably allowed
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+                -->
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="required"/>
+            <xs:attribute name="errors" type="xs:string" use="required"/>
+            <xs:attribute name="disabled" type="xs:string" use="required"/>
+            <xs:attribute name="skipped" type="xs:string" use="required"/>
+            <xs:attribute name="time" type="xs:float" use="required"/>
+            <xs:attribute name="timestamp" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="time" type="xs:float" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/tmt/steps/report/junit/templates/subresults.xml.j2
+++ b/tmt/steps/report/junit/templates/subresults.xml.j2
@@ -21,7 +21,7 @@
 
             {% set num_of_errored = result.subresult.errored | length %}
             {% set num_of_failed = result.subresult.failed | length %}
-            {% set num_of_skipped = result.subresult.failed | length %}
+            {% set num_of_skipped = result.subresult.skipped | length %}
 
             {#
                 Fix the test counts in testsuite tag for errors, failures and

--- a/tmt/steps/report/junit/templates/subresults.xml.j2
+++ b/tmt/steps/report/junit/templates/subresults.xml.j2
@@ -11,8 +11,6 @@
 
     {% block testsuites %}
         {% for result in RESULTS %}
-            {% set main_log = result.log | first | read_log %}
-            {% set main_log_failures = main_log | failures | e %}
             {% set main_test_duration = result.duration | duration_to_seconds %}
 
             {# TODO: Fix the test counts in testsuite tag #}
@@ -27,39 +25,37 @@
                 #}
                 <testcase name="{{ result.name | e }}" {% if result_test_duration %}time="{{ result_test_duration }}"{% endif %}>
                     {% if result.result.value == 'error' or result.result.value == 'warn' %}
-                        <error type="error" message="{{ result.result.value | e }}">{{ main_log_failures }}</error>
+                        <error type="error" message="{{ result.result.value | e }}">{{ result.log | first | read_log | failures | e }}</error>
                     {% elif result.result.value == 'fail' %}
-                        <failure type="failure" message="{{ result.result.value | e }}">{{ main_log_failures }}</failure>
+                        <failure type="failure" message="{{ result.result.value | e }}">{{ result.log | first | read_log | failures | e }}</failure>
                     {% elif result.result.value == 'info' %}
-                        <skipped type="skipped" message="{{ result.result.value | e }}">{{ main_log_failures }}</skipped>
+                        <skipped type="skipped" message="{{ result.result.value | e }}">{{ result.log | first | read_log | failures | e }}</skipped>
                     {% endif %}
 
-                    {% if INCLUDE_OUTPUT_LOG and main_log %}
-                        <system-out>{{ main_log | e }}</system-out>
+                    {% if INCLUDE_OUTPUT_LOG and result.log %}
+                        <system-out>{{ result.log | first | read_log | e }}</system-out>
                     {% endif %}
                 </testcase>
 
                 {% for subresult in result.subresult %}
-                    {% set subresult_log = subresult.log | first | read_log %}
-                    {% set subresult_log_failures = main_log | failures | e %}
                     {% set subresult_test_duration = subresult.duration | duration_to_seconds %}
 
                     <testcase name="{{ subresult.name | e }}" {% if subresult_test_duration %}time="{{ subresult_test_duration }}"{% endif %}>
                         {% if subresult.result.value == 'error' or subresult.result.value == 'warn' %}
-                            <error type="error" message="{{ subresult.result.value | e }}">{{ subresult_log_failures }}</error>
+                            <error type="error" message="{{ subresult.result.value | e }}">{{ subresult.log | first | read_log | failures | e }}</error>
                         {% elif subresult.result.value == 'fail' %}
-                            <failure type="failure" message="{{ subresult.result.value | e }}">{{ subresult_log_failures }}</failure>
+                            <failure type="failure" message="{{ subresult.result.value | e }}">{{ subresult.log | first | read_log | failures | e }}</failure>
                         {% elif subresult.result.value == 'info' %}
-                            <skipped type="skipped" message="{{ subresult.result.value | e }}">{{ subresult_log_failures }}</skipped>
+                            <skipped type="skipped" message="{{ subresult.result.value | e }}">{{ subresult.log | first | read_log | failures | e }}</skipped>
                         {% endif %}
 
-                        {% if INCLUDE_OUTPUT_LOG and subresult_log %}
-                            <system-out>{{ subresult_log | e }}</system-out>
+                        {% if INCLUDE_OUTPUT_LOG and subresult.log %}
+                            <system-out>{{ subresult.log | first | read_log | e }}</system-out>
                         {% endif %}
                     </testcase>
                 {% endfor %}
 
-                {# Optionally add the result properties #}
+                {# Optionally add the main result properties #}
                 {% if result.properties is defined %}
                     {% with properties=result.properties %}
                         {% include "includes/_properties.xml.j2" %}

--- a/tmt/steps/report/junit/templates/subresults.xml.j2
+++ b/tmt/steps/report/junit/templates/subresults.xml.j2
@@ -1,0 +1,80 @@
+{% extends "_base.xml.j2" %}
+
+{#
+    This flavor changes the level of `<testsuite>` and `<testcase>` tags. The
+    `tmt.Result` becomes ``<testsuite>`` instead of ``testcase`` and
+    ``<testcase>`` tags become ``tmt.SubResult``.
+#}
+
+{% block content %}
+    <testsuites disabled="0" errors="{{ RESULTS.errored | length }}" failures="{{ RESULTS.failed | length }}" tests="{{ RESULTS | length }}" time="{{ RESULTS.duration }}">
+
+    {% block testsuites %}
+        {% for result in RESULTS %}
+            {% set main_log = result.log | first | read_log %}
+            {% set main_log_failures = main_log | failures | e %}
+            {% set main_test_duration = result.duration | duration_to_seconds %}
+
+            {# TODO: Fix the test counts in testsuite tag #}
+            {# TODO: Also fix the counts because now with an additional testcase for parent results, the counts will not match. #}
+
+            <testsuite name="{{ result.name | trim | e }}" disabled="0" errors="{{ result.subresult.errored | length }}" failures="{{ result.subresult.failed | length }}" skipped="{{ result.subresult.skipped | length }}" tests="{{ result.subresult | length }}" time="{{ main_test_duration }}" timestamp="{{ result.start_time }}">
+
+                {#
+                    Always include a `testcase` representing the main result.
+                    The `error/failure/skipped` tags must not exists inside a
+                    `testsuite`, they are only allowed inside of a `testcase`.
+                #}
+                <testcase name="{{ result.name | e }}" {% if result_test_duration %}time="{{ result_test_duration }}"{% endif %}>
+                    {% if result.result.value == 'error' or result.result.value == 'warn' %}
+                        <error type="error" message="{{ result.result.value | e }}">{{ main_log_failures }}</error>
+                    {% elif result.result.value == 'fail' %}
+                        <failure type="failure" message="{{ result.result.value | e }}">{{ main_log_failures }}</failure>
+                    {% elif result.result.value == 'info' %}
+                        <skipped type="skipped" message="{{ result.result.value | e }}">{{ main_log_failures }}</skipped>
+                    {% endif %}
+
+                    {% if INCLUDE_OUTPUT_LOG and main_log %}
+                        <system-out>{{ main_log | e }}</system-out>
+                    {% endif %}
+                </testcase>
+
+                {% for subresult in result.subresult %}
+                    {% set subresult_log = subresult.log | first | read_log %}
+                    {% set subresult_log_failures = main_log | failures | e %}
+                    {% set subresult_test_duration = subresult.duration | duration_to_seconds %}
+
+                    <testcase name="{{ subresult.name | e }}" {% if subresult_test_duration %}time="{{ subresult_test_duration }}"{% endif %}>
+                        {% if subresult.result.value == 'error' or subresult.result.value == 'warn' %}
+                            <error type="error" message="{{ subresult.result.value | e }}">{{ subresult_log_failures }}</error>
+                        {% elif subresult.result.value == 'fail' %}
+                            <failure type="failure" message="{{ subresult.result.value | e }}">{{ subresult_log_failures }}</failure>
+                        {% elif subresult.result.value == 'info' %}
+                            <skipped type="skipped" message="{{ subresult.result.value | e }}">{{ subresult_log_failures }}</skipped>
+                        {% endif %}
+
+                        {% if INCLUDE_OUTPUT_LOG and subresult_log %}
+                            <system-out>{{ subresult_log | e }}</system-out>
+                        {% endif %}
+                    </testcase>
+                {% endfor %}
+
+                {# Optionally add the result properties #}
+                {% if result.properties is defined %}
+                    {% with properties=result.properties %}
+                        {% include "includes/_properties.xml.j2" %}
+                    {% endwith %}
+                {% endif %}
+            </testsuite>
+        {% endfor %}
+    {% endblock %}
+
+    {# Optionally include the properties section in testsuites tag #}
+    {% if RESULTS.properties is defined %}
+        {% with properties=RESULTS.properties %}
+            {% include "includes/_properties.xml.j2" %}
+        {% endwith %}
+    {% endif %}
+
+    </testsuites>
+{% endblock %}

--- a/tmt/steps/report/junit/templates/subresults.xml.j2
+++ b/tmt/steps/report/junit/templates/subresults.xml.j2
@@ -19,10 +19,12 @@
             <testsuite name="{{ result.name | trim | e }}" disabled="0" errors="{{ result.subresult.errored | length }}" failures="{{ result.subresult.failed | length }}" skipped="{{ result.subresult.skipped | length }}" tests="{{ result.subresult | length }}" time="{{ main_test_duration }}" timestamp="{{ result.start_time }}">
 
                 {#
-                    Always include a `testcase` representing the main result.
-                    The `error/failure/skipped` tags must not exists inside a
-                    `testsuite`, they are only allowed inside of a `testcase`.
+                    Always include an extra `testcase` representing the main
+                    result. The `error/failure/skipped` tags must not exists
+                    inside a `testsuite`, they are only allowed inside of a
+                    `testcase`.
                 #}
+                <!-- The extra testcase representing the parent result. -->
                 <testcase name="{{ result.name | e }}" {% if result_test_duration %}time="{{ result_test_duration }}"{% endif %}>
                     {% if result.result.value == 'error' or result.result.value == 'warn' %}
                         <error type="error" message="{{ result.result.value | e }}">{{ result.log | first | read_log | failures | e }}</error>

--- a/tmt/steps/report/junit/templates/subresults.xml.j2
+++ b/tmt/steps/report/junit/templates/subresults.xml.j2
@@ -13,10 +13,30 @@
         {% for result in RESULTS %}
             {% set main_test_duration = result.duration | duration_to_seconds %}
 
-            {# TODO: Fix the test counts in testsuite tag #}
-            {# TODO: Also fix the counts because now with an additional testcase for parent results, the counts will not match. #}
+            {#
+                Fix the count of test cases in the testsuite, because one extra
+                test case for a parent result is added.
+            #}
+            {% set num_of_tests = result.subresult | length + 1 %}
 
-            <testsuite name="{{ result.name | trim | e }}" disabled="0" errors="{{ result.subresult.errored | length }}" failures="{{ result.subresult.failed | length }}" skipped="{{ result.subresult.skipped | length }}" tests="{{ result.subresult | length }}" time="{{ main_test_duration }}" timestamp="{{ result.start_time }}">
+            {% set num_of_errored = result.subresult.errored | length %}
+            {% set num_of_failed = result.subresult.failed | length %}
+            {% set num_of_skipped = result.subresult.failed | length %}
+
+            {#
+                Fix the test counts in testsuite tag for errors, failures and
+                skipped params. This is due to an extra parent test case which
+                must also get counted.
+            #}
+            {% if result.result.value == "error" %}
+                {% set num_of_errored = num_of_errored + 1 %}
+            {% elif result.result.value == "fail" %}
+                {% set num_of_failed = num_of_failed + 1 %}
+            {% elif result.result.value == "info" %}
+                {% set num_of_skipped = num_of_skipped + 1 %}
+            {% endif %}
+
+            <testsuite name="{{ result.name | trim | e }}" disabled="0" errors="{{ num_of_errored }}" failures="{{ num_of_failed }}" skipped="{{ num_of_skipped }}" tests="{{ num_of_tests }}" time="{{ main_test_duration }}" timestamp="{{ result.start_time }}">
 
                 {#
                     Always include an extra `testcase` representing the main
@@ -24,7 +44,7 @@
                     inside a `testsuite`, they are only allowed inside of a
                     `testcase`.
                 #}
-                <!-- The extra testcase representing the parent result. -->
+                <!-- The extra test case representing the parent result. -->
                 <testcase name="{{ result.name | e }}" {% if result_test_duration %}time="{{ result_test_duration }}"{% endif %}>
                     {% if result.result.value == 'error' or result.result.value == 'warn' %}
                         <error type="error" message="{{ result.result.value | e }}">{{ result.log | first | read_log | failures | e }}</error>
@@ -38,6 +58,7 @@
                         <system-out>{{ result.log | first | read_log | e }}</system-out>
                     {% endif %}
                 </testcase>
+                <!-- End of the extra parent test case. -->
 
                 {% for subresult in result.subresult %}
                     {% set subresult_test_duration = subresult.duration | duration_to_seconds %}


### PR DESCRIPTION
This PR adds a `subresults` junit report plugin flavor to show the `tmt.result.SubResult` instances within the `tmt.Result`. It tries to map the `tmt.Result` to `<testsuite>` and `tmt.result.SubResult` to `<testcase>` respectively.

Discussion from 10.9. 2024:

> This flavor will be probably used by testing-farm to generate the `results-junit.xml` in the future.
> 
> There are two results files in Testing Farm:
>   - results.xml (converted from tmt’s results.yaml)
>   - results-junit.xml (in the future should be generated by tmt)


For more info see:
- https://github.com/teemtee/tmt/issues/2826#issuecomment-2077125937
- [JUnit examples](https://github.com/testmoapp/junitxml)

Related to:
- https://github.com/teemtee/tmt/pull/3150
- https://github.com/teemtee/tmt/pull/3200
- https://github.com/teemtee/tmt/issues/2826

Blocked on:
- https://github.com/teemtee/tmt/pull/3307
- https://github.com/teemtee/tmt/pull/3370

# TODO:
- [x] Test with https://github.com/teemtee/tmt/pull/3166
- [x] Add/fix tests to cover the subresults flavor
- ~~Maybe use `classname` to define a parent test name and `name` for a subresult test name (https://github.com/teemtee/tmt/issues/2826#issuecomment-2038166924)~~

Pull Request Checklist:
* [x] implement the feature
* [x] extend the test coverage
* [x] include a release note
