### PR TITLE
Fix missing `f-string` in the `tmt lint` check

### DIFF
--- a/tests/lint/plan/data/invalid-plugin-key.fmf
+++ b/tests/lint/plan/data/invalid-plugin-key.fmf
@@ -1,0 +1,5 @@
+prepare:
+    how: feature
+    wrong: key
+execute:
+    how: tmt

--- a/tests/lint/plan/test.sh
+++ b/tests/lint/plan/test.sh
@@ -67,6 +67,10 @@ rlJournalStart
         rlAssertGrep "fail P001 unknown key \"discove\" is used" $rlRun_LOG
         rlAssertGrep "fail P001 unknown key \"environmen\" is used" $rlRun_LOG
         rlAssertGrep "fail P001 unknown key \"summaryABCDEF\" is used" $rlRun_LOG
+
+        rlRun -s "$tmt plan lint invalid-plugin-key" 0
+        rlAssertGrep 'warn C000 key "wrong" not recognized by schema$' $rlRun_LOG
+        rlAssertGrep 'warn C000 key "wrong" not recognized by schema /schemas/prepare/feature' $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "P007: step phases require existing guests and roles"

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -939,7 +939,7 @@ class Core(
                             f'key "{bad_property}" not recognized by schema {error.schema["$id"]}'
                     else:
                         yield LinterOutcome.WARN, \
-                            'key "{bad_property}" not recognized by schema'
+                            f'key "{bad_property}" not recognized by schema'
 
             # A key not recognized, but when patternProperties are allowed. In that case,
             # the key is both not listed and not matching the pattern.


### PR DESCRIPTION
Instead of the key name `key "{bad_property}" not recognized` was printed to the user when an invalid key was present in the step phase configuration.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage