### PR TITLE
Start splitting `tmt.cli` into submodules

### DIFF
--- a/stories/cli/common.fmf
+++ b/stories/cli/common.fmf
@@ -18,8 +18,8 @@ story:
         - tmt test show -vvv
         - tmt test show --verbose
     link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
+      - documented-by: /tmt/cli/__init__.py
       - verified-by: /tests/core/dry
 
 /quiet:
@@ -28,8 +28,8 @@ story:
         - tmt test show -q
         - tmt test show --quiet
     link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
+      - documented-by: /tmt/cli/__init__.py
 
 /force:
     summary: Force dangerous operations like overwriting files
@@ -37,8 +37,8 @@ story:
         - tmt test create -f
         - tmt test create --force
     link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
+      - documented-by: /tmt/cli/__init__.py
       - relates: /stories/cli/test/create
 
 /format:
@@ -48,9 +48,9 @@ story:
         - tmt plan export --how yaml
         - tmt story export --how rst
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - implemented-by: /tmt/base.py
-      - documented-by: /tmt/cli.py
+      - documented-by: /tmt/cli/__init__.py
 
 /debug:
     summary: Print additional information for debugging
@@ -68,8 +68,8 @@ story:
         - tmt run -ddd
         - tmt run --debug
     link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
+      - documented-by: /tmt/cli/__init__.py
       - verified-by: /tests/core/dry
 
 /dry:
@@ -82,6 +82,6 @@ story:
         - tmt run -n
         - tmt run --dry
     link:
-      - implemented-by: /tmt/cli.py
-      - documented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
+      - documented-by: /tmt/cli/__init__.py
       - verified-by: /tests/core/dry

--- a/stories/cli/common.fmf
+++ b/stories/cli/common.fmf
@@ -18,8 +18,8 @@ story:
         - tmt test show -vvv
         - tmt test show --verbose
     link:
-      - implemented-by: /tmt/cli/__init__.py
-      - documented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
+      - documented-by: /tmt/cli
       - verified-by: /tests/core/dry
 
 /quiet:
@@ -28,8 +28,8 @@ story:
         - tmt test show -q
         - tmt test show --quiet
     link:
-      - implemented-by: /tmt/cli/__init__.py
-      - documented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
+      - documented-by: /tmt/cli
 
 /force:
     summary: Force dangerous operations like overwriting files
@@ -37,8 +37,8 @@ story:
         - tmt test create -f
         - tmt test create --force
     link:
-      - implemented-by: /tmt/cli/__init__.py
-      - documented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
+      - documented-by: /tmt/cli
       - relates: /stories/cli/test/create
 
 /format:
@@ -48,9 +48,9 @@ story:
         - tmt plan export --how yaml
         - tmt story export --how rst
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - implemented-by: /tmt/base.py
-      - documented-by: /tmt/cli/__init__.py
+      - documented-by: /tmt/cli
 
 /debug:
     summary: Print additional information for debugging
@@ -68,8 +68,8 @@ story:
         - tmt run -ddd
         - tmt run --debug
     link:
-      - implemented-by: /tmt/cli/__init__.py
-      - documented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
+      - documented-by: /tmt/cli
       - verified-by: /tests/core/dry
 
 /dry:
@@ -82,6 +82,6 @@ story:
         - tmt run -n
         - tmt run --dry
     link:
-      - implemented-by: /tmt/cli/__init__.py
-      - documented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
+      - documented-by: /tmt/cli
       - verified-by: /tests/core/dry

--- a/stories/cli/init.fmf
+++ b/stories/cli/init.fmf
@@ -1,7 +1,7 @@
 story: As a user I want to start using tmt in my git repository.
 summary: Initialize a new metadata tree
 link:
-  - implemented-by: /tmt/cli.py
+  - implemented-by: /tmt/cli/__init__.py
   - verified-by: /tests/unit/.*/basic
 
 /empty:

--- a/stories/cli/init.fmf
+++ b/stories/cli/init.fmf
@@ -1,7 +1,7 @@
 story: As a user I want to start using tmt in my git repository.
 summary: Initialize a new metadata tree
 link:
-  - implemented-by: /tmt/cli/__init__.py
+  - implemented-by: /tmt/cli
   - verified-by: /tests/unit/.*/basic
 
 /empty:

--- a/stories/cli/plan.fmf
+++ b/stories/cli/plan.fmf
@@ -4,7 +4,7 @@ story: 'As a user I want to comfortably work with plans'
     story: 'List available plans'
     example: tmt plan ls
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - verified-by: /tests/core/ls
       - documented-by: /docs/examples.rst#explore-plans
 
@@ -12,7 +12,7 @@ story: 'As a user I want to comfortably work with plans'
     story: 'Show plan configuration'
     example: tmt plan show
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - documented-by: /docs/examples.rst#explore-plans
       - verified-by: /tests/plan/select
 
@@ -41,7 +41,7 @@ story: 'As a user I want to comfortably work with plans'
         present and that all attributes have correct type.
     example: tmt plan lint
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - verified-by: /tests/lint/plan
 
 /create:
@@ -54,6 +54,6 @@ story: 'As a user I want to comfortably work with plans'
         - tmt plan create /plans/smoke --template=mini
         - tmt plan create /plans/features --template=full
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - documented-by: /docs/examples.rst#create-plans
       - verified-by: /tests/plan/create

--- a/stories/cli/plan.fmf
+++ b/stories/cli/plan.fmf
@@ -4,7 +4,7 @@ story: 'As a user I want to comfortably work with plans'
     story: 'List available plans'
     example: tmt plan ls
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - verified-by: /tests/core/ls
       - documented-by: /docs/examples.rst#explore-plans
 
@@ -12,7 +12,7 @@ story: 'As a user I want to comfortably work with plans'
     story: 'Show plan configuration'
     example: tmt plan show
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - documented-by: /docs/examples.rst#explore-plans
       - verified-by: /tests/plan/select
 
@@ -41,7 +41,7 @@ story: 'As a user I want to comfortably work with plans'
         present and that all attributes have correct type.
     example: tmt plan lint
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - verified-by: /tests/lint/plan
 
 /create:
@@ -54,6 +54,6 @@ story: 'As a user I want to comfortably work with plans'
         - tmt plan create /plans/smoke --template=mini
         - tmt plan create /plans/features --template=full
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - documented-by: /docs/examples.rst#create-plans
       - verified-by: /tests/plan/create

--- a/stories/cli/story.fmf
+++ b/stories/cli/story.fmf
@@ -4,7 +4,7 @@ story: 'As a developer I want to comfortably work with stories'
     story: 'List available stories'
     example: tmt story ls
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - verified-by: /tests/core/ls
       - documented-by: /docs/examples.rst#explore-stories
 
