### PR TITLE
Fix null example in report specs

### DIFF
--- a/spec/plans/report.fmf
+++ b/spec/plans/report.fmf
@@ -4,7 +4,7 @@ story:
     the testing is finished.
 description:
     Report test results according to user preferences.
-example:
+example: []
 
 /display:
     summary: Show results in the terminal window


### PR DESCRIPTION
`example` is a list of strings, as such it cannot be left empty, `null`. To reset the list to "no examples" state, use an empty list.

Pull Request Checklist

* [x] implement the feature