### PR TITLE
Store multiple invocations of dmesg check for the same test in one file

### DIFF
--- a/tests/test/check/data/main.fmf
+++ b/tests/test/check/data/main.fmf
@@ -13,6 +13,15 @@
             failure-pattern:
               - 'Hypervisor detected'
 
+    /multiple-reports:
+        check:
+          - how: dmesg
+            result: respect
+          - how: dmesg
+            result: respect
+          - how: dmesg
+            result: respect
+
 /avc:
   check:
     - how: avc

--- a/tests/test/check/test-dmesg.sh
+++ b/tests/test/check/test-dmesg.sh
@@ -20,6 +20,7 @@ rlJournalStart
         rlRun "harmless=$run/plan/execute/data/guest/default-0/dmesg/harmless-1"
         rlRun "segfault=$run/plan/execute/data/guest/default-0/dmesg/segfault-1"
         rlRun "custom_patterns=$run/plan/execute/data/guest/default-0/dmesg/custom-patterns-1"
+        rlRun "multiple_reports=$run/plan/execute/data/guest/default-0/dmesg/multiple-reports-1"
 
         rlRun "pushd data"
         rlRun "set -o pipefail"
@@ -96,6 +97,22 @@ rlJournalStart
 
             rlAssertExists "$dump_after"
             rlLogInfo "$(cat $dump_after)"
+        rlPhaseEnd
+
+        rlPhaseStartTest "Test multiple dmesg reports with $PROVISION_HOW"
+            rlRun "dump_before=$multiple_reports/checks/dmesg-before-test.txt"
+            rlRun "dump_after=$multiple_reports/checks/dmesg-after-test.txt"
+
+            rlRun "tmt run --id $run --scratch -a -vv provision -h $PROVISION_HOW test -n /dmesg/multiple-reports"
+            rlRun "cat $results"
+
+            rlLogInfo "$(cat $dump_before)"
+            rlAssertEquals "There should be 3 reports before the test" \
+                           "$(grep 'Acquired at' $dump_before | wc -l)" "3"
+
+            rlLogInfo "$(cat $dump_after)"
+            rlAssertEquals "There should be 3 reports after the test" \
+                           "$(grep 'Acquired at' $dump_after | wc -l)" "3"
         rlPhaseEnd
     fi
 


### PR DESCRIPTION
This should prevent loosing dmesg reports in the case of tests that restart or reboot: all reports except the last one are lost.

The filename remains the same, but it's no longer overwritten. `dmesg` check invocations append to it, with proper headers:

```
## Acquired at 2024-12-03T13:12:23.536502+00:00

# stdout (812 lines)
[    0.000000] Linux version 6.11.4-301.fc41.x86_64 (mockbuild@9b6b61418589428cb880a7020233b56f) (gcc (GCC) 14.2.1 20240912 (Red Hat 14.2.1-3), GNU ld version 2.43.1-2.fc41) #1 SMP PREEMPT_DYNAMIC Sun Oct 20 15:02:33 UTC 2024
[    0.000000] Command line: BOOT_IMAGE=(hd0,gpt3)/vmlinuz-6.11.4-301.fc41.x86_64 no_timer_check console=tty1 console=ttyS0,115200n8 systemd.firstboot=off root=UUID=815e66c2-6a8a-4984-a890-1a3c710bf933 rootflags=subvol=root
[    0.000000] BIOS-provided physical RAM map:
[    0.000000] BIOS-e820: [mem 0x0000000000000000-0x000000000009fbff] usable
...
## Acquired at 2024-12-03T13:12:23.596179+00:00
...
## Acquired at 2024-12-03T13:12:23.622283+00:00
...
```

Fixes #3317

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage