### PR TITLE
Add fallback method for generating shorter SSH master socket

### DIFF
--- a/tests/provision/ssh-multiplexing/test.sh
+++ b/tests/provision/ssh-multiplexing/test.sh
@@ -16,7 +16,7 @@ rlJournalStart
 
     rlPhaseStartTest "SSH multiplexing should be disabled when SSH socket path gets too long ($PROVISION_HOW)"
         rlRun "tmt -vv run -i $long_run -a provision -h $PROVISION_HOW"
-        rlAssertGrep "warn: SSH multiplexing will not be used because the SSH socket path '.*' is too long." "$long_run/log.txt"
+        rlAssertGrep "warn: SSH multiplexing will not be used because the SSH master socket path '.*' is too long." "$long_run/log.txt"
         rlAssertGrep "The SSH master process cannot be terminated because it is disabled." "$long_run/log.txt"
     rlPhaseEnd
 

--- a/tests/unit/provision/test_ssh.py
+++ b/tests/unit/provision/test_ssh.py
@@ -1,0 +1,126 @@
+import os
+import re
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+import tmt.log
+from tmt.steps.provision import (
+    _socket_path_hash,
+    _socket_path_trivial,
+    )
+from tmt.utils import Path
+
+
+@pytest.mark.parametrize(
+    ('socket_dir', 'limit_size', 'expected'),
+    [(Path('/tmp'),
+      True,
+      Path('/tmp/dummy-id.socket')),
+     (Path('/very/log/socket/dir/which/is/almost/over/the/limit/but/just/and/soo'),
+      True,
+      None),
+     (Path('/very/log/socket/dir/which/is/over/the/limit/by/itself/and/does/not/need'),
+      True,
+      None),
+     (Path('/very/log/socket/dir/which/is/almost/over/the/limit/but/just/and/soo'),
+      False,
+      Path('/very/log/socket/dir/which/is/almost/over/the/limit/but/just/and/soo/dummy-id.socket')),
+     (Path('/very/log/socket/dir/which/is/over/the/limit/by/itself/and/does/not/need'),
+      False,
+      Path('/very/log/socket/dir/which/is/over/the/limit/by/itself/and/does/not/need/dummy-id.socket')),
+     ])
+def test_socket_path_trivial(
+        socket_dir: Path,
+        limit_size: bool,
+        expected: Optional[Path],
+        root_logger: tmt.log.Logger) -> None:
+
+    actual = _socket_path_trivial(
+        socket_dir=socket_dir,
+        guest_id='dummy-id',
+        limit_size=limit_size,
+        logger=root_logger)
+
+    if expected is None:
+        assert actual is expected
+
+    else:
+        assert str(actual) == str(expected)
+
+
+@pytest.mark.parametrize(
+    ('socket_dir', 'limit_size', 'expected'),
+    [(Path('/tmp'),
+      True,
+      r'/tmp/[a-z0-9]{4}.socket'),
+     (Path('/very/log/socket/dir/which/is/almost/over/the/limit/but/just/and/soo'),
+      True,
+      r'/very/log/socket/dir/which/is/almost/over/the/limit/but/just/and/soo/[a-z0-9]{4}.socket'),
+     (Path('/very/log/socket/dir/which/is/over/the/limit/by/itself/and/does/not/need'),
+      True,
+      None),
+     (Path('/very/log/socket/dir/which/is/almost/over/the/limit/but/just/and/soo'),
+      False,
+      r'/very/log/socket/dir/which/is/almost/over/the/limit/but/just/and/soo/[a-z0-9]{4}.socket'),
+     (Path('/very/log/socket/dir/which/is/over/the/limit/by/itself/and/does/not/need'),
+      False,
+      r'/very/log/socket/dir/which/is/over/the/limit/by/itself/and/does/not/need/[a-z0-9]{4}.socket'),
+     ])
+def test_socket_path_hash(
+        socket_dir: Path,
+        limit_size: bool,
+        expected: Optional[str],
+        monkeypatch,
+        root_logger: tmt.log.Logger) -> None:
+
+    monkeypatch.setattr(os, 'open', MagicMock(name='<mock>os.open'))
+    monkeypatch.setattr(os, 'close', MagicMock(name='<mock>os.close'))
+
+    actual = _socket_path_hash(
+        socket_dir=socket_dir,
+        guest_id='dummy-id',
+        limit_size=limit_size,
+        logger=root_logger)
+
+    if expected is None:
+        assert actual is expected
+
+    else:
+        assert re.match(expected, str(actual))
+
+
+def test_socket_path_hash_conflict(
+        monkeypatch,
+        root_logger: tmt.log.Logger) -> None:
+
+    monkeypatch.setattr(os, 'close', MagicMock(name='<mock>os.close'))
+
+    socket_dir = Path('/tmp')
+
+    # First, "create" a socket for the first guest.
+    monkeypatch.setattr(os, 'open', MagicMock(name='<mock>os.open'))
+
+    actual1 = _socket_path_hash(
+        socket_dir=socket_dir,
+        guest_id='dummy-id',
+        logger=root_logger)
+
+    # Second, simulate "file exists" error to inject the conflict. We
+    # did not create the file, just pretending via capturing `os.open`.
+    def _raise_but_once(filepath: Path, **kwargs):
+        if str(filepath).replace('.reservation', '') == str(actual1):
+            raise FileExistsError
+
+        return MagicMock()
+
+    monkeypatch.setattr(os, 'open', MagicMock(name='<mock>os.open', side_effect=_raise_but_once))
+
+    actual2 = _socket_path_hash(
+        socket_dir=socket_dir,
+        guest_id='dummy-id',
+        logger=root_logger)
+
+    assert re.match(r'/tmp/[a-z0-9]{4}.socket', str(actual1))
+    assert re.match(r'/tmp/[a-z0-9]{5}.socket', str(actual2))

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -163,11 +163,15 @@ def _socket_path_trivial(
         *,
         socket_dir: Path,
         guest_id: str,
-        limit_size: bool = False,
+        limit_size: bool = True,
         logger: tmt.log.Logger) -> Optional[Path]:
     """ Generate SSH socket path using guest IDs """
 
     socket_path = socket_dir / f'{guest_id}.socket'
