### PR TITLE
Add a new `lint` check for empty environment files

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -12,7 +12,8 @@ The :ref:`/plugins/provision/beaker` provision plugin gains
 support for :ref:`system.model-name</spec/hardware/system>` and
 :ref:`system.vendor-name</spec/hardware/system>` hardware requirements.
 
-``tmt lint`` now reports a failure if empty environment files are found.
+The ``tmt lint`` command now reports a failure if empty
+environment files are found.
 
 
 tmt-1.38.0

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -12,6 +12,8 @@ The :ref:`/plugins/provision/beaker` provision plugin gains
 support for :ref:`system.model-name</spec/hardware/system>` and
 :ref:`system.vendor-name</spec/hardware/system>` hardware requirements.
 
+``tmt lint`` now reports a failure if empty environment files are found.
+
 
 tmt-1.38.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/lint/plan/data/empty_env_file.fmf
+++ b/tests/lint/plan/data/empty_env_file.fmf
@@ -1,0 +1,5 @@
+summary: Empty environment file plan
+environment-file:
+    - empty_env
+execute:
+    script: tmt --help

--- a/tests/lint/plan/data/empty_env_file.fmf
+++ b/tests/lint/plan/data/empty_env_file.fmf
@@ -1,5 +1,5 @@
 summary: Empty environment file plan
 environment-file:
-    - empty_env
+  - empty_env
 execute:
     script: tmt --help

--- a/tests/lint/plan/data/env
+++ b/tests/lint/plan/data/env
@@ -1,0 +1,1 @@
+test=test

--- a/tests/lint/plan/data/good.fmf
+++ b/tests/lint/plan/data/good.fmf
@@ -2,3 +2,5 @@ summary: Basic smoke test
 execute:
     script: tmt --help
 id: 9c73e336-983e-4349-9586-b63c20ea2b89
+environment-file:
+    - env

--- a/tests/lint/plan/test.sh
+++ b/tests/lint/plan/test.sh
@@ -74,7 +74,7 @@ rlJournalStart
         rlAssertGrep 'warn C000 key "wrong" not recognized by schema /schemas/prepare/feature' $rlRun_LOG
 
         rlRun -s "$tmt plan lint empty_env_file" 1
-        rlAssertGrep "fail P008 the environment file '$(pwd)/empty_env' is empty" $rlRun_LOG
+        rlAssertGrep "fail P008 the environment file '.*/tests/lint/plan/data/empty_env' is empty" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "P007: step phases require existing guests and roles"

--- a/tests/lint/plan/test.sh
+++ b/tests/lint/plan/test.sh
@@ -50,6 +50,7 @@ rlJournalStart
 
         rlRun -s "$tmt plan lint invalid_url" 1
         rlAssertGrep "fail P005 remote fmf id in \"default-0\" is invalid, repo 'http://invalid-url' cannot be cloned" $rlRun_LOG
+        rlAssertGrep "skip P008 no environment files found" $rlRun_LOG
 
         rlRun -s "$tmt plan lint invalid_ref" 1
         rlAssertGrep "fail P005 remote fmf id in \"default-0\" is invalid, git ref 'invalid-ref-123456' is invalid" $rlRun_LOG
@@ -71,6 +72,9 @@ rlJournalStart
         rlRun -s "$tmt plan lint invalid-plugin-key" 0
         rlAssertGrep 'warn C000 key "wrong" not recognized by schema$' $rlRun_LOG
         rlAssertGrep 'warn C000 key "wrong" not recognized by schema /schemas/prepare/feature' $rlRun_LOG
+
+        rlRun -s "$tmt plan lint empty_env_file" 1
+        rlAssertGrep "fail P008 the file \"$(pwd)/empty_env\" is empty" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "P007: step phases require existing guests and roles"

--- a/tests/lint/plan/test.sh
+++ b/tests/lint/plan/test.sh
@@ -74,7 +74,7 @@ rlJournalStart
         rlAssertGrep 'warn C000 key "wrong" not recognized by schema /schemas/prepare/feature' $rlRun_LOG
 
         rlRun -s "$tmt plan lint empty_env_file" 1
-        rlAssertGrep "fail P008 the file \"$(pwd)/empty_env\" is empty" $rlRun_LOG
+        rlAssertGrep "fail P008 the environment file '$(pwd)/empty_env' is empty" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "P007: step phases require existing guests and roles"

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2348,7 +2348,7 @@ class Plan(
         yield from _lint_step('finish')
 
     def lint_empty_env_files(self) -> LinterReturn:
-        """ P008: env files are not empty """
+        """ P008: environment files are not empty """
 
         env_files = self.node.get("environment-file") or []
 
@@ -2359,7 +2359,7 @@ class Plan(
         for env_file in env_files:
             env_file = (self.anchor_path / Path(env_file)).resolve()
             if not env_file.stat().st_size:
-                yield LinterOutcome.FAIL, f'the file "{env_file}" is empty'
+                yield LinterOutcome.FAIL, f"the environment file '{env_file}' is empty"
                 return
 
         yield LinterOutcome.PASS, 'no empty environment files'

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2347,6 +2347,23 @@ class Plan(
         yield from _lint_step('execute')
         yield from _lint_step('finish')
 
+    def lint_empty_env_files(self) -> LinterReturn:
+        """ P008: env files are not empty """
+
+        env_files = self.node.get("environment-file") or []
+
+        if not env_files:
+            yield LinterOutcome.SKIP, 'no environment files found'
+            return
+
+        for env_file in env_files:
+            env_file = (self.anchor_path / Path(env_file)).resolve()
+            if not env_file.stat().st_size:
+                yield LinterOutcome.FAIL, f'the file "{env_file}" is empty'
+                return
+
+        yield LinterOutcome.PASS, 'no empty environment files'
+
     def wake(self) -> None:
         """ Wake up all steps """
 


### PR DESCRIPTION
New function that raises a failure if the size of
the environment file, if this one exists, is zero.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [x] include a release note
