### PR TITLE
Add support to set number of CPUs for virtual run

### DIFF
--- a/tests/provision/virtual.testcloud/data/plan.fmf
+++ b/tests/provision/virtual.testcloud/data/plan.fmf
@@ -10,6 +10,7 @@ provision:
     image: fedora
     disk: 10
     memory: 2048
+    cpu: 3
     #user: custom_user
     connection: system
     arch: x86_64


### PR DESCRIPTION
Without this some tests could be pretty slow because standard is 2 CPUs which is not much these days.

Hi, I'm fighting with mypy and other things and I have hard time to work on this. So I'm creating a PR if someone wants to help me with debugging to finish this if you see the benefit. 


Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