+
+    logger.debug(
+        f"Possible SSH master socket path '{socket_path}' (trivial method).",
+        level=4)
 
     if not limit_size:
         return socket_path
@@ -212,6 +216,10 @@ def _socket_path_hash(
 
         socket_path = socket_dir / f'{digest}.socket'
         socket_reservation_path = f'{socket_path}.reservation'
+
+        logger.debug(
+            f"Possible SSH master socket path '{socket_path}' (hash method).",
+            level=4)
 
         if limit_size and len(str(socket_path)) >= SSH_MASTER_SOCKET_LENGTH_LIMIT:
             return None
@@ -1563,7 +1571,7 @@ class GuestSsh(Guest):
         """ Whether the SSH master socket path we create is acceptable by SSH """
 
         if len(str(self._ssh_master_socket_path)) >= SSH_MASTER_SOCKET_LENGTH_LIMIT:
-            self.warn("SSH multiplexing will not be used because the SSH socket path "
+            self.warn("SSH multiplexing will not be used because the SSH master socket path "
                       f"'{self._ssh_master_socket_path}' is too long.")
             return False
 
@@ -1627,7 +1635,9 @@ class GuestSsh(Guest):
             logger=self._logger)
 
         if socket_path is not None:
-            self.debug(f"SSH master socket path will be '{socket_path}'.", level=4)
+            self.debug(
+                f"SSH master socket path will be '{socket_path}' (trivial method).",
+                level=4)
 
             return socket_path
 
@@ -1642,7 +1652,9 @@ class GuestSsh(Guest):
             logger=self._logger)
 
         if socket_path is not None:
-            self.debug(f"SSH master socket path will be '{socket_path}'.", level=4)
+            self.debug(
+                f"SSH master socket path will be '{socket_path}' (hash method).",
+                level=4)
 
             return socket_path
 
@@ -1655,7 +1667,9 @@ class GuestSsh(Guest):
             limit_size=False,
             logger=self._logger)
 
-        self.debug(f"SSH master socket path will be '{socket_path}'.", level=4)
+        self.debug(
+            f"SSH master socket path will be '{socket_path}' (trivial method, no size limit).",
+            level=4)
 
         return socket_path
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -131,9 +131,9 @@ SSH_MASTER_SOCKET_LENGTH_LIMIT = 104 - 20
 #: A minimal number of characters of guest ID hash used by
 #: :py:func:`_socket_path_hash` when looking for a free SSH socket
 #: filename.
-SSH_MASTER_SOCKET_MIN_HASH_LENGTH = 8
+SSH_MASTER_SOCKET_MIN_HASH_LENGTH = 4
 
-#: A minimal number of characters of guest ID hash used by
+#: A maximal number of characters of guest ID hash used by
 #: :py:func:`_socket_path_hash` when looking for a free SSH socket
 #: filename.
 SSH_MASTER_SOCKET_MAX_HASH_LENGTH = 64


### PR DESCRIPTION
It turns out that even when using a hashing function, the final filepath may still be too long.

Changing the process slightly: still using a hashing function as a fallback - different one - and trying to use short substrings of the hash. Just like git forges do, showing and accepting short commit IDs. This also offers a nice way to prevent possible hash collisions that, while extremely unlikely, cannot be ruled out and would be terribly hard to debug.

Pull Request Checklist

* [x] implement the feature
* [ ] extend the test coverage