### PR TITLE
Increase `linkcheck` retries from 1 to 3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -308,6 +308,7 @@ man_pages = [
 # man_show_urls = False
 
 # -- Options for linkcheck builder ----------------------------------------
+linkcheck_retries = 3
 linkcheck_ignore = [
     # Github "source code line" anchors are apparently too dynamic for linkcheck
     # to detect correctly. The link exists, a browser can open it, but linkcheck


### PR DESCRIPTION
Preventing doc linkcheck test failures due to rate limiting, as discussed on Matrix.  
`contribute: line   65) broken    https://xxxx - 429 Client Error: Too Many Requests`