### PR TITLE
Test `result` key should be implemented as enum, not a string

### DIFF
--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -8,6 +8,7 @@ import pytest
 
 import tmt
 import tmt.cli
+import tmt.result
 from tests import CliRunner
 from tmt.base import FmfId, Link, LinkNeedle, Links, expand_node_data
 from tmt.utils import Path, SpecificationError
@@ -41,7 +42,7 @@ def test_test_defaults(root_logger):
     assert test.environment == {}
     assert test.duration == '5m'
     assert test.enabled is True
-    assert test.result == 'respect'
+    assert test.result == tmt.result.ResultInterpret.RESPECT
     assert test.tag == []
 
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -57,7 +57,7 @@ import tmt.utils.git
 import tmt.utils.jira
 from tmt.checks import Check
 from tmt.lint import LinterOutcome, LinterReturn
-from tmt.result import Result
+from tmt.result import Result, ResultInterpret
 from tmt.utils import (
     Command,
     Environment,
@@ -1074,7 +1074,12 @@ class Test(
         exporter=lambda environment: environment.to_fmf_spec())
 
     duration: str = DEFAULT_TEST_DURATION_L1
-    result: str = 'respect'
+    result: ResultInterpret = field(
+        default=ResultInterpret.RESPECT,
+        normalize=ResultInterpret.normalize,
+        serialize=lambda result: result.value,
+        unserialize=ResultInterpret.from_spec,
+        exporter=lambda result: result.value)
 
     where: list[str] = field(default_factory=list)
 

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1358,6 +1358,9 @@ class Test(
                     [check.to_spec() for check in cast(list[Check], value)]
                     ))
                 continue
+            if key == 'result':
+                echo(tmt.utils.format(key, value.value))
+                continue
             if value not in [None, [], {}]:
                 echo(tmt.utils.format(key, value))
         if self.verbosity_level:

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -22,7 +22,7 @@ import tmt.utils
 from tmt.checks import CheckEvent
 from tmt.options import option
 from tmt.plugins import PluginRegistry
-from tmt.result import CheckResult, Result, ResultGuestData, ResultOutcome
+from tmt.result import CheckResult, Result, ResultGuestData, ResultInterpret, ResultOutcome
 from tmt.steps import Action, ActionTask, PhaseQueue, PluginTask, Step
 from tmt.steps.discover import Discover, DiscoverPlugin, DiscoverStepData
 from tmt.steps.provision import Guest
@@ -895,11 +895,11 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
 
         self.debug(f"Extract results of '{invocation.test.name}'.")
 
-        if invocation.test.result == 'custom':
+        if invocation.test.result == ResultInterpret.CUSTOM:
             return self.extract_custom_results(invocation)
 
         # Handle the 'tmt-report-result' command results as separate tests
-        if invocation.test.result == 'restraint':
+        if invocation.test.result == ResultInterpret.RESTRAINT:
             return self.extract_tmt_report_results_restraint(
                 invocation=invocation,
                 default_log=invocation.relative_path / TEST_OUTPUT_FILENAME)


### PR DESCRIPTION
This is a leftover from transitioning to enums in the past.

Pull Request Checklist

* [x] implement the feature