### PR TITLE
Add missing colon to the `tmt-try` tldr page

### DIFF
--- a/docs/tldr/tmt-try.md
+++ b/docs/tldr/tmt-try.md
@@ -4,7 +4,7 @@
 > See also: `tmt`, `tmt-run`.
 > More information: <https://tmt.readthedocs.io/en/stable/stories/cli.html#try>.
 
-- Quickly experiment with the default provision method (no tests in cwd)
+- Quickly experiment with the default provision method (no tests in cwd):
 
 `tmt try`
 


### PR DESCRIPTION
@psss Sorry about missing this during the updates. I've hit this now with tldr-lint. The other two files are ok.