### PR TITLE
Enable the `epel-10` building and testing

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,6 +26,7 @@ actions: &base-actions
 targets: &all-targets
   - fedora-all
   - epel-9
+  - epel-10
 
 # Uncomment below line if OpenScanHub scans are failing
 # osh_diff_scan_after_copr_build: false

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -69,7 +69,7 @@ _:
   # Latest fedora & epel targets
   - &latest-targets
     - fedora-latest-stable
-    - epel-9
+    - epel-10
 
   # Internal jobs
   - &internal
@@ -188,3 +188,4 @@ jobs:
     dist_git_branches:
       - fedora-branched
       - epel-9
+      - epel-10

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -23,6 +23,9 @@ a warn with an exit code 0 when an invalid key is encountered in fmf
 metadata. Schema validation is now also aware of step default values
 filled in by tmt if they are missing.
 
+Packages for ``epel-10`` are now built as well so that users can
+easily install ``tmt`` on ``rhel-10`` and ``centos-stream-10``.
+
 
 tmt-1.54.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/discover/data/add-tmt-test.patch
+++ b/tests/discover/data/add-tmt-test.patch
@@ -5,4 +5,4 @@
 +require:
 +- tree
 +recommend:
-+- pcre
++- nmap

--- a/tests/discover/distgit.sh
+++ b/tests/discover/distgit.sh
@@ -72,7 +72,7 @@ rlJournalStart
                 rlRun "tmt init"
             )
             # Checks packages added by patch thus fails if patching didn't happen properly
-            echo 'test: rpm -q tree pcre' > "$tmp/with-tmt-1/tests/from-source.fmf"
+            echo 'test: rpm -q tree nmap' > "$tmp/with-tmt-1/tests/from-source.fmf"
             echo 'recommend: from-source' >> "$tmp/with-tmt-1/tests/from-source.fmf"
             touch $tmp/with-tmt-1/from-source.txt
             touch $tmp/outsider
@@ -615,7 +615,7 @@ provision:
 execute:
     how: tmt
 EOF
-        rlRun -s "tmt run -kv --id $tmp/rundir --skip report"
+        rlRun -s "tmt run -vvv --keep --id $tmp/rundir --skip report"
         rlAssertGrep 'summary: 0 tests selected' $rlRun_LOG
 
         # Assert both tests are discovered

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -69,8 +69,12 @@ require+:
     adjust+:
       - when: initiator == packit
         because: Enable in CI only
-
         enabled: true
+      - when: distro == centos-stream-10
+        enabled: false
+        because: |
+            hatch is not packaged for epel-10 yet:
+            https://bugzilla.redhat.com/show_bug.cgi?id=2388175
       - when: distro == fedora-rawhide
         enabled: false
         because: |

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -25,11 +25,13 @@ require+:
   - jq
   - podman
   - buildah
-  - hatch
 
 # Run against development packages via `hatch`.
 /with-development-packages:
     enabled: false
+
+    require+:
+      - hatch
 
     adjust+:
       - when: initiator is not defined or distro == fedora-rawhide
@@ -70,11 +72,6 @@ require+:
       - when: initiator == packit
         because: Enable in CI only
         enabled: true
-      - when: distro == centos-stream-10
-        enabled: false
-        because: |
-            hatch is not packaged for epel-10 yet:
-            https://bugzilla.redhat.com/show_bug.cgi?id=2388175
       - when: distro == fedora-rawhide
         enabled: false
         because: |

--- a/tests/unit/test.sh
+++ b/tests/unit/test.sh
@@ -34,7 +34,6 @@ rlJournalStart
         rlRun "PYTEST_COMMAND='pytest -vvv -ra --showlocals'"
 
         rlLogInfo "pip is $(which pip), $(pip --version)"
-        rlLogInfo "hatch is $(which hatch), $(hatch --version)"
 
         . ../images.sh || exit 1
         build_container_images --force
@@ -55,6 +54,7 @@ rlJournalStart
     else
         rlPhaseStartTest "Unit tests"
             # Note: we're not in the root directory!
+            rlLogInfo "hatch is $(which hatch), $(hatch --version)"
             rlRun "hatch -v run $HATCH_ENVIRONMENT:$PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK ."
         rlPhaseEnd
     fi


### PR DESCRIPTION
All dependencies should now be available in `epel-10`. Let's enable package building, testing and bodhi updates creation. Update the `latest-targets` to run core test jobs on `epel-10` instead of `epel-9`.