### PR TITLE
Uninstall bootc in Fedora CoreOS testing image

### DIFF
--- a/containers/fedora/coreos/Containerfile
+++ b/containers/fedora/coreos/Containerfile
@@ -19,6 +19,7 @@ RUN    rpm-ostree install dnf5 \
     # or any other dnf4-ish command.
     && rpm-ostree uninstall diffutils \
                             # Removing diffutils, these need to be removed too.
+                            bootc \
                             containers-common-extra \
                             passt \
                             passt-selinux \

--- a/containers/fedora/coreos/ostree/Containerfile
+++ b/containers/fedora/coreos/ostree/Containerfile
@@ -21,6 +21,7 @@ RUN    rpm-ostree install dnf5 \
     # or any other dnf4-ish command.
     && rpm-ostree uninstall diffutils \
                             # Removing diffutils, these need to be removed too.
+                            bootc \
                             containers-common-extra \
                             passt \
                             passt-selinux \


### PR DESCRIPTION
bootc depends on podman, podman depends on diffutils, diffutils are being removed for the purpose of tmt tests. And rpm-ostree does not remove dependants automatically.

Pull Request Checklist

* [x] implement the feature