@@ -12,7 +12,7 @@ story: 'As a developer I want to comfortably work with stories'
     story: 'Show story details'
     example: tmt story show
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - documented-by: /docs/examples.rst#explore-stories
 
 /filter:
@@ -33,7 +33,7 @@ story: 'As a developer I want to comfortably work with stories'
         - tmt story ls --documented
         - tmt story ls --undocumented
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - documented-by: /docs/examples.rst#filter-stories
 
 /create:
@@ -46,7 +46,7 @@ story: 'As a developer I want to comfortably work with stories'
         - tmt story create /stories/area/story --template mini
         - tmt story create /stories/area/story --template mini --force
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - documented-by: /docs/examples.rst#create-stories
 
 /coverage:
@@ -56,7 +56,7 @@ story: 'As a developer I want to comfortably work with stories'
         have been implemented, are covered by tests and
         documented and which still need work to be done.
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - documented-by: /docs/examples.rst#story-coverage
 
     /overview:
@@ -93,7 +93,7 @@ story: 'As a developer I want to comfortably work with stories'
             So that they can be included in tmt documentation.
         example: tmt story export --rst
         link:
-          - implemented-by: /tmt/cli.py
+          - implemented-by: /tmt/cli/__init__.py
           - implemented-by: /tmt/base.py
 
     /html:

--- a/stories/cli/story.fmf
+++ b/stories/cli/story.fmf
@@ -4,7 +4,7 @@ story: 'As a developer I want to comfortably work with stories'
     story: 'List available stories'
     example: tmt story ls
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - verified-by: /tests/core/ls
       - documented-by: /docs/examples.rst#explore-stories
 
@@ -12,7 +12,7 @@ story: 'As a developer I want to comfortably work with stories'
     story: 'Show story details'
     example: tmt story show
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - documented-by: /docs/examples.rst#explore-stories
 
 /filter:
@@ -33,7 +33,7 @@ story: 'As a developer I want to comfortably work with stories'
         - tmt story ls --documented
         - tmt story ls --undocumented
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - documented-by: /docs/examples.rst#filter-stories
 
 /create:
@@ -46,7 +46,7 @@ story: 'As a developer I want to comfortably work with stories'
         - tmt story create /stories/area/story --template mini
         - tmt story create /stories/area/story --template mini --force
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - documented-by: /docs/examples.rst#create-stories
 
 /coverage:
@@ -56,7 +56,7 @@ story: 'As a developer I want to comfortably work with stories'
         have been implemented, are covered by tests and
         documented and which still need work to be done.
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - documented-by: /docs/examples.rst#story-coverage
 
     /overview:
@@ -93,7 +93,7 @@ story: 'As a developer I want to comfortably work with stories'
             So that they can be included in tmt documentation.
         example: tmt story export --rst
         link:
-          - implemented-by: /tmt/cli/__init__.py
+          - implemented-by: /tmt/cli
           - implemented-by: /tmt/base.py
 
     /html:

--- a/stories/cli/test.fmf
+++ b/stories/cli/test.fmf
@@ -4,7 +4,7 @@ story: 'As a user I want to comfortably work with tests'
     story: 'List available tests'
     example: tmt test ls
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - verified-by: /tests/core/ls
       - documented-by: /docs/examples.rst#explore-tests
 
@@ -12,7 +12,7 @@ story: 'As a user I want to comfortably work with tests'
     story: 'Show test metadata'
     example: tmt test show
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - documented-by: /docs/examples.rst#explore-tests
 
 /lint:
@@ -23,7 +23,7 @@ story: 'As a user I want to comfortably work with tests'
         present and that all attributes have correct type.
     example: tmt test lint
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - documented-by: /docs/examples.rst#lint-tests
 
 /create:
@@ -40,7 +40,7 @@ story: 'As a user I want to comfortably work with tests'
         - tmt test create /tests/area/feature --skeleton beakerlib
         - tmt test create /tests/area/feature --duration=1h
     link:
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli/__init__.py
       - documented-by: /docs/examples.rst#create-tests
 
 /import:

--- a/stories/cli/test.fmf
+++ b/stories/cli/test.fmf
@@ -4,7 +4,7 @@ story: 'As a user I want to comfortably work with tests'
     story: 'List available tests'
     example: tmt test ls
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - verified-by: /tests/core/ls
       - documented-by: /docs/examples.rst#explore-tests
 
@@ -12,7 +12,7 @@ story: 'As a user I want to comfortably work with tests'
     story: 'Show test metadata'
     example: tmt test show
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - documented-by: /docs/examples.rst#explore-tests
 
 /lint:
@@ -23,7 +23,7 @@ story: 'As a user I want to comfortably work with tests'
         present and that all attributes have correct type.
     example: tmt test lint
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - documented-by: /docs/examples.rst#lint-tests
 
 /create:
@@ -40,7 +40,7 @@ story: 'As a user I want to comfortably work with tests'
         - tmt test create /tests/area/feature --skeleton beakerlib
         - tmt test create /tests/area/feature --duration=1h
     link:
-      - implemented-by: /tmt/cli/__init__.py
+      - implemented-by: /tmt/cli
       - documented-by: /docs/examples.rst#create-tests
 
 /import:

--- a/stories/cli/try.fmf
+++ b/stories/cli/try.fmf
@@ -174,4 +174,4 @@ link:
             - tmt try fedora@virtual --arch aarch64
 
         link:
-          - implemented-by: /tmt/cli.py
+          - implemented-by: /tmt/cli

--- a/stories/cli/usability.fmf
+++ b/stories/cli/usability.fmf
@@ -10,7 +10,7 @@ story:
             - tmt st sh
             - tmt s s
         link:
-          - implemented-by: /tmt/cli.py
+          - implemented-by: /tmt/cli/__init__.py
 
     /options:
         summary: Allow option abbreviation

--- a/stories/cli/usability.fmf
+++ b/stories/cli/usability.fmf
@@ -10,7 +10,7 @@ story:
             - tmt st sh
             - tmt s s
         link:
-          - implemented-by: /tmt/cli/__init__.py
+          - implemented-by: /tmt/cli
 
     /options:
         summary: Allow option abbreviation

--- a/stories/docs.fmf
+++ b/stories/docs.fmf
@@ -16,7 +16,7 @@ story:
         - tmt test import --help
     link:
       - verified-by: /tests/core/docs
-      - implemented-by: /tmt/cli.py
+      - implemented-by: /tmt/cli
 
 /man:
     story:

--- a/stories/features/feeling-safe.fmf
+++ b/stories/features/feeling-safe.fmf
@@ -33,6 +33,6 @@ description: |
 # example:
 
 link:
-  - implemented-by: /tmt/cli.py
+  - implemented-by: /tmt/cli
   - implemented-by: /tmt/base.py
   - verified-by: /tests/core/feeling-safe

