### PR TITLE
Drop bootstrap logger requirement from module importer

### DIFF
--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -389,22 +389,20 @@ class ModuleImporter(Generic[ModuleT]):
             self,
             module: str,
             exc_class: type[Exception],
-            exc_message: str,
-            logger: Logger) -> None:
+            exc_message: str) -> None:
         self._module_name = module
         self._exc_class = exc_class
         self._exc_message = exc_message
-        self._logger = logger
 
         self._module: Optional[ModuleT] = None
 
-    def __call__(self) -> ModuleT:
+    def __call__(self, logger: Logger) -> ModuleT:
         if self._module is None:
             self._module = _import_or_raise(
                 module=self._module_name,
                 exc_class=self._exc_class,
                 exc_message=self._exc_message,
-                logger=self._logger)
+                logger=logger)
 
         assert self._module  # narrow type
         return self._module

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -46,8 +46,7 @@ DEFAULT_TEMPLATE_DIR = Path('steps/report/junit/templates/')
 import_lxml: ModuleImporter['lxml'] = ModuleImporter(  # type: ignore[valid-type]
     'lxml',
     tmt.utils.ReportError,
-    "Missing 'lxml', fixable by 'pip install tmt[report-junit]'.",
-    tmt.log.Logger.get_bootstrap_logger())
+    "Missing 'lxml', fixable by 'pip install tmt[report-junit]'.")
 
 
 @overload


### PR DESCRIPTION
It is not needed during import time, it is needed in runtime and importing code can provide logger when needed.

Pull Request Checklist

* [x] implement the feature