### PR TITLE
Fix badly added info about changes in junit report plugin

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,7 +4,7 @@
     Releases
 ======================
 
-tmt-1.37
+tmt-1.37.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :ref:`/plugins/report/junit` report plugin now validates all the XML
@@ -21,7 +21,7 @@ new ``--flavor`` argument. Using this argument the user can choose between a
 ``--template-path`` argument.
 
 
-tmt-1.37.0
+tmt-1.36.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 tmt will now put SSH master control socket into ``ssh-socket``
@@ -47,7 +47,8 @@ support for submitting jobs on behalf of other users, through
 ``beaker-job-owner`` key. The current user must be a submission delegate
 for the given job owner.
 
-In preparation for subresults: subresults and their checks have been integrated into HTML report and display plugin, result phase renamed to subresult.
+In preparation for subresults: subresults and their checks have been integrated
+into HTML report and display plugin, result phase renamed to subresult.
 
 
 tmt-1.35.0


### PR DESCRIPTION
Fix the formating in `releases.rst` after merging https://github.com/teemtee/tmt/pull/3150 .

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [x] include a release note
