### PR TITLE
Call the `tmt-file-submit` script directly

### DIFF
--- a/tmt/frameworks/beakerlib.py
+++ b/tmt/frameworks/beakerlib.py
@@ -36,7 +36,8 @@ class Beakerlib(TestFramework):
         return Environment({
             'BEAKERLIB_DIR': EnvVarValue(invocation.path),
             'BEAKERLIB_COMMAND_SUBMIT_LOG': EnvVarValue(
-                f'bash {invocation.guest.scripts_path / tmt.steps.execute.TMT_FILE_SUBMIT_SCRIPT.source_filename}')  # noqa: E501
+                invocation.guest.scripts_path /
+                tmt.steps.execute.TMT_FILE_SUBMIT_SCRIPT.source_filename),
             })
 
     @classmethod


### PR DESCRIPTION
The `tmt-file-submit` script is executable so it should not be necessary to use `bash` explicitly when submitting files from beakerlib.

Pull Request Checklist

* [x] implement the feature