### PR TITLE
Pass `{USER, COREOS}_DATA` separately in `testcloud`

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -24,6 +24,11 @@ discovered tests. This can be useful especially when fetching
 tests from remote repositories where the user does not have write
 access.
 
+A race condition in the
+:ref:`/plugins/provision/virtual.testcloud` plugin has been fixed,
+thus multihost tests using this provision method should now work
+reliably without unexpected connection failures.
+
 
 tmt-1.37.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ provision-beaker = [
     "mrack>=1.15.1",
     ]
 provision-virtual = [
-    "testcloud>=0.11.2",
+    "testcloud>=0.11.3",
     ]
 provision-container = []
 report-junit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ provision-beaker = [
     "mrack>=1.15.1",
     ]
 provision-virtual = [
-    "testcloud>=0.9.13",
+    "testcloud>=0.11.2",
     ]
 provision-container = []
 report-junit = [

--- a/tests/execute/reboot/shorten-timeout-data/tests/example/main.fmf
+++ b/tests/execute/reboot/shorten-timeout-data/tests/example/main.fmf
@@ -1,3 +1,3 @@
 summary: Reboot quickly
-test: '[ "$TMT_REBOOT_COUNT" == "0" ] && tmt-reboot -t 1 || echo'
+test: '[ "$TMT_REBOOT_COUNT" == "0" ] && tmt-reboot -t 1 -c reboot || echo'
 framework: shell

--- a/tmt.spec
+++ b/tmt.spec
@@ -75,7 +75,7 @@ Provides:       tmt-provision-virtual == %{version}-%{release}
 Obsoletes:      tmt-provision-virtual < %{version}-%{release}
 %endif
 Requires:       tmt == %{version}-%{release}
-Requires:       python3-testcloud >= 0.11.2
+Requires:       python3-testcloud >= 0.11.3
 Requires:       libvirt-daemon-config-network
 Requires:       openssh-clients
 Requires:       (ansible or ansible-core)

--- a/tmt.spec
+++ b/tmt.spec
@@ -75,7 +75,7 @@ Provides:       tmt-provision-virtual == %{version}-%{release}
 Obsoletes:      tmt-provision-virtual < %{version}-%{release}
 %endif
 Requires:       tmt == %{version}-%{release}
-Requires:       python3-testcloud >= 0.9.13
+Requires:       python3-testcloud >= 0.11.2
 Requires:       libvirt-daemon-config-network
 Requires:       openssh-clients
 Requires:       (ansible or ansible-core)

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -1082,7 +1082,7 @@ class GuestTestcloud(tmt.GuestSsh):
         """ Reboot the guest, return True if successful """
         # Use custom reboot command if provided
         if command:
-            return super().reboot(hard=hard, command=command)
+            return super().reboot(hard=hard, command=command, timeout=timeout)
         if not self._instance:
             raise tmt.utils.ProvisionError("No instance initialized.")
         self._instance.reboot(soft=not hard)

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -740,6 +740,9 @@ class GuestTestcloud(tmt.GuestSsh):
         self._domain = DomainConfiguration(self.instance_name)
         self._apply_hw_arch(self._domain, self.is_kvm, self.is_legacy_os)
 
+        # Is this a CoreOS?
+        self._domain.coreos = self.is_coreos
+
         self._instance = testcloud.instance.Instance(
             domain_configuration=self._domain,
             image=self._image, desired_arch=self.arch,

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -745,7 +745,7 @@ class GuestTestcloud(tmt.GuestSsh):
             image=self._image, desired_arch=self.arch,
             connection=f"qemu:///{self.connection}")
 
-    def prepare_ssh_key(self, key_type: Optional[str] = None) -> None:
+    def prepare_ssh_key(self, key_type: Optional[str] = None) -> str:
         """ Prepare ssh key for authentication """
         assert self.workdir is not None
 
@@ -754,6 +754,7 @@ class GuestTestcloud(tmt.GuestSsh):
             self.debug("Extract public key from the provided private one.")
             command = Command("ssh-keygen", "-f", self.key[0], "-y")
             public_key = self._run_guest_command(command, silent=True).stdout
+            assert public_key is not None
         # Generate new ssh key pair
         else:
             self.debug('Generating an ssh key.')
@@ -766,11 +767,7 @@ class GuestTestcloud(tmt.GuestSsh):
             self.verbose('key', self.key[0], 'green')
             public_key = (self.workdir / f'{key_name}.pub').read_text()
 
-        # Place public key content into the machine configuration
-        self.config.USER_DATA = Template(USER_DATA).safe_substitute(
-            user_name=self.user, public_key=public_key)
-        self.config.COREOS_DATA = Template(COREOS_DATA).safe_substitute(
-            user_name=self.user, public_key=public_key)
+        return public_key
 
     def prepare_config(self) -> None:
         """ Prepare common configuration """
@@ -1008,18 +1005,23 @@ class GuestTestcloud(tmt.GuestSsh):
 
         # Prepare ssh key
         # TODO: Maybe... some better way to do this?
+        public_key = self.prepare_ssh_key(SSH_KEYGEN_TYPE)
         if self._domain.coreos:
             self._instance.coreos = True
             # prepare_ssh_key() writes key directly to COREOS_DATA
             self._instance.ssh_path = []
-        self.prepare_ssh_key(SSH_KEYGEN_TYPE)
+            data_tpl = Template(COREOS_DATA).safe_substitute(
+                user_name=self.user, public_key=public_key)
+        else:
+            data_tpl = Template(USER_DATA).safe_substitute(
+                user_name=self.user, public_key=public_key)
 
         # Boot the virtual machine
         self.info('progress', 'booting...', 'cyan')
         assert libvirt is not None
 
         try:
-            self._instance.prepare()
+            self._instance.prepare(data_tpl=data_tpl)
             self._instance.spawn_vm()
             self._instance.start(BOOT_TIMEOUT * time_coeff)
         except (testcloud.exceptions.TestcloudInstanceError,


### PR DESCRIPTION
Together with now staged testcloud-0.11.0, should resolve https://github.com/teemtee/tmt/issues/3235 once and for all.

Required testcloud is built at: https://copr.fedorainfracloud.org/coprs/frantisekz/testcloud-temp/

The {USER, COREOS}_DATA variables were affected by threads overwriting them directly in testcloud's config object as observed in https://github.com/teemtee/tmt/pull/3244#issuecomment-2392236256 and following comments. Testcloud-side change can be seen here: https://pagure.io/testcloud/c/ee1202bcf57cd475f4586f3693e2127f9a12e92e?branch=master . 

Only these two variables can differ between various instances in tmt's use of testcloud, the others are kept separately since the domain api switchover last year: https://github.com/teemtee/tmt/pull/2078 .

Co-authored by @jskladan 

@happz @psss 

Pull Request Checklist

* [x] implement the feature
* [x] include a release note