### PR TITLE
Add possibility to export multiple test contacts into the ReportPortal

### DIFF
--- a/tests/report/reportportal/data/test.fmf
+++ b/tests/report/reportportal/data/test.fmf
@@ -1,11 +1,13 @@
 /bad:
     summary: Failing test
-    contact: tester@redhat.com
+    contact:
+      - tester1@redhat.com
+      - tester2@redhat.com
     test: echo "Something bad happened!"; false
 
 /good:
     summary: Passing test
-    contact: tester_2@redhat.com
+    contact: tester3@redhat.com
     test: echo "Everything's fine!"
     id: 63f26fb7-69c4-4781-a06e-098e2b58129f
 

--- a/tests/report/reportportal/test.sh
+++ b/tests/report/reportportal/test.sh
@@ -191,6 +191,14 @@ rlJournalStart
                     key="contact"
                     value="$(yq -r ".\"$test_name\".$key" test.fmf)"
                     if [[ $value != null ]]; then
+                        # TODO: Fix the test here! The output of yq is list of
+                        # contact in the case of multiple contacts (test==/bad)
+                        # and a string in a case when one contact is provided
+                        # for the test (test==/good). We must somehow handle
+                        # both situations.
+                        #
+                        # If yq returns list, we must check both contacts in the response JSON
+                        # If yq returns just a string value, we must check only one contact in the response JSON
                         rlAssertGrep "$key" tmp_attributes.json -A1 > tmp_attributes_selection
                         rlAssertGrep "$value" tmp_attributes_selection
                     else
@@ -200,6 +208,10 @@ rlJournalStart
                     key="TMT_TREE"
                     rlAssertNotGrep "$key" tmp_attributes.json
                 fi
+
+                # REMOVE ME: just for testing
+                #echo "EXITING OMG"
+                #exit 99
 
                 rm tmp_attributes*
             done

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -618,7 +618,8 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
                     if not test_name:
                         test_name = test.name
                     if test.contact:
-                        item_attributes.append({"key": "contact", "value": test.contact[0]})
+                        item_attributes += [
+                            {'key': 'contact', 'value': contact} for contact in test.contact]
                     if test.summary:
                         test_description = test.summary
                     if test.web_link():


### PR DESCRIPTION
Add the possibility of exporting multiple test contacts into the report portal instance.

Closes: https://github.com/teemtee/tmt/issues/3407

TODO:
- [ ] Fix the local reportportal "contact" attribute test

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
