### PR TITLE
Switch to the new `tmt` logo

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -29,12 +29,6 @@ STEPS = discover provision prepare execute finish report
 # A list of `plugins/*.rst` files to generate
 PLUGIN_TARGETS = $(addsuffix .rst,$(addprefix plugins/,$(STEPS))) plugins/test-checks.rst
 
-# A source of logo picture for Sphinx docs favicon
-LOGO_SRC = https://raw.githubusercontent.com/teemtee/docs/main/logo/tmt-small.png
-
-# Local filepath to fetched logo
-LOGO_DST = _static/tmt-small.png
-
 .DEFAULT_GOAL := help
 
 .PHONY: help \
@@ -74,11 +68,6 @@ endef
 define plugins-checks-dependencies =
 $(SCRIPTSDIR)/generate-plugins.py $(PLUGINS_TEMPLATE) $(TMTDIR)/steps/__init__.py $(TMTDIR)/checks/*.py
 endef
-
-# We can ignore the error: later, during the build, if the logo is
-# missing, Sphinx will complain.
-$(LOGO_DST):
-	-curl -f $(LOGO_SRC) -o $(LOGO_DST)
 
 # Generate plugin documentation sources for a given step
 define build-plugins =
@@ -146,7 +135,7 @@ generate-stories: stories $(TEMPLATESDIR)/story.rst.j2  ## Generate documentatio
 generate-template-filters: code/template-filters.rst  ## Generate documentation sources for Jinja2 template filters
 
 clean:  ## Remove all generated content
-	rm -rf _build $(GENERATED_DIRECTORIES) code/autodocs/*.rst code/template-filters.rst plugins/hardware-matrix.rst guide/test-runner-guest-compatibility-matrix.inc.rst $(PLUGIN_TARGETS) $(LOGO_DST)
+	rm -rf _build $(GENERATED_DIRECTORIES) code/autodocs/*.rst code/template-filters.rst plugins/hardware-matrix.rst guide/test-runner-guest-compatibility-matrix.inc.rst $(PLUGIN_TARGETS)
 
 ##
 ## Help!

--- a/docs/_static/tmt-custom.css
+++ b/docs/_static/tmt-custom.css
@@ -4,3 +4,6 @@
 /* Used for HW requirement support matrix */
 .supported   { color: green; }
 .unsupported { color: red; }
+.logo {
+    padding: 10px 50px !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -217,12 +217,11 @@ html_theme = HTML_THEME
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = 'https://raw.githubusercontent.com/teemtee/docs/main/logo/tmt-transparent-175x175.png'
+html_logo = 'https://raw.githubusercontent.com/teemtee/docs/main/logo/tmt-logo-dark-background.png'
 
 # The name of an image file (within the static path) to use as favicon of the
-# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
-# pixels large.
-html_favicon = 'https://raw.githubusercontent.com/teemtee/docs/main/logo/tmt-favicon.ico'
+# docs.
+html_favicon = 'https://raw.githubusercontent.com/teemtee/docs/main/logo/tmt-logo-dark-background.svg'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -20,6 +20,10 @@ calling the ``tmt-report-result`` or by calling beakerlib's
 ``rlPhaseEnd`` saved in ``results.yaml`` are now relative to the
 ``execute`` directory.
 
+Documentation pages now use the `new tmt logo`__ designed by Maria Leonova.
+
+__ https://github.com/teemtee/docs/tree/main/logo
+
 
 tmt-1.39.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Dependent on https://github.com/teemtee/docs/pull/9 See for additional context.
Cleaned up some (I presume) obsolete logo-related-steps from conf.py

Pull Request Checklist

* [x] implement the feature
* [x] include a release note
