### PR TITLE
Encourage contributors to keep pull requests up-to-date

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -512,6 +512,12 @@ commits with your changes on the top of the branch instead of
 amending the original commit and doing a force push. This will
 make it easier for the reviewers to see what has recently changed.
 
+It's good to keep the pull request up-to-date with the ``main``
+branch. Rebase regularly or use ``/packit build`` command in the
+pull request comment if there were significant changes on the
+default branch otherwise newly added tests might cause unexpected
+and irrelevant failures in your test jobs.
+
 Once the pull request has been successfully reviewed and all tests
 passed, please rebase on the latest ``main`` branch content and
 squash the changes into a single commit. Use multiple commits to


### PR DESCRIPTION
Both Packit and Testing Farm by default merge the pull request content into the `main` branch (the `merge_pr_in_ci` option is `true` by default) before building the rpm and executing tests.

This can cause that newly added tests in the `main` branch cause unexpected failures in the pull request tests if test jobs are rescheduled without rebuilding the pull request rpms.

See also: https://packit.dev/docs/configuration#merge_pr_in_ci

Pull Request Checklist

* [x] write the documentation