### PR TITLE
Fix docs building caused by `pint` traceback

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,9 @@ repos:
           - "jinja2>=2.11.3"         # 3.1.2 / 3.1.2
           - "packaging>=20"          # 20 seems to be available with RHEL8
           - "pint>=0.16.1"           # 0.16.1
+          # Pin the flexparser version until pint fix is released
+          # https://github.com/hgrecco/pint/issues/1969
+          - "flexparser<0.4"
           - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
           - "requests>=2.25.1"       # 2.28.2 / 2.31.0
           - "ruamel.yaml>=0.16.6"    # 0.17.32 / 0.17.32
@@ -86,6 +89,9 @@ repos:
           - "jinja2>=2.11.3"         # 3.1.2 / 3.1.2
           - "packaging>=20"          # 20 seems to be available with RHEL8
           - "pint>=0.16.1"           # 0.16.1 / 0.19.x  TODO: Pint 0.20 requires larger changes to tmt.hardware
+          # Pin the flexparser version until pint fix is released
+          # https://github.com/hgrecco/pint/issues/1969
+          - "flexparser<0.4"
           - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
           - "requests>=2.25.1"       # 2.28.2 / 2.31.0
           - "ruamel.yaml>=0.16.6"    # 0.17.32 / 0.17.32
@@ -158,6 +164,9 @@ repos:
         - "docutils>=0.16"         # 0.16 is the current one available for RHEL9
         - "packaging>=20"          # 20 seems to be available with RHEL8
         - "pint<0.20"
+        # Pin the flexparser version until pint fix is released
+        # https://github.com/hgrecco/pint/issues/1969
+        - "flexparser<0.4"
         - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
         # Help installation by reducing the set of inspected botocore release.
         # There is *a lot* of them, and hatch might fetch many of them.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
           - "pint>=0.16.1"           # 0.16.1
           # Pin the flexparser version until pint fix is released
           # https://github.com/hgrecco/pint/issues/1969
-          - "flexparser<0.4"
+          - "flexparser<0.4; python_version >= '3.12'"
           - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
           - "requests>=2.25.1"       # 2.28.2 / 2.31.0
           - "ruamel.yaml>=0.16.6"    # 0.17.32 / 0.17.32
@@ -91,7 +91,7 @@ repos:
           - "pint>=0.16.1"           # 0.16.1 / 0.19.x  TODO: Pint 0.20 requires larger changes to tmt.hardware
           # Pin the flexparser version until pint fix is released
           # https://github.com/hgrecco/pint/issues/1969
-          - "flexparser<0.4"
+          - "flexparser<0.4; python_version >= '3.12'"
           - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
           - "requests>=2.25.1"       # 2.28.2 / 2.31.0
           - "ruamel.yaml>=0.16.6"    # 0.17.32 / 0.17.32
@@ -166,7 +166,7 @@ repos:
         - "pint<0.20"
         # Pin the flexparser version until pint fix is released
         # https://github.com/hgrecco/pint/issues/1969
-        - "flexparser<0.4"
+        - "flexparser<0.4; python_version >= '3.12'"
         - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
         # Help installation by reducing the set of inspected botocore release.
         # There is *a lot* of them, and hatch might fetch many of them.

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,4 +9,6 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    # Pin python version to 3.12 until pint fix is released
+    # https://github.com/hgrecco/pint/issues/1969
+    python: "3.12"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,4 @@ python:
 build:
   os: ubuntu-22.04
   tools:
-    # Pin python version to 3.12 until pint fix is released
-    # https://github.com/hgrecco/pint/issues/1969
-    python: "3.12"
+    python: "3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [              # F39 / PyPI
     "jinja2>=2.11.3",         # 3.1.2 / 3.1.2
     "packaging>=20",          # 20 seems to be available with RHEL8
     "pint>=0.16.1",           # 0.16.1
+    # Pin the flexparser version until pint fix is released
+    # https://github.com/hgrecco/pint/issues/1969
+    "flexparser<0.4",
     "pygments>=2.7.4",        # 2.7.4 is the current one available for RHEL9
     "requests>=2.25.1",       # 2.28.2 / 2.31.0
     "ruamel.yaml>=0.16.6",    # 0.17.32 / 0.17.32
@@ -88,9 +91,6 @@ docs = [
     "docutils>=0.18.1",
     "Sphinx==7.3.7",
     "fmf>=1.4.0",
-    # Pin the flexparser version until pint fix is released
-    # https://github.com/hgrecco/pint/issues/1969
-    "flexparser<0.4",
     ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ docs = [
     "docutils>=0.18.1",
     "Sphinx==7.3.7",
     "fmf>=1.4.0",
+    "flexparser<0.4",
     ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [              # F39 / PyPI
     "pint>=0.16.1",           # 0.16.1
     # Pin the flexparser version until pint fix is released
     # https://github.com/hgrecco/pint/issues/1969
-    "flexparser<0.4",
+    "flexparser<0.4; python_version >= '3.12'",
     "pygments>=2.7.4",        # 2.7.4 is the current one available for RHEL9
     "requests>=2.25.1",       # 2.28.2 / 2.31.0
     "ruamel.yaml>=0.16.6",    # 0.17.32 / 0.17.32

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,8 @@ docs = [
     "docutils>=0.18.1",
     "Sphinx==7.3.7",
     "fmf>=1.4.0",
+    # Pin the flexparser version until pint fix is released
+    # https://github.com/hgrecco/pint/issues/1969
     "flexparser<0.4",
     ]
 


### PR DESCRIPTION
Pin the `flexparser` version until `pint` fix is released.

* https://github.com/hgrecco/pint/issues/1969