### PR TITLE
Remove `skip` from the `ResultInterpret` enumeration

### DIFF
--- a/tmt/result.py
+++ b/tmt/result.py
@@ -47,7 +47,6 @@ class ResultInterpret(enum.Enum):
     INFO = 'info'
     WARN = 'warn'
     ERROR = 'error'
-    SKIP = 'skip'
 
     # Special interpret values
     RESPECT = 'respect'

--- a/tmt/schemas/common.yaml
+++ b/tmt/schemas/common.yaml
@@ -478,7 +478,6 @@ definitions:
       - warn
       - error
       - fail
-      - skip
       - custom
       - restraint
 


### PR DESCRIPTION
As discussed today, the `skip` value was never documented in the test `result` key specification and was added by an accident.

There seems to be a use case to support skipping selected tests but that functionality is substantially different from the result interpretation configured by the `result` key which happens only after test execution is completed so most probably a new test key should be introduced for it.

Pull Request Checklist

* [x] implement the feature
* [x] modify the json schema