### PR TITLE
Enable the `huge_tree` option for the `lxml` parser

### DIFF
--- a/tests/report/junit/data/custom-deep-tree.xml.j2
+++ b/tests/report/junit/data/custom-deep-tree.xml.j2
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+{#
+Test that very deep trees are correctly handled by junit plugin.
+
+Refs.:
+- [PR#3365](https://github.com/teemtee/tmt/pull/3365)
+- [`huge_tree` option](https://lxml.de/api/lxml.etree.XMLParser-class.html)
+#}
+
+{% set DEPTH = 257 %}
+<root>
+{% for i in range(1, DEPTH + 1) %}
+    {{ "  " * i }}<tag{{ i }}>
+{% endfor %}
+
+{% for i in range(DEPTH, 0, -1) %}
+    {{ "  " * i }}</tag{{ i }}>
+{% endfor %}
+</root>

--- a/tests/report/junit/data/main.fmf
+++ b/tests/report/junit/data/main.fmf
@@ -38,13 +38,7 @@
               - verifies: https://github.com/teemtee/tmt/issues/3363
             require:
               - python
-
-            # The test must fail to generate output into a <system-out> tag
-            result: fail
-            test: python -c "print('a' * (10 * 1024 * 1024 + 1))"
-
-            # Do not enable the test by default to not waste the CI resources
-            enabled: false
+            test: python -c "print((('a' * 1023) + '\n') * 1024 * 10)"
 
         /subresults/pass:
             summary: Basic pass test of shell subresults

--- a/tests/report/junit/data/main.fmf
+++ b/tests/report/junit/data/main.fmf
@@ -32,6 +32,20 @@
         /escape"<speci&l>_chars:
             test: ./special_chars.sh
 
+        /big-output:
+            summary: Generate huge text data into <system-out> JUnit tag
+            link:
+              - verifies: https://github.com/teemtee/tmt/issues/3363
+            require:
+              - python
+
+            # The test must fail to generate output into a <system-out> tag
+            result: fail
+            test: python -c "print('a' * (10 * 1024 * 1024 + 1))"
+
+            # Do not enable the test by default to not waste the CI resources
+            enabled: false
+
         /subresults/pass:
             summary: Basic pass test of shell subresults
             test: |

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -53,6 +53,7 @@ rlJournalStart
             rlAssertGrep '<test name="/test/shell/pass" value="pass"/>' "custom-template-out.xml"
             rlAssertGrep '<test name="/test/shell/timeout" value="error"/>' "custom-template-out.xml"
             rlAssertGrep '<test name="/test/shell/escape&quot;&lt;speci&amp;l&gt;_chars" value="pass"/>' "custom-template-out.xml"
+            rlAssertGrep '<test name="/test/shell/big-output" value="pass"/>' "custom-template-out.xml"
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the 'custom' flavor with very deep XML trees"

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -11,9 +11,9 @@ rlJournalStart
 
     for method in tmt; do
         rlPhaseStartTest "[$method] Basic format checks"
-            rlRun "tmt run -av --id $run_dir execute -h $method report -h junit --file junit.xml 2>&1 >/dev/null | tee output" 2
-            rlAssertGrep "6 tests passed, 5 tests failed and 2 errors" "output"
-            rlAssertGrep '00:00:00 pass /test/shell/escape"<speci&l>_chars (on default-0)' "output"
+            rlRun -s "tmt run -av --id $run_dir execute -h $method report -h junit --file junit.xml 2>&1 >/dev/null" 2
+            rlAssertGrep "6 tests passed, 5 tests failed and 2 errors" "$rlRun_LOG"
+            rlAssertGrep '00:00:00 pass /test/shell/escape"<speci&l>_chars (on default-0)' "$rlRun_LOG"
             rlAssertGrep '<testsuite name="/plan" disabled="0" errors="2" failures="5" skipped="0" tests="13"' "junit.xml"
             rlAssertGrep 'fail</failure>' "junit.xml"
 
@@ -22,31 +22,31 @@ rlJournalStart
             rlAssertGrep '<system-out>&lt;speci&amp;l&gt;"chars and control chars</system-out>' "junit.xml"
 
             # Check there is no schema problem reported
-            rlAssertNotGrep 'The generated XML output is not a valid XML file or it is not valid against the XSD schema\.' "output"
+            rlAssertNotGrep 'The generated XML output is not a valid XML file or it is not valid against the XSD schema\.' "$rlRun_LOG"
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the flavor argument is working"
-            rlRun "tmt run --last -v --id $run_dir execute -h $method report -h junit --file junit.xml --flavor default --force 2>&1 >/dev/null | tee output" 2
-            rlAssertGrep "6 tests passed, 5 tests failed and 2 errors" "output"
+            rlRun -s "tmt run --last -v --id $run_dir execute -h $method report -h junit --file junit.xml --flavor default --force 2>&1 >/dev/null" 2
+            rlAssertGrep "6 tests passed, 5 tests failed and 2 errors" "$rlRun_LOG"
 
             # Check there is no schema problem reported
-            rlAssertNotGrep 'The generated XML output is not a valid XML file or it is not valid against the XSD schema\.' "output"
+            rlAssertNotGrep 'The generated XML output is not a valid XML file or it is not valid against the XSD schema\.' "$rlRun_LOG"
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the mutually exclusive arguments"
-            rlRun "tmt run --last -v --id $run_dir execute -h $method report -h junit --file junit.xml --flavor custom --force 2>&1 >/dev/null | tee output" 2
-            rlAssertGrep "The 'custom' flavor requires the '--template-path' argument." "output"
+            rlRun -s "tmt run --last -v --id $run_dir execute -h $method report -h junit --file junit.xml --flavor custom --force 2>&1 >/dev/null" 2
+            rlAssertGrep "The 'custom' flavor requires the '--template-path' argument." "$rlRun_LOG"
 
-            rlRun "tmt run --last -v execute -h $method report -h junit --file junit.xml --template-path custom.xml.j2 --force 2>&1 >/dev/null | tee output" 2
-            rlAssertGrep "The '--template-path' can be used only with '--flavor=custom'." "output"
+            rlRun -s "tmt run --last -v execute -h $method report -h junit --file junit.xml --template-path custom.xml.j2 --force 2>&1 >/dev/null" 2
+            rlAssertGrep "The '--template-path' can be used only with '--flavor=custom'." "$rlRun_LOG"
 
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the 'custom' flavor with a custom XML template"
-            rlRun "tmt run --last -v --id $run_dir execute -h $method report -h junit --file custom-template-out.xml --template-path custom.xml.j2 --flavor custom --force 2>&1 >/dev/null | tee output" 2
+            rlRun -s "tmt run --last -v --id $run_dir execute -h $method report -h junit --file custom-template-out.xml --template-path custom.xml.j2 --flavor custom --force 2>&1 >/dev/null" 2
 
             # There must not be a schema check when using a custom flavor
-            rlAssertGrep "The 'custom' JUnit flavor is used, you are solely responsible for the validity of the XML schema\." "output"
+            rlAssertGrep "The 'custom' JUnit flavor is used, you are solely responsible for the validity of the XML schema\." "$rlRun_LOG"
 
             rlAssertGrep '<test name="/test/beakerlib/fail" value="fail"/>' "custom-template-out.xml"
             rlAssertGrep '<test name="/test/beakerlib/pass" value="pass"/>' "custom-template-out.xml"
@@ -56,13 +56,13 @@ rlJournalStart
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] The 'custom' flavor with a custom **non-XML** template must not work"
-            rlRun "tmt run --last -v execute -h $method report -h junit --file custom-template-out.xml --template-path non-xml-custom.j2 --flavor custom --force 2>&1 >/dev/null | tee output" 2
+            rlRun -s "tmt run --last -v execute -h $method report -h junit --file custom-template-out.xml --template-path non-xml-custom.j2 --flavor custom --force 2>&1 >/dev/null" 2
 
-            rlAssertGrep 'The generated XML output is not a valid XML file.' "output"
+            rlAssertGrep 'The generated XML output is not a valid XML file.' "$rlRun_LOG"
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the 'custom' flavor and context for subresults"
-            rlRun "tmt run --last -v execute -h $method report -h junit --file custom-subresults-template-out.xml --template-path custom-subresults.xml.j2 --flavor custom --force 2>&1 >/dev/null | tee output" 2
+            rlRun "tmt run --last -v execute -h $method report -h junit --file custom-subresults-template-out.xml --template-path custom-subresults.xml.j2 --flavor custom --force 2>&1 >/dev/null" 2
 
             # Beakerlib subresults
             rlAssertGrep '<subresult name="/Test" outcome="fail"/>' "custom-subresults-template-out.xml"
@@ -87,7 +87,7 @@ rlJournalStart
     done
 
     rlPhaseStartCleanup
-        rlRun "rm output junit.xml custom-template-out.xml custom-subresults-template-out.xml"
+        rlRun "rm junit.xml custom-template-out.xml custom-subresults-template-out.xml"
         rlRun "popd"
         rlRun "rm -rf $tmp"
     rlPhaseEnd

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -55,6 +55,12 @@ rlJournalStart
             rlAssertGrep '<test name="/test/shell/escape&quot;&lt;speci&amp;l&gt;_chars" value="pass"/>' "custom-template-out.xml"
         rlPhaseEnd
 
+        rlPhaseStartTest "[$method] Check the 'custom' flavor with very deep XML trees"
+            rlRun -s "tmt run --last -v --id $run_dir execute -h $method report -h junit --file custom-deep-tree-template-out.xml --template-path custom-deep-tree.xml.j2 --flavor custom --force 2>&1 >/dev/null" 2
+
+            rlAssertNotGrep 'Excessive depth in document' "$rlRun_LOG"
+        rlPhaseEnd
+
         rlPhaseStartTest "[$method] The 'custom' flavor with a custom **non-XML** template must not work"
             rlRun -s "tmt run --last -v execute -h $method report -h junit --file custom-template-out.xml --template-path non-xml-custom.j2 --flavor custom --force 2>&1 >/dev/null" 2
 
@@ -87,7 +93,7 @@ rlJournalStart
     done
 
     rlPhaseStartCleanup
-        rlRun "rm junit.xml custom-template-out.xml custom-subresults-template-out.xml"
+        rlRun "rm junit.xml custom-template-out.xml custom-deep-tree-template-out.xml custom-subresults-template-out.xml"
         rlRun "popd"
         rlRun "rm -rf $tmp"
     rlPhaseEnd

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -23,6 +23,9 @@ rlJournalStart
 
             # Check there is no schema problem reported
             rlAssertNotGrep 'The generated XML output is not a valid XML file or it is not valid against the XSD schema\.' "$rlRun_LOG"
+
+            # Check the junit plugin prints the warning about huge test output (/test/shell/big-output)
+            rlAssertGrep 'There are huge test outputs or deep XML trees in the generated XML' "$rlRun_LOG"
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the flavor argument is working"
@@ -53,12 +56,14 @@ rlJournalStart
             rlAssertGrep '<test name="/test/shell/pass" value="pass"/>' "custom-template-out.xml"
             rlAssertGrep '<test name="/test/shell/timeout" value="error"/>' "custom-template-out.xml"
             rlAssertGrep '<test name="/test/shell/escape&quot;&lt;speci&amp;l&gt;_chars" value="pass"/>' "custom-template-out.xml"
+            rlAssertGrep '<test name="/test/shell/big-output" value="pass"/>' "custom-template-out.xml"
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the 'custom' flavor with very deep XML trees"
             rlRun -s "tmt run --last -v --id $run_dir execute -h $method report -h junit --file custom-deep-tree-template-out.xml --template-path custom-deep-tree.xml.j2 --flavor custom --force 2>&1 >/dev/null" 2
 
             rlAssertNotGrep 'Excessive depth in document' "$rlRun_LOG"
+            rlAssertGrep 'There are huge test outputs or deep XML trees in the generated XML' "$rlRun_LOG"
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] The 'custom' flavor with a custom **non-XML** template must not work"

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -93,7 +93,7 @@ rlJournalStart
     done
 
     rlPhaseStartCleanup
-        rlRun "rm junit.xml custom-template-out.xml custom-deep-tree-template-out.xml custom-subresults-template-out.xml"
+        rlRun "rm *.xml"
         rlRun "popd"
         rlRun "rm -rf $tmp"
     rlPhaseEnd

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -5,11 +5,13 @@ rlJournalStart
     rlPhaseStartSetup
         rlRun "pushd data"
         rlRun "set -o pipefail"
+        rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory"
+        rlRun "run_dir=$tmp/run-subresults"
     rlPhaseEnd
 
     for method in tmt; do
         rlPhaseStartTest "[$method] Basic format checks"
-            rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml 2>&1 >/dev/null | tee output" 2
+            rlRun "tmt run -av --id $run_dir execute -h $method report -h junit --file junit.xml 2>&1 >/dev/null | tee output" 2
             rlAssertGrep "6 tests passed, 5 tests failed and 2 errors" "output"
             rlAssertGrep '00:00:00 pass /test/shell/escape"<speci&l>_chars (on default-0)' "output"
             rlAssertGrep '<testsuite name="/plan" disabled="0" errors="2" failures="5" skipped="0" tests="13"' "junit.xml"
@@ -24,7 +26,7 @@ rlJournalStart
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the flavor argument is working"
-            rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml --flavor default 2>&1 >/dev/null | tee output" 2
+            rlRun "tmt run --last -v --id $run_dir execute -h $method report -h junit --file junit.xml --flavor default --force 2>&1 >/dev/null | tee output" 2
             rlAssertGrep "6 tests passed, 5 tests failed and 2 errors" "output"
 
             # Check there is no schema problem reported
@@ -32,16 +34,16 @@ rlJournalStart
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the mutually exclusive arguments"
-            rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml --flavor custom 2>&1 >/dev/null | tee output" 2
+            rlRun "tmt run --last -v --id $run_dir execute -h $method report -h junit --file junit.xml --flavor custom --force 2>&1 >/dev/null | tee output" 2
             rlAssertGrep "The 'custom' flavor requires the '--template-path' argument." "output"
 
-            rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml --template-path custom.xml.j2 2>&1 >/dev/null | tee output" 2
+            rlRun "tmt run --last -v execute -h $method report -h junit --file junit.xml --template-path custom.xml.j2 --force 2>&1 >/dev/null | tee output" 2
             rlAssertGrep "The '--template-path' can be used only with '--flavor=custom'." "output"
 
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the 'custom' flavor with a custom XML template"
-            rlRun "tmt run -avr execute -h $method report -h junit --file custom-template-out.xml --template-path custom.xml.j2 --flavor custom 2>&1 >/dev/null | tee output" 2
+            rlRun "tmt run --last -v --id $run_dir execute -h $method report -h junit --file custom-template-out.xml --template-path custom.xml.j2 --flavor custom --force 2>&1 >/dev/null | tee output" 2
 
             # There must not be a schema check when using a custom flavor
             rlAssertGrep "The 'custom' JUnit flavor is used, you are solely responsible for the validity of the XML schema\." "output"
@@ -54,13 +56,13 @@ rlJournalStart
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] The 'custom' flavor with a custom **non-XML** template must not work"
-            rlRun "tmt run -avr execute -h $method report -h junit --file custom-template-out.xml --template-path non-xml-custom.j2 --flavor custom 2>&1 >/dev/null | tee output" 2
+            rlRun "tmt run --last -v execute -h $method report -h junit --file custom-template-out.xml --template-path non-xml-custom.j2 --flavor custom --force 2>&1 >/dev/null | tee output" 2
 
             rlAssertGrep 'The generated XML output is not a valid XML file.' "output"
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the 'custom' flavor and context for subresults"
-            rlRun "tmt run -avr execute -h $method report -h junit --file custom-subresults-template-out.xml --template-path custom-subresults.xml.j2 --flavor custom 2>&1 >/dev/null | tee output" 2
+            rlRun "tmt run --last -v execute -h $method report -h junit --file custom-subresults-template-out.xml --template-path custom-subresults.xml.j2 --flavor custom --force 2>&1 >/dev/null | tee output" 2
 
             # Beakerlib subresults
             rlAssertGrep '<subresult name="/Test" outcome="fail"/>' "custom-subresults-template-out.xml"
