### PR TITLE
Add missing fields to report plugin schemas

### DIFF
--- a/tmt/schemas/report/junit.yaml
+++ b/tmt/schemas/report/junit.yaml
@@ -25,6 +25,18 @@ properties:
   file:
     type: string
 
+  flavor:
+    type: string
+    enum:
+      - default
+      - custom
+
+  template-path:
+    type: string
+
+  prettify:
+    type: boolean
+
   include-output-log:
     type: boolean
 

--- a/tmt/schemas/report/polarion.yaml
+++ b/tmt/schemas/report/polarion.yaml
@@ -73,6 +73,9 @@ properties:
   fips:
     type: boolean
 
+  prettify:
+    type: boolean
+
   include-output-log:
     type: boolean
 


### PR DESCRIPTION
This PR adds missing fields to **polarion** and **junit** report plugin schemas. These new fields were added to CLI options in these PRs:

- **junit** - https://github.com/teemtee/tmt/pull/3150
- **polarion** - https://github.com/teemtee/tmt/pull/3166

Related to:
- https://github.com/teemtee/tmt/issues/2826

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
