### PR TITLE
Document the `known issue` label on the contribute page

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -10,6 +10,10 @@ Introduction
 
 Feel free and welcome to contribute to this project. You can start
 with filing issues and ideas for improvement in GitHub tracker__.
+Before creating a new issue you might want to check the existing
+issues to prevent filing a duplicate. Important issues affecting
+many users are marked with the `known issue`__ label.
+
 Our favorite thoughts from The Zen of Python:
 
 * Beautiful is better than ugly.
@@ -33,7 +37,8 @@ first word capitalized and enclose any names in single quotes:
 
     self.warn(f"File '{path}' not found.")
 
-__ https://github.com/teemtee/tmt
+__ https://github.com/teemtee/tmt/issues
+__ https://github.com/teemtee/tmt/labels/known%20issue
 __ https://www.python.org/dev/peps/pep-0008/
 
 

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -38,7 +38,7 @@ first word capitalized and enclose any names in single quotes:
     self.warn(f"File '{path}' not found.")
 
 __ https://github.com/teemtee/tmt/issues
-__ https://github.com/teemtee/tmt/labels/known%20issue
+__ https://github.com/teemtee/tmt/issues?q=label%3A%22known+issue%22
 __ https://www.python.org/dev/peps/pep-0008/
 
 


### PR DESCRIPTION
The label is supposed to be used for tracking important issues affecting many users so that those can be identified easily without wasting time and repeated questions on the chat.

Pull Request Checklist

* [x] write the documentation