@@ -87,5 +89,6 @@ rlJournalStart
     rlPhaseStartCleanup
         rlRun "rm output junit.xml custom-template-out.xml custom-subresults-template-out.xml"
         rlRun "popd"
+        rlRun "rm -rf $tmp"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -10,9 +10,9 @@ rlJournalStart
     for method in tmt; do
         rlPhaseStartTest "[$method] Basic format checks"
             rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml 2>&1 >/dev/null | tee output" 2
-            rlAssertGrep "5 tests passed, 5 tests failed and 2 errors" "output"
+            rlAssertGrep "6 tests passed, 5 tests failed and 2 errors" "output"
             rlAssertGrep '00:00:00 pass /test/shell/escape"<speci&l>_chars (on default-0)' "output"
-            rlAssertGrep '<testsuite name="/plan" disabled="0" errors="2" failures="5" skipped="0" tests="12"' "junit.xml"
+            rlAssertGrep '<testsuite name="/plan" disabled="0" errors="2" failures="5" skipped="0" tests="13"' "junit.xml"
             rlAssertGrep 'fail</failure>' "junit.xml"
 
             # Test the escape of special characters
@@ -25,7 +25,7 @@ rlJournalStart
 
         rlPhaseStartTest "[$method] Check the flavor argument is working"
             rlRun "tmt run -avr execute -h $method report -h junit --file junit.xml --flavor default 2>&1 >/dev/null | tee output" 2
