### PR TITLE
Mark the two known `avc` failures with `xfail`

### DIFF
--- a/tests/run/permissions/main.fmf
+++ b/tests/run/permissions/main.fmf
@@ -13,3 +13,8 @@ adjust+:
   - enabled: true
     when: how == full or trigger == commit
     because: it needs to be executed with root permissions
+  - check:
+      - how: avc
+        result: xfail
+    when: distro == fedora-rawhide
+    because: https://bugzilla.redhat.com/show_bug.cgi?id=2330476

--- a/tests/run/shell/main.fmf
+++ b/tests/run/shell/main.fmf
@@ -6,3 +6,9 @@ tag+:
   - as_root
   - provision-only
   - provision-local
+adjust+:
+  - check:
+      - how: avc
+        result: xfail
+    when: distro == fedora-rawhide
+    because: https://bugzilla.redhat.com/show_bug.cgi?id=2330476


### PR DESCRIPTION
On `fedora-rawhide` there is a known issue causing avc:

* https://bugzilla.redhat.com/show_bug.cgi?id=2330476

Let's mark the two affected tests as expected failure.