### PR TITLE
Avoid using raw step data when injecting phases

### DIFF
--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -16,7 +16,7 @@ from tmt.steps.discover.fmf import DiscoverFmf, DiscoverFmfStepData, normalize_r
 from tmt.steps.execute import ExecutePlugin
 from tmt.steps.execute.internal import ExecuteInternal, ExecuteInternalData
 from tmt.steps.prepare import PreparePlugin
-from tmt.steps.prepare.install import _RawPrepareInstallStepData
+from tmt.steps.prepare.install import PrepareInstallData
 from tmt.utils import Environment, EnvVarValue, Path, field
 
 STATUS_VARIABLE = 'IN_PLACE_UPGRADE'
@@ -267,17 +267,14 @@ class ExecuteUpgrade(ExecuteInternal):
             recommends: bool = False) -> None:
         """ Install packages required/recommended for upgrade """
         phase_name = 'recommended' if recommends else 'required'
-        data: _RawPrepareInstallStepData = {
-            'how': 'install',
-            'name': f'{phase_name}-packages-upgrade',
-            'summary': f'Install packages {phase_name} by the upgrade',
-            'package': [
-                dependency.to_spec()
-                for dependency in tmt.utils.uniq(dependencies)
-                ],
-            'missing': 'skip' if recommends else 'fail'
-            }
-        PreparePlugin.delegate(self.step, raw_data=data).go(  # type:ignore[attr-defined]
+        data = PrepareInstallData(
+            how='install',
+            name=f'{phase_name}-packages-upgrade',
+            summary=f'Install packages {phase_name} by the upgrade',
+            package=tmt.utils.uniq(dependencies),
+            missing='skip' if recommends else 'fail')
+
+        PreparePlugin.delegate(self.step, data=data).go(  # type:ignore[attr-defined]
             guest=guest, logger=self._logger)
 
     def _prepare_remote_discover_data(self, plan: tmt.base.Plan) -> tmt.steps._RawStepData:

--- a/tmt/steps/prepare/distgit.py
+++ b/tmt/steps/prepare/distgit.py
@@ -10,7 +10,7 @@ import tmt.utils
 from tmt.package_managers import Package
 from tmt.result import PhaseResult
 from tmt.steps.prepare import PreparePlugin
-from tmt.steps.prepare.install import _RawPrepareInstallStepData
+from tmt.steps.prepare.install import PrepareInstallData
 from tmt.steps.provision import Guest
 from tmt.utils import Command, Path, ShellScript, field, uniq
 
@@ -55,30 +55,30 @@ def insert_to_prepare_step(
     prepare_step = discover_plugin.step.plan.prepare
     where = cast(tmt.steps.discover.DiscoverStepData, discover_plugin.data).where
     # Future install require
-    data_require: _RawPrepareInstallStepData = {
-        'how': 'install',
-        'name': 'requires (dist-git)',
-                'summary': 'Install required packages of tests detected by dist-git',
-                'order': tmt.utils.DEFAULT_PLUGIN_ORDER_REQUIRES,
-                'where': where,
-                'package': []}
+    data_require = PrepareInstallData(
+        how='install',
+        name='requires (dist-git)',
+        summary='Install required packages of tests detected by dist-git',
+        order=tmt.utils.DEFAULT_PLUGIN_ORDER_REQUIRES,
+        where=where,
+        package=[])
     future_requires: PreparePlugin[Any] = cast(
-        PreparePlugin[Any], PreparePlugin.delegate(
-            prepare_step, raw_data=data_require))
+        PreparePlugin[Any],
+        PreparePlugin.delegate(prepare_step, data=data_require))
     prepare_step._phases.append(future_requires)
 
     # Future install recommend
-    data_recommend: _RawPrepareInstallStepData = {
-        'how': 'install',
-        'name': 'recommends (dist-git)',
-                'summary': 'Install recommended packages of tests detected by dist-git',
-                'order': tmt.utils.DEFAULT_PLUGIN_ORDER_RECOMMENDS,
-                'where': where,
-                'package': [],
-        'missing': 'skip'}
+    data_recommend = PrepareInstallData(
+        how='install',
+        name='recommends (dist-git)',
+        summary='Install recommended packages of tests detected by dist-git',
+        order=tmt.utils.DEFAULT_PLUGIN_ORDER_RECOMMENDS,
+        where=where,
+        package=[],
+        missing='skip')
     future_recommends: PreparePlugin[Any] = cast(
-        PreparePlugin[Any], PreparePlugin.delegate(
-            prepare_step, raw_data=data_recommend))
+        PreparePlugin[Any],
+        PreparePlugin.delegate(prepare_step, data=data_recommend))
     prepare_step._phases.append(future_recommends)
 
     prepare_step._phases.append(

--- a/tmt/steps/prepare/feature.py
+++ b/tmt/steps/prepare/feature.py
@@ -78,10 +78,6 @@ _FEATURES: dict[str, type[Feature]] = {
     }
 
 
-class _RawPrepareFeatureStepData(tmt.steps.prepare._RawPrepareStepData, total=False):
-    epel: str
-
-
 @dataclasses.dataclass
 class PrepareFeatureData(tmt.steps.prepare.PrepareStepData):
     epel: Optional[str] = field(

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -526,14 +526,6 @@ class InstallApk(InstallBase):
             'installing debuginfo packages.')
 
 
-class _RawPrepareInstallStepData(tmt.steps.prepare._RawPrepareStepData, total=False):
-    package: Union[str, list[str]]
-    directory: Union[str, list[str]]
-    copr: Union[str, list[str]]
-    exclude: Union[str, list[str]]
-    missing: str
-
-
 @dataclasses.dataclass
 class PrepareInstallData(tmt.steps.prepare.PrepareStepData):
     package: list[tmt.base.DependencySimple] = field(

--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -21,8 +21,6 @@ import tmt.utils
 from tmt import Plan
 from tmt.base import RunData
 from tmt.steps.prepare import PreparePlugin
-from tmt.steps.prepare.feature import _RawPrepareFeatureStepData
-from tmt.steps.prepare.install import _RawPrepareInstallStepData
 from tmt.utils import MetadataError, Path
 
 USER_PLAN_NAME = "/user/plan"
@@ -417,31 +415,34 @@ class Try(tmt.utils.Common):
         """ Enable EPEL repository """
 
         # tmt run prepare --how feature --epel enabled
-        data: _RawPrepareFeatureStepData = {
-            "name": "tmt-try-epel",
-            'how': 'feature',
-            'epel': "enabled",
-            }
+        from tmt.steps.prepare.feature import PrepareFeatureData
+
+        data = PrepareFeatureData(
+            name="tmt-try-epel",
+            how='feature',
+            epel="enabled")
 
         phase: PreparePlugin[Any] = cast(
-            PreparePlugin[Any], PreparePlugin.delegate(
-                plan.prepare, raw_data=data))
+            PreparePlugin[Any],
+            PreparePlugin.delegate(plan.prepare, data=data))
+
         plan.prepare._phases.append(phase)
 
     def handle_install(self, plan: Plan) -> None:
         """ Install local rpm package on the guest. """
-        packages = list(self.opt("install"))
 
         # tmt run prepare --how install --package PACKAGE
-        data: _RawPrepareInstallStepData = {
-            "name": "tmt-try-install",
-            'how': 'install',
-            'package': packages,
-            }
+        from tmt.steps.prepare.install import PrepareInstallData
+
+        data = PrepareInstallData(
+            name="tmt-try-install",
+            how='install',
+            package=list(self.opt("install")))
 
         phase: PreparePlugin[Any] = cast(
-            PreparePlugin[Any], PreparePlugin.delegate(
-                plan.prepare, raw_data=data))
+            PreparePlugin[Any],
+            PreparePlugin.delegate(plan.prepare, data=data))
+
         plan.prepare._phases.append(phase)
 
     def go(self) -> None:


### PR DESCRIPTION
Actual step data containers come with type annotations and better checking.

Pull Request Checklist

* [x] implement the feature