### PR TITLE
Remove `xfail` for the fixed `pint` issue

### DIFF
--- a/tests/pip/install.fmf
+++ b/tests/pip/install.fmf
@@ -5,12 +5,6 @@ require:
     - python3
     - python3-devel
 tier: null
-adjust:
-    when: distro == fedora-rawhide or distro == fedora-41
-    result: xfail
-    # Depends on https://github.com/hgrecco/pint/issues/1969
-    # The 'full' dependes on https://github.com/psss/python-nitrate/pull/49
-    because: "Un-installable dependencies on Python 3.13"
 
 /mini:
     summary: Ensure the minimal pip install works

--- a/tests/precommit/main.fmf
+++ b/tests/precommit/main.fmf
@@ -4,9 +4,3 @@ require:
 - git-core
 - tmt
 tier: 4
-adjust:
-    when: distro == fedora-rawhide or distro == fedora-41
-    result: xfail
-    # Remove the xfail adjust once it starts passing.
-    # https://github.com/hgrecco/pint/issues/1969
-    because: "Un-installable dependencies on Python 3.13"


### PR DESCRIPTION
Seems that the issue has been fixed and released both for `fedora-41` and `rawhide`, time to remove the `xfail`.