### PR TITLE
Disable the OpenScanHub job for now

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,6 +25,8 @@ targets: &all-targets
   - fedora-all
   - epel-9
 
+osh_diff_scan_after_copr_build: false
+
 jobs:
   # Build pull requests
   - &copr_build


### PR DESCRIPTION
As for now it just fails and causes test jobs are never green.

Config reference:

* https://packit.dev/docs/configuration#osh_diff_scan_after_copr_build

Related issues:

* https://github.com/rpm-software-management/mock/pull/1393
* https://github.com/openscanhub/fedora-infra/issues/75