### PR TITLE
Allow dynamic plugin data classes & convert feature plugins

### DIFF
--- a/docs/scripts/generate-plugins.py
+++ b/docs/scripts/generate-plugins.py
@@ -120,7 +120,11 @@ def _create_step_plugin_iterator(registry: tmt.plugins.PluginRegistry[tmt.steps.
         for plugin_id in registry.iter_plugin_ids():
             plugin = registry.get_plugin(plugin_id).class_
 
-            yield plugin_id, plugin, plugin._data_class
+            if hasattr(plugin, 'get_data_class'):
+                yield plugin_id, plugin, plugin.get_data_class()
+
+            else:
+                yield plugin_id, plugin, plugin._data_class
 
     return plugin_iterator
 

--- a/tmt/steps/prepare/feature/epel.py
+++ b/tmt/steps/prepare/feature/epel.py
@@ -1,13 +1,28 @@
-from typing import Any
+import dataclasses
+from typing import Any, Optional
 
 import tmt.log
-from tmt.steps.prepare.feature import Feature, provides_feature
+import tmt.steps.prepare
+import tmt.utils
+from tmt.steps.prepare.feature import Feature, PrepareFeatureData, provides_feature
 from tmt.steps.provision import Guest
+from tmt.utils import field
+
+
+@dataclasses.dataclass
+class EpelStepData(PrepareFeatureData):
+    epel: Optional[str] = field(
+        default=None,
+        option='--epel',
+        metavar='enabled|disabled',
+        help='Whether EPEL repository should be installed & enabled or disabled.')
 
 
 @provides_feature('epel')
 class Epel(Feature):
     NAME = "epel"
+
+    _data_class = EpelStepData
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -902,6 +902,17 @@ class Guest(tmt.utils.Common):
     # Used by save() to construct the correct container for keys.
     _data_class: type[GuestData] = GuestData
 
+    @classmethod
+    def get_data_class(cls) -> type[GuestData]:
+        """
+        Return step data class for this plugin.
+
+        By default, :py:attr:`_data_class` is returned, but plugin may
+        override this method to provide different class.
+        """
+
+        return cls._data_class
+
     role: Optional[str]
 
     #: Primary hostname or IP address for tmt/guest communication.
@@ -922,7 +933,7 @@ class Guest(tmt.utils.Common):
     # (used for import/export to/from attributes during load and save)
     @property
     def _keys(self) -> list[str]:
-        return list(self._data_class.keys())
+        return list(self.get_data_class().keys())
 
     def __init__(self,
                  *,
@@ -1014,7 +1025,7 @@ class Guest(tmt.utils.Common):
         the guest. Everything needed to attach to a running instance
         should be added into the data dictionary by child classes.
         """
-        return self._data_class.extract_from(self)
+        return self.get_data_class().extract_from(self)
 
     def wake(self) -> None:
         """

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -3038,6 +3038,10 @@ def container_fields(container: Container) -> Iterator[dataclasses.Field[Any]]:
     yield from dataclasses.fields(container)
 
 
+def container_has_field(container: Container, key: str) -> bool:
+    return key in list(container_keys(container))
+
+
 def container_keys(container: Container) -> Iterator[str]:
     """ Iterate over key names in a container """
 


### PR DESCRIPTION
Plugins' `_data_class` is no longer the source of plugins' data classes. Instead, new `get_data_class()` method is added (see [1]). `_data_class` is not gone, it serves as the default for `get_data_class()`, but plugins now can provide their own implementation.

Which is exactly what `prepare/feature` and feature plugins do now, the plugin builds its data class from collected smaller data classes, one for each feature plugin.

There are some loose ends, namely type annorations, but the code works, both in runtime and when rendering docs.

[1] a `data_class` property would be nice, but the attribute must be a class-level attribute and those cannot be properties.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation