### PR TITLE
Add subresults support for reportportal report plugin

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,11 +4,17 @@
     Releases
 ======================
 
+
 tmt-1.43
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Add the ``--workdir-root`` option for the ``tmt clean images``
 command so that users can specify the directory they want.
+
+A new ``upload-subresults`` key has been introduced for the
+:ref:`/plugins/report/reportportal` plugin, allowing the import of
+tmt subresults as child test items into ReportPortal. This
+behavior is optional and is disabled by default.
 
 
 tmt-1.42.1

--- a/tests/report/reportportal/data/beaker-phases-subresults.sh
+++ b/tests/report/reportportal/data/beaker-phases-subresults.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+
+rlJournalStart
+    rlPhaseStartSetup "phase-setup"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "pushd $tmp"
+    rlPhaseEnd
+
+    rlPhaseStartTest "phase-test pass"
+        rlRun -s "echo mytest-pass" 0 "Check output"
+        rlAssertGrep "mytest-pass" "$rlRun_LOG"
+    rlPhaseEnd
+
+    rlPhaseStartTest "phase-test fail"
+        rlRun -s "echo mytest-fail" 0 "Check output"
+        rlAssertGrep "this-will-intentionally-fail" "$rlRun_LOG"
+    rlPhaseEnd
+
+    rlPhaseStartTest "phase-test multiple tmt-report-result"
+        rlRun "echo bkr_good_log > bkr_good.log"
+        rlRun "echo bkr_bad_log > bkr_bad.log"
+        rlRun "echo bkr_weird_log > bkr_weird.log"
+        rlRun "echo bkr_skip_log > bkr_skip.log"
+        rlRun "echo bkr_good_rhts_log > bkr_good_rhts.log"
+
+        # This will create more subresults for each
+        # tmt-report-result/rhts-report-result call
+        rlRun "tmt-report-result -o bkr_good.log extra-tmt-report-result/good PASS"
+        rlRun "tmt-report-result -o bkr_bad.log extra-tmt-report-result/bad FAIL"
+        rlRun "tmt-report-result -o bkr_weird.log extra-tmt-report-result/weird WARN"
+        rlRun "tmt-report-result -o bkr_skip.log extra-tmt-report-result/skip SKIP"
+        rlRun "rhts-report-result extra-rhts-report-result/good PASS bkr_good_rhts.log"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup "phase-cleanup"
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/report/reportportal/data/plan.fmf
+++ b/tests/report/reportportal/data/plan.fmf
@@ -3,12 +3,13 @@ summary: Testing the integration of tmt and Report Portal via its API
 discover:
     how: fmf
 provision:
-    how: local
+    how: container
 execute:
     how: tmt
 report:
     how: reportportal
     project: test_tmt
+    upload-subresults: true
 
 context:
     component: tmt

--- a/tests/report/reportportal/data/test.fmf
+++ b/tests/report/reportportal/data/test.fmf
@@ -14,3 +14,23 @@
 /weird:
     summary: An error encountered
     test: this-is-a-weird-command
+
+/subresults:
+    summary: Test the tmt subresults (ReportPortal child items)
+    test: |
+        tmt-report-result /subtest/good PASS
+        tmt-report-result /subtest/fail FAIL
+        tmt-report-result /subtest/weird WARN
+
+/subresults-restraint:
+    result: restraint
+    test: |
+        tmt-report-result /subtest-restraint/good PASS
+        tmt-report-result /subtest-restraint/fail FAIL
+        tmt-report-result /subtest-restraint/weird WARN
+
+# TODO: Enable test of subresults for beakerlib phases
+#/subresults-beakerlib:
+#    summary: Test the Beakerlib phases are propagated as tmt subresults
+#    framework: beakerlib
+#    test: ./beaker-phases-subresults.sh

