### PR TITLE
Define a new context dimension for image mode

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -11,6 +11,11 @@ tmt-1.42.0
 The ``tmt show`` command now prints in verbose mode manual test
 instructions as well.
 
+A new context :ref:`/spec/context/dimension` ``deployment-mode``
+has been added to the specification. It can be used to
+:ref:`/spec/core/adjust` test and plan metadata for the
+``package`` or ``image`` mode context.
+
 
 tmt-1.41.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/spec/context/dimension.fmf
+++ b/spec/context/dimension.fmf
@@ -14,14 +14,10 @@ description: |
         runs (fedora, fedora-33, centos, centos-8, centos-8.4,
         centos-stream, centos-stream-9, rhel, rhel-8, rhel-8.4).
 
-    distro-mode
-        Distribution mode, ``package`` for the standard way using
-        packages or ``image`` for the new way of distributing
-        using container images.
-
-    image-mode
-        Flag denoting how new content is distributed. Use ``true``
-        for container images and ``false`` for standard packages.
+    deployment-mode
+        Deployment mode of the distribution, ``package`` for the
+        standard way using packages or ``image`` for the new way
+        of distributing using container images.
 
     variant
         The distribution variant (Client, Desktop, Server

--- a/spec/context/dimension.fmf
+++ b/spec/context/dimension.fmf
@@ -14,6 +14,15 @@ description: |
         runs (fedora, fedora-33, centos, centos-8, centos-8.4,
         centos-stream, centos-stream-9, rhel, rhel-8, rhel-8.4).
 
+    distro-mode
+        Distribution mode, ``package`` for the standard way using
+        packages or ``image`` for the new way of distributing
+        using container images.
+
+    image-mode
+        Flag denoting how new content is distributed. Use ``true``
+        for container images and ``false`` for standard packages.
+
     variant
         The distribution variant (Client, Desktop, Server
         Workstation, Silverblue, CoreOS).


### PR DESCRIPTION
Introduce a new context dimension key `deployment-mode` in order to allow enabling/disabling/adjusting tests and plans based on the distribution mode.

Pull Request Checklist

* [x] update the specification
* [x] include a release note