### PR TITLE
Readme badges and pyproject cleanup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
           - "pygments>=2.7.4"
           - "requests>=2.25.1"
           - "ruamel.yaml>=0.16.6"
-          - "urllib3>=1.26.5, <2.0"
+          - "urllib3>=1.26.5, <3.0"
           - "jira>=3.5.0, <4"
 
           # report-junit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,23 +27,23 @@ repos:
         #
         # For now, we simply copy & paste from pyproject.toml :(
         additional_dependencies:
-          - "click>=8.0.3,!=8.1.4"   # 8.1.3 / 8.1.6 TODO type annotations tmt.cli.Context -> click.core.Context click/issues/2558
-          - "docutils>=0.16"         # 0.16 is the current one available for RHEL9
-          - "fmf>=1.3.0"
-          - "jinja2>=2.11.3"         # 3.1.2 / 3.1.2
-          - "packaging>=20"          # 20 seems to be available with RHEL8
-          - "pint>=0.16.1"           # 0.16.1
+          - "click>=8.0.3"
+          - "docutils>=0.16"
+          - "fmf>=1.7.0"
+          - "jinja2>=2.11.3"
+          - "packaging>=20"
+          - "pint>=0.16.1"
           - "pydantic>=1.10.14"
-          - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
-          - "requests>=2.25.1"       # 2.28.2 / 2.31.0
-          - "ruamel.yaml>=0.16.6"    # 0.17.32 / 0.17.32
-          - "urllib3>=1.26.5, <2.0"  # 1.26.16 / 2.0.4
+          - "pygments>=2.7.4"
+          - "requests>=2.25.1"
+          - "ruamel.yaml>=0.16.6"
+          - "urllib3>=1.26.5, <2.0"
           - "jira>=3.5.0, <4"
 
           # report-junit
           - "lxml>=4.6.5"
 
-          - "typing-extensions>=4.9.0; python_version < '3.13'"
+          - "typing-extensions>=4.12.2; python_version < '3.13'"
           - "pytest"
           - "requre"
           # Do not install *types-click* - it's not recommended with Click 8 & newer,
@@ -75,17 +75,17 @@ repos:
         #
         # For now, we simply copy & paste from pyproject.toml :(
         additional_dependencies:
-          - "click>=8.0.3,!=8.1.4"   # 8.1.3 / 8.1.6 TODO type annotations tmt.cli.Context -> click.core.Context click/issues/2558
-          - "docutils>=0.16"         # 0.16 is the current one available for RHEL9
-          - "fmf>=1.3.0"
-          - "jinja2>=2.11.3"         # 3.1.2 / 3.1.2
-          - "packaging>=20"          # 20 seems to be available with RHEL8
-          - "pint>=0.16.1"           # 0.16.1 / 0.19.x  TODO: Pint 0.20 requires larger changes to tmt.hardware
+          - "click>=8.0.3"
+          - "docutils>=0.16"
+          - "fmf>=1.7.0"
+          - "jinja2>=2.11.3"
+          - "packaging>=20"
+          - "pint>=0.16.1"
           - "pydantic>=1.10.14"
-          - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
-          - "requests>=2.25.1"       # 2.28.2 / 2.31.0
-          - "ruamel.yaml>=0.16.6"    # 0.17.32 / 0.17.32
-          - "urllib3>=1.26.5, <2.0"  # 1.26.16 / 2.0.4
+          - "pygments>=2.7.4"
+          - "requests>=2.25.1"
+          - "ruamel.yaml>=0.16.6"
+          - "urllib3>=1.26.5, <2.0"
           - "jira>=3.5.0, <4"
 
           # report-junit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
           - "pygments>=2.7.4"
           - "requests>=2.25.1"
           - "ruamel.yaml>=0.16.6"
-          - "urllib3>=1.26.5, <2.0"
+          - "urllib3>=1.26.5, <3.0"
           - "jira>=3.5.0, <4"
 
           # report-junit

--- a/README.rst
+++ b/README.rst
@@ -24,25 +24,25 @@ efficiently, preventing unnecessary duplication.
 
 See the https://tmt.readthedocs.io web for detailed documentation.
 
-.. |docs| image:: https://img.shields.io/readthedocs/tmt
+.. |docs| image:: https://img.shields.io/badge/Read%20the%20Docs-8CA1AF?logo=readthedocs&logoColor=fff
     :target: https://tmt.readthedocs.io/
-    :alt: Documentation Status
+    :alt: Documentation
 
-.. |matrix| image:: https://img.shields.io/badge/Matrix-green?logo=matrix&logoColor=white&color=black
+.. |matrix| image:: https://img.shields.io/badge/Matrix-000?logo=matrix&logoColor=fff
     :target: https://matrix.to/#/#tmt:fedoraproject.org
     :alt: Matrix chat
 
