### PR TITLE
Use the current directory as `anchor_path` if there is no `fmf_root`

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -775,7 +775,7 @@ class Core(
     # TODO: cached_property candidates
     @property
     def fmf_root(self) -> Optional[Path]:
-        # Check if fmf root exists
+        # Check if fmf root is defined
         if self.node.root is not None:
             return Path(self.node.root)
         return None

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -773,7 +773,12 @@ class Core(
     # TODO: cached_property candidates
     @property
     def fmf_root(self) -> Path:
-        return Path(self.node.root)
+        # Check if fmf root exists
+        try:
+            return Path(self.node.root)
+        except TypeError:
+            raise tmt.utils.GeneralError(
+                "No fmf root found. Directory is not initialized with `tmt init`")
 
     @property
     def git_root(self) -> Optional[Path]:

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -147,8 +147,7 @@ class FmfId(
     VALID_KEYS: ClassVar[list[str]] = ['url', 'ref', 'path', 'name']
 
     #: Keys that are present, might be set, but shall not be exported.
-    NONEXPORTABLE_KEYS: ClassVar[list[str]] = [
-        'fmf_root', 'git_root', 'default_branch']
+    NONEXPORTABLE_KEYS: ClassVar[list[str]] = ['fmf_root', 'git_root', 'default_branch']
 
     # Save context of the ID for later - there are places where it matters,
     # e.g. to not display `ref` under some conditions.

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -776,10 +776,9 @@ class Core(
     @property
     def fmf_root(self) -> Optional[Path]:
         # Check if fmf root exists
-        try:
+        if self.node.root is not None:
             return Path(self.node.root)
-        except TypeError:
-            return None
+        return None
 
     @property
     def anchor_path(self) -> Path:

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -148,12 +148,11 @@ class FmfId(
 
     #: Keys that are present, might be set, but shall not be exported.
     NONEXPORTABLE_KEYS: ClassVar[list[str]] = [
-        'fmf_root', 'anchor_path', 'git_root', 'default_branch']
+        'fmf_root', 'git_root', 'default_branch']
 
     # Save context of the ID for later - there are places where it matters,
     # e.g. to not display `ref` under some conditions.
     fmf_root: Optional[Path] = None
-    anchor_path: Optional[Path] = None
     git_root: Optional[Path] = None
     default_branch: Optional[str] = None
 

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -167,16 +167,9 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
 
                 logger.info('playbook-path', playbook_path, 'green')
 
-            # Check if fmf root exists
-            try:
-                playbook_root = self.step.plan.fmf_root
-            except TypeError:
-                raise PrepareError(
-                    "No fmf root found. Directory is not initialized with `tmt init`")
-
             guest.ansible(
                 playbook_path,
-                playbook_root=playbook_root,
+                playbook_root=self.step.plan.fmf_root,
                 extra_args=self.data.extra_args)
 
         return results

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -167,9 +167,16 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
 
                 logger.info('playbook-path', playbook_path, 'green')
 
+            # Check if fmf root exists
+            try:
+                playbook_root = self.step.plan.fmf_root
+            except TypeError:
+                raise PrepareError(
+                    "No fmf root found. Directory is not initialized with `tmt init`")
+
             guest.ansible(
                 playbook_path,
-                playbook_root=self.step.plan.fmf_root,
+                playbook_root=playbook_root,
                 extra_args=self.data.extra_args)
 
         return results

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -74,8 +74,8 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
         When specifying playbooks with paths:
 
         * If a metadata tree root exists, all paths must be relative to the metadata tree root.
-        * If the metadata tree root does not exist, \
-all paths must be relative to the current working directory.
+        * If the metadata tree root does not exist,
+          all paths must be relative to the current working directory.
 
     Run a single playbook on the guest:
 

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -73,7 +73,8 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
 
         When specifying playbooks with paths:
 
-        * If a metadata tree root exists, all paths must be relative to the metadata tree root.
+        * If a metadata tree root exists, all paths must be relative to
+          the metadata tree root.
         * If the metadata tree root does not exist,
           all paths must be relative to the current working directory.
 

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -169,7 +169,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
 
             guest.ansible(
                 playbook_path,
-                playbook_root=self.step.plan.fmf_root,
+                playbook_root=self.step.plan.anchor_path,
                 extra_args=self.data.extra_args)
 
         return results

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -72,10 +72,10 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
     .. warning::
 
         When specifying playbooks with paths:
-        if metadata tree root exist:
-            all paths must be relative to the metadata tree root.
-        if metadata tree root NOT exist:
-            all paths must be relative to the current working directory.
+
+        * If a metadata tree root exists, all paths must be relative to the metadata tree root.
+        * If the metadata tree root does not exist, \
+all paths must be relative to the current working directory.
 
     Run a single playbook on the guest:
 

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -71,8 +71,11 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
 
     .. warning::
 
-        When specifying playbooks with paths, all paths must be
-        relative to the metadata tree root.
+        When specifying playbooks with paths:
+        if metadata tree root exist:
+            all paths must be relative to the metadata tree root.
+        if metadata tree root NOT exist:
+            all paths must be relative to the current working directory.
 
     Run a single playbook on the guest:
 

--- a/tmt/utils/git.py
+++ b/tmt/utils/git.py
@@ -448,7 +448,7 @@ def validate_git_status(test: 'tmt.base.Test') -> tuple[bool, str]:
     """
     sources = [
         *test.fmf_sources,
-        test.fmf_root / '.fmf' / 'version'
+        test.anchor_path / '.fmf' / 'version'
         ]
 
     # Use tmt's run instead of subprocess.run

--- a/tmt/utils/git.py
+++ b/tmt/utils/git.py
@@ -19,6 +19,7 @@ from tmt.utils import (
     Environment,
     GeneralError,
     GitUrlError,
+    MetadataError,
     Path,
     RunError,
     )
@@ -446,9 +447,14 @@ def validate_git_status(test: 'tmt.base.Test') -> tuple[bool, str]:
 
     When all checks pass returns (True, '').
     """
+
+    # There has to be an fmf tree root defined
+    if not test.fmf_root:
+        raise MetadataError(f"Test '{test.name}' does not have fmf root defined.")
+
     sources = [
         *test.fmf_sources,
-        test.anchor_path / '.fmf' / 'version'
+        test.fmf_root / '.fmf' / 'version'
         ]
 
     # Use tmt's run instead of subprocess.run


### PR DESCRIPTION
Pull Request Checklist

* [x] implement the feature

