### PR TITLE
Export `PATH` with `TMT_SCRIPTS_DIR` if needed

### DIFF
--- a/tests/execute/tmt-scripts/data/plan.fmf
+++ b/tests/execute/tmt-scripts/data/plan.fmf
@@ -3,4 +3,4 @@ provision:
     image: $IMAGE
 execute:
     how: tmt
-    script: ls $PATHS
+    script: ./test.sh

--- a/tests/execute/tmt-scripts/data/test.sh
+++ b/tests/execute/tmt-scripts/data/test.sh
@@ -1,0 +1,2 @@
+ls $PATHS
+echo "PATH=$PATH"

--- a/tests/execute/tmt-scripts/main.fmf
+++ b/tests/execute/tmt-scripts/main.fmf
@@ -3,6 +3,7 @@ summary: Verify correct location of tmt scripts
 /fedora:
   environment:
     IMAGE: registry.fedoraproject.org/fedora:rawhide
+    DEFAULT_TMT_SCRIPTS_DIR: /usr/local/bin
     FOUND: |
       /usr/local/bin/rhts-abort
       /usr/local/bin/rhts-reboot
@@ -26,6 +27,7 @@ summary: Verify correct location of tmt scripts
   environment:
     IMAGE: registry.fedoraproject.org/fedora:rawhide
     TMT_SCRIPTS_DIR: /usr/bin
+    DEFAULT_TMT_SCRIPTS_DIR: /usr/local/bin
     FOUND: |
       /usr/bin/rhts-abort
       /usr/bin/rhts-reboot
@@ -62,6 +64,7 @@ summary: Verify correct location of tmt scripts
 /fedora-bootc:
   environment:
     IMAGE: quay.io/fedora/fedora-bootc:rawhide
+    DEFAULT_TMT_SCRIPTS_DIR: /var/lib/tmt/scripts
     FOUND: |
       /var/lib/tmt/scripts/rhts-abort
       /var/lib/tmt/scripts/rhts-reboot
@@ -103,6 +106,7 @@ summary: Verify correct location of tmt scripts
   environment:
     IMAGE: quay.io/fedora/fedora-bootc:rawhide
     TMT_SCRIPTS_DIR: /var/tmp/tmt/bin
+    DEFAULT_TMT_SCRIPTS_DIR: /var/lib/tmt/scripts
     FOUND: |
       /etc/profile.d/tmt.sh
       /var/tmp/tmt/bin/rhts-abort

--- a/tests/execute/tmt-scripts/test.sh
+++ b/tests/execute/tmt-scripts/test.sh
@@ -21,7 +21,7 @@ rlJournalStart
             rlAssertGrep "ls: cannot access '$NOT_FOUND_PATH': No such file or directory" $rlRun_LOG
         done
 
-        TMT_SCRIPTS_DIR=${TMT_SCRIPTS_DIR:-/var/lib/tmt/scripts}
+        TMT_SCRIPTS_DIR=${TMT_SCRIPTS_DIR:-$DEFAULT_TMT_SCRIPTS_DIR}
         rlAssertGrep "PATH=.*$TMT_SCRIPTS_DIR.*" $rlRun_LOG
     rlPhaseEnd
 

--- a/tests/execute/tmt-scripts/test.sh
+++ b/tests/execute/tmt-scripts/test.sh
@@ -11,7 +11,7 @@ rlJournalStart
         # List of paths to check, on a single line
         PATHS=$(echo $FOUND $NOT_FOUND)
 
-        rlRun -s "tmt run -vvv -e IMAGE=$IMAGE -e \"PATHS='$PATHS'\" --id $run" 2 "Run the plan"
+        rlRun -s "tmt run -vvv -e IMAGE=$IMAGE -e \"PATHS='$PATHS'\" --id $run" 0 "Run the plan"
 
         for FOUND_PATH in $FOUND; do
             rlAssertGrep "out: $FOUND_PATH" $rlRun_LOG
@@ -20,6 +20,9 @@ rlJournalStart
         for NOT_FOUND_PATH in $NOT_FOUND; do
             rlAssertGrep "ls: cannot access '$NOT_FOUND_PATH': No such file or directory" $rlRun_LOG
         done
+
+        TMT_SCRIPTS_DIR=${TMT_SCRIPTS_DIR:-/var/lib/tmt/scripts}
+        rlAssertGrep "PATH=.*$TMT_SCRIPTS_DIR.*" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -111,6 +111,10 @@ TEST_WRAPPER_FILENAME_TEMPLATE = \
 #   and simulation of tty not available for output is not run.
 #
 TEST_WRAPPER_TEMPLATE = jinja2.Template(textwrap.dedent("""
+if ! grep -q "{{ GUEST_SCRIPTS_PATH }}" <<< "${PATH}"; then
+    export PATH={{ GUEST_SCRIPTS_PATH }}:${PATH}
+fi
+
 {% macro enter() %}
 flock "$TMT_TEST_PIDFILE_LOCK" -c "echo '${test_pid} ${TMT_REBOOT_REQUEST}' > ${TMT_TEST_PIDFILE}" || exit 122
 {%- endmacro %}
@@ -354,7 +358,8 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         remote_command = ShellScript(TEST_WRAPPER_TEMPLATE.render(
             INTERACTIVE=self.data.interactive,
             TTY=test.tty,
-            REMOTE_COMMAND=ShellScript(command)
+            REMOTE_COMMAND=ShellScript(command),
+            GUEST_SCRIPTS_PATH=guest.scripts_path
             ).strip())
 
         def _test_output_logger(


### PR DESCRIPTION
Make sure we export the `PATH` with `TMT_SCRIPTS_DIR` in case it is needed. This is needed if tests scripts call distributed tmt scripts.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
