### PR TITLE
Adjust tests to the latest fedora container image

### DIFF
--- a/tests/execute/framework/test.sh
+++ b/tests/execute/framework/test.sh
@@ -14,7 +14,7 @@ rlJournalStart
         rlAssertGrep "Execute '/tests/shell/explicit' as a 'shell' test." $rlRun_LOG
         rlAssertGrep "Execute '/tests/beakerlib' as a 'beakerlib' test." $rlRun_LOG
         # Beakerlib dependency should be detected from framework
-        rlAssertGrep "dnf install.*beakerlib" $rlRun_LOG
+        rlAssertGrep "dnf.* install.*beakerlib" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/execute/tty/data/plan.fmf
+++ b/tests/execute/tty/data/plan.fmf
@@ -9,6 +9,9 @@ environment:
 # Exercise prepare and finish as well. We use the very same commands,
 # just in different steps.
 prepare:
+  - how: install
+    package: python3
+
   - how: shell
     script: STEP=prepare ./shell.sh
 

--- a/tests/try/basic/test.sh
+++ b/tests/try/basic/test.sh
@@ -37,8 +37,7 @@ rlJournalStart
     rlPhaseStartTest "Install"
         rlRun -s "./install.exp"
         rlAssertGrep "Let's try.*/plans/basic" $rlRun_LOG
-        rlAssertGrep "cmd: rpm -q --whatprovides tree || dnf install -y  tree" $rlRun_LOG
-        rlAssertGrep "out: Installed:" $rlRun_LOG
+        rlAssertGrep "cmd: rpm -q --whatprovides tree || dnf.* install -y  tree" $rlRun_LOG
         rlAssertGrep "Run .* successfully finished. Bye for now!" $rlRun_LOG
     rlPhaseEnd
 

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -107,7 +107,7 @@ class PreparePlugin(tmt.steps.Plugin[PrepareStepDataT, list[PhaseResult]]):
 # guests. For example, a test running on the "server" guest might
 # require package `foo` while the test running on the "client" might
 # require package `bar`, and `foo` and `bar` cannot be installed at the
-# sametime.
+# same time.
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
The default Fedora container image has been updated to `fedora:41` which uses `dnf5`. Modify tests which are checking for the `dnf` output. Require `python3` which is not included in the container image. Fix a minor typo.

Pull Request Checklist

* [x] extend the test coverage