### PR TITLE
Do not traceback upon an empty docstring

### DIFF
--- a/tmt/utils/rest.py
+++ b/tmt/utils/rest.py
@@ -91,7 +91,7 @@ class RestVisitor(docutils.nodes.NodeVisitor):
         # To simplify the implementation, this is merging of multiple
         # empty lines into one. Rendering of nodes than does not have
         # to worry about an empty line already being on the stack.
-        if self._rendered_paragraphs[-1] != '':
+        if self._rendered_paragraphs and self._rendered_paragraphs[-1] != '':
             self._emit_paragraphs([''])
 
     # Simple logging for nodes that have no effect


### PR DESCRIPTION
Providing no docstring for a `click` command would result into a confusing `list index out of range` error. Check for the rendered paragraphs first to prevent the traceback.