### PR TITLE
Change result note key from a string to a list of strings

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -22,6 +22,9 @@ support for submitting jobs on behalf of a group through the
 ``beaker-job-group`` key. The submitting user must be a member of
 the given job group.
 
+The ``note`` field of tmt :ref:`/spec/plans/results` changes from
+a string to a list of strings, to better accommodate multiple notes.
+
 
 tmt-1.40.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/spec/plans/results.fmf
+++ b/spec/plans/results.fmf
@@ -33,8 +33,9 @@ description: |
        # String, the original outcome of the test execution.
        original-result: "pass"|"fail"|"info"|"warn"|"error"|"skip"
 
-       # String, optional comment to report with the result.
-       note: "Things were great."
+       # List of strings, optional comments to report with the result.
+       note:
+         - "Things were great."
 
        # List of strings, paths to log files.
        log:
@@ -88,8 +89,9 @@ description: |
           # String, the original outcome of the check execution.
           original-result: "pass"|"fail"|"info"|"warn"|"error"|"skip"
 
-          # String, optional comment to report with the result.
-          note: "Things were great."
+          # List of strings, optional comments to report with the result.
+          note:
+            - "Things were great."
 
           # List of strings, paths to logs files.
           log:
@@ -126,8 +128,9 @@ description: |
           # String, the original outcome of the phase execution.
           original-result: "pass"|"fail"|"info"|"warn"|"error"|"skip"
 
-          # String, optional comment to report with the result.
-          note: "Things were great."
+          # List of strings, optional comments to report with the result.
+          note:
+            - "Things were great."
 
           # List of strings, paths to log files.
           log:
@@ -269,7 +272,8 @@ example:
       start-time: "2023-03-10T09:44:14.439120+00:00"
       end-time: "2023-03-10T09:44:24.242227+00:00"
       duration: 00:00:09
-      note: good result
+      note:
+        - good result
       ids:
         extra-nitrate: some-nitrate-id
       guest:
@@ -284,7 +288,8 @@ example:
       start-time: "2023-03-10T09:44:14.439120+00:00"
       end-time: "2023-03-10T09:44:24.242227+00:00"
       duration: 00:00:09
-      note: fail result
+      note:
+        - fail result
       guest:
         name: default-0
 
@@ -295,7 +300,8 @@ example:
       log:
         - pass_log
       duration: 00:11:22
-      note: good result
+      note:
+        - good result
       ids:
         extra-nitrate: some-nitrate-id
 
@@ -305,7 +311,8 @@ example:
         - fail_log
         - another_log
       duration: 00:22:33
-      note: fail result
+      note:
+        - fail result
 
   - |
     # Example of a perfectly valid, yet stingy custom results file
@@ -325,7 +332,8 @@ example:
       start-time: "2023-03-10T09:44:14.439120+00:00"
       end-time: "2023-03-10T09:44:24.242227+00:00"
       duration: 00:00:09
-      note: good result
+      note:
+        - good result
       ids:
         extra-nitrate: some-nitrate-id
       guest:
@@ -335,12 +343,12 @@ example:
           event: after-test
           result: pass
           log: []
-          note:
+          note: []
         - name: kernel-panic
           event: after-test
           result: pass
           log: []
-          note:
+          note: []
 
   - |
     # syntax: json

--- a/spec/plans/results.fmf
+++ b/spec/plans/results.fmf
@@ -35,7 +35,7 @@ description: |
 
        # List of strings, optional comments to report with the result.
        note:
-         - "Things were great."
+         - Things were great.
 
        # List of strings, paths to log files.
        log:
@@ -91,7 +91,7 @@ description: |
 
           # List of strings, optional comments to report with the result.
           note:
-            - "Things were great."
+            - Things were great.
 
           # List of strings, paths to logs files.
           log:
@@ -130,7 +130,7 @@ description: |
 
           # List of strings, optional comments to report with the result.
           note:
-            - "Things were great."
+            - Things were great.
 
           # List of strings, paths to log files.
           log:
@@ -259,6 +259,9 @@ description: |
     .. versionchanged:: 1.37
        original result of test, subtest and check is stored in ``original-result`` key.
 
+    .. versionchanged:: 1.41
+       ``note`` field changed from a string to a list of strings.
+
     __ https://github.com/teemtee/tmt/blob/main/tmt/schemas/results.yaml
 
 example:
@@ -359,7 +362,7 @@ example:
         "result": "pass",
         "log": ["pass_log"],
         "duration": "00:11:22",
-        "note": "good result"
+        "note": ["good result"]
       }
     ]
 

