### PR TITLE
Require setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [              # F39 / PyPI
     "requests>=2.25.1",       # 2.28.2 / 2.31.0
     "ruamel.yaml>=0.16.6",    # 0.17.32 / 0.17.32
     "urllib3>=1.26.5, <3.0",  # 1.26.16 / 2.0.4
+    "setuptools>=53.0.0",     # 53.0.0 is the one available with RHEL9
     "typing-extensions>=4.9.0; python_version < '3.13'",
     ]
 


### PR DESCRIPTION
tmt depends on `pkg_resources` package shipped by `setuptools`, but it seems `setuptools` may be missing in some virtualenvs, not being installed by default.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
