### PR TITLE
Isolate "effective config path" code in a function

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -217,7 +217,7 @@ def test_last_run_race(tmppath: Path, monkeypatch):
     """ Race in last run symlink shouldn't be fatal """
     config_path = tmppath / 'config'
     config_path.mkdir()
-    monkeypatch.setattr(tmt.utils, 'CONFIG_DIR', config_path)
+    monkeypatch.setattr(tmt.utils, 'effective_config_dir', MagicMock(return_value=config_path))
     mock_logger = unittest.mock.MagicMock()
     monkeypatch.setattr(tmt.utils.log, 'warning', mock_logger)
     config = tmt.utils.Config()

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -145,7 +145,22 @@ DEFAULT_PLUGIN_ORDER_REQUIRES = 70
 DEFAULT_PLUGIN_ORDER_RECOMMENDS = 75
 
 # Config directory
-CONFIG_DIR = Path('~/.config/tmt')
+DEFAULT_CONFIG_DIR = Path('~/.config/tmt')
+
+
+def effective_config_dir() -> Path:
+    """
+    Find out what the actual config directory is.
+
+    If ``TMT_CONFIG_DIR`` variable is set, it is used. Otherwise,
+    :py:const:`DEFAULT_CONFIG_DIR` is picked.
+    """
+
+    if 'TMT_CONFIG_DIR' in os.environ:
+        return Path(os.environ['TMT_CONFIG_DIR']).expanduser()
+
+    return DEFAULT_CONFIG_DIR.expanduser()
+
 
 # Special process return codes
 
@@ -857,14 +872,13 @@ class Config:
 
     def __init__(self) -> None:
         """ Initialize config directory path """
-        raw_path = os.getenv('TMT_CONFIG_DIR', None)
-        self.path = (Path(raw_path) if raw_path else CONFIG_DIR).expanduser()
+        self.path = effective_config_dir()
 
         try:
             self.path.mkdir(parents=True, exist_ok=True)
         except OSError as error:
             raise GeneralError(
-                f"Failed to create config '{self.path}'.\n{error}")
+                f"Failed to create config '{self.path}'.") from error
 
     @property
     def _last_run_symlink(self) -> Path:


### PR DESCRIPTION
This now matches how other configurable paths are handled, workdir root, pid root.

Pull Request Checklist

* [x] implement the feature