--- a/tests/execute/restraint/tmt-abort/test.sh
+++ b/tests/execute/restraint/tmt-abort/test.sh
@@ -14,8 +14,11 @@ rlJournalStart
         rlAssertNotGrep "This test should not be executed." $rlRun_LOG
         rlAssertNotGrep "This should not be executed either." $rlRun_LOG
 
+
         rlAssertGrep "result: error" "${run}/plan/execute/results.yaml"
-        rlAssertGrep "note: aborted" "${run}/plan/execute/results.yaml"
+        rlAssertEquals "results should record the test aborted" \
+            "$(yq -r '.[] | .note | join(", ")' ${run}/plan/execute/results.yaml)" \
+            "beakerlib: State 'started', aborted"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/execute/result/custom/results.json
+++ b/tests/execute/result/custom/results.json
@@ -2,7 +2,9 @@
   {
     "name": "/test/passing",
     "result": "pass",
-    "note": "good result",
+    "note": [
+      "good result"
+    ],
     "log": [
       "pass_log"
     ],
@@ -28,7 +30,9 @@
       "another-id": "bar2"
     },
     "duration": "00:23:34",
-    "note": "fail result",
+    "note": [
+      "fail result"
+    ],
     "serial-number": 2,
     "guest": {
       "name": "client-1",

--- a/tests/execute/result/custom/results.yaml
+++ b/tests/execute/result/custom/results.yaml
@@ -1,6 +1,7 @@
 - name: /test/passing
   result: pass
-  note: good result
+  note:
+    - good result
   log:
     - pass_log
   ids:
@@ -20,7 +21,8 @@
     some-id: foo2
     another-id: bar2
   duration: 00:22:33
-  note: fail result
+  note:
+    - fail result
   serial-number: 2
   guest:
     name: client-1

--- a/tests/report/html/test.sh
+++ b/tests/report/html/test.sh
@@ -37,13 +37,14 @@ rlJournalStart
             grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix
             rlAssertGrep 'class="result error">error</td>' $tmp/$test_name_suffix -F
             sed -e "/name\">\/test\/$test_name_suffix/,/\/tr/!d" $HTML | tee $tmp/$test_name_suffix-note
-            rlAssertGrep '<td class="note">timeout</td>' $tmp/$test_name_suffix-note -F
+            rlAssertGrep '<li class="note">timeout</li>' $tmp/$test_name_suffix-note -F
 
             test_name_suffix=xfail
             grep -B 1 "/test/$test_name_suffix</td>" $HTML | tee $tmp/$test_name_suffix
             rlAssertGrep 'class="result pass">pass</td>' $tmp/$test_name_suffix -F
             sed -e "/name\">\/test\/$test_name_suffix/,/\/tr/!d" $HTML | tee $tmp/$test_name_suffix-note
-            rlAssertGrep '<td class="note">test failed as expected, original test result: fail</td>' $tmp/$test_name_suffix-note -F
+            rlAssertGrep '<li class="note">test failed as expected</li>' $tmp/$test_name_suffix-note -F
+            rlAssertGrep '<li class="note">original test result: fail</li>' $tmp/$test_name_suffix-note -F
         rlPhaseEnd
 
         if [ "$option" = "" ]; then

--- a/tmt/frameworks/shell.py
+++ b/tmt/frameworks/shell.py
@@ -85,7 +85,7 @@ class Shell(TestFramework):
             invocation=invocation,
             result=actual_outcome,
             log=test_logs,
-            note=note,
+            note=[note] if note else [],
             subresult=[result.to_subresult() for result in results])]
 
     @classmethod