--- a/tests/report/reportportal/test.sh
+++ b/tests/report/reportportal/test.sh
@@ -8,10 +8,19 @@ ARTIFACTS=$TMT_REPORT_ARTIFACTS_URL
 
 PLAN_PREFIX='/plan'
 PLAN_STATUS='FAILED'
-TEST_PREFIX='/test'
-declare -A test=([1,'uuid']="" [1,'name']='/bad'   [1,'status']='FAILED'
-                 [2,'uuid']="" [2,'name']='/good'  [2,'status']='PASSED'
-                 [3,'uuid']="" [3,'name']='/weird' [3,'status']='FAILED')
+TEST_PREFIX=''
+
+# TODO: Subresults for beakerlib
+declare -A test=([1,'uuid']="" [1,'name']='/test/bad'        [1,'status']='FAILED'
+                 [2,'uuid']="" [2,'name']='/test/good'       [2,'status']='PASSED'
+                 [3,'uuid']="" [3,'name']='/test/subresults' [3,'status']='FAILED'
+                 [4,'uuid']="" [4,'name']='/subtest/good' [4,'status']='PASSED'
+                 [5,'uuid']="" [5,'name']='/subtest/fail' [5,'status']='FAILED'
+                 [6,'uuid']="" [6,'name']='/subtest/weird' [6,'status']='FAILED'
+                 [7,'uuid']="" [7,'name']='/test/subresults-restraint/subtest-restraint/good' [7,'status']='PASSED'
+                 [8,'uuid']="" [8,'name']='/test/subresults-restraint/subtest-restraint/fail' [8,'status']='FAILED'
+                 [9,'uuid']="" [9,'name']='/test/subresults-restraint/subtest-restraint/weird' [9,'status']='FAILED'
+                 [10,'uuid']="" [10,'name']='/test/weird'      [10,'status']='FAILED')
 DIV="|"
 
 
