### PR TITLE
Rewrite `reportportal` test results reporting 

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -66,6 +66,10 @@ The :ref:`/plugins/provision/beaker` provision plugin now newly
 supports providing a custom :ref:`/spec/plans/provision/kickstart`
 configuration.
 
+The :ref:`/plugins/report/reportportal` plugin now uploads the
+complete set of discovered tests, including those which have not
+been executed. These tests are marked as ``skipped``.
+
 
 tmt-1.36.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1170,8 +1170,10 @@ class Execute(tmt.steps.Step):
         """
         return self._results
 
-    def results_for_tests(self, tests: list['tmt.base.Test']) \
-            -> list[tuple[Optional[Result], Optional['tmt.base.Test']]]:
+    def results_for_tests(
+            self,
+            tests: list['tmt.base.Test']
+            ) -> list[tuple[Optional[Result], Optional['tmt.base.Test']]]:
         """
         Collect results and corresponding tests.
 

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1169,3 +1169,29 @@ class Execute(tmt.steps.Step):
         https://tmt.readthedocs.io/en/latest/spec/plans.html#execute
         """
         return self._results
+
+    def results_for_tests(self, tests: list['tmt.base.Test']) \
+            -> list[tuple[Optional[Result], Optional['tmt.base.Test']]]:
+        """
+        Collect results and corresponding tests.
+
+        :returns: a list of result and test pairs.
+            * if there is not test found for the result, e.g. when
+            results were loaded from storage but tests were not,
+            ``None`` represents the missing test: ``(result, None)``.
+            * if there is no result for a test, e.g. when the test was
+            not executed, ``None`` represents the missing result:
+            ``(None, test)``.
+        """
+
+        known_serial_numbers = {test.serial_number: test for test in tests}
+        referenced_serial_numbers = {result.serial_number for result in self._results}
+
+        return [
+            (result, known_serial_numbers.get(result.serial_number))
+            for result in self._results
+            ] + [
+            (None, test)
+            for test in tests
+            if test.serial_number not in referenced_serial_numbers
+            ]


### PR DESCRIPTION
Modifies test results reporting in the following way:
 - All results from execute.results() are reported.
 - All tests from discover.tests() that have not been executed are reported as 'skipped' at the end.

Pull Request Checklist

* [x] implement the feature
* [x] include a release note