### PR TITLE
Multiple reportportal plugin improvements and fixes

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -30,6 +30,13 @@ current working directory is set to the path of the last
 executed test, so that users can easily investigate the test
 code there and experiment with it directly on the guest.
 
+The :ref:`/plugins/report/reportportal` plugin now handles the
+timestamps for ``custom`` and ``restraint`` results correctly. It
+should never happen that the result's ``end-time`` will be higher
+then the ``start-time``. It should be also ensured that the start
+time of all launch items is the same or higher then the start time
+of a parent item/launch.
+
 
 tmt-1.39.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -32,9 +32,9 @@ code there and experiment with it directly on the guest.
 
 The :ref:`/plugins/report/reportportal` plugin now handles the
 timestamps for ``custom`` and ``restraint`` results correctly. It
-should never happen that the result's ``end-time`` will be higher
-then the ``start-time``. It should be also ensured that the start
-time of all launch items is the same or higher then the start time
+should never happen that the result's ``start-time`` will be higher
+than the ``end-time``. It should be also ensured that the end
+time of all launch items is the same or higher than the start time
 of a parent item/launch.
 
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -32,10 +32,10 @@ code there and experiment with it directly on the guest.
 
 The :ref:`/plugins/report/reportportal` plugin now handles the
 timestamps for ``custom`` and ``restraint`` results correctly. It
-should never happen that the result's ``start-time`` will be higher
-than the ``end-time``. It should be also ensured that the end
-time of all launch items is the same or higher than the start time
-of a parent item/launch.
+should never happen that the result's ``start-time`` will be
+higher than the ``end-time``. It should be also ensured that the
+end time of all launch items is the same or higher than the start
+time of a parent item/launch.
 
 
 tmt-1.39.0

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -32,10 +32,10 @@ code there and experiment with it directly on the guest.
 
 The :ref:`/plugins/report/reportportal` plugin now handles the
 timestamps for ``custom`` and ``restraint`` results correctly. It
-should never happen that the result's ``start-time`` will be
-higher than the ``end-time``. It should be also ensured that the
-end time of all launch items is the same or higher than the start
-time of a parent item/launch.
+should prevent the ``start-time`` of a result being higher than
+the ``end-time``. It should be also ensured that the end time of
+all launch items is the same or higher than the start time of a
+parent item/launch.
 
 
 tmt-1.39.0

--- a/tmt/schemas/report/reportportal.yaml
+++ b/tmt/schemas/report/reportportal.yaml
@@ -70,6 +70,9 @@ properties:
   traceback-size-limit:
     type: integer
 
+  ssl-verify:
+    type: boolean
+
 required:
   - how
   - project

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -79,7 +79,7 @@ def _filter_log_per_size(data: str,
                   f"exceeds tmt reportportal plugin limit of {settings.size}. "
                   f"The limit is controlled with {option} plugin option or "
                   f"{variable} environment variable.\n\n")
-        return f"{header}{data[:settings.size.to('bytes').magnitude]}"
+        return f"{header}{data[:int(settings.size.to('bytes').magnitude)]}"
     return data
 
 

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -318,10 +318,10 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
     TMT_TO_RP_RESULT_STATUS = {
         ResultOutcome.PASS: "PASSED",
         ResultOutcome.FAIL: "FAILED",
-        ResultOutcome.ERROR: "FAILED",
+        ResultOutcome.INFO: "SKIPPED",
         ResultOutcome.WARN: "FAILED",
-        ResultOutcome.INFO: "SKIPPED"
-        }
+        ResultOutcome.ERROR: "FAILED",
+        ResultOutcome.SKIP: "SKIPPED"}
 
     def handle_response(self, response: requests.Response) -> None:
         """ Check the endpoint response and raise an exception if needed """

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -471,8 +471,9 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
         # Support for idle tests
         executed = bool(self.step.plan.execute.results())
         if executed:
-            # launch time should be the earliest start time of all plans
-            # TODO: Does the 'min' work with datetime isoformat correctly?
+            # Launch time should be the earliest start time of all plans. The minimum over datetime
+            # strings will work, because the datetime in ISO format is designed to be
+            # lexicographically sortable.
             launch_time = min([r.start_time or self.datetime
                                for r in self.step.plan.execute.results()])
 

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -351,15 +351,18 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
             self.warn("Unexpected option combination: '--launch-rerun' "
                       "may cause an unexpected behaviour with launch-per-plan structure")
 
+    @property
     def time(self) -> str:
         return str(int(time() * 1000))
 
