### PR TITLE
Fix quay.io builds

### DIFF
--- a/containers/Containerfile.full
+++ b/containers/Containerfile.full
@@ -8,7 +8,7 @@ RUN set -x && \
 # Install necessary packages
 RUN set -x && \
     dnf install -y dnf-plugins-core && \
-    dnf copr enable -y psss/tmt && \
+    dnf copr enable -y teemtee/tmt && \
     dnf install -y tmt+all-[0-9].[0-9][0-9].[0-9]* beakerlib && \
     dnf autoremove -y && \
     dnf clean all

--- a/containers/Containerfile.mini
+++ b/containers/Containerfile.mini
@@ -8,7 +8,7 @@ RUN set -x && \
 # Install necessary packages
 RUN set -x && \
     dnf install -y dnf-plugins-core && \
-    dnf copr enable -y psss/tmt && \
+    dnf copr enable -y teemtee/tmt && \
     dnf install -y tmt-[0-9].[0-9][0-9].[0-9]* && \
     dnf autoremove -y && \
     dnf clean all

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -268,8 +268,8 @@ the latest greatest version from the ``copr`` repository::
 Not sure, just want to try out how it works? Experiment safely and
 easily inside a container::
 
-    podman run -it --rm quay.io/testing-farm/tmt bash
-    podman run -it --rm quay.io/testing-farm/tmt-all bash
+    podman run -it --rm quay.io/teemtee/tmt bash
+    podman run -it --rm quay.io/teemtee/tmt-all bash
 
 .. _pip_install:
 


### PR DESCRIPTION
Reflecting changes in quay.io repositories and move from psss/tmt to teemtee/tmt in copr.