-.. |fedora-pkg| image:: https://img.shields.io/fedora/v/tmt?logo=fedora&logoColor=white
+.. |fedora-pkg| image:: https://img.shields.io/fedora/v/tmt?logo=fedora&logoColor=fff&color=fff&labelColor=51a2da
     :target: https://src.fedoraproject.org/rpms/tmt
     :alt: Fedora package
 
-.. |copr-build| image:: https://img.shields.io/badge/dynamic/json?color=blue&label=copr&query=builds.latest.state&url=https%3A%2F%2Fcopr.fedorainfracloud.org%2Fapi_3%2Fpackage%3Fownername%3D%40teemtee%26projectname%3Dlatest%26packagename%3Dtmt%26with_latest_build%3DTrue
+.. |copr-build| image:: https://img.shields.io/badge/dynamic/json?color=blue&label=Copr&query=builds.latest.state&url=https%3A%2F%2Fcopr.fedorainfracloud.org%2Fapi_3%2Fpackage%3Fownername%3D%40teemtee%26projectname%3Dlatest%26packagename%3Dtmt%26with_latest_build%3DTrue
     :target: https://copr.fedorainfracloud.org/coprs/g/teemtee/tmt/
     :alt: Copr build status
 
-.. |pypi-version| image:: https://img.shields.io/pypi/v/tmt
+.. |pypi-version| image:: https://img.shields.io/badge/PyPI-3775A9?logo=pypi&logoColor=fff
     :target: https://pypi.org/project/tmt/
-    :alt: PyPI version
+    :alt: PyPI
 
 .. |python-versions| image:: https://img.shields.io/pypi/pyversions/tmt
     :target: https://pypi.org/project/tmt/
@@ -53,8 +53,8 @@ See the https://tmt.readthedocs.io web for detailed documentation.
     :alt: Ruff
 
 .. |pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit
-    :target: https://github.com/pre-commit/pre-commit
-    :alt: pre-commit
+   :target: https://github.com/pre-commit/pre-commit
+   :alt: pre-commit
 
 .. |license| image:: https://img.shields.io/badge/license-MIT-blue.svg
     :target: https://opensource.org/licenses/MIT

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@
                     tmt - Test Management Tool
 ==================================================================
 
+|docs| |matrix| |fedora-pkg| |copr-build| |pypi-version| |python-versions| |ruff| |pre-commit| |license|
+
 The ``tmt`` tool provides a user-friendly way to work with tests.
 You can comfortably create new tests, safely and easily run tests
 across different environments, review test results, debug test
@@ -21,3 +23,39 @@ inheritance and elasticity metadata are organized in the structure
 efficiently, preventing unnecessary duplication.
 
 See the https://tmt.readthedocs.io web for detailed documentation.
+
+.. |docs| image:: https://img.shields.io/readthedocs/tmt
+    :target: https://tmt.readthedocs.io/
+    :alt: Documentation Status
+
+.. |matrix| image:: https://img.shields.io/badge/Matrix-green?logo=matrix&logoColor=white&color=black
+    :target: https://matrix.to/#/#tmt:fedoraproject.org
+    :alt: Matrix chat
+
+.. |fedora-pkg| image:: https://img.shields.io/fedora/v/tmt?logo=fedora&logoColor=white
+    :target: https://src.fedoraproject.org/rpms/tmt
+    :alt: Fedora package
+
+.. |copr-build| image:: https://img.shields.io/badge/dynamic/json?color=blue&label=copr&query=builds.latest.state&url=https%3A%2F%2Fcopr.fedorainfracloud.org%2Fapi_3%2Fpackage%3Fownername%3D%40teemtee%26projectname%3Dtmt%26packagename%3Dtmt%26with_latest_build%3DTrue
+    :target: https://copr.fedorainfracloud.org/coprs/g/teemtee/tmt/
+    :alt: Copr build status
+
+.. |pypi-version| image:: https://img.shields.io/pypi/v/tmt
+    :target: https://pypi.org/project/tmt/
+    :alt: PyPI version
+
+.. |python-versions| image:: https://img.shields.io/pypi/pyversions/tmt
+    :target: https://pypi.org/project/tmt/
+    :alt: Python versions
+
+.. |ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+    :target: https://github.com/astral-sh/ruff
+    :alt: Ruff
+
+.. |pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit
+    :target: https://github.com/pre-commit/pre-commit
+    :alt: pre-commit
+
+.. |license| image:: https://img.shields.io/badge/license-MIT-blue.svg
+    :target: https://opensource.org/licenses/MIT
+    :alt: MIT License

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ See the https://tmt.readthedocs.io web for detailed documentation.
     :target: https://src.fedoraproject.org/rpms/tmt
     :alt: Fedora package
 
