### PR TITLE
Do not use `mypy` cache for `ruamel.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,6 @@ repos:
           - "types-lxml"
 
         pass_filenames: false
-        args: [--config-file=pyproject.toml]
 
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.390

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,6 +235,11 @@ module = [
     ]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+# Workaround for https://github.com/python/mypy/issues/12664
+module = "ruamel.*"
+cache_dir = "/dev/null"
+
 [tool.pyright]
 include = [
     "tmt/**/*.py",


### PR DESCRIPTION
Trying to fix the annoying mypy fails every second run. Tested locally by running `pre-commit run --all-files` repeatably.

See https://github.com/python/mypy/issues/12664#issuecomment-2518393807