### PR TITLE
Suggest using `direnv` when working on `tmt` tests

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -139,8 +139,9 @@ You might want to set some useful environment variables when
 working on ``tmt`` tests, for example ``TMT_FEELING_SAFE`` to
 allow the ``local`` provision method or ``TMT_SHOW_TRACEBACK`` to
 show the full details for all failures. Consider installing the
-``direnv`` command which can take care of these for you.
+`direnv`__ command which can take care of these for you.
 
+__ https://direnv.net/#basic-installation
 
 
 Unit Tests

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -135,6 +135,13 @@ Run selected tests or plans in verbose mode:
     tmt run --verbose plan --name basic
     tmt run -v test -n smoke
 
+You might want to set some useful environment variables when
+working on ``tmt`` tests, for example ``TMT_FEELING_SAFE`` to
+allow the ``local`` provision method or ``TMT_SHOW_TRACEBACK`` to
+show the full details for all failures. Consider installing the
+``direnv`` command which can take care of these for you.
+
+
 
 Unit Tests
 ------------------------------------------------------------------

--- a/tests/.envrc
+++ b/tests/.envrc
@@ -1,0 +1,2 @@
+export TMT_FEELING_SAFE=1
+export TMT_SHOW_TRACEBACK=full


### PR DESCRIPTION
Add a short mention about useful environment variables into the contribution section, mention the `direnv` command and add a simple `.envrc` file under the `tests` directory.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation