### PR TITLE
Improve CLI rendering of plugin docs

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -1179,7 +1179,7 @@ class Method:
         lines = self.doc.splitlines()
 
         self.summary: str = lines[0].strip()
-        self.description: str = '\n'.join(lines[1:])
+        self.description: str = '\n'.join(lines[1:]).strip()
 
     def __repr__(self) -> str:
         return f'<{self.name} from {self.class_.__module__}>'

--- a/tmt/utils/rest.py
+++ b/tmt/utils/rest.py
@@ -18,10 +18,11 @@ import tmt.log
 from tmt.log import Logger
 from tmt.utils import GeneralError
 
+#: Special string representing a new-line in the stack of rendered
+#: paragraphs.
+NL = ''
 
-#
-# ReST rendering
-#
+
 class RestVisitor(docutils.nodes.NodeVisitor):
     """
     Custom renderer of docutils nodes.
@@ -63,6 +64,10 @@ class RestVisitor(docutils.nodes.NodeVisitor):
     def rendered(self) -> str:
         """ Return the rendered document as a single string """
 
+        # Drop any trailing empty lines
+        while self._rendered_paragraphs and self._rendered_paragraphs[-1] == NL:
+            self._rendered_paragraphs.pop(-1)
+
         return '\n'.join(self._rendered_paragraphs)
 
     def _emit(self, s: str) -> None:
@@ -91,8 +96,8 @@ class RestVisitor(docutils.nodes.NodeVisitor):
         # To simplify the implementation, this is merging of multiple
         # empty lines into one. Rendering of nodes than does not have
         # to worry about an empty line already being on the stack.
-        if self._rendered_paragraphs and self._rendered_paragraphs[-1] != '':
-            self._emit_paragraphs([''])
+        if self._rendered_paragraphs and self._rendered_paragraphs[-1] != NL:
+            self._emit_paragraphs([NL])
 
     # Simple logging for nodes that have no effect
     def _noop_visit(self, node: docutils.nodes.Node) -> None:
@@ -130,6 +135,13 @@ class RestVisitor(docutils.nodes.NodeVisitor):
 
     def depart_paragraph(self, node: docutils.nodes.paragraph) -> None:
         self.log_departure(str(node))
+
+        # Top-level paragraphs should be followed by an empty line to
+        # prevent pargraphs sticking together. Only the top-level ones
+        # though, we do not want empty lines after every paragraph-like
+        # string, because a lot of nodes are also paragraphs.
+        if isinstance(node.parent, docutils.nodes.document):
+            self.nl()
 
         self.flush()
 

--- a/tmt/utils/rest.py
+++ b/tmt/utils/rest.py
@@ -137,7 +137,7 @@ class RestVisitor(docutils.nodes.NodeVisitor):
         self.log_departure(str(node))
 
         # Top-level paragraphs should be followed by an empty line to
-        # prevent pargraphs sticking together. Only the top-level ones
+        # prevent paragraphs sticking together. Only the top-level ones
         # though, we do not want empty lines after every paragraph-like
         # string, because a lot of nodes are also paragraphs.
         if isinstance(node.parent, docutils.nodes.document):


### PR DESCRIPTION
* some paragraphs were glued together, that has been fixed by enforcing new line between top-level paragraphs,
* plugin's one-line "summary" and "description" were separated by one extra empty line, which is now gone.

Related to #3300.

Pull Request Checklist

* [x] implement the feature