--- a/tests/integration/test_nitrate.py
+++ b/tests/integration/test_nitrate.py
@@ -9,7 +9,7 @@ from requre import RequreTestCase
 from ruamel.yaml import YAML
 
 import tmt.base
-import tmt.cli
+import tmt.cli._root
 import tmt.log
 from tests import CliRunner
 from tmt.utils import ConvertError, Path
@@ -53,7 +53,7 @@ class NitrateExport(Base):
         os.chdir(self.tmpdir / "new_testcase")
         runner = CliRunner()
         self.runner_output = runner.invoke(
-            tmt.cli.main,
+            tmt.cli._root.main,
             ["test", "export", "--how", "nitrate", "--ignore-git-validation",
              "--create", "--general", "--append-summary", "."],
             catch_exceptions=False)
@@ -68,7 +68,7 @@ class NitrateExport(Base):
         os.chdir(self.tmpdir / "new_testcase")
         runner = CliRunner()
         self.runner_output = runner.invoke(
-            tmt.cli.main,
+            tmt.cli._root.main,
             ["test", "export", "--how", "nitrate", "--ignore-git-validation",
              "--create", "--dry", "--general", "--append-summary", "."],
             catch_exceptions=False)
@@ -84,7 +84,7 @@ class NitrateExport(Base):
         os.chdir(self.tmpdir / "existing_testcase")
         runner = CliRunner()
         self.runner_output = runner.invoke(
-            tmt.cli.main,
+            tmt.cli._root.main,
             ["test", "export", "--how", "nitrate", "--ignore-git-validation",
              "--create", "--general", "--append-summary", "."],
             catch_exceptions=False)
@@ -97,7 +97,7 @@ class NitrateExport(Base):
         os.chdir(self.tmpdir / "existing_dryrun_testcase")
         runner = CliRunner()
         self.runner_output = runner.invoke(
-            tmt.cli.main,
+            tmt.cli._root.main,
             ["test", "export", "--how", "nitrate", "--ignore-git-validation",
              "--debug", "--dry", "--general", "--bugzilla", "--append-summary", "."],
             catch_exceptions=False)
@@ -109,7 +109,7 @@ class NitrateExport(Base):
 
         os.chdir(self.tmpdir / "existing_dryrun_release_testcase")
         runner = CliRunner()