-.. |copr-build| image:: https://img.shields.io/badge/dynamic/json?color=blue&label=copr&query=builds.latest.state&url=https%3A%2F%2Fcopr.fedorainfracloud.org%2Fapi_3%2Fpackage%3Fownername%3D%40teemtee%26projectname%3Dtmt%26packagename%3Dtmt%26with_latest_build%3DTrue
+.. |copr-build| image:: https://img.shields.io/badge/dynamic/json?color=blue&label=copr&query=builds.latest.state&url=https%3A%2F%2Fcopr.fedorainfracloud.org%2Fapi_3%2Fpackage%3Fownername%3D%40teemtee%26projectname%3Dlatest%26packagename%3Dtmt%26with_latest_build%3DTrue
     :target: https://copr.fedorainfracloud.org/coprs/g/teemtee/tmt/
     :alt: Copr build status
 

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
                     tmt - Test Management Tool
 ==================================================================
 
-|docs| |matrix| |fedora-pkg| |copr-build| |pypi-version| |python-versions| |ruff| |pre-commit| |license|
+|docs| |matrix| |fedora-pkg| |copr-build| |pypi-version| |python-versions| |license|
 
 The ``tmt`` tool provides a user-friendly way to work with tests.
 You can comfortably create new tests, safely and easily run tests

--- a/README.rst
+++ b/README.rst
@@ -36,8 +36,8 @@ See the https://tmt.readthedocs.io web for detailed documentation.
     :target: https://src.fedoraproject.org/rpms/tmt
     :alt: Fedora package
 
-.. |copr-build| image:: https://img.shields.io/badge/dynamic/json?color=blue&label=Copr&query=builds.latest.state&url=https%3A%2F%2Fcopr.fedorainfracloud.org%2Fapi_3%2Fpackage%3Fownername%3D%40teemtee%26projectname%3Dlatest%26packagename%3Dtmt%26with_latest_build%3DTrue
-    :target: https://copr.fedorainfracloud.org/coprs/g/teemtee/stable/
+.. |copr-build| image:: https://img.shields.io/badge/dynamic/json?logo=fedora&color=blue&label=dev-build&query=builds.latest.state&url=https%3A%2F%2Fcopr.fedorainfracloud.org%2Fapi_3%2Fpackage%3Fownername%3D%40teemtee%26projectname%3Dlatest%26packagename%3Dtmt%26with_latest_build%3DTrue
+    :target: https://copr.fedorainfracloud.org/coprs/g/teemtee/latest/
     :alt: Copr build status
 
 .. |pypi-version| image:: https://img.shields.io/badge/PyPI-3775A9?logo=pypi&logoColor=fff

--- a/README.rst
+++ b/README.rst
@@ -48,14 +48,6 @@ See the https://tmt.readthedocs.io web for detailed documentation.
     :target: https://pypi.org/project/tmt/
     :alt: Python versions
 
-.. |ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
-    :target: https://github.com/astral-sh/ruff
-    :alt: Ruff
-
-.. |pre-commit| image:: https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit
-   :target: https://github.com/pre-commit/pre-commit
-   :alt: pre-commit
-
 .. |license| image:: https://img.shields.io/badge/license-MIT-blue.svg
     :target: https://opensource.org/licenses/MIT
     :alt: MIT License

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
                     tmt - Test Management Tool
 ==================================================================
 
-|docs| |matrix| |fedora-pkg| |copr-build| |pypi-version| |python-versions| |license|
+|docs| |matrix| |fedora-pkg| |copr-build| |pypi-version| |license|
 
 The ``tmt`` tool provides a user-friendly way to work with tests.
 You can comfortably create new tests, safely and easily run tests
@@ -43,10 +43,6 @@ See the https://tmt.readthedocs.io web for detailed documentation.
 .. |pypi-version| image:: https://img.shields.io/badge/PyPI-3775A9?logo=pypi&logoColor=fff
     :target: https://pypi.org/project/tmt/
     :alt: PyPI
-
-.. |python-versions| image:: https://img.shields.io/pypi/pyversions/tmt
-    :target: https://pypi.org/project/tmt/
-    :alt: Python versions
 
 .. |license| image:: https://img.shields.io/badge/license-MIT-blue.svg
     :target: https://opensource.org/licenses/MIT

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ See the https://tmt.readthedocs.io web for detailed documentation.
     :alt: Fedora package
 
 .. |copr-build| image:: https://img.shields.io/badge/dynamic/json?color=blue&label=Copr&query=builds.latest.state&url=https%3A%2F%2Fcopr.fedorainfracloud.org%2Fapi_3%2Fpackage%3Fownername%3D%40teemtee%26projectname%3Dlatest%26packagename%3Dtmt%26with_latest_build%3DTrue
