### PR TITLE
Adjust `avc` check setup and fix docs generation

### DIFF
--- a/docs/scripts/generate-stories.py
+++ b/docs/scripts/generate-stories.py
@@ -53,8 +53,8 @@ def main() -> None:
     logger = tmt.Logger.create()
     logger.add_console_handler()
 
-    # Explore available *export* plugins - do not import other plugins, we don't need them.
-    tmt.plugins.explore_export_package(logger)
+    # Explore available plugins
+    tmt.plugins.explore(logger)
 
     # Generate stories
     tree = tmt.Tree(logger=logger, path=Path.cwd())

--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -3,10 +3,14 @@ framework: beakerlib
 contact: Petr Šplíchal <psplicha@redhat.com>
 tier: 2
 require: [tmt]
+check: [avc]
 duration: 10m
 environment:
     TMT_FEELING_SAFE: 1
 
 adjust:
-  - check: [avc]
-    when: initiator == packit
+  - check: []
+    when: initiator is not defined or initiator != packit
+    because:
+        we don't want to run the avc check for local testing as it
+        needs root and we're executing tests under a regular user

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -293,14 +293,6 @@ def import_member(
     return (imported, getattr(imported, member))
 
 
-# Small helper for one specific package - export plugins are needed when
-# generating docs.
-def explore_export_package(logger: Logger) -> None:
-    """ Import all plugins bundled into tmt.export package """
-
-    _explore_package('tmt.export', _TMT_ROOT / 'export', logger.descend())
-
-
 RegisterableT = TypeVar('RegisterableT')
 
 


### PR DESCRIPTION
Allow individual tests set their `avc` checks as needed

Let's go the other way round: Enable the check by default, allow individual tests to set it according to their needs by a simple definition and disable it globally when not initiated by packit.

Explore all available plugins when generating docs

We also need test checks and who knows what else in the future as well. So let's just explore them all.