### PR TITLE
Disable credentials persistence in Github checkout action

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,6 +12,8 @@ jobs:
       SKIP: no-commit-to-branch
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: actions/setup-python@v5
       with:
         python-version: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,13 @@ jobs:
       # Check out the repo
       - uses: actions/checkout@v4
         if: ${{ github.event_name == 'release' }}
+        with:
+          persist-credentials: false
       - uses: actions/checkout@v4
         if: ${{ github.event_name == 'workflow_dispatch' }}
         with:
           ref: ${{ github.event.inputs.ref }}
+          persist-credentials: false
 
       # Setup python
       - uses: actions/setup-python@v5

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - id: ShellCheck
         name: Differential ShellCheck


### PR DESCRIPTION
According to a couple of articles, the default should be `false`, but it's not, which makes the token exposed to actions that do not need it. According to a linter I tried just for fun, we should enforce it to close this hole.

[1] https://github.com/actions/checkout/issues/485
[2] https://github.com/woodruffw/zizmor

Pull Request Checklist

* [x] implement the feature