### PR TITLE
Fix missing Testing Farm link in release notes

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -74,6 +74,7 @@ invalid XML characters from the final JUnit XML.
 A new :ref:`test-runner` section has been added to the tmt
 :ref:`guide`. It describes some important differences between
 running tests on a :ref:`user-system` and scheduling test jobs in
+Testing Farm.
 
 A race condition in the
 :ref:`/plugins/provision/virtual.testcloud` plugin has been fixed,

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -74,7 +74,7 @@ invalid XML characters from the final JUnit XML.
 A new :ref:`test-runner` section has been added to the tmt
 :ref:`guide`. It describes some important differences between
 running tests on a :ref:`user-system` and scheduling test jobs in
-Testing Farm.
+:ref:`testing-farm`.
 
 A race condition in the
 :ref:`/plugins/provision/virtual.testcloud` plugin has been fixed,


### PR DESCRIPTION
Some bad rebase caused the sentence to be not finished. Not sure where that happened, but let's fix it :)