### PR TITLE
Use `TMT_REPORT_ARTIFACTS_URL` envvar again

### DIFF
--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -163,7 +163,8 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
     artifacts_url: Optional[str] = field(
         metavar="ARTIFACTS_URL",
         option="--artifacts-url",
-        default=os.getenv('TMT_REPORT_ARTIFACTS_URL'),
+        default=_str_env_to_default('artifacts_url',
+                                    os.getenv('TMT_REPORT_ARTIFACTS_URL')),
         help="Link to test artifacts provided for report plugins.")
 
     launch_url: Optional[str] = None

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -163,7 +163,7 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
     artifacts_url: Optional[str] = field(
         metavar="ARTIFACTS_URL",
         option="--artifacts-url",
-        default=_str_env_to_default('artifacts_url', None),
+        default=os.getenv('TMT_REPORT_ARTIFACTS_URL'),
         help="Link to test artifacts provided for report plugins.")
 
     launch_url: Optional[str] = None


### PR DESCRIPTION
The former change accidentally switched the code to use TMT_PLUGIN_REPORT_REPORTPORTAL_ARTIFACTS_URL
environment variable. That broke the functionality until a workaround had been implemented in TF.
This change restores the original usage of TMT_REPORT_ARTIFACTS_URL due to the fact that this variable is not reportportal plugin specific.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
