### PR TITLE
Speed up the `/plans/provision/container` plan

### DIFF
--- a/plans/provision/container.fmf
+++ b/plans/provision/container.fmf
@@ -25,3 +25,15 @@ environment:
     PROVISION_HOW: container
 
 enabled: true
+
+/install:
+    discover+:
+        test: install
+
+/ansible:
+    discover+:
+        test: ansible
+
+/the-rest:
+    discover+:
+        exclude: (install|ansible)


### PR DESCRIPTION
While the rest of the full tmt plans take about 20 minutes, `/plans/provision/container` takes over an hour to complete. Let's speed up the testing by running the install and ansible tests separately as they take the most time.