### PR TITLE
Add "Edit on GitHub" links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -203,6 +203,16 @@ autodoc_typehints_description_target = 'all'
 # a list of builtin themes.
 html_theme = HTML_THEME
 
+print("Using theme: " + HTML_THEME)
+
+# ## Edit on GitHub feature, inherited by renku theme from rtd theme
+html_context = {
+    'display_github': True,
+    'github_user': 'teemtee',
+    'github_repo': 'tmt',
+    'github_version': 'main/docs/'
+    }
+
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.

--- a/docs/scripts/generate-stories.py
+++ b/docs/scripts/generate-stories.py
@@ -63,6 +63,11 @@ def main() -> None:
         logger.info(f'Generating rst files from {area}')
 
         with open(f"{area.lstrip('/')}.rst", 'w') as doc:
+            # Metadata - https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html
+            doc.write(
+                ':github_url: https://github.com/teemtee/tmt/blob/main/docs/scripts/generate-stories.py'
+            )
+            doc.write('\n\n')
             # Anchor and title
             doc.write(f'.. _{area}:\n\n')
             doc.write(f"{title}\n{'=' * len(title)}\n")

--- a/docs/scripts/generate-stories.py
+++ b/docs/scripts/generate-stories.py
@@ -63,10 +63,11 @@ def main() -> None:
         logger.info(f'Generating rst files from {area}')
 
         with open(f"{area.lstrip('/')}.rst", 'w') as doc:
-            # Metadata - https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html
+            # Metadata -
+            # https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html
             doc.write(
-                ':github_url: https://github.com/teemtee/tmt/blob/main/docs/scripts/generate-stories.py'
-            )
+                f':github_url: https://github.com/teemtee/tmt/blob/main{area}'
+                )
             doc.write('\n\n')
             # Anchor and title
             doc.write(f'.. _{area}:\n\n')

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -124,15 +124,6 @@
 {% endmacro %}
 
 
-{# --- The real template body --- #}
-
-{#
-    Explicit URL for "Edit on GitHub" links.
-#}
-.. meta::
-
-   :github_url: https://github.com/teemtee/tmt/blob/main/docs/scripts/generate-plugins.py
-
 {% if INCLUDE_TITLE %}
 {% set depth = STORY.name | regex_findall('/') | length - 1 %}
 {% set title_underline = '=~^:-><'[depth] %}

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -123,6 +123,14 @@
 * {{ printable_relation(link) }} :ref:`{{ matched.group(1) }}{# {% if matched.group(2) %}:{{ matched.group(2).replace('-', ' ') }}{% endif %} #}`
 {% endmacro %}
 
+
+{# --- The real template body --- #}
+
+{#
+    Explicit URL for "Edit on GitHub" links.
+#}
+{% set github_url = 'https://github.com/teemtee/tmt/blob/main/docs/scripts/generate-plugins.py' %}
+
 {% if INCLUDE_TITLE %}
 {% set depth = STORY.name | regex_findall('/') | length - 1 %}
 {% set title_underline = '=~^:-><'[depth] %}

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -123,7 +123,6 @@
 * {{ printable_relation(link) }} :ref:`{{ matched.group(1) }}{# {% if matched.group(2) %}:{{ matched.group(2).replace('-', ' ') }}{% endif %} #}`
 {% endmacro %}
 
-
 {% if INCLUDE_TITLE %}
 {% set depth = STORY.name | regex_findall('/') | length - 1 %}
 {% set title_underline = '=~^:-><'[depth] %}

--- a/docs/templates/story.rst.j2
+++ b/docs/templates/story.rst.j2
@@ -129,7 +129,9 @@
 {#
     Explicit URL for "Edit on GitHub" links.
 #}
-{% set github_url = 'https://github.com/teemtee/tmt/blob/main/docs/scripts/generate-plugins.py' %}
+.. meta::
+
+   :github_url: https://github.com/teemtee/tmt/blob/main/docs/scripts/generate-plugins.py
 
 {% if INCLUDE_TITLE %}
 {% set depth = STORY.name | regex_findall('/') | length - 1 %}


### PR DESCRIPTION
Allow to easily jump to documentation page contents in repository.

The explanation is here https://stackoverflow.com/a/62904217
Related https://github.com/readthedocs/sphinx_rtd_theme/pull/1635

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
