### PR TITLE
Update the `actions/upload-artifact` version

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -35,7 +35,7 @@ jobs:
 
       - if: ${{ always() }}
         name: Upload artifact with ShellCheck defects in SARIF format
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Differential ShellCheck SARIF
           path: ${{ steps.ShellCheck.outputs.sarif }}


### PR DESCRIPTION
Version 3 is planned to be [deprecated](https://github.com/actions/upload-artifact/?tab=readme-ov-file#actionsupload-artifact) on December 5, 2024.