@@ -108,7 +108,7 @@ class Shell(TestFramework):
         :returns: list of results.
         """
         assert invocation.return_code is not None
-        note = None
+        note: list[str] = []
 
         # Handle the `tmt-report-result` command results as a single test with assigned tmt
         # subresults.
@@ -124,11 +124,11 @@ class Shell(TestFramework):
             result = ResultOutcome.ERROR
             # Add note about the exceeded duration
             if invocation.return_code == tmt.utils.ProcessExitCodes.TIMEOUT:
-                note = 'timeout'
+                note.append('timeout')
                 invocation.phase.timeout_hint(invocation)
 
             elif tmt.utils.ProcessExitCodes.is_pidfile(invocation.return_code):
-                note = 'pidfile locking'
+                note.append('pidfile locking')
 
         return [tmt.Result.from_test_invocation(
             invocation=invocation,

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -176,7 +176,8 @@ class BaseResult(SerializableContainer):
         serialize=lambda result: result.value,
         unserialize=ResultOutcome.from_spec
         )
-    note: Optional[str] = None
+    note: list[str] = field(
+        default_factory=cast(Callable[[], list[str]], list))
     log: list[Path] = field(
         default_factory=cast(Callable[[], list[Path]], list),
         serialize=lambda logs: [str(log) for log in logs],
@@ -200,9 +201,13 @@ class BaseResult(SerializableContainer):
             ]
 
         if self.note:
-            components.append(f'({self.note})')
+            components.append(f'({self.printable_note})')
 
         return ' '.join(components)
+
+    @property
+    def printable_note(self) -> str:
+        return ', '.join(self.note)
 
 
 @dataclasses.dataclass
@@ -297,7 +302,7 @@ class Result(BaseResult):
             *,
             invocation: 'tmt.steps.execute.TestInvocation',
             result: ResultOutcome,
-            note: Optional[str] = None,
+            note: Optional[list[str]] = None,
             ids: Optional[ResultIds] = None,
             log: Optional[list[Path]] = None,
             subresult: Optional[list[SubResult]] = None) -> 'Result':
@@ -341,7 +346,7 @@ class Result(BaseResult):
             fmf_id=invocation.test.fmf_id,
             context=invocation.phase.step.plan._fmf_context,
             result=result,
-            note=note,
+            note=note or [],
             start_time=invocation.start_time,
             end_time=invocation.end_time,
             duration=invocation.real_duration,
@@ -355,13 +360,6 @@ class Result(BaseResult):
         interpret_checks = {check.how: check.result for check in invocation.test.check}
 
         return _result.interpret_result(invocation.test.result, interpret_checks)
-
-    def append_note(self, note: str) -> None:
-        """ Append text to result note """
-        if self.note:
-            self.note += f", {note}"
-        else:
-            self.note = note
 
     def interpret_check_result(
             self,
@@ -385,21 +383,21 @@ class Result(BaseResult):
 
         if interpret == CheckResultInterpret.RESPECT:
             if interpreted_outcome == ResultOutcome.FAIL:
-                self.append_note(f"check '{check_name}' failed")
+                self.note.append(f"check '{check_name}' failed")
 
         elif interpret == CheckResultInterpret.INFO:
             interpreted_outcome = ResultOutcome.INFO
-            self.append_note(f"check '{check_name}' is informational")
+            self.note.append(f"check '{check_name}' is informational")
 
         elif interpret == CheckResultInterpret.XFAIL:
 
             if reduced_outcome == ResultOutcome.PASS:
                 interpreted_outcome = ResultOutcome.FAIL
-                self.append_note(f"check '{check_name}' did not fail as expected")
+                self.note.append(f"check '{check_name}' did not fail as expected")
 
             if reduced_outcome == ResultOutcome.FAIL:
                 interpreted_outcome = ResultOutcome.PASS
-                self.append_note(f"check '{check_name}' failed as expected")
+                self.note.append(f"check '{check_name}' failed as expected")
 
         return interpreted_outcome
 
@@ -437,11 +435,11 @@ class Result(BaseResult):
         # Override result with result outcome provided by user
         if interpret not in (ResultInterpret.RESPECT, ResultInterpret.XFAIL):
             self.result = ResultOutcome(interpret.value)
-            self.append_note(f"test result overridden: {self.result.value}")
+            self.note.append(f"test result overridden: {self.result.value}")
 
             # Add original result to note if the result has changed
             if self.result != self.original_result:
-                self.append_note(f"original test result: {self.original_result.value}")
+                self.note.append(f"original test result: {self.original_result.value}")
 
             return self
 
@@ -450,15 +448,15 @@ class Result(BaseResult):
 
             if self.result == ResultOutcome.PASS:
                 self.result = ResultOutcome.FAIL
-                self.append_note("test was expected to fail")
+                self.note.append("test was expected to fail")
 
             elif self.result == ResultOutcome.FAIL:
                 self.result = ResultOutcome.PASS
-                self.append_note("test failed as expected")
+                self.note.append("test failed as expected")
 
         # Add original result to note if the result has changed
         if self.result != self.original_result:
-            self.append_note(f"original test result: {self.original_result.value}")
+            self.note.append(f"original test result: {self.original_result.value}")
 
         return self
 
@@ -522,7 +520,7 @@ class Result(BaseResult):
             components.append(f'(on {format_guest_full_name(self.guest.name, self.guest.role)})')
 
         if self.note:
-            components.append(f'({self.note})')
+            components.append(f'({self.printable_note})')
 
         return ' '.join(components)
 

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -177,7 +177,8 @@ class BaseResult(SerializableContainer):
         unserialize=ResultOutcome.from_spec
         )
     note: list[str] = field(
-        default_factory=cast(Callable[[], list[str]], list))
+        default_factory=cast(Callable[[], list[str]], list),
+        unserialize=lambda value: [] if value is None else value)
     log: list[Path] = field(
         default_factory=cast(Callable[[], list[Path]], list),
         serialize=lambda logs: [str(log) for log in logs],

--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -492,7 +492,9 @@ definitions:
       - restraint
 
   result_note:
-    type: string
+    type: array
+    items:
+      type: string
 
   result_log:
     type: array

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -824,10 +824,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
 
             else:
                 if not partial_result.name.startswith('/'):
-                    if partial_result.note and isinstance(partial_result.note, str):
-                        partial_result.note += ", custom test result name should start with '/'"
-                    else:
-                        partial_result.note = "custom test result name should start with '/'"
+                    partial_result.note.append("custom test result name should start with '/'")
                     partial_result.name = '/' + partial_result.name
                 partial_result.name = test.name + partial_result.name
 
@@ -878,13 +875,13 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
         if not collection.file_exists:
             return [tmt.Result.from_test_invocation(
                 invocation=invocation,
-                note=f"custom results file not found in '{invocation.test_data_path}'",
+                note=[f"custom results file not found in '{invocation.test_data_path}'"],
                 result=ResultOutcome.ERROR)]
 
         if not collection.results:
             return [tmt.Result.from_test_invocation(
                 invocation=invocation,
-                note="no custom results were provided",
+                note=["no custom results were provided"],
                 result=ResultOutcome.ERROR)]
 
         collection.validate()

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -561,13 +561,14 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                     except tmt.utils.RebootTimeoutError:
                         for result in invocation.results:
                             result.result = ResultOutcome.ERROR
-                            result.note = 'reboot timeout'
+                            result.note.append('reboot timeout')
 
                     else:
                         for result in invocation.results:
                             result.result = ResultOutcome.ERROR
-                            result.note = ('crashed too many times, '
-                                           'you may want to set restart-max-count larger')
+                            result.note.append(
+                                'crashed too many times, '
+                                'you may want to set restart-max-count larger')
 
                 # Handle reboot, abort, exit-first
                 if invocation.reboot_requested:
@@ -580,12 +581,12 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                     except tmt.utils.RebootTimeoutError:
                         for result in invocation.results:
                             result.result = ResultOutcome.ERROR
-                            result.note = 'reboot timeout'
+                            result.note.append('reboot timeout')
 
                 if invocation.abort_requested:
                     for result in invocation.results:
                         # In case of aborted all results in list will be aborted
-                        result.note = 'aborted'
+                        result.note.append('aborted')
 
                 self._results.extend(invocation.results)
 

--- a/tmt/steps/report/html/template.html.j2
+++ b/tmt/steps/report/html/template.html.j2
@@ -266,7 +266,7 @@ Context:
         {% endfor %}
         </td>
         <td class="data"><a href="{{ base_dir | linkable_path | urlencode }}/{{ result.data_path | urlencode }}">data</a></td>
-        <td class="note">{% if result.note %}{{ result.note | e }}{% else %}-{% endif %}</td>
+        <td class="note">{% if result.note %}{{ result.printable_note | e }}{% else %}-{% endif %}</td>
         <td class="action">
             {% if result.check %}
             <button onclick="toggle_row_visibility(this, 'check-{{ loop.index }}')" title="Show / hide checks">checks&nbsp;[+]</button>

--- a/tmt/steps/report/html/template.html.j2
+++ b/tmt/steps/report/html/template.html.j2
@@ -117,6 +117,11 @@
             width: 22ex;
         }
 
+        #results ul {
+            margin: 0px;
+            padding-inline-start: 16px;
+        }
+
         .context-dimension {
             display: inline-block;
             text-align: center;

--- a/tmt/steps/report/html/template.html.j2
+++ b/tmt/steps/report/html/template.html.j2
@@ -266,7 +266,17 @@ Context:
         {% endfor %}
         </td>
         <td class="data"><a href="{{ base_dir | linkable_path | urlencode }}/{{ result.data_path | urlencode }}">data</a></td>
-        <td class="note">{% if result.note %}{{ result.printable_note | e }}{% else %}-{% endif %}</td>
+        <td class="note">
+          {% if result.note %}
+            <ul>
+              {% for note in result.note %}
+                <li class="note">{{ note | e }}</li>
+              {% endfor %}
+            </ul>
+          {% else %}
+            -
+          {% endif %}
+        </td>
         <td class="action">
             {% if result.check %}
             <button onclick="toggle_row_visibility(this, 'check-{{ loop.index }}')" title="Show / hide checks">checks&nbsp;[+]</button>


### PR DESCRIPTION
This better represents its real nature: a collection of various notes, there may be more than one note or topic tmt needed to share with user depending on what happened while the test was running.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] update the specification
* [x] modify the json schema
* [x] mention the version
* [x] include a release note