-            rlAssertGrep "5 tests passed, 5 tests failed and 2 errors" "output"
+            rlAssertGrep "6 tests passed, 5 tests failed and 2 errors" "output"
 
             # Check there is no schema problem reported
             rlAssertNotGrep 'The generated XML output is not a valid XML file or it is not valid against the XSD schema\.' "output"

--- a/tests/report/junit/test.sh
+++ b/tests/report/junit/test.sh
@@ -23,9 +23,6 @@ rlJournalStart
 
             # Check there is no schema problem reported
             rlAssertNotGrep 'The generated XML output is not a valid XML file or it is not valid against the XSD schema\.' "$rlRun_LOG"
-
-            # Check the junit plugin prints the warning about huge test output (/test/shell/big-output)
-            rlAssertGrep 'There are huge test outputs or deep XML trees in the generated XML' "$rlRun_LOG"
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the flavor argument is working"
@@ -56,14 +53,12 @@ rlJournalStart
             rlAssertGrep '<test name="/test/shell/pass" value="pass"/>' "custom-template-out.xml"
             rlAssertGrep '<test name="/test/shell/timeout" value="error"/>' "custom-template-out.xml"
             rlAssertGrep '<test name="/test/shell/escape&quot;&lt;speci&amp;l&gt;_chars" value="pass"/>' "custom-template-out.xml"
