### PR TITLE
`scripts/bootstrap` to rule them all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,8 @@ rpm: tarball ver2spec  ## Build RPMs
 srpm: tarball ver2spec  ## Build SRPM
 	rpmbuild --define '_topdir $(TMP)' -bs tmt.spec
 
-_deps:  # Minimal dependencies (common for 'deps' and 'develop' targets)
-	sudo dnf install -y hatch python3-devel python3-hatch-vcs rpm-build
-
-build-deps: _deps tarball ver2spec  ## Install build dependencies
+build-deps: tarball ver2spec  ## Install build dependencies
+	scripts/bootstrap
 	rpmbuild --define '_topdir $(TMP)' -br tmt.spec || sudo dnf builddep -y $(TMP)/SRPMS/tmt-*buildreqs.nosrc.rpm
 
 packages: rpm srpm  ## Build RPM and SRPM packages
@@ -204,7 +202,8 @@ $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/debian/1
 ##
 ## Development
 ##
-develop: _deps  ## Install development requirements
+develop: ## Install development requirements
+	scripts/bootstrap
 	sudo dnf install -y gcc git python3-nitrate {libvirt,krb5,libpq,python3}-devel jq podman buildah /usr/bin/python3.9
 
 # Git vim tags and cleanup

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -71,20 +71,23 @@ __ https://stackoverflow.com/questions/2290016/
 Develop
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In order to experiment, play with the latest bits and develop
-improvements it is best to use a virtual environment. Make sure
-that you have all required packages installed on your box:
+To install minimal set of packages for building the project, run
+the bootstrap script:
+
+..code-block:: shell
+
+    scripts/bootstrap
+
+To get complete development setup, run:
 
 .. code-block:: shell
 
     make develop
 
-Create a development virtual environment with hatch:
+Create a virtual environment with hatch:
 
 .. code-block:: shell
 
-    git clone https://github.com/teemtee/tmt
-    cd tmt
     hatch env create dev
 
 Enter the environment by running:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,9 @@
+## Scripts To Rule Them All
+
+Scripts that use https://github.com/dxw/scripts-to-rule-them-all convention,
+with the exception that `scripts' dirname is plural.
+
+### `scripts/bootstrap`
+
+[`scripts/bootstrap`][bootstrap] installs minimal dependencies necessary to
+work with the project.

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sudo dnf install -y make hatch python3-devel python3-hatch-vcs rpm-build


### PR DESCRIPTION
`make` is not available by default in Fedora containers, so use `scripts/bootstrap` to get all the stuff ready.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
