### PR TITLE
Wait for guest connection before test restart

### DIFF
--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -443,6 +443,15 @@ class TestInvocation:
         else:
             self._restart_count += 1
 
+            # Even though the reboot was not requested, it might have
+            # still happened! Imagine a test configuring autoreboot on
+            # kernel panic plus a test restart. The reboot would happen
+            # beyond tmt's control, and tmt would try to restart the
+            # test, but the guest may be still booting. Make sure it's
+            # alive.
+            if not self.guest.reconnect():
+                return False
+
         self.logger.debug(
             f"Test restart during test '{self.test}'"
             f" with reboot count {self._reboot_count}"


### PR DESCRIPTION
Even without a reboot, tmt still needs to verify the guest is up and running. The reboot might be triggered beyond the control of tmt, and that is fine, we just need to be sure we restart the test on guest that's alive.

Related to https://github.com/teemtee/tmt/issues/3284

Pull Request Checklist

* [x] implement the feature