### PR TITLE
Refresh metadata cache after failed package installation

### DIFF
--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -186,3 +186,6 @@ class PackageManager(tmt.utils.Common):
             *installables: Installable,
             options: Optional[Options] = None) -> CommandOutput:
         raise NotImplementedError
+
+    def refresh_metadata(self) -> CommandOutput:
+        raise NotImplementedError

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -122,6 +122,12 @@ class Apk(tmt.package_managers.PackageManager):
 
         return results
 
+    def refresh_metadata(self) -> CommandOutput:
+        script = ShellScript(
+            f'{self.command.to_script()} update')
+
+        return self.guest.execute(script)
+
     def install(
             self,
             *installables: Installable,

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -139,6 +139,14 @@ class Apt(tmt.package_managers.PackageManager):
 
         return extra_options
 
+    def refresh_metadata(self) -> CommandOutput:
+        script = ShellScript(
+            f'{self.command.to_script()} update')
+
+        return self.guest.execute(script, env=Environment({
+            'DEBIAN_FRONTEND': EnvVarValue('noninteractive')
+            }))
+
     def install(
             self,
             *installables: Installable,

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -155,6 +155,13 @@ class Dnf(tmt.package_managers.PackageManager):
             f'{self.options.to_script()} {extra_options} '
             f'{" ".join(escape_installables(*installables))}')
 
+    def refresh_metadata(self) -> CommandOutput:
+        script = ShellScript(
+            f'{self.command.to_script()} makecache '
+            f'{self.options.to_script()} --refresh')
+
+        return self.guest.execute(script)
+
     def install(
             self,
             *installables: Installable,
@@ -275,5 +282,11 @@ class Yum(Dnf):
                 ShellScript,
                 self._construct_presence_script(  # type: ignore[reportGeneralIssues,unused-ignore]
                     *installables))
+
+        return self.guest.execute(script)
+
+    def refresh_metadata(self) -> CommandOutput:
+        script = ShellScript(
+            f'{self.command.to_script()} makecache')
 
         return self.guest.execute(script)

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -100,6 +100,22 @@ class RpmOstree(tmt.package_managers.PackageManager):
 
         return extra_options
 
+    def refresh_metadata(self) -> CommandOutput:
+        self.guest.warn("Metadata refresh is not supported with rpm-ostree.")
+
+        return CommandOutput(stdout=None, stderr=None)
+
+        # The following should work, but it hits some ostree issue:
+        #
+        #   System has not been booted with systemd as init system (PID 1). Can't operate.
+        #   Failed to connect to bus: Host is down
+        #   System has not been booted with systemd as init system (PID 1). Can't operate.
+        #   Failed to connect to bus: Host is down
+        #   error: Loading sysroot: exit status: 1
+        #
+        # script = ShellScript(f'{self.command.to_script()} refresh-md --force')
+        # return self.guest.execute(script)
+
     def install(
             self,
             *installables: Installable,

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -165,6 +165,24 @@ class InstallBase(tmt.utils.Common):
 
     def install(self) -> None:
         """ Perform the actual installation """
+        try:
+            self._install()
+
+        except Exception as exc1:
+            # We do not have any special handling for exceptions raised by the following code.
+            # Wrapping them with try/except gives us a chance to attach the original exception
+            # to whatever the code may raise, and therefore preserve the information attached
+            # to the original exception.
+            try:
+                # Refresh cache in case of recent but not updated change do repodata
+                self.guest.package_manager.refresh_metadata()
+                self._install()
+
+            except Exception as exc2:
+                raise exc2 from exc1
+
+    def _install(self) -> None:
+        """ Helper method to perform the actual installation steps """
         if self.local_packages:
             self.prepare_install_local()
             self.install_local()


### PR DESCRIPTION
Fixes [#3277](https://github.com/teemtee/tmt/issues/3277)

When testing I found out that there is different behavior in dnf5 compared to dnf4, where a mere `dnf makecache` would be enough, but dnf5 needs the --refresh option as well (or `dnf clean metadata` or `dnf clean expire-cache`), see https://bugzilla.redhat.com/show_bug.cgi?id=2324177

Not sure about the Exception being too generic. Should I create a new one, something like InstallationError? And notify the user through logger as to why `metadata --refresh` is happening?

Pull Request Checklist

* [x] implement the feature


