### PR TITLE
Require netstat for the extended unit test plan workaround

### DIFF
--- a/plans/features/extended-unit-tests.fmf
+++ b/plans/features/extended-unit-tests.fmf
@@ -15,6 +15,7 @@ adjust+:
         how: shell
         script: |
             set -x
+            dnf install -y /usr/bin/netstat
             systemctl unmask systemd-resolved
             systemctl disable systemd-resolved
             systemctl stop systemd-resolved


### PR DESCRIPTION
Pull Request Checklist

* [x] implement the feature