### PR TITLE
Update label names used for configuring packit jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -61,9 +61,9 @@ jobs:
     require: &require-full-tests
       label:
         present:
-          - full test
+          - ci | full test
         absent:
-          - discuss
+          - status | discuss
     identifier: full
     tf_extra_params:
       test:


### PR DESCRIPTION
New label names have been introduced which use prefixes for label namespace. We need to adjust the packit jobs config accordingly.