-        self.runner_output = runner.invoke(tmt.cli.main,
+        self.runner_output = runner.invoke(tmt.cli._root.main,
                                            ["test",
                                             "export",
                                             "--how",
@@ -135,7 +135,7 @@ class NitrateExport(Base):
 
         os.chdir(self.tmpdir / "existing_testcase")
         runner = CliRunner()
-        self.runner_output = runner.invoke(tmt.cli.main,
+        self.runner_output = runner.invoke(tmt.cli._root.main,
                                            ["test",
                                             "export",
                                             "--how",
@@ -152,7 +152,7 @@ class NitrateExport(Base):
         runner = CliRunner()
         with pytest.raises(ConvertError):
             self.runner_output = runner.invoke(
-                tmt.cli.main,
+                tmt.cli._root.main,
                 ["test", "export", "--how", "nitrate",
                  "--debug", "--dry", "."],
                 catch_exceptions=False)
@@ -165,7 +165,7 @@ class NitrateExport(Base):
         runner = CliRunner()
         with pytest.raises(ConvertError) as error:
             self.runner_output = runner.invoke(
-                tmt.cli.main,
+                tmt.cli._root.main,
                 ["test", "export", "--nitrate", "--debug", "--dry", "--append-summary", "."],
                 catch_exceptions=False)
         assert "Uncommitted changes" in str(error.value)
@@ -179,7 +179,7 @@ class NitrateExport(Base):
         runner = CliRunner()
 
         self.runner_output = runner.invoke(
-            tmt.cli.main,
+            tmt.cli._root.main,
             ["test", "export", "--nitrate", "--debug", "--ignore-git-validation",
              "--append-summary", "."],
             catch_exceptions=False)
@@ -193,7 +193,7 @@ class NitrateImport(Base):
         runner = CliRunner()
         # TODO: import does not respect --root param anyhow (could)
         self.runner_output = runner.invoke(
-            tmt.cli.main,
+            tmt.cli._root.main,
             ['-vvvvdddd', '--root', self.tmpdir / "import_case",
              "test", "import", "--no-general", "--nitrate", "--manual", "--case=609704"],
             catch_exceptions=False)
@@ -220,8 +220,9 @@ class NitrateImport(Base):
     def test_import_manual_proposed(self):
         runner = CliRunner()
         self.runner_output = runner.invoke(
-            tmt.cli.main, ['--root', self.tmpdir / "import_case", "test",
-                           "import", "--no-general", "--nitrate", "--manual", "--case=609705"],
+            tmt.cli._root.main, ['--root', self.tmpdir / "import_case", "test",
+                                 "import", "--no-general", "--nitrate", "--manual",
+                                 "--case=609705"],
             catch_exceptions=False)
         assert self.runner_output.exit_code == 0
         # TODO: This is strange, expect at least some output in
@@ -297,7 +298,7 @@ extra-task: /tmt/integration
         assert "test.md" not in files
         runner = CliRunner()
         self.runner_output = runner.invoke(
-            tmt.cli.main, [
+            tmt.cli._root.main, [
                 "test", "import", "--nitrate"], catch_exceptions=False)
         assert self.runner_output.exit_code == 0
         files = os.listdir()
@@ -318,7 +319,7 @@ extra-task: /tmt/integration
         assert files == ["Makefile"]
         runner = CliRunner()
         self.runner_output = runner.invoke(
-            tmt.cli.main, [
+            tmt.cli._root.main, [
                 "test", "import", "--nitrate", "--no-general"], catch_exceptions=False)
         assert self.runner_output.exit_code == 0
 

--- a/tests/integration/test_polarion.py
+++ b/tests/integration/test_polarion.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from fmf import Tree
 
-import tmt.cli
+import tmt.cli._root
 from tests import CliRunner
 from tmt.identifier import ID_KEY
 
@@ -20,7 +20,7 @@ class PolarionExport(Base):
 
         os.chdir(self.tmpdir / "new_testcase")
         runner = CliRunner()
-        self.runner_output = runner.invoke(tmt.cli.main, [
+        self.runner_output = runner.invoke(tmt.cli._root.main, [
             "test", "export", "--how", "polarion", "--project-id",
             "RHIVOS", "--create", "."])
         # Reload the node data to see if it appears there
@@ -34,7 +34,7 @@ class PolarionExport(Base):
         os.chdir(self.tmpdir / "new_testcase")
         runner = CliRunner()
         self.runner_output = runner.invoke(
-            tmt.cli.main,
+            tmt.cli._root.main,
             ["test", "export", "--how", "polarion", "--create", "--dry", "."],
             catch_exceptions=False)
         fmf_node = Tree(self.tmpdir).find("/new_testcase")
@@ -48,7 +48,7 @@ class PolarionExport(Base):
 
         os.chdir(self.tmpdir / "existing_testcase")
         runner = CliRunner()
-        self.runner_output = runner.invoke(tmt.cli.main, [
+        self.runner_output = runner.invoke(tmt.cli._root.main, [
             "test", "export", "--how", "polarion", "--project-id",
             "RHIVOS", "--create", "."])
 
@@ -62,7 +62,7 @@ class PolarionExport(Base):
         os.chdir(self.tmpdir / "existing_dryrun_testcase")
         runner = CliRunner()
         self.runner_output = runner.invoke(
-            tmt.cli.main,
+            tmt.cli._root.main,
             ["test", "export", "--how", "polarion", "--debug", "--dry",
              "--bugzilla", "."],
             catch_exceptions=False)
@@ -74,7 +74,7 @@ class PolarionExport(Base):
 
         os.chdir(self.tmpdir / "existing_testcase")
         runner = CliRunner()
-        self.runner_output = runner.invoke(tmt.cli.main, [
+        self.runner_output = runner.invoke(tmt.cli._root.main, [
             "test", "export", "--how", "polarion", "--project-id",
             "RHIVOS", "--bugzilla", "."])
         assert self.runner_output.exit_code == 0

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -7,7 +7,7 @@ import jsonschema
 import pytest
 
 import tmt
-import tmt.cli
+import tmt.cli._root
 import tmt.result
 from tests import CliRunner
 from tmt.base import FmfId, Link, LinkNeedle, Links, expand_node_data
@@ -21,10 +21,10 @@ def test_invalid_yaml_syntax():
     tmp = tempfile.mkdtemp()
     original_directory = os.getcwd()
     os.chdir(tmp)
-    result = runner.invoke(tmt.cli.main, ['init', '--template', 'mini'])
+    result = runner.invoke(tmt.cli._root.main, ['init', '--template', 'mini'])
     with open('plans/example.fmf', 'a') as plan:
         plan.write('bad line')
-    result = runner.invoke(tmt.cli.main)
+    result = runner.invoke(tmt.cli._root.main)
     assert isinstance(result.exception, tmt.utils.GeneralError)
     assert result.exit_code != 0
     os.chdir(original_directory)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -7,7 +7,7 @@ import tempfile
 import _pytest.monkeypatch
 import pytest
 
-import tmt.cli
+import tmt.cli._root
 import tmt.log
 from tests import CliRunner
 from tmt.utils import Path
@@ -28,7 +28,7 @@ def test_mini():
     """ Minimal smoke test """
     tmp = tempfile.mkdtemp()
     result = runner.invoke(
-        tmt.cli.main,
+        tmt.cli._root.main,
         ['--root', example('mini'), 'run', '-i', tmp, '-dv', 'discover'])
     assert result.exit_code == 0
     assert 'Found 1 plan.' in result.output
@@ -42,24 +42,24 @@ def test_init():
     tmp = tempfile.mkdtemp()
     original_directory = os.getcwd()
     os.chdir(tmp)
-    result = runner.invoke(tmt.cli.main, ['init'])
+    result = runner.invoke(tmt.cli._root.main, ['init'])
     assert 'Initialized the fmf tree root' in result.output
-    result = runner.invoke(tmt.cli.main, ['init'])
+    result = runner.invoke(tmt.cli._root.main, ['init'])
     assert 'already exists' in result.output
-    result = runner.invoke(tmt.cli.main, ['init', '--template', 'mini'])
+    result = runner.invoke(tmt.cli._root.main, ['init', '--template', 'mini'])
     assert 'plans/example' in result.output
-    result = runner.invoke(tmt.cli.main, ['init', '--template', 'mini'])
+    result = runner.invoke(tmt.cli._root.main, ['init', '--template', 'mini'])
     assert result.exception
-    result = runner.invoke(tmt.cli.main, ['init', '--template', 'full',
-                                          '--force'])
+    result = runner.invoke(tmt.cli._root.main, ['init', '--template', 'full',
+                                                '--force'])
     assert 'overwritten' in result.output
     # tmt init --template mini in a clean directory
     os.system('rm -rf .fmf *')
-    result = runner.invoke(tmt.cli.main, ['init', '--template', 'mini'])
+    result = runner.invoke(tmt.cli._root.main, ['init', '--template', 'mini'])
     assert 'plans/example' in result.output
     # tmt init --template full in a clean directory
     os.system('rm -rf .fmf *')
-    result = runner.invoke(tmt.cli.main, ['init', '--template', 'full'])
+    result = runner.invoke(tmt.cli._root.main, ['init', '--template', 'full'])
     assert 'tests/example' in result.output
     os.chdir(original_directory)
     shutil.rmtree(tmp)
@@ -82,7 +82,7 @@ def test_create():
         'story create -t full test',
         ]
     for command in commands:
-        result = runner.invoke(tmt.cli.main, command.split())
+        result = runner.invoke(tmt.cli._root.main, command.split())
         assert result.exit_code == 0
         os.system('rm -rf *')
     # Test directory cleanup
@@ -95,7 +95,8 @@ def test_step():
     for step in ['discover', 'provision', 'prepare']:
         tmp = tempfile.mkdtemp()
         result = runner.invoke(
-            tmt.cli.main, ['--feeling-safe', '--root', example('local'), 'run', '-i', tmp, step])
+            tmt.cli._root.main,
+            ['--feeling-safe', '--root', example('local'), 'run', '-i', tmp, step])
         assert result.exit_code == 0
         assert step in result.output
         assert 'finish' not in result.output
@@ -108,7 +109,7 @@ def test_step_execute():
     step = 'execute'
 
     result = runner.invoke(
-        tmt.cli.main, ['--root', example('local'), 'run', '-i', tmp, step])
+        tmt.cli._root.main, ['--root', example('local'), 'run', '-i', tmp, step])
 
     # Test execute empty with discover output missing
     assert result.exit_code != 0
@@ -123,11 +124,11 @@ def test_step_execute():
 def test_systemd():
     """ Check systemd example """
     result = runner.invoke(
-        tmt.cli.main, ['--root', example('systemd'), 'plan'])
+        tmt.cli._root.main, ['--root', example('systemd'), 'plan'])
     assert result.exit_code == 0
     assert 'Found 2 plans' in result.output
     result = runner.invoke(
-        tmt.cli.main, ['--root', example('systemd'), 'plan', 'show'])
+        tmt.cli._root.main, ['--root', example('systemd'), 'plan', 'show'])
     assert result.exit_code == 0
     assert 'Tier two functional tests' in result.output
 

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 import fmf
 
 import tmt
-import tmt.cli
+import tmt.cli._root
 import tmt.log
 from tests import CliRunner
 from tmt.identifier import ID_KEY
@@ -66,10 +66,10 @@ class TestGeneratorDefined(TestCase):
 
     def test_test_dry(self):
         result = runner.invoke(
-            tmt.cli.main, ["test", "id", "--dry", "^/no"])
+            tmt.cli._root.main, ["test", "id", "--dry", "^/no"])
         assert "added to test '/no" in result.output
         result = runner.invoke(
-            tmt.cli.main, ["test", "id", "--dry", "^/no"])
+            tmt.cli._root.main, ["test", "id", "--dry", "^/no"])
         assert "added to test '/no" in result.output
 
     def test_test_real(self):
@@ -78,9 +78,9 @@ class TestGeneratorDefined(TestCase):
         assert node.get(ID_KEY) is None
 
         # Generate only when called for the first time
-        result = runner.invoke(tmt.cli.main, ["test", "id", "^/no"])
+        result = runner.invoke(tmt.cli._root.main, ["test", "id", "^/no"])
         assert "added to test '/no" in result.output
-        result = runner.invoke(tmt.cli.main, ["test", "id", "^/no"])
+        result = runner.invoke(tmt.cli._root.main, ["test", "id", "^/no"])
         assert "added to test '/no" not in result.output
 
         # Defined after
@@ -102,17 +102,17 @@ class TestGeneratorEmpty(TestCase):
 
     def test_test_dry(self):
         result = runner.invoke(
-            tmt.cli.main, ["test", "id", "--dry"])
+            tmt.cli._root.main, ["test", "id", "--dry"])
         assert "added to test '/some/structure'" in result.output
         result = runner.invoke(
-            tmt.cli.main, ["test", "id", "--dry"])
+            tmt.cli._root.main, ["test", "id", "--dry"])
         assert "added to test '/some/structure'" in result.output
 
     def test_test_real(self):
-        result = runner.invoke(tmt.cli.main, ["test", "id"])
+        result = runner.invoke(tmt.cli._root.main, ["test", "id"])
         assert "added to test '/some/structure'" in result.output
 
-        result = runner.invoke(tmt.cli.main, ["test", "id"])
+        result = runner.invoke(tmt.cli._root.main, ["test", "id"])
         assert "added to test '/some/structure'" not in result.output
 
         base_tree = fmf.Tree(self.path)

--- a/tests/unit/test_try.py
+++ b/tests/unit/test_try.py
@@ -18,4 +18,4 @@ import tmt.cli
     )
 def test_options_arch(params: dict[str, Any], expected: dict[str, Any]):
 
-    assert tmt.cli._construct_trying_provision_options(params) == expected
+    assert tmt.cli._root._construct_trying_provision_options(params) == expected

--- a/tmt/__main__.py
+++ b/tmt/__main__.py
@@ -14,8 +14,14 @@ def run_cli() -> None:
     """
     try:
         import tmt.utils  # noqa: I001
-        import tmt.cli
-        tmt.cli.main()
+
+        # Import CLI commands.
+        # TODO: some kind of `import tmt.cli.*` would be nice
+        import tmt.cli._root
+        import tmt.cli.status
+
+        tmt.cli._root.main()
+
     except ImportError as error:
         print("Error: tmt package does not seem to be installed")
         raise SystemExit(1) from error

--- a/tmt/_pre_commit/__main__.py
+++ b/tmt/_pre_commit/__main__.py
@@ -47,7 +47,7 @@ def _run_precommit() -> None:  # pyright: ignore[reportUnusedFunction] (used by 
             # ["tmt", "tests", "lint", "--fix", "--root", "/some/path", "some_file"]
             # - argv[0]: name of the program is always first
             #   ["tmt"]
-            # - argv[indx:indx+1+nargs]: args to move (pass to `tmt.cli.main`)
+            # - argv[indx:indx+1+nargs]: args to move (pass to `tmt.cli._root.main`)
             #   ["--root", "/some/path"]
             # - argv[1:indx]: all other keywords (`lint` keyword is in here)
             #   ["tests", "lint", "--fix"]

--- a/tmt/cli/__init__.py
+++ b/tmt/cli/__init__.py
@@ -16,6 +16,7 @@ import tmt.base
 import tmt.log
 import tmt.plugins
 import tmt.utils
+import tmt.utils.rest
 
 if TYPE_CHECKING:
     from tmt._compat.typing import Concatenate, ParamSpec
@@ -231,7 +232,7 @@ class HelpFormatter(click.HelpFormatter):
             col_max: int = 30,
             col_spacing: int = 2) -> None:
         rows = [
-            (option, tmt.utils.render_rst(help, _BOOTSTRAP_LOGGER))
+            (option, tmt.utils.rest.render_rst(help, _BOOTSTRAP_LOGGER))
             for option, help in rows
             ]
 

--- a/tmt/cli/__init__.py
+++ b/tmt/cli/__init__.py
@@ -1,0 +1,241 @@
+""" Basic classes and code for tmt command line interface """
+
+import collections
+import dataclasses
+import enum
+import functools
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar
+
+import click
+import fmf
+import fmf.utils
+
+import tmt
+import tmt.base
+import tmt.log
+import tmt.plugins
+import tmt.utils
+
+if TYPE_CHECKING:
+    from tmt._compat.typing import Concatenate, ParamSpec
+
+    P = ParamSpec('P')
+    R = TypeVar('R')
+
+
+#: A logger to use before the proper one can be established.
+#:
+#: .. warning::
+#:
+#:    This logger should be used with utmost care for logging while tmt
+#:    is still starting. Once properly configured logger is spawned,
+#:    honoring relevant options, this logger should not be used anymore.
+_BOOTSTRAP_LOGGER = tmt.log.Logger.get_bootstrap_logger()
+
+#: A logger to use for exception logging.
+#:
+#: .. warning::
+#:
+#:    This logger should be used with utmost care for logging exceptions
+#:    only, no other traffic should be allowed. On top of that, the
+#:    exception logging is handled by a dedicated function,
+#:    :py:func:`tmt.utils.show_exception` - if you find yourself in need
+#:    of logging an exception somewhere in the code, and you think about
+#:    using this logger or calling ``show_exception()`` explicitly,
+#:    it is highly likely you are not on the right track.
+EXCEPTION_LOGGER: tmt.log.Logger = _BOOTSTRAP_LOGGER
+
+
+# Explore available plugins (need to detect all supported methods first)
+tmt.plugins.explore(_BOOTSTRAP_LOGGER)
+
+
+class TmtExitCode(enum.IntEnum):
+    # Quoting the specification:
+
+    #: At least one test passed, there was no fail, warn or error.
+    SUCCESS = 0
+
+    #: There was a fail or warn identified, but no error.
+    FAIL = 1
+
+    #: Errors occurred during test execution.
+    ERROR = 2
+
+    #: No test results found.
+    NO_RESULTS_FOUND = 3
+
+    #: Tests were executed, and all reported the ``skip`` result.
+    ALL_TESTS_SKIPPED = 4
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Click Context Object Container
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+@dataclasses.dataclass
+class ContextObject:
+    """
+    Click Context Object container.
+
+    In Click terms, this is "an arbitrary object of user data." In this container,
+    tmt CLI code stores all structures relevant for the command execution. The
+    container itself is then attached to :py:class:`click.Context` object Click
+    manages across commands.
+    """
+
+    # "Parent" Click context
+    cli_context: 'Context'
+
+    logger: tmt.log.Logger
+    common: tmt.utils.Common
+    fmf_context: tmt.utils.FmfContext
+    tree: tmt.Tree
+    steps: set[str] = dataclasses.field(default_factory=set)
+    clean: Optional[tmt.Clean] = None
+    clean_logger: Optional[tmt.log.Logger] = None
+    clean_partials: collections.defaultdict[str, list[tmt.base.CleanCallback]] = dataclasses.field(
+        default_factory=lambda: collections.defaultdict(list))
+    run: Optional[tmt.Run] = None
+
+
+class Context(click.Context):
+    """
+    Custom :py:class:`click.Context`-like class for typing purposes.
+
+    Objects of this class are never instantiated, it serves only as a type
+    stub in commands below, to simplify handling and static analysis of
+    ``context.obj``. There is no added functionality, the only change is
+    a much narrower type of ``obj`` attribute.
+
+    This class shall be used instead of the original :py:class:`click.Context`.
+    Click is obviously not aware of our type annotations, and ``context``
+    objects managed by Click would always be of type :py:class:`click.Context`,
+    we would just convince mypy their ``obj`` attribute is no longer ``Any``.
+    """
+
+    # In contrast to the original Context, we *know* we do set obj to a valid
+    # object, and every time we touch it, it should absolutely be not-None.
+    obj: ContextObject
+
+    max_content_width: Optional[int]
+
+
+def pass_context(fn: 'Callable[Concatenate[Context, P], R]') -> 'Callable[P, R]':
+    """
+    Custom :py:func:`click.pass_context`-like decorator.
+
+    Complementing the :py:class:`Context`, the goal of this decorator to
+    announce the correct type of the ``context`` parameter. The original
+    decorator annotates the parameter as ``click.Context``, but that is not
+    what our command callables accept. So, on this boundary between tmt code
+    and ``click`` API, we trick type checkers by isolating the necessary
+    ``type: ignore[arg-type]``.
+    """
+
+    return click.pass_context(fn)  # type: ignore[arg-type]
+
+
+@dataclasses.dataclass
+class CliInvocation:
+    """
+    A single CLI invocation of a tmt subcommand.
+
+    Bundles together the Click context and options derived from it.
+    A context alone might be good enough, but sometimes tmt needs to
+    modify saved options. For custom command line options injected
+    manually 'sources' is used to keep the parameter source.
+
+    Serves as a clear boundary between invocations of classes
+    representing various tmt subcommands and groups.
+    """
+
+    context: Optional[Context]
+    options: dict[str, Any]
+
+    @classmethod
+    def from_context(cls, context: Context) -> 'CliInvocation':
+        return CliInvocation(context=context, options=context.params)
+
+    @classmethod
+    def from_options(cls, options: dict[str, Any]) -> 'CliInvocation':
+        """ Inject custom options coming from the command line """
+        invocation = CliInvocation(context=None, options=options)
+
+        # ignore[reportGeneralTypeIssues]: pyright has troubles understanding it
+        # *is* possible to assign to a cached property. Might an issue of our
+        # simplified implementation.
+        # ignore[unused-ignore]: silencing mypy's complaint about silencing
+        # pyright's warning :)
+        invocation.option_sources = {  # type: ignore[reportGeneralTypeIssues,unused-ignore]
+            key: click.core.ParameterSource.COMMANDLINE
+            for key in options
+            }
+        return invocation
+
+    @functools.cached_property
+    def option_sources(self) -> dict[str, click.core.ParameterSource]:
+        if not self.context:
+            return {}
+
+        return self.context._parameter_source
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#  Custom Group
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+class CustomGroup(click.Group):
+    """ Custom Click Group """
+
+    # ignore[override]: expected, we want to use more specific `Context`
+    # type than the one declared in superclass.
+    def list_commands(self, context: Context) -> list[str]:  # type: ignore[override]
+        """ Prevent alphabetical sorting """
+        return list(self.commands.keys())
+
+    # ignore[override]: expected, we want to use more specific `Context`
+    # type than the one declared in superclass.
+    def get_command(  # type: ignore[override]
+            self,
+            context: Context,
+            cmd_name: str
+            ) -> Optional[click.Command]:
+        """ Allow command shortening """
+        # Backward-compatible 'test convert' (just temporary for now FIXME)
+        cmd_name = cmd_name.replace('convert', 'import')
+        # Support both story & stories
+        cmd_name = cmd_name.replace('story', 'stories')
+        found = click.Group.get_command(self, context, cmd_name)
+        if found is not None:
+            return found
+        matches = [command for command in self.list_commands(context)
+                   if command.startswith(cmd_name)]
+        if not matches:
+            return None
+        if len(matches) == 1:
+            return click.Group.get_command(self, context, matches[0])
+        context.fail(f"Did you mean {fmf.utils.listed(sorted(matches), join='or')}?")
+        return None
+
+
+class HelpFormatter(click.HelpFormatter):
+    """ Custom help formatter capable of rendering ReST syntax """
+
+    # Override parent implementation
+    def write_dl(
+            self,
+            rows: Sequence[tuple[str, str]],
+            col_max: int = 30,
+            col_spacing: int = 2) -> None:
+        rows = [
+            (option, tmt.utils.render_rst(help, _BOOTSTRAP_LOGGER))
+            for option, help in rows
+            ]
+
+        super().write_dl(rows, col_max=col_max, col_spacing=col_spacing)
+
+
+click.Context.formatter_class = HelpFormatter

--- a/tmt/cli/_root.py
+++ b/tmt/cli/_root.py
@@ -1,13 +1,16 @@
+"""
+Main top-level command implementations.
 
-""" Command line interface for the Test Management Tool """
+.. note::
 
-import collections
-import dataclasses
-import enum
-import functools
+    We are currently refactoring :py:mod:`tmt.cli` into smaller modules.
+    As of now, this module contains vast majority of tmt commands, but
+    those will be continuously extracted until only the top-level
+    command remains.
+"""
+
 import re
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import click
 import fmf
@@ -16,6 +19,7 @@ from click import echo, style
 
 import tmt
 import tmt.base
+import tmt.cli
 import tmt.convert
 import tmt.export
 import tmt.identifier
@@ -29,6 +33,7 @@ import tmt.trying
 import tmt.utils
 import tmt.utils.jira
 import tmt.utils.rest
+from tmt.cli import CliInvocation, Context, ContextObject, CustomGroup, pass_context
 from tmt.options import Deprecated, create_options_decorator, option
 from tmt.utils import Command, Path
 
@@ -39,227 +44,6 @@ if TYPE_CHECKING:
     import tmt.steps.prepare
     import tmt.steps.provision
     import tmt.steps.report
-    from tmt._compat.typing import Concatenate, ParamSpec
-
-    P = ParamSpec('P')
-    R = TypeVar('R')
-
-
-#: A logger to use before the proper one can be established.
-#:
-#: .. warning::
-#:
-#:    This logger should be used with utmost care for logging while tmt
-#:    is still starting. Once properly configured logger is spawned,
-#:    honoring relevant options, this logger should not be used anymore.
-_BOOTSTRAP_LOGGER = tmt.log.Logger.get_bootstrap_logger()
-
-#: A logger to use for exception logging.
-#:
-#: .. warning::
-#:
-#:    This logger should be used with utmost care for logging exceptions
-#:    only, no other traffic should be allowed. On top of that, the
-#:    exception logging is handled by a dedicated function,
-#:    :py:func:`tmt.utils.show_exception` - if you find yourself in need
-#:    of logging an exception somewhere in the code, and you think about
-#:    using this logger or calling ``show_exception()`` explicitly,
-#:    it is highly likely you are not on the right track.
-EXCEPTION_LOGGER: tmt.log.Logger = _BOOTSTRAP_LOGGER
-
-
-# Explore available plugins (need to detect all supported methods first)
-tmt.plugins.explore(_BOOTSTRAP_LOGGER)
-
-
-class TmtExitCode(enum.IntEnum):
-    # Quoting the specification:
-
-    #: At least one test passed, there was no fail, warn or error.
-    SUCCESS = 0
-
-    #: There was a fail or warn identified, but no error.
-    FAIL = 1
-
-    #: Errors occurred during test execution.
-    ERROR = 2
-
-    #: No test results found.
-    NO_RESULTS_FOUND = 3
-
-    #: Tests were executed, and all reported the ``skip`` result.
-    ALL_TESTS_SKIPPED = 4
-
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#  Click Context Object Container
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
-@dataclasses.dataclass
-class ContextObject:
-    """
-    Click Context Object container.
-
-    In Click terms, this is "an arbitrary object of user data." In this container,
-    tmt CLI code stores all structures relevant for the command execution. The
-    container itself is then attached to :py:class:`click.Context` object Click
-    manages across commands.
-    """
-
-    # "Parent" Click context
-    cli_context: 'Context'
-
-    logger: tmt.log.Logger
-    common: tmt.utils.Common
-    fmf_context: tmt.utils.FmfContext
-    tree: tmt.Tree
-    steps: set[str] = dataclasses.field(default_factory=set)
-    clean: Optional[tmt.Clean] = None
-    clean_logger: Optional[tmt.log.Logger] = None
-    clean_partials: collections.defaultdict[str, list[tmt.base.CleanCallback]] = dataclasses.field(
-        default_factory=lambda: collections.defaultdict(list))
-    run: Optional[tmt.Run] = None
-
-
-class Context(click.Context):
-    """
-    Custom :py:class:`click.Context`-like class for typing purposes.
-
-    Objects of this class are never instantiated, it serves only as a type
-    stub in commands below, to simplify handling and static analysis of
-    ``context.obj``. There is no added functionality, the only change is
-    a much narrower type of ``obj`` attribute.
-
-    This class shall be used instead of the original :py:class:`click.Context`.
-    Click is obviously not aware of our type annotations, and ``context``
-    objects managed by Click would always be of type :py:class:`click.Context`,
-    we would just convince mypy their ``obj`` attribute is no longer ``Any``.
-    """
-
-    # In contrast to the original Context, we *know* we do set obj to a valid
-    # object, and every time we touch it, it should absolutely be not-None.
-    obj: ContextObject
-
-    max_content_width: Optional[int]
-
-
-def pass_context(fn: 'Callable[Concatenate[Context, P], R]') -> 'Callable[P, R]':
-    """
-    Custom :py:func:`click.pass_context`-like decorator.
-
-    Complementing the :py:class:`Context`, the goal of this decorator to
-    announce the correct type of the ``context`` parameter. The original
-    decorator annotates the parameter as ``click.Context``, but that is not
-    what our command callables accept. So, on this boundary between tmt code
-    and ``click`` API, we trick type checkers by isolating the necessary
-    ``type: ignore[arg-type]``.
-    """
-
-    return click.pass_context(fn)  # type: ignore[arg-type]
-
-
-@dataclasses.dataclass
-class CliInvocation:
-    """
-    A single CLI invocation of a tmt subcommand.
-
-    Bundles together the Click context and options derived from it.
-    A context alone might be good enough, but sometimes tmt needs to
-    modify saved options. For custom command line options injected
-    manually 'sources' is used to keep the parameter source.
-
-    Serves as a clear boundary between invocations of classes
-    representing various tmt subcommands and groups.
-    """
-
-    context: Optional[Context]
-    options: dict[str, Any]
-
-    @classmethod
-    def from_context(cls, context: Context) -> 'CliInvocation':
-        return CliInvocation(context=context, options=context.params)
-
-    @classmethod
-    def from_options(cls, options: dict[str, Any]) -> 'CliInvocation':
-        """ Inject custom options coming from the command line """
-        invocation = CliInvocation(context=None, options=options)
-
-        # ignore[reportGeneralTypeIssues]: pyright has troubles understanding it
-        # *is* possible to assign to a cached property. Might an issue of our
-        # simplified implementation.
-        # ignore[unused-ignore]: silencing mypy's complaint about silencing
-        # pyright's warning :)
-        invocation.option_sources = {  # type: ignore[reportGeneralTypeIssues,unused-ignore]
-            key: click.core.ParameterSource.COMMANDLINE
-            for key in options
-            }
-        return invocation
-
-    @functools.cached_property
-    def option_sources(self) -> dict[str, click.core.ParameterSource]:
-        if not self.context:
-            return {}
-
-        return self.context._parameter_source
-
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#  Custom Group
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-class CustomGroup(click.Group):
-    """ Custom Click Group """
-
-    # ignore[override]: expected, we want to use more specific `Context`
-    # type than the one declared in superclass.
-    def list_commands(self, context: Context) -> list[str]:  # type: ignore[override]
-        """ Prevent alphabetical sorting """
-        return list(self.commands.keys())
-
-    # ignore[override]: expected, we want to use more specific `Context`
-    # type than the one declared in superclass.
-    def get_command(  # type: ignore[override]
-            self,
-            context: Context,
-            cmd_name: str
-            ) -> Optional[click.Command]:
-        """ Allow command shortening """
-        # Backward-compatible 'test convert' (just temporary for now FIXME)
-        cmd_name = cmd_name.replace('convert', 'import')
-        # Support both story & stories
-        cmd_name = cmd_name.replace('story', 'stories')
-        found = click.Group.get_command(self, context, cmd_name)
-        if found is not None:
-            return found
-        matches = [command for command in self.list_commands(context)
-                   if command.startswith(cmd_name)]
-        if not matches:
-            return None
-        if len(matches) == 1:
-            return click.Group.get_command(self, context, matches[0])
-        context.fail(f"Did you mean {fmf.utils.listed(sorted(matches), join='or')}?")
-        return None
-
-
-class HelpFormatter(click.HelpFormatter):
-    """ Custom help formatter capable of rendering ReST syntax """
-
-    # Override parent implementation
-    def write_dl(
-            self,
-            rows: Sequence[tuple[str, str]],
-            col_max: int = 30,
-            col_spacing: int = 2) -> None:
-        rows = [
-            (option, tmt.utils.rest.render_rst(help, _BOOTSTRAP_LOGGER))
-            for option, help in rows
-            ]
-
-        super().write_dl(rows, col_max=col_max, col_spacing=col_spacing)
-
-
-click.Context.formatter_class = HelpFormatter
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -355,8 +139,7 @@ def main(
     #
     # ignore[unused-ignore]: mypy does not report this issue, and the
     # ignore fools mypy into reporting the waiver as unused.
-    global EXCEPTION_LOGGER
-    EXCEPTION_LOGGER = logger  # type: ignore[reportConstantRedefinition,unused-ignore]
+    tmt.cli.EXCEPTION_LOGGER = logger  # type: ignore[reportConstantRedefinition,unused-ignore]
 
     # Save click context and fmf context for future use
     tmt.utils.Common.store_cli_invocation(click_contex)
@@ -1835,59 +1618,6 @@ def _construct_trying_provision_options(params: Any) -> dict[str, Any]:
         options['guest'] = options.pop('image')
 
     return options
-
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#  Status
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-@main.command()
-@pass_context
-@workdir_root_options
-@option(
-    '-i', '--id', metavar="ID", multiple=True,
-    help='Run id(name or directory path) to show status of. Can be specified multiple times.')
-@option(
-    '--abandoned', is_flag=True, default=False,
-    help='List runs which have provision step completed but finish step not yet done.')
-@option(
-    '--active', is_flag=True, default=False,
-    help='List runs where at least one of the enabled steps has not been finished.')
-@option(
-    '--finished', is_flag=True, default=False,
-    help='List all runs which have all enabled steps completed.')
-@verbosity_options
-def status(
-        context: Context,
-        workdir_root: str,
-        abandoned: bool,
-        active: bool,
-        finished: bool,
-        **kwargs: Any) -> None:
-    """
-    Show status of runs.
-
-    Lists past runs in the given directory filtered using options.
-    /var/tmp/tmt is used by default.
-
-    By default, status of the whole runs is listed. With more
-    verbosity (-v), status of every plan is shown. By default,
-    the last completed step is displayed, 'done' is used when
-    all enabled steps are completed. Status of every step is
-    displayed with the most verbosity (-vv).
-
-    """
-    if [abandoned, active, finished].count(True) > 1:
-        raise tmt.utils.GeneralError(
-            "Options --abandoned, --active and --finished cannot be "
-            "used together.")
-    if not Path(workdir_root).exists():
-        raise tmt.utils.GeneralError(f"Path '{workdir_root}' doesn't exist.")
-
-    status_obj = tmt.Status(
-        logger=context.obj.logger.clone().apply_verbosity_options(**kwargs),
-        cli_invocation=CliInvocation.from_context(context))
-    status_obj.show()
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tmt/cli/status.py
+++ b/tmt/cli/status.py
@@ -1,0 +1,58 @@
+""" ``tmt status`` implementation """
+
+from typing import Any
+
+import tmt.utils
+from tmt.cli import CliInvocation, Context, pass_context
+from tmt.cli._root import main, verbosity_options, workdir_root_options
+from tmt.options import option
+from tmt.utils import Path
+
+
+@main.command()
+@pass_context
+@workdir_root_options
+@option(
+    '-i', '--id', metavar="ID", multiple=True,
+    help='Run id(name or directory path) to show status of. Can be specified multiple times.')
+@option(
+    '--abandoned', is_flag=True, default=False,
+    help='List runs which have provision step completed but finish step not yet done.')
+@option(
+    '--active', is_flag=True, default=False,
+    help='List runs where at least one of the enabled steps has not been finished.')
+@option(
+    '--finished', is_flag=True, default=False,
+    help='List all runs which have all enabled steps completed.')
+@verbosity_options
+def status(
+        context: Context,
+        workdir_root: str,
+        abandoned: bool,
+        active: bool,
+        finished: bool,
+        **kwargs: Any) -> None:
+    """
+    Show status of runs.
+
+    Lists past runs in the given directory filtered using options.
+    /var/tmp/tmt is used by default.
+
+    By default, status of the whole runs is listed. With more
+    verbosity (-v), status of every plan is shown. By default,
+    the last completed step is displayed, 'done' is used when
+    all enabled steps are completed. Status of every step is
+    displayed with the most verbosity (-vv).
+
+    """
+    if [abandoned, active, finished].count(True) > 1:
+        raise tmt.utils.GeneralError(
+            "Options --abandoned, --active and --finished cannot be "
+            "used together.")
+    if not Path(workdir_root).exists():
+        raise tmt.utils.GeneralError(f"Path '{workdir_root}' doesn't exist.")
+
+    status_obj = tmt.Status(
+        logger=context.obj.logger.clone().apply_verbosity_options(**kwargs),
+        cli_invocation=CliInvocation.from_context(context))
+    status_obj.show()

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -873,11 +873,12 @@ class Logger:
 
             This logger has a **very** limited use case span, i.e.
             before tmt can digest its command-line options and create a
-            proper logger. This happens inside :py:func:`tmt.cli.main`
-            function, but there are some actions taken by tmt code
-            before this function is called by Click, actions that need
-            to emit logging messages. Using it anywhere outside of this
-            brief time in tmt's runtime should be ruled out.
+            proper logger. This happens inside
+            :py:func:`tmt.cli._root.main` function, but there are some
+            actions taken by tmt code before this function is called by
+            Click, actions that need to emit logging messages. Using it
+            anywhere outside of this brief time in tmt's runtime should
+            be ruled out.
         """
 
         if cls._bootstrap_logger is None:


### PR DESCRIPTION
* `tmt.cli` remains the module with utilities and basic code,
* `tmt.cli._root` contains all commands for now, but eventualy it would be just the top-level command,
* `tmt status` is moved into `tmt.cli.status` as an example of how it would look like.

Pull Request Checklist

* [x] implement the feature