@@ -56,15 +65,16 @@ function identify_suite(){
 # Read and verify reported test names and uuids from $rlRun_LOG
 #
 # GLOBALS:
-# >> $test_uuid[1..3], $test_fullname[1..3]
+# >> $test_uuid[1..10], $test_fullname[1..10]
 function identify_tests(){
     rlLog "Verify and get test data"
 
-    for i in {1..3}; do
+    for i in {1..10}; do
         test_fullname[$i]=${TEST_PREFIX}${test[$i,'name']}
 
+        rlAssertGrep " \(sub-\)\?test: ${test_fullname[$i]}" $rlRun_LOG
         rlAssertGrep "test: ${test_fullname[$i]}" $rlRun_LOG
-        test_uuid[$i]=$(rlRun "grep -m$i -A1 'test:' $rlRun_LOG | tail -n1 | awk '{print \$NF}' ")
+        test_uuid[$i]=$(rlRun "grep -m$i -A1 ' \(sub-\)\?test:' $rlRun_LOG | tail -n1 | awk '{print \$NF}' ")
         rlAssertNotEquals "Assert the test$i UUID is not empty" "${test_uuid[$i]}" ""
         test[$i,'uuid']=${test_uuid[$i]}
     done
@@ -77,9 +87,8 @@ function identify_tests(){
 # ARGUMENT:
 #   request_url
 function rest_api(){
-
     rlLog "REST API request (GET $1)"
-    response=$(curl --write-out "$DIV%{http_code}" --silent -X GET "$1" -H  "accept: */*" -H  "Authorization: bearer $TOKEN")
+    response=$(curl --write-out "$DIV%{http_code}" --silent -X GET "$1" -H  "Accept: */*" -H  "Authorization: Bearer $TOKEN")
 
     response_code=${response##*"$DIV"}
     response=${response%"$DIV"*}
@@ -102,7 +111,6 @@ rlJournalStart
         fi
     rlPhaseEnd
 
-
     echo -e "\n\n\n::   PART 1\n"
 
     rlPhaseStartTest "Core Functionality"
@@ -112,9 +120,9 @@ rlJournalStart
         # TMT RUN
         rlLogInfo "A run with default setup"
         rlRun -s "tmt run --id $run --verbose --all" 2
-        rlAssertGrep "url: http.*redhat.com.ui/#${PROJECT}/launches/all/[0-9]{4}" $rlRun_LOG -Eq
+        rlAssertGrep "url: https?://.*\.redhat\.com/ui/#${PROJECT}/launches/all/[0-9]+" $rlRun_LOG -Eq
         identify_launch  # >> $launch_uuid, $launch_id
-        identify_tests   # >> $test_uuid[1..3], $test_fullname[1..3]
+        identify_tests   # >> $test_uuid[1..10], $test_fullname[1..10]
     rlPhaseEnd
 
 
@@ -150,10 +158,15 @@ rlJournalStart
         done
         rm tmp_attributes*
 
-        for i in {1..3}; do
+        for i in {1..10}; do
             echo ""
             test_name[$i]=${test[$i,'name']}
             test_name=${test_name[$i]}
+
+            # Strip the '/test' prefix from the name cause the tests are saved
+            # in `test.fmf` without this prefix.
+            test_name=${test_name#/test}
+
             test_fullname=${test_fullname[$i]}
             test_uuid=${test_uuid[$i]}
             test_status[$i]=${test[$i,'status']}
@@ -166,52 +179,53 @@ rlJournalStart
             rlAssertNotEquals "Assert the test id is not empty" "$test_id" ""
             rlAssertEquals "Assert the name is correct" "$(echo $response | jq -r '.name')" "$test_fullname"
             rlAssertEquals "Assert the status is correct" "$(echo $response | jq -r '.status')" "$test_status"
-            test_description=$(yq -r ".\"$test_name\".summary" test.fmf)
-            rlAssertEquals "Assert the description is correct" "$(echo $response | jq -r '.description')" "$test_description"
+            test_description=$(yq -er ".\"$test_name\".summary" test.fmf) || test_description=''
+            rlAssertEquals "Assert the description is correct" "$(echo $response | jq -r '.description // ""')" "$test_description"
             test_case_id=$(yq -r ".\"$test_name\".id" test.fmf)
+
             [[ $test_case_id != null ]] && rlAssertEquals "Assert the testCaseId is correct" "$(echo $response | jq -r '.testCaseId')" "$test_case_id"
 
-            for jq_element in attributes parameters; do
-
+            # Check the test attributes only for parent test items, do not check them for subresults
+            if [[ ! "$test_name" =~ ^/subtest/ ]]; then
                 # Check all the common test attributes/parameters
-                [[ $jq_element == attributes ]] && fmf_label="context"
-                [[ $jq_element == parameters ]] && fmf_label="environment"
-                rlLogInfo "Check the $jq_element for test $test_name ($fmf_label)"
-                echo "$response" | jq -r ".$jq_element" > tmp_attributes.json || rlFail "$jq_element listing into tmp_attributes.json"
-                length=$(yq -r ".$fmf_label | length" plan.fmf)
-                for ((item_index=0; item_index<$length; item_index++ )); do
-                    key=$(yq -r ".$fmf_label | keys | .[$item_index]" plan.fmf)
-                    value=$(yq -r ".$fmf_label.$key" plan.fmf)
-                    rlAssertGrep "$key" tmp_attributes.json -A1 > tmp_attributes_selection
-                    rlAssertGrep "$value" tmp_attributes_selection
-                done
-
-                # Check the rarities in the test attributes/parameters
-                if [[ $jq_element == attributes ]]; then
-                    key="contact"
-
-                    value="$(yq -r ".\"$test_name\".$key" test.fmf)"
-                    if [[ $value != null ]]; then
-                        if [[ "$value" == *","* ]]; then
-                          # Get the contact items as CSV (separated by a comma)
-                          value="$(yq -r ". | @csv" <<< $value)"
-                        fi
+                for jq_element in attributes parameters; do
+                    [[ $jq_element == attributes ]] && fmf_label="context"
+                    [[ $jq_element == parameters ]] && fmf_label="environment"
+                    rlLogInfo "Check the $jq_element for test $test_name ($fmf_label)"
+                    echo "$response" | jq -r ".$jq_element" > tmp_attributes.json || rlFail "$jq_element listing into tmp_attributes.json"
+                    length=$(yq -r ".$fmf_label | length" plan.fmf)
+                    for ((item_index=0; item_index<$length; item_index++ )); do
+                        key=$(yq -r ".$fmf_label | keys | .[$item_index]" plan.fmf)
+                        value=$(yq -r ".$fmf_label.$key" plan.fmf)
                         rlAssertGrep "$key" tmp_attributes.json -A1 > tmp_attributes_selection
+                        rlAssertGrep "$value" tmp_attributes_selection
+                    done
 
-                        IFS=, read -r -a contact_items <<< "$value"
-                        for contact_item in "${contact_items[@]}"; do
-                            rlAssertGrep "$contact_item" tmp_attributes_selection
-                        done
-                    else
+                    # Check the rarities in the test attributes/parameters
+                    if [[ $jq_element == attributes ]]; then
+                        key="contact"
+                        value="$(yq -r ".\"$test_name\".$key" test.fmf)"
+
+                        if [[ $value != null ]]; then
+                            # Get the contact items as values separated by a comma
+                            value="$(yq -r '. | join(",")' <<< $value)"
+                            rlAssertGrep "$key" tmp_attributes.json -A1 > tmp_attributes_selection
+
+                            IFS=, read -r -a contact_items <<< "$value"
+                            for contact_item in "${contact_items[@]}"; do
+                                rlAssertGrep "$contact_item" tmp_attributes_selection
+                            done
+                        else
+                            rlAssertNotGrep "$key" tmp_attributes.json
+                        fi
+                    elif [[ $jq_element == parameters ]]; then
+                        key="TMT_TREE"
                         rlAssertNotGrep "$key" tmp_attributes.json
                     fi
-                elif [[ $jq_element == parameters ]]; then
-                    key="TMT_TREE"
-                    rlAssertNotGrep "$key" tmp_attributes.json
-                fi
 
-                rm tmp_attributes*
-            done
+                    rm tmp_attributes*
+                done
+            fi
 
             # REST API | [GET] log-controller | parent_id
             rlLogInfo "Get all logs from the test $test_name"
@@ -220,7 +234,9 @@ rlJournalStart
             level=("INFO" "ERROR")
             for ((content_index=0; content_index<$length; content_index++ )); do
                 rlAssertEquals "Assert the level of the info log is correct" "$(echo $response | jq -r .content[$content_index].level)" "${level[$content_index]}"
-                if [[ $i -ne 3 ]]; then
+
+                # Check the log message is correct (except the weird parent test)
+                if [[ $i -ne 10 ]]; then
                     log_message=$(yq -r ".\"$test_name\".test" test.fmf | awk -F '"' '{print $2}' )
                     rlAssertEquals "Assert the message of the info log is correct" "$(echo $response | jq -r .content[$content_index].message)" "$log_message"
                 fi
@@ -228,7 +244,6 @@ rlJournalStart
         done
 
     rlPhaseEnd
-
 
     echo -e "\n\n\n::   PART 2\n"
 
@@ -241,16 +256,24 @@ rlJournalStart
         rlRun -s "tmt run --verbose --all report --how reportportal --launch-per-plan --launch '$launch_name' " 2 "" 1>/dev/null
         identify_launch  # >> $launch_uuid, $launch_id
         rlAssertNotGrep "suite:" $rlRun_LOG
-        identify_tests   # >> $test_uuid[1..3], $test_fullname[1..3]
+        identify_tests   # >> $test_uuid[1..10], $test_fullname[1..10]
 
         # REST API | [GET] test-item-controller | launch_id
         rlLogInfo "Get info about all launch items"
         response=$(rest_api "$URL/api/v1/$PROJECT/item?filter.eq.launchId=$launch_id")
         length=$(echo $response | jq -r ".content | length")
         for ((content_index=0; content_index<$length; content_index++ )); do
-            rlAssertEquals "Assert the item is no suite" "$(echo $response | jq -r .content[$content_index].hasChildren)" "false"
-        done
+            parent_item_json=$(echo $response | jq -r .content[$content_index])
+            parent_item_name=$(echo $parent_item_json | jq -r .name)
 
+            if jq -e '.name == "/test/subresults"' <<< "$parent_item_json" > /dev/null; then
+                # All parent tests with subresults must have child subresult items
+                rlAssertEquals "Assert the item ($parent_item_name) has child items" "$(echo $parent_item_json | jq -r .hasChildren)" "true"
+            else
+                # Tests with no subresults must not have any child items
+                rlAssertEquals "Assert the item ($parent_item_name) has no child items" "$(echo $parent_item_json | jq -r .hasChildren)" "false"
+            fi
+        done
     rlPhaseEnd
 
     # Testing suite-per-plan mapping with launch-suite-test structure
@@ -266,7 +289,7 @@ rlJournalStart
         rlRun -s "tmt run --verbose --all report --how reportportal --suite-per-plan --launch '$launch_name' --launch-description '$launch_description'" 2 "" 1>/dev/null
         identify_launch  # >> $launch_uuid, $launch_id
         identify_suite   # >> $suite_uuid, $suite_id
-        identify_tests   # >> $test_uuid[1..3], $test_fullname[1..3]
+        identify_tests   # >> $test_uuid[1..10], $test_fullname[1..10]
         echo ""
 
         # REST API | [GET] launch-controller | uuid
@@ -297,15 +320,25 @@ rlJournalStart
         length=$(echo $response | jq -r ".content | length")
         for ((content_index=0; content_index<$length; content_index++ )); do
             echo ""
+
+            parent_item_json=$(echo $response | jq -r .content[$content_index])
+            parent_item_name=$(echo $parent_item_json | jq -r .name)
+
             if [[ $content_index -eq 0 ]]; then
-                rlAssertEquals "Assert the item is a suite" "$(echo $response | jq -r .content[$content_index].hasChildren)" "true"
-                rlAssertEquals "Assert the name of suite item ${suite_name}" "$(echo $response | jq -r .content[$content_index].name)" "${suite_name}"
-                rlAssertEquals "Assert the description of suite item ${suite_name}" "$(echo $response | jq -r .content[$content_index].description)" "$plan_summary"
+                # Check the suite item
+                rlAssertEquals "Assert the item is a suite" "$(echo $parent_item_json | jq -r .hasChildren)" "true"
+                rlAssertEquals "Assert the name of suite item ${suite_name}" "$(echo $parent_item_json | jq -r .name)" "${suite_name}"
+                rlAssertEquals "Assert the description of suite item ${suite_name}" "$(echo $parent_item_json | jq -r .description)" "${plan_summary}<br>${launch_description}"
             else
-                i=$content_index
-                rlAssertEquals "Assert the item is no suite" "$(echo $response | jq -r .content[$content_index].hasChildren)" "false"
-                rlAssertEquals "Assert the name of test item ${test_name[$i]}" "$(echo $response | jq -r .content[$content_index].name)" "${test_fullname[$i]}"
-                rlAssertEquals "Assert the UUID of test item ${test_name[$i]}" "$(echo $response | jq -r .content[$content_index].uuid)" "${test_uuid[$i]}"
+                if jq -e '.name == "/test/subresults"' <<< "$parent_item_json" > /dev/null; then
+                    # All parent tests with subresults must have child subresult items
+                    rlAssertEquals "Assert the item (${parent_item_name}) has child items" "$(echo $parent_item_json | jq -r .hasChildren)" "true"
+                else
+                    # Tests with no subresults must not have any child items
+                    rlAssertEquals "Assert the item (${parent_item_name}) has no child items" "$(echo $parent_item_json | jq -r .hasChildren)" "false"
+                fi
+                rlAssertEquals "Assert the name of test item ${test_fullname[$content_index]}" "$(echo $parent_item_json | jq -r .name)" "${test_fullname[$content_index]}"
+                rlAssertEquals "Assert the UUID of test item ${test_fullname[$content_index]}" "$(echo $parent_item_json | jq -r .uuid)" "${test_uuid[$content_index]}"
             fi
         done
 
@@ -319,7 +352,7 @@ rlJournalStart
         # TMT RUN [0]
         rlLogInfo "Initial run that creates a launch for history"
         rlRun -s "tmt run --verbose --all report --how reportportal --suite-per-plan --launch '${launch_name}_1'" 2 "" 1>/dev/null
-        for i in {1..3}; do
+        for i in {1..10}; do
             echo ""
             test_fullname=${TEST_PREFIX}${test[$i,'name']}
             test_uuid=$(rlRun "grep -m$i -A1 'test:' $rlRun_LOG | tail -n1 | awk '{print \$NF}' ")
@@ -337,7 +370,7 @@ rlJournalStart
         # TMT RUN [1]
         rlLogInfo "A run that creates a launch with filtered environment variables (by default)"
         rlRun -s "tmt run --verbose --all report --how reportportal --suite-per-plan --launch '${launch_name}_2'" 2 "" 1>/dev/null
-        for i in {1..3}; do
+        for i in {1..10}; do
             echo ""
             test_name=${test[$i,'name']}
             test_fullname=${TEST_PREFIX}${test_name}
@@ -361,7 +394,7 @@ rlJournalStart
         # TMT RUN [2]
         rlLogInfo "A run that creates a launch without filtering the environment variables that break history aggregation"
         rlRun -s "tmt run --verbose --all report --how reportportal --suite-per-plan --launch '${launch_name}_3' --exclude-variables ''" 2 "" 1>/dev/null
-        for i in {1..3}; do
+        for i in {1..10}; do
             echo ""
             test_name=${test[$i,'name']}
             test_fullname=${TEST_PREFIX}${test_name}
@@ -376,7 +409,12 @@ rlJournalStart
             test_case_id=$(yq -r ".\"$test_name\".id" test.fmf)
             [[ $test_case_id != null ]] && rlAssertEquals "Assert the test ${test_name} has a correct testCaseId" "$(echo $response | jq -r '.testCaseId')" "$test_case_id"
             echo "$response" | jq -r ".$jq_element" > tmp_attributes.json || rlFail "$jq_element listing into tmp_attributes.json"
-            rlAssertGrep "TMT_TREE" tmp_attributes.json
+
+            # FIXME: Ignore the check for subtests
+            if [[ ! "$test_name" =~ ^/subtest/ ]]; then
+                rlAssertGrep "TMT_TREE" tmp_attributes.json
+            fi
+
             rm tmp_attributes*
 
             # history is not aggregated unless test case id is defined for given test (only test_2)
@@ -399,7 +437,7 @@ rlJournalStart
         # TMT RUN [0]
         rlLogInfo "Initial run that creates a launch"
         rlRun -s "tmt run --verbose --all report --how reportportal --suite-per-plan --launch '$launch_name'" 2 "" 1>/dev/null
-        for i in {1..3}; do
+        for i in {1..10}; do
             core_test_uuid[$i]=$(rlRun "grep -m$i -A1 'test:' $rlRun_LOG | tail -n1 | awk '{print \$NF}' ")
             rlAssertNotEquals "Assert the test$i UUID is not empty" "{$core_test_uuid[$i]}" ""
         done
@@ -410,7 +448,7 @@ rlJournalStart
         rlRun -s "tmt run --verbose --all report --how reportportal --suite-per-plan --launch '$launch_name' --launch-rerun" 2 "" 1>/dev/null
         identify_launch  # >> $launch_uuid, $launch_id
         identify_suite   # >> $suite_uuid
-        identify_tests   # >> $test_uuid[1..3], $test_fullname[1..3]
+        identify_tests   # >> $test_uuid[1..10], $test_fullname[1..10]
         rlAssertGrep "suite: $suite_name" $rlRun_LOG
 
         # REST API | [GET] launch-controller | uuid
@@ -439,7 +477,7 @@ rlJournalStart
         # TMT RUN [0]
         rlLogInfo "Initial run that creates a launch"
         rlRun -s "tmt run --verbose --all report --how reportportal --suite-per-plan --launch '$launch_name'" 2 "" 1>/dev/null
-        identify_tests   # >> $test_uuid[1..3], $test_fullname[1..3]
+        identify_tests   # >> $test_uuid[1..10], $test_fullname[1..10]
         echo ""
 
         # TMT RE-RUN [1]
@@ -488,7 +526,7 @@ rlJournalStart
         rlLogInfo "Initial run that only creates an empty launch (with empty suite and empty test items within) with defect type 'Idle' (pre-defined in the project within 'To Investigate' category)"
         rlRun -s "tmt run discover report --verbose --how reportportal --suite-per-plan --launch '$launch_name' --defect-type 'IDLE'" 3  "" 1>/dev/null
         identify_launch  # >> $launch_uuid, $launch_id
-        identify_tests   # >> $test_uuid[1..3], $test_fullname[1..3]
+        identify_tests   # >> $test_uuid[1..10], $test_fullname[1..10]
 
         # REST API | [GET] test-item-controller | launch_id
         rlLogInfo "Get info about all launch items"
@@ -528,7 +566,8 @@ rlJournalStart
         suite_name=$PLAN_PREFIX
 
         # TMT RUN [0]
-        rlLogInfo "Initial run that creates a launch (with suite item and 3 test items within)"
+        # FIXME: 7 tests within? - spis ne - opravit
+        rlLogInfo "Initial run that creates a launch (with suite item and 7 test items within)"
         rlRun -s "tmt run --all report --verbose --how reportportal --suite-per-plan --launch '$launch_name'" 2 "" 1>/dev/null
         identify_launch  # >> $launch_uuid, $launch_id
         init_launch_uuid=$launch_uuid
@@ -536,11 +575,12 @@ rlJournalStart
         # REST API | [GET] test-item-controller | launch_id
         rlLogInfo "Get info about all launch items (1)"
         response=$(rest_api "$URL/api/v1/$PROJECT/item?filter.eq.launchId=$launch_id")
-        rlAssertEquals "Assert launch contains suite and 3 test items" "$(echo $response | jq -r .page.totalElements)" "4"
+        rlAssertEquals "Assert launch contains suite and 7 test items" "$(echo $response | jq -r .page.totalElements)" "7"
         echo ""
 
         # TMT RUN [1]
-        rlLogInfo "Additional run for an upload (of a suite item with 3 test items) to the launch"
+        # FIXME: 7 tests  - spis ne - opravit
+        rlLogInfo "Additional run for an upload (of a suite item with 7 test items) to the launch"
         rlRun -s "tmt run --all report --verbose --how reportportal --suite-per-plan --upload-to-launch '$launch_id'" 2 "" 1>/dev/null
         identify_launch  # >> $launch_uuid, $launch_id
         rlAssertEquals "Assert the launch UUID is the same as the initial one" "$init_launch_uuid" "$launch_uuid"
@@ -548,19 +588,19 @@ rlJournalStart
         # REST API | [GET] test-item-controller | launch_id
         rlLogInfo "Get info about all launch items (2)"
         response=$(rest_api "$URL/api/v1/$PROJECT/item?filter.eq.launchId=$launch_id")
-        rlAssertEquals "Assert launch contains another suite and 3 test items" "$(echo $response | jq -r .page.totalElements)" "8"
+        rlAssertEquals "Assert launch contains another suite and 7 test items" "$(echo $response | jq -r .page.totalElements)" "8"
         echo ""
 
         # TMT RUN [2]
-        rlLogInfo "Additional run for an upload (of 3 test items) to the launch"
+        rlLogInfo "Additional run for an upload (of 7 test items) to the launch"
         rlRun -s "tmt run --all report --verbose --how reportportal --launch-per-plan --upload-to-launch '$launch_id'" 2 "" 1>/dev/null
         identify_launch  # >> $launch_uuid, $launch_id
         rlAssertEquals "Assert the launch UUID is the same as the initial one" "$init_launch_uuid" "$launch_uuid"
 
         # REST API | [GET] test-item-controller | launch_id
-        rlLogInfo "Get info about all launch items (3)"
+        rlLogInfo "Get info about all launch items (7)"
         response=$(rest_api "$URL/api/v1/$PROJECT/item?filter.eq.launchId=$launch_id")
-        rlAssertEquals "Assert launch contains another 3 test items" "$(echo $response | jq -r .page.totalElements)" "11"
+        rlAssertEquals "Assert launch contains another 7 test items" "$(echo $response | jq -r .page.totalElements)" "11"
     rlPhaseEnd
 
 
@@ -570,7 +610,7 @@ rlJournalStart
         suite_name=$PLAN_PREFIX
 
         # TMT RUN [0]
-        rlLogInfo "Initial run that creates a suite item (with 3 test items)"
+        rlLogInfo "Initial run that creates a suite item (with 7 test items)"
         rlRun -s "tmt run --all report --verbose --how reportportal --suite-per-plan --launch '$launch_name'" 2 "" 1>/dev/null
         identify_launch  # >> $launch_uuid, $launch_id
         identify_suite   # >> $suite_uuid

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -267,6 +267,13 @@ class SubResult(BaseResult):
         ],
     )
 
+    @staticmethod
+    def failures(log: Optional[str], msg_type: str = 'FAIL') -> str:
+        """
+        Filter stdout and get only messages with certain type
+        """
+        return Result.failures(log, msg_type)
+
 
 @container
 class PhaseResult(BaseResult):

--- a/tmt/schemas/report/reportportal.yaml
+++ b/tmt/schemas/report/reportportal.yaml
@@ -77,6 +77,9 @@ properties:
   ssl-verify:
     type: boolean
 
+  upload-subresults:
+    type: boolean
+
   when:
     $ref: "/schemas/common#/definitions/when"
 


### PR DESCRIPTION
This PR adds support for tmt subresults for tmt reportportal plugin. It tries to map the subresults as child items of parent test result in a specific launch.

Please don't review this PR while it is marked as a draft.

More info:
- https://reportportal.io/docs/api/service-api/start-child-item-using-post-1

## TODOs:
- [x] Core functionality (import of tmt subresults into RP)
- [x] Find a way to map the subresults to parent test/step reportportal launch items
- [x] Should the import of subresults be optional via argument? Or via fmf test metadata proposed by @kkaarreell ? What should be the default behavior? 
- [x] Try to resolve `status:interrupted` issues for subresults in RP, why is this happening?
- [ ] There are still some problems in local reportportal tests (subresults need special handling) - will be handled by @4N0body5 
- [ ] Missing tests for beakerlib subresults (subresults reported by shell tests using the `tmt-report-result` command should be already covered) - Nice to have (can be added in follow-up PR)

Blocked by:
- https://github.com/teemtee/tmt/pull/3356
- https://github.com/teemtee/tmt/pull/3370
- https://github.com/teemtee/tmt/pull/3372

Related:
- https://github.com/teemtee/tmt/issues/2826
- https://issues.redhat.com/browse/TT-306

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [x] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [x] include a release note
