### PR TITLE
Document overview of supported `restraint` scripts

### DIFF
--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -158,6 +158,25 @@ Metadata Specification and are supposed to be synced temporarily
 to keep backward compatibility.
 
 
+Restraint Compatibility
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For backward-compatibility ``tmt`` provides selected commands
+of the `restraint`__ framework so that existing tests can be more
+easily migrated. Currently the following scripts are supported:
+
+* ``rhts-abort`` and ``rhts-abort`` — :ref:`/stories/features/abort`
+* ``rhts-reboot`` and ``rhts-reboot`` — :ref:`/stories/features/reboot`
+* ``rhts-submit-log`` and ``rhts-submit-log`` — :ref:`/stories/features/report-log`
+* ``rhts-report-result`` and ``rhts-report-result`` — :ref:`/stories/features/report-result`
+
+Note that these scripts cover only the common use cases and some
+of their irrelevant options, such as ``--server`` used for the
+restraint server, are ignored.
+
+__ https://restraint.readthedocs.io/
+
+
 Why is the 'id' key added to my test during export?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -158,6 +158,8 @@ Metadata Specification and are supposed to be synced temporarily
 to keep backward compatibility.
 
 
+.. _restraint-compatibility:
+
 Restraint Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -167,10 +167,10 @@ For backward-compatibility ``tmt`` provides selected commands
 of the `restraint`__ framework so that existing tests can be more
 easily migrated. Currently the following scripts are supported:
 
-* ``rhts-abort`` and ``rhts-abort`` — :ref:`/stories/features/abort`
-* ``rhts-reboot`` and ``rhts-reboot`` — :ref:`/stories/features/reboot`
-* ``rhts-submit-log`` and ``rhts-submit-log`` — :ref:`/stories/features/report-log`
-* ``rhts-report-result`` and ``rhts-report-result`` — :ref:`/stories/features/report-result`
+* ``rhts-abort`` and ``rstrnt-abort`` — :ref:`/stories/features/abort`
+* ``rhts-reboot`` and ``rstrnt-reboot`` — :ref:`/stories/features/reboot`
+* ``rhts-submit-log`` and ``rstrnt-report-log`` — :ref:`/stories/features/report-log`
+* ``rhts-report-result`` and ``rstrnt-report-result`` — :ref:`/stories/features/report-result`
 
 Note that these scripts cover only the common use cases and some
 of their irrelevant options, such as ``--server`` used for the

--- a/stories/deferred/restraint.fmf
+++ b/stories/deferred/restraint.fmf
@@ -13,19 +13,8 @@ description: |
 
     Although implementation of the full execute step plugin has
     been deferred, backward compatibility scripts have been
-    provided for several most commonly used restraint commands:
-
-    rstrnt-abort
-        :ref:`/stories/features/abort`
-
-    rstrnt-reboot
-        :ref:`/stories/features/reboot`
-
-    rstrnt-report-log
-        :ref:`/stories/features/report-log`
-
-    rstrnt-report-result
-        :ref:`/stories/features/report-result`
+    provided for several most commonly used restraint commands.
+    See the :ref:`restraint-compatibility` section for details.
 
 example:
   - tmt run --all execute --how restraint


### PR DESCRIPTION
Seems we don't have an overview of the `restraint` scripts which are supported by `tmt`. Let's add a new section to `Questions`.

Pull Request Checklist

* [x] write the documentation