### PR TITLE
Get rid of an irrelevant avc failure

### DIFF
--- a/tests/execute/tmt-scripts/main.fmf
+++ b/tests/execute/tmt-scripts/main.fmf
@@ -94,7 +94,7 @@ summary: Verify correct location of tmt scripts
       /usr/local/bin/tmt-reboot-core
       /usr/local/bin/tmt-report-result
   adjust:
-    result: xfail
+    result: info
     when: distro == fedora-39
     because: there is an irrelevant avc
 
@@ -149,6 +149,6 @@ summary: Verify correct location of tmt scripts
       /var/lib/tmt/scripts/tmt-reboot-core
       /var/lib/tmt/scripts/tmt-report-result
   adjust:
-    result: xfail
+    result: info
     when: distro == fedora-39
     because: there is an irrelevant avc

--- a/tests/execute/tmt-scripts/main.fmf
+++ b/tests/execute/tmt-scripts/main.fmf
@@ -93,6 +93,10 @@ summary: Verify correct location of tmt scripts
       /usr/local/bin/tmt-reboot
       /usr/local/bin/tmt-reboot-core
       /usr/local/bin/tmt-report-result
+  adjust:
+    result: xfail
+    when: distro == fedora-39
+    because: there is an irrelevant avc
 
 
 /fedora-bootc-force:
@@ -144,3 +148,7 @@ summary: Verify correct location of tmt scripts
       /var/lib/tmt/scripts/tmt-reboot
       /var/lib/tmt/scripts/tmt-reboot-core
       /var/lib/tmt/scripts/tmt-report-result
+  adjust:
+    result: xfail
+    when: distro == fedora-39
+    because: there is an irrelevant avc


### PR DESCRIPTION
Does not make sense to investigate as `fedora-39` is going away in a couple of weeks.