### PR TITLE
Add missing `where`, `name` and `order` keywords into schema

### DIFF
--- a/tmt/schemas/prepare/errata.yaml
+++ b/tmt/schemas/prepare/errata.yaml
@@ -42,5 +42,15 @@ properties:
   no-filter:
     type: boolean
 
+  name:
+    type: string
+
+  order:
+    $ref: "/schemas/core#/definitions/order"
+
+  where:
+    $ref: "/schemas/common#/definitions/where"
+
+
 required:
   - how

--- a/tmt/schemas/prepare/feature.yaml
+++ b/tmt/schemas/prepare/feature.yaml
@@ -25,5 +25,14 @@ properties:
       - enabled
       - disabled
 
+  name:
+    type: string
+
+  order:
+    $ref: "/schemas/core#/definitions/order"
+
+  where:
+    $ref: "/schemas/common#/definitions/where"
+
 required:
   - how


### PR DESCRIPTION
Pull Request Checklist

* [x] implement the feature
* [x] modify the json schema

Fixes issue #2984 and #3008.
Regarding #3008 - `where` (and  `order` and `name`) is present in all other prepare schemas (except errata). Not sure whether to include it in this one as well?
