### PR TITLE
Fix the copr repo name in the container files

### DIFF
--- a/containers/Containerfile.full
+++ b/containers/Containerfile.full
@@ -8,7 +8,7 @@ RUN set -x && \
 # Install necessary packages
 RUN set -x && \
     dnf install -y dnf-plugins-core && \
-    dnf copr enable -y teemtee/tmt && \
+    dnf copr enable -y @teemtee/tmt && \
     dnf install -y tmt+all-[0-9].[0-9][0-9].[0-9]* beakerlib && \
     dnf autoremove -y && \
     dnf clean all

--- a/containers/Containerfile.mini
+++ b/containers/Containerfile.mini
@@ -8,7 +8,7 @@ RUN set -x && \
 # Install necessary packages
 RUN set -x && \
     dnf install -y dnf-plugins-core && \
-    dnf copr enable -y teemtee/tmt && \
+    dnf copr enable -y @teemtee/tmt && \
     dnf install -y tmt-[0-9].[0-9][0-9].[0-9]* && \
     dnf autoremove -y && \
     dnf clean all


### PR DESCRIPTION
The missing group character `@` resulted in container image build in quay to fail.