-    def get_headers(self) -> dict[str, str]:
+    @property
+    def headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self.data.token}",
                 "Accept": "*/*",
                 "Content-Type": "application/json"}
 
-    def get_url(self) -> str:
+    @property
+    def url(self) -> str:
         return f"{self.data.url}/api/{self.data.api_version}/{self.data.project}"
 
     def construct_launch_attributes(self, suite_per_plan: bool,
@@ -405,21 +408,21 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
         return str(dt_locator)
 
     def rp_api_get(self, session: requests.Session, path: str) -> requests.Response:
-        response = session.get(url=f"{self.get_url()}/{path}",
-                               headers=self.get_headers())
+        response = session.get(url=f"{self.url}/{path}",
+                               headers=self.headers)
         self.handle_response(response)
         return response
 
     def rp_api_post(self, session: requests.Session, path: str, json: JSON) -> requests.Response:
-        response = session.post(url=f"{self.get_url()}/{path}",
-                                headers=self.get_headers(),
+        response = session.post(url=f"{self.url}/{path}",
+                                headers=self.headers,
                                 json=json)
         self.handle_response(response)
         return response
 
     def rp_api_put(self, session: requests.Session, path: str, json: JSON) -> requests.Response:
-        response = session.put(url=f"{self.get_url()}/{path}",
-                               headers=self.get_headers(),
+        response = session.put(url=f"{self.url}/{path}",
+                               headers=self.headers,
                                json=json)
         self.handle_response(response)
         return response
@@ -464,13 +467,13 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
             self.warn("SSL verification is disabled for all requests being made to ReportPortal "
                       f"instance ({self.data.url}).")
 
-        launch_time = self.time()
+        launch_time = self.time
 
         # Support for idle tests
         executed = bool(self.step.plan.execute.results())
         if executed:
             # launch time should be the earliest start time of all plans
-            launch_time = min([r.start_time or self.time()
+            launch_time = min([r.start_time or self.time
                                for r in self.step.plan.execute.results()])
 
         # Create launch, suites (if "--suite_per_plan") and tests;
@@ -601,7 +604,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
 
             for result, test in self.step.plan.execute.results_for_tests(
                     self.step.plan.discover.tests()):
-                test_time = self.time()
+                test_time = self.time
                 test_name = None
                 test_description = ''
                 test_link = None
@@ -612,7 +615,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
                 if result:
                     serial_number = result.serial_number
                     test_name = result.name
-                    test_time = result.start_time or self.time()
+                    test_time = result.start_time or self.time
                     # for guests, save their primary address
                     if result.guest.primary_address:
                         item_attributes.append({
@@ -715,7 +718,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
                                       "level": "ERROR",
                                       "time": result.end_time})
 
-                    test_time = result.end_time or self.time()
+                    test_time = result.end_time or self.time
 
                 # Finish the test item
                 response = self.rp_api_put(

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -12,7 +12,7 @@ import tmt.log
 import tmt.steps.report
 import tmt.utils
 from tmt.result import ResultOutcome
-from tmt.utils import ActionType, catch_warnings, field, format_timestamp, yaml_to_dict
+from tmt.utils import ActionType, catch_warnings_safe, field, format_timestamp, yaml_to_dict
 
 if TYPE_CHECKING:
     from tmt._compat.typing import TypeAlias
@@ -778,7 +778,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
             self.warn("SSL verification is disabled for all requests being made to ReportPortal "
                       f"instance ({self.data.url}).")
 
-        with catch_warnings(
+        with catch_warnings_safe(
                 action=warning_filter_action,
                 category=urllib3.exceptions.InsecureRequestWarning):
             self.execute_rp_import()

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -355,8 +355,8 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
         return str(int(time() * 1000))
 
     def get_headers(self) -> dict[str, str]:
-        return {"Authorization": "bearer " + str(self.data.token),
-                "accept": "*/*",
+        return {"Authorization": f"Bearer {self.data.token}",
+                "Accept": "*/*",
                 "Content-Type": "application/json"}
 
     def get_url(self) -> str:

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -12,7 +12,7 @@ import tmt.log
 import tmt.steps.report
 import tmt.utils
 from tmt.result import ResultOutcome
-from tmt.utils import field, format_timestamp, suppress_warning, yaml_to_dict
+from tmt.utils import ActionType, catch_warnings, field, format_timestamp, yaml_to_dict
 
 if TYPE_CHECKING:
     from tmt._compat.typing import TypeAlias
@@ -772,11 +772,13 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
         self.check_options()
 
         # If SSL verification is disabled, do not print warnings with urllib3
-        suppress_category = None
+        warning_filter_action: ActionType = 'default'
         if not self.data.ssl_verify:
-            suppress_category = urllib3.exceptions.InsecureRequestWarning
+            warning_filter_action = 'ignore'
             self.warn("SSL verification is disabled for all requests being made to ReportPortal "
                       f"instance ({self.data.url}).")
 
-        with suppress_warning(suppress_category):
+        with catch_warnings(
+                action=warning_filter_action,
+                category=urllib3.exceptions.InsecureRequestWarning):
             self.execute_rp_import()

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -6289,7 +6289,7 @@ ActionType = Literal['default', 'error', 'ignore', 'always', 'module', 'once']
 
 
 @contextlib.contextmanager
-def catch_warnings(
+def catch_warnings_safe(
         action: ActionType,
         category: type[Warning] = Warning) -> Iterator[None]:
     """
@@ -6305,7 +6305,7 @@ def catch_warnings(
 
     .. code-block:: python
 
-        with catch_warnings('ignore', urllib3.exceptions.InsecureRequestWarning):
+        with catch_warnings_safe('ignore', urllib3.exceptions.InsecureRequestWarning):
             ...
     """
     with _catch_warning_lock, warnings.catch_warnings():

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -24,6 +24,7 @@ import time
 import traceback
 import unicodedata
 import urllib.parse
+import warnings
 from collections import Counter
 from collections.abc import Iterable, Iterator, Sequence
 from math import ceil
@@ -6280,3 +6281,30 @@ def is_url(url: str) -> bool:
     """ Check if the given string is a valid URL """
     parsed = urllib.parse.urlparse(url)
     return bool(parsed.scheme and parsed.netloc)
+
+
+@contextlib.contextmanager
+def suppress_warning(category: Optional[type[Warning]]) -> Iterator[None]:
+    """
+    Optionally disable the given warning.
+
+    Using this context manager you can suppress a warning. This warning gets re-enabled with an
+    exit from this context manager.
+
+    The example can be suppressing of the urllib insecure request warning:
+
+    .. code-block:: python
+
+        with suppress_warning(urllib3.exceptions.InsecureRequestWarning):
+            ...
+
+    """
+    if category is not None:
+        try:
+            warnings.simplefilter('ignore', category)
+            yield
+        finally:
+            # Reset the warning to its default for a specific category
+            warnings.simplefilter('default', category)
+    else:
+        yield

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -6285,7 +6285,7 @@ def is_url(url: str) -> bool:
 
 # Handle the thread synchronization for the `catch_warnings(...)` context manager
 _catch_warning_lock = RLock()
-ActionType = Literal['default', 'error', 'ignore', 'always', 'all', 'module', 'once']
+ActionType = Literal['default', 'error', 'ignore', 'always', 'module', 'once']
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This PR should fix [the problem](https://github.com/teemtee/tmt/issues/3360) with a possible reportportal error when using `result: restraint` or `result: custom`:

```
Received non-ok status code 406 from ReportPortal: {"errorCode":40025,"message":"Start time of child ['Tue Nov 12 11:10:19 UTC 2024'] item should be same or later than start time ['2024-11-12T11:36:35.007'] of the parent item/launch '
11810'"}
```

The PR fixes multiple bugs, for more info see:
- https://github.com/teemtee/tmt/issues/3360
- https://github.com/teemtee/tmt/pull/3356#issuecomment-2503345143

This error is probably caused by the [badly sorted result start times](https://github.com/teemtee/tmt/blob/1933c03437006ce7d72881ca8c3706d6d81a8f38/tmt/steps/report/reportportal.py#L387). It can happen the datetime formats in the list are not in the same format. The `Result.start_time` is in ISO format but the `self.time()` returns `str(int(time() * 1000))`.

### The basic reproducer

```
$ cat main.fmf
test: |
    tmt-report-result /test/good PASS
    tmt-report-result /test/fail FAIL
    tmt-report-result /test/weird WARN

result: restraint

duration: 5m
```

```
$ python -m tmt -r ~/tmt-learning/20 run -a report --how reportportal -v --force
```

### Other improvements
There are also small code improvements like the possibility to ignore the SSL verification, adding the usage of Python properties instead of class methods, or adding handling of `ResultOutcome.SKIP` outcome which I believe is missing from the mapping.

### TODOs:
- [x] Link the issue with the problem description as soon as it's created.

Pull Request Checklist

* [x] implement the feature
* [x] update reportportal schema for `ssl-verify` option
* [ ] extend the test coverage - Tests will be extended and fixed (only for local testing) as a part of https://github.com/teemtee/tmt/pull/3331
* [x] include a release note
