### PR TITLE
Use shorter package names for `latest` copr builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -86,6 +86,7 @@ jobs:
     trigger: commit
     branch: main
     project: latest
+    release_suffix: "{PACKIT_PROJECT_BRANCH}"
 
   # Build pull requests
   - <<: *copr-under-packit


### PR DESCRIPTION
To keep the naming consistent with `fmf` packages. There's no need to track miliseconds, the `devX` suffix bump is enough to keep the latest package to appear as newest.