-    :target: https://copr.fedorainfracloud.org/coprs/g/teemtee/tmt/
+    :target: https://copr.fedorainfracloud.org/coprs/g/teemtee/stable/
     :alt: Copr build status
 
 .. |pypi-version| image:: https://img.shields.io/badge/PyPI-3775A9?logo=pypi&logoColor=fff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,23 +24,24 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Utilities",
     "Topic :: Software Development :: Testing",
     "Operating System :: POSIX :: Linux",
     ]
-dependencies = [              # F39 / PyPI
+dependencies = [
     "click>=8.0.3,!=8.1.4",   # 8.1.3 / 8.1.6 TODO type annotations tmt.cli.Context -> click.core.Context click/issues/2558
-    "docutils>=0.16",         # 0.16 is the current one available for RHEL9
+    "docutils>=0.16",
     "fmf>=1.7.0",
-    "jinja2>=2.11.3",         # 3.1.2 / 3.1.2
-    "packaging>=20",          # 20 seems to be available with RHEL8
-    "pint>=0.16.1",           # 0.16.1
+    "jinja2>=2.11.3",
+    "packaging>=20",
+    "pint>=0.16.1",
     "pydantic>=1.10.14",
-    "pygments>=2.7.4",        # 2.7.4 is the current one available for RHEL9
-    "requests>=2.25.1",       # 2.28.2 / 2.31.0
-    "ruamel.yaml>=0.16.6",    # 0.17.32 / 0.17.32
-    "urllib3>=1.26.5, <3.0",  # 1.26.16 / 2.0.4
+    "pygments>=2.7.4",
+    "requests>=2.25.1",
+    "ruamel.yaml>=0.16.6",
+    "urllib3>=1.26.5, <3.0",
     "typing-extensions>=4.9.0; python_version < '3.13'",
     ]
 
@@ -182,7 +183,7 @@ template = "dev"
 description = "Run scripts with multiple Python versions"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.11", "3.12"]
+python = ["3.9", "3.12", "3.13"]
 
 [tool.hatch.envs.docs]
 dependencies = ["tmt[docs]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ export-polarion = [
     "pylero>=0.1.0",
     ]
 provision-beaker = [
-    "mrack>=1.23.3",
+    "mrack>=1.23.2",
     ]
 provision-virtual = [
     "testcloud>=0.11.7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Utilities",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,35 +31,36 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     ]
 dependencies = [
-    "click>=8.0.3,!=8.1.4",   # 8.1.3 / 8.1.6 TODO type annotations tmt.cli.Context -> click.core.Context click/issues/2558
+    # Minimal versions based on c9s rpms
+    "click>=8.0.3",
     "docutils>=0.16",
     "fmf>=1.7.0",
     "jinja2>=2.11.3",
-    "packaging>=20",
+    "packaging>=20.9",
     "pint>=0.16.1",
     "pydantic>=1.10.14",
     "pygments>=2.7.4",
     "requests>=2.25.1",
     "ruamel.yaml>=0.16.6",
     "urllib3>=1.26.5, <3.0",
-    "typing-extensions>=4.9.0; python_version < '3.13'",
+    "typing-extensions>=4.12.2; python_version < '3.13'",
     ]
 
 [project.optional-dependencies]
 ansible = [
-    "ansible-core",
+    "ansible-core>=2.14.18",
     ]
 test-convert = [
     "html2text>=2020.1.16",
     "markdown>=3.3.4",
-    "nitrate>=1.8.2",
+    "nitrate>=1.9.0",
     "python-bugzilla>=3.2.0",
     ]
 export-polarion = [
-    "pylero>=0.0.8",
+    "pylero>=0.1.0",
     ]
 provision-beaker = [
-    "mrack>=1.23.1",
+    "mrack>=1.23.3",
     ]
 provision-virtual = [
     "testcloud>=0.11.7",


### PR DESCRIPTION
I'm not a friend with rst and have more experience with markdown. Will this render ok on PyPI page and other places? We also need to deal with man generation I presume?
PyPA should be ok based on: 
```
$ twine check dist/tmt-1.40.0.dev2+ga31e8651-py3-none-any.whl --strict
Checking dist/tmt-1.40.0.dev2+ga31e8651-py3-none-any.whl: PASSED
```


github would look like this:
![image](https://github.com/user-attachments/assets/2a4b3aed-8835-48be-8a41-e48dd7e07293)

In pyproject, I've replaced Python 3.11 with 3.13 and removed the unmaintainable comments of what versions are available where.

Pull Request Checklist

* [x] implement the feature