### PR TITLE
Handle invalid option in the `tmt-reboot` script

### DIFF
--- a/tmt/steps/execute/scripts/tmt-reboot
+++ b/tmt/steps/execute/scripts/tmt-reboot
@@ -18,6 +18,7 @@ while getopts "c:t:e" flag; do
         c) command="${OPTARG}";;
         t) timeout="${OPTARG}";;
         e) efi=False;;
+        *) exit 1;;
     esac
 done
 


### PR DESCRIPTION
Fix a minor issues [detected](https://openscanhub.fedoraproject.org/task/21963/log/tmt-1.39.dev888-1.20241112125004934013.pr3342.26.gffd43d85/scan-results.html) by the shell-check.