-            rlAssertGrep '<test name="/test/shell/big-output" value="pass"/>' "custom-template-out.xml"
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] Check the 'custom' flavor with very deep XML trees"
             rlRun -s "tmt run --last -v --id $run_dir execute -h $method report -h junit --file custom-deep-tree-template-out.xml --template-path custom-deep-tree.xml.j2 --flavor custom --force 2>&1 >/dev/null" 2
 
             rlAssertNotGrep 'Excessive depth in document' "$rlRun_LOG"
-            rlAssertGrep 'There are huge test outputs or deep XML trees in the generated XML' "$rlRun_LOG"
         rlPhaseEnd
 
         rlPhaseStartTest "[$method] The 'custom' flavor with a custom **non-XML** template must not work"

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -358,8 +358,8 @@ def make_junit_xml(
         except etree.XMLSyntaxError as error:
             phase.verbose('rendered XML', xml_data, 'red')
             raise tmt.utils.ReportError(
-                'The generated XML output is not a valid XML file (SyntaxError). Use `--verbose` '
-                'argument to show the output.') from error
+                'The generated XML output is not a valid XML file. Use `--verbose` argument '
+                'to show the output.') from error
 
     # Do not be fooled by the `encoding` parameter: even with `utf-8`,
     # `tostring()` will still return bytes. `unicode`, on the other

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -312,8 +312,7 @@ def make_junit_xml(
     xml_parser_kwargs: dict[str, Any] = {
         'remove_blank_text': prettify,
         'huge_tree': True,
-        'schema': None,
-        }
+        'schema': None}
 
     # The schema check must be done only for a non-custom JUnit flavors
     if flavor != CUSTOM_FLAVOR_NAME:
