### PR TITLE
New tests for adjusting `duration` of a test

### DIFF
--- a/tests/core/adjust/data/tests.fmf
+++ b/tests/core/adjust/data/tests.fmf
@@ -7,6 +7,24 @@
         duration: 1m
         when: arch == ppc64
 
+/adjust-duration-combine:
+    test: echo 'adjust duration combine'
+    duration: 1s
+    adjust:
+      - duration+: 1h1m
+
+/adjust-duration-multi:
+    test: echo 'adjust duration multi'
+    duration: 1m
+    adjust:
+      - duration+: '*2.5'
+
+/adjust-duration-sum:
+    test: echo 'adjust duration sum'
+    duration: 1s
+    adjust:
+      - duration+: '+10s'
+
 /pidof:
     test: pidof sh
     adjust:

--- a/tests/core/adjust/test.sh
+++ b/tests/core/adjust/test.sh
@@ -26,6 +26,15 @@ rlJournalStart
         rlAssertGrep 'enabled\s+false' $output -E
         rlRun "tmt -c @context.yaml test show uptime | tee $output"
         rlAssertGrep 'duration\s+1m' $output -E
+        # uptime duration adjusted with combination
+        rlRun "tmt test show adjust-duration-combine | tee $output"
+        rlAssertGrep 'duration\s+1s1h1m' $output -E
+        # uptime duration adjusted with multiplication
+        rlRun "tmt test show adjust-duration-multi | tee $output"
+        rlAssertGrep 'duration\s+1m\*2\.5' $output -E
+        # uptime duration adjusted with sum
+        rlRun "tmt test show adjust-duration-sum | tee $output"
+        rlAssertGrep 'duration\s+1s\+10s' $output -E
     rlPhaseEnd
 
     rlPhaseStartTest "Show plans"


### PR DESCRIPTION
Adding 3 new tests for adjust duration:

- Combining multiple duration strings
- Multiplying by a value
- Adding a value

It refers also to #3278


Pull Request Checklist

* [X] extend the test coverage