### PR TITLE
Mark AVC check as expected when running AVC check test on localhost

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/plans/provision/connect.fmf
+++ b/plans/provision/connect.fmf
@@ -5,3 +5,6 @@ provision:
 #    key: /home/psss/.ssh/devel_rsa
 #    user: root
 #    password: secret
+
+context+:
+  provision_how: connect

--- a/plans/provision/container.fmf
+++ b/plans/provision/container.fmf
@@ -18,6 +18,9 @@ prepare+:
     summary: Fetch dnf cache to speed up the test execution
     script: prepare/podman-images.sh
 
+context+:
+  provision_how: container
+
 environment:
     PROVISION_HOW: container
 

--- a/plans/provision/local.fmf
+++ b/plans/provision/local.fmf
@@ -14,6 +14,9 @@ discover:
     how: fmf
     filter: 'tag:provision-local'
 
+context+:
+  provision_how: local
+
 environment:
     PROVISION_HOW: local
 

--- a/plans/provision/virtual.fmf
+++ b/plans/provision/virtual.fmf
@@ -32,6 +32,9 @@ prepare+:
             virt-customize --add $image --run-command 'dnf --refresh install -y beakerlib'
         done
 
+context+:
+  provision_how: virtual
+
 environment:
     PROVISION_HOW: virtual
 

--- a/tests/test/check/main.fmf
+++ b/tests/test/check/main.fmf
@@ -16,6 +16,12 @@ tier: 2
       - provision-local
       - provision-virtual
 
+    adjust+:
+      - when: provision_how == local
+        check:
+          - how: avc
+            result: xfail
+
 /watchdog:
     test: ./test-watchdog.sh
     duration: 15m


### PR DESCRIPTION
This is an unexpected consequence of checks being interpreted in 1.38:
tmt in TF runs a test, test runs another tmt which triggers an AVC
denial, on purpose, but thanks to all this happening on localhost, TF
tmt can notice the AVC denial, and report it as a failed check. Adding
`xfail` to prevent this.

Pull Request Checklist

* [x] implement the feature