@@ -335,10 +334,8 @@ def make_junit_xml(
 
     xml_parser = etree.XMLParser(**xml_parser_kwargs)
     try:
-        # S320: Parsing of untrusted data is known to be vulnerable to XML
-        # attacks.
+        # S320: Parsing of untrusted data is known to be vulnerable to XML attacks.
         tree_root: XMLElement = etree.fromstring(xml_data, xml_parser)  # noqa: S320
-
     except etree.XMLSyntaxError as e:
         phase.warn(
             'The generated XML output is not a valid XML file or it is not valid against the '
@@ -363,16 +360,16 @@ def make_junit_xml(
                 'The generated XML output is not a valid XML file. Use `--verbose` argument '
                 'to show the output.') from error
 
-    # Do not be fooled by the `encoding` parameter: even with `utf-8`,
-    # `tostring()` will still return bytes. `unicode`, on the other
-    # hand, would give us a string, but then, no XML declaration.
-    # So, we get bytes, and we need to apply `decode()` on our own.
+    # Do not be fooled by the `encoding` parameter: even with `utf-8`, `tostring()` will still
+    # return bytes. `unicode`, on the other hand, would give us a string, but then, no XML
+    # declaration.  So, we get bytes, and we need to apply `decode()` on our own.
     xml_output: bytes = etree.tostring(
         tree_root,
         xml_declaration=True,
         pretty_print=prettify,
-        # The 'utf-8' encoding must be used instead of 'unicode', otherwise
-        # the XML declaration is not included in the output.
+
+        # The 'utf-8' encoding must be used instead of 'unicode', otherwise the XML declaration is
+        # not included in the output.
         encoding='utf-8')
 
     return str(xml_output.decode('utf-8'))

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -311,6 +311,7 @@ def make_junit_xml(
 
     xml_parser_kwargs: dict[str, Any] = {
         'remove_blank_text': prettify,
+        'huge_tree': True,
         'schema': None,
         }
 

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -336,6 +336,7 @@ def make_junit_xml(
     try:
         # S320: Parsing of untrusted data is known to be vulnerable to XML attacks.
         tree_root: XMLElement = etree.fromstring(xml_data, xml_parser)  # noqa: S320
+
     except etree.XMLSyntaxError as e:
         phase.warn(
             'The generated XML output is not a valid XML file or it is not valid against the '
@@ -360,16 +361,16 @@ def make_junit_xml(
                 'The generated XML output is not a valid XML file (SyntaxError). Use `--verbose` '
                 'argument to show the output.') from error
 
-    # Do not be fooled by the `encoding` parameter: even with `utf-8`, `tostring()` will still
-    # return bytes. `unicode`, on the other hand, would give us a string, but then, no XML
-    # declaration.  So, we get bytes, and we need to apply `decode()` on our own.
+    # Do not be fooled by the `encoding` parameter: even with `utf-8`,
+    # `tostring()` will still return bytes. `unicode`, on the other
+    # hand, would give us a string, but then, no XML declaration.
+    # So, we get bytes, and we need to apply `decode()` on our own.
     xml_output: bytes = etree.tostring(
         tree_root,
         xml_declaration=True,
         pretty_print=prettify,
-
-        # The 'utf-8' encoding must be used instead of 'unicode', otherwise the XML declaration is
-        # not included in the output.
+        # The 'utf-8' encoding must be used instead of 'unicode', otherwise
+        # the XML declaration is not included in the output.
         encoding='utf-8')
 
     return str(xml_output.decode('utf-8'))

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -357,8 +357,8 @@ def make_junit_xml(
         except etree.XMLSyntaxError as error:
             phase.verbose('rendered XML', xml_data, 'red')
             raise tmt.utils.ReportError(
-                'The generated XML output is not a valid XML file. Use `--verbose` argument '
-                'to show the output.') from error
+                'The generated XML output is not a valid XML file (SyntaxError). Use `--verbose` '
+                'argument to show the output.') from error
 
     # Do not be fooled by the `encoding` parameter: even with `utf-8`, `tostring()` will still
     # return bytes. `unicode`, on the other hand, would give us a string, but then, no XML

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -311,9 +311,7 @@ def make_junit_xml(
 
     xml_parser_kwargs: dict[str, Any] = {
         'remove_blank_text': prettify,
-        'huge_tree': True,
-        'schema': None,
-        }
+        'schema': None}
 
     # The schema check must be done only for a non-custom JUnit flavors
     if flavor != CUSTOM_FLAVOR_NAME:
@@ -338,30 +336,42 @@ def make_junit_xml(
         # S320: Parsing of untrusted data is known to be vulnerable to XML
         # attacks.
         tree_root: XMLElement = etree.fromstring(xml_data, xml_parser)  # noqa: S320
+    except etree.XMLSyntaxError as error:
+        if any(
+            err_msg in error.msg for err_msg in [
+                'xmlSAX2Characters: huge text node',
+                'Excessive depth in document']):
 
-    except etree.XMLSyntaxError as e:
-        phase.warn(
-            'The generated XML output is not a valid XML file or it is not valid against the '
-            'XSD schema.')
+            phase.warn('There are huge test outputs or deep XML trees in the generated XML, '
+                       "trying again with 'huge_tree' option enabled which allows to use more of "
+                       'the system resources. For more info, please see: '
+                       'https://lxml.de/FAQ.html#is-lxml-vulnerable-to-xml-bombs')
 
-        if flavor != CUSTOM_FLAVOR_NAME:
-            phase.warn('Please, report this problem to project maintainers.')
+            xml_parser_kwargs['huge_tree'] = True
+        else:
+            phase.warn('The generated XML output is not a valid XML file or it is not valid '
+                       'against the XSD schema.')
 
-        for err in e.error_log:
-            phase.warn(str(err))
+            if flavor != CUSTOM_FLAVOR_NAME:
+                phase.warn('Please, report this problem to project maintainers.')
 
-        # Return the prettified XML without checking the XSD
-        del xml_parser_kwargs['schema']
+            for err_log in error.error_log:
+                phase.warn(str(err_log))
+
+            # Disable the checking of XSD schema
+            del xml_parser_kwargs['schema']
 
         xml_parser = etree.XMLParser(**xml_parser_kwargs)
-
         try:
             tree_root = etree.fromstring(xml_data, xml_parser)  # noqa: S320
         except etree.XMLSyntaxError as error:
+            for err_log in error.error_log:
+                phase.warn(str(err_log))
+
             phase.verbose('rendered XML', xml_data, 'red')
             raise tmt.utils.ReportError(
-                'The generated XML output is not a valid XML file. Use `--verbose` argument '
-                'to show the output.') from error
+                'The generated XML output is not a valid XML file (SyntaxError). Use `--verbose` '
+                'argument to show the output.') from error
 
     # Do not be fooled by the `encoding` parameter: even with `utf-8`,
     # `tostring()` will still return bytes. `unicode`, on the other


### PR DESCRIPTION
This PR should resolve the problem with the LXML limit on the size of text nodes it can handle:
- #3363 

For more info about a `huge_tree` option, please see:
- https://lxml.de/api/lxml.etree.XMLParser-class.html

> `huge_tree` - disable security restrictions and support very deep trees and very long text content (only affects libxml2 2.7+)

Especially this LXML FAQ section about **security concerns**:
- https://lxml.de/FAQ.html#is-lxml-vulnerable-to-xml-bombs

> Is lxml vulnerable to XML bombs?
> 
> This has nothing to do with lxml itself, only with the parser of libxml2. Since libxml2 version 2.7, the parser imposes hard security limits on input documents to prevent DoS attacks with forged input data. Since lxml 2.2.1, you can disable these limits with the `huge_tree` parser option if you need to parse really large, trusted documents. All lxml versions will leave these restrictions enabled by default.
> 
> Note that libxml2 versions of the 2.6 series do not restrict their parser and are therefore vulnerable to DoS attacks.

### TODOs:
- [x] Try to test the test with huge output without lxml (with just jinja) to check if bottleneck is really lxml (schema or pretty print)
- [x] Enable the "huge output" test in the CI? -> yes
- [x] Add a test for XML deep trees (using a custom junit flavor)


Pull Request Checklist:
* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
