### PR TITLE
Support running playbooks from Ansible collections

### DIFF
--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -13,7 +13,12 @@ import tmt.steps.prepare
 import tmt.steps.provision
 import tmt.utils
 from tmt.result import PhaseResult
-from tmt.steps.provision import Guest
+from tmt.steps.provision import (
+    ANSIBLE_COLLECTION_PLAYBOOK_PATTERN,
+    AnsibleApplicable,
+    AnsibleCollectionPlaybook,
+    Guest,
+    )
 from tmt.utils import (
     DEFAULT_RETRIABLE_HTTP_CODES,
     ENVFILE_RETRY_SESSION_RETRIES,
@@ -132,8 +137,10 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
 
         prepare --how ansible --playbook one.yml --playbook two.yml --extra-args '-vvv'
 
-    Remote playbooks can be referenced as well as local ones, and both
-    kinds can be intermixed:
+    Remote playbooks - provided as URLs starting with ``http://`` or
+    ``https://`` -, local playbooks - optionally starting with a
+    ``file://`` schema - , and playbooks bundled with collections can be
+    referenced as well as local ones, and all kinds can be intermixed:
 
     .. code-block:: yaml
 
@@ -142,10 +149,15 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
             playbook:
               - https://foo.bar/one.yml
               - two.yml
+              - file://three.yml
+              - ansible_galaxy_namespace.cool_collection.four
 
     .. code-block:: shell
 
-        prepare --how ansible --playbook https://foo.bar/two.yml --playbook two.yml
+        prepare --how ansible --playbook https://foo.bar/two.yml \\
+                              --playbook two.yml \\
+                              --playbook file://three.yml \\
+                              --playbook ansible_galaxy_namespace.cool_collection.four
     """
 
     _data_class = PrepareAnsibleData
@@ -160,13 +172,12 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
         results = super().go(guest=guest, environment=environment, logger=logger)
 
         # Apply each playbook on the guest
-        for playbook in self.data.playbook:
-            logger.info('playbook', playbook, 'green')
+        for _playbook in self.data.playbook:
+            logger.info('playbook', _playbook, 'green')
 
-            lowercased_playbook = playbook.lower()
-            playbook_path = Path(playbook)
+            lowercased_playbook = _playbook.lower()
 
-            if lowercased_playbook.startswith(('http://', 'https://')):
+            def normalize_remote_playbook(raw_playbook: str) -> Path:
                 assert self.step.plan.my_run is not None  # narrow type
                 assert self.step.plan.my_run.tree is not None  # narrow type
                 assert self.step.plan.my_run.tree.root is not None  # narrow type
@@ -176,15 +187,15 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
                     with retry_session(
                             retries=ENVFILE_RETRY_SESSION_RETRIES,
                             status_forcelist=DEFAULT_RETRIABLE_HTTP_CODES) as session:
-                        response = session.get(playbook)
+                        response = session.get(raw_playbook)
 
                     if not response.ok:
                         raise PrepareError(
-                            f"Failed to fetch remote playbook '{playbook}'.")
+                            f"Failed to fetch remote playbook '{raw_playbook}'.")
 
                 except requests.RequestException as exc:
                     raise PrepareError(
-                        f"Failed to fetch remote playbook '{playbook}'.") from exc
+                        f"Failed to fetch remote playbook '{raw_playbook}'.") from exc
 
                 with tempfile.NamedTemporaryFile(
                         mode='w+b',
@@ -195,12 +206,33 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
                     file.write(response.content)
                     file.flush()
 
-                    playbook_path = Path(file.name).relative_to(root_path)
+                    return Path(file.name).relative_to(root_path)
 
-                logger.info('playbook-path', playbook_path, 'green')
+            def normalize_local_playbook(raw_playbook: str) -> Path:
+                if raw_playbook.startswith('file://'):
+                    return Path(raw_playbook[7:])
+
+                return Path(raw_playbook)
+
+            def normalize_collection_playbook(raw_playbook: str) -> AnsibleCollectionPlaybook:
+                return AnsibleCollectionPlaybook(raw_playbook)
+
+            playbook: AnsibleApplicable
+
+            if lowercased_playbook.startswith(('http://', 'https://')):
+                playbook = normalize_remote_playbook(lowercased_playbook)
+
+            elif lowercased_playbook.startswith('file://'):
+                playbook = normalize_local_playbook(lowercased_playbook)
+
+            elif ANSIBLE_COLLECTION_PLAYBOOK_PATTERN.match(lowercased_playbook):
+                playbook = normalize_collection_playbook(lowercased_playbook)
+
+            else:
+                playbook = normalize_local_playbook(lowercased_playbook)
 
             guest.ansible(
-                playbook_path,
+                playbook,
                 playbook_root=self.step.plan.anchor_path,
                 extra_args=self.data.extra_args)
 

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -138,8 +138,8 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
         prepare --how ansible --playbook one.yml --playbook two.yml --extra-args '-vvv'
 
     Remote playbooks - provided as URLs starting with ``http://`` or
-    ``https://`` -, local playbooks - optionally starting with a
-    ``file://`` schema - , and playbooks bundled with collections can be
+    ``https://``, local playbooks - optionally starting with a
+    ``file://`` schema, and playbooks bundled with collections can be
     referenced as well as local ones, and all kinds can be intermixed:
 
     .. code-block:: yaml

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -20,6 +20,7 @@ from typing import (
     Any,
     Callable,
     Literal,
+    NewType,
     Optional,
     TypeVar,
     Union,
@@ -48,6 +49,7 @@ from tmt.plugins import PluginRegistry
 from tmt.steps import Action, ActionTask, PhaseQueue
 from tmt.utils import (
     Command,
+    GeneralError,
     OnProcessStartCallback,
     Path,
     ProvisionError,
@@ -62,6 +64,7 @@ from tmt.utils import (
 if TYPE_CHECKING:
     import tmt.base
     import tmt.cli
+    from tmt._compat.typing import TypeAlias
 
 
 #: How many seconds to wait for a connection to succeed after guest reboot.
@@ -77,6 +80,13 @@ REBOOT_TIMEOUT: int = configure_constant(DEFAULT_REBOOT_TIMEOUT, 'TMT_REBOOT_TIM
 # this many seconds.
 RECONNECT_WAIT_TICK = 5
 RECONNECT_WAIT_TICK_INCREASE = 1.0
+
+# Types for things Ansible can execute
+ANSIBLE_COLLECTION_PLAYBOOK_PATTERN = re.compile(r'[a-zA-z0-9_]+\.[a-zA-z0-9_]+\.[a-zA-z0-9_]+')
+
+AnsiblePlaybook: 'TypeAlias' = Path
+AnsibleCollectionPlaybook = NewType('AnsibleCollectionPlaybook', str)
+AnsibleApplicable = Union[AnsibleCollectionPlaybook, AnsiblePlaybook]
 
 
 def configure_ssh_options() -> tmt.utils.RawCommand:
@@ -1136,8 +1146,8 @@ class Guest(tmt.utils.Common):
 
     def _sanitize_ansible_playbook_path(
             self,
-            playbook: Path,
-            playbook_root: Optional[Path]) -> Path:
+            playbook: AnsibleApplicable,
+            playbook_root: Optional[Path]) -> AnsibleApplicable:
         """
         Prepare full ansible playbook path.
 
@@ -1150,21 +1160,29 @@ class Guest(tmt.utils.Common):
             the eventual playbook path is not absolute.
         """
 
-        # Some playbooks must be under playbook root, which is often
-        # a metadata tree root.
-        if playbook_root is not None:
-            playbook = playbook_root / playbook.unrooted()
+        if isinstance(playbook, Path):
+            # Some playbooks must be under playbook root, which is often
+            # a metadata tree root.
+            if playbook_root is not None:
+                playbook = playbook_root / playbook.unrooted()
 
-            if not playbook.is_relative_to(playbook_root):
-                raise tmt.utils.GeneralError(
-                    f"'{playbook}' is not relative to the expected root '{playbook_root}'.")
+                if not playbook.is_relative_to(playbook_root):
+                    raise tmt.utils.GeneralError(
+                        f"'{playbook}' is not relative to the expected root '{playbook_root}'.")
 
-        if not playbook.exists():
-            raise tmt.utils.FileError(f"Playbook '{playbook}' does not exist.")
+            if not playbook.exists():
+                raise tmt.utils.FileError(f"Playbook '{playbook}' does not exist.")
 
-        self.debug(f"Playbook full path: '{playbook}'", level=2)
+            self.debug(f"Playbook full path: '{playbook}'", level=2)
 
-        return playbook
+            return playbook
+
+        if isinstance(playbook, str):
+            self.debug(f"Collection playbook: '{playbook}'", level=2)
+
+            return playbook
+
+        raise GeneralError(f"Unknown Ansible object type, '{type(playbook)}'.")
 
     def _prepare_environment(
         self,
@@ -1243,7 +1261,7 @@ class Guest(tmt.utils.Common):
 
     def _run_ansible(
             self,
-            playbook: Path,
+            playbook: AnsibleApplicable,
             playbook_root: Optional[Path] = None,
             extra_args: Optional[str] = None,
             friendly_command: Optional[str] = None,
@@ -1272,7 +1290,7 @@ class Guest(tmt.utils.Common):
 
     def ansible(
             self,
-            playbook: Path,
+            playbook: AnsibleApplicable,
             playbook_root: Optional[Path] = None,
             extra_args: Optional[str] = None,
             friendly_command: Optional[str] = None,
@@ -1821,7 +1839,7 @@ class GuestSsh(Guest):
 
     def _run_ansible(
             self,
-            playbook: Path,
+            playbook: AnsibleApplicable,
             playbook_root: Optional[Path] = None,
             extra_args: Optional[str] = None,
             friendly_command: Optional[str] = None,

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1160,6 +1160,13 @@ class Guest(tmt.utils.Common):
             the eventual playbook path is not absolute.
         """
 
+        # Handle the individual types under the hood of `AnsibleApplicable`.
+        # Note that `isinstance()` calls do not use our fancy names,
+        # `AnsibleCollectionPlaybook` and `AnsiblePlaybook`. These are
+        # extremely helpful to type checkers, but Python interpreter
+        # sees only the aliased types, `Path` and `str`.
+
+        # First, a path:
         if isinstance(playbook, Path):
             # Some playbooks must be under playbook root, which is often
             # a metadata tree root.
@@ -1177,6 +1184,7 @@ class Guest(tmt.utils.Common):
 
             return playbook
 
+        # Second, a collection playbook:
         if isinstance(playbook, str):
             self.debug(f"Collection playbook: '{playbook}'", level=2)
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -29,7 +29,7 @@ class GuestLocal(tmt.Guest):
 
     def _run_ansible(
             self,
-            playbook: Path,
+            playbook: tmt.steps.provision.AnsibleApplicable,
             playbook_root: Optional[Path] = None,
             extra_args: Optional[str] = None,
             friendly_command: Optional[str] = None,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -236,7 +236,7 @@ class GuestContainer(tmt.Guest):
 
     def _run_ansible(
             self,
-            playbook: Path,
+            playbook: tmt.steps.provision.AnsibleApplicable,
             playbook_root: Optional[Path] = None,
             extra_args: Optional[str] = None,
             friendly_command: Optional[str] = None,


### PR DESCRIPTION
Ansible collections can also ship playbooks, which can be given to `ansible-playbook` command as any actual playbook path. They have a special format, `<namespace>.<collection>.<playbook>`. Playbook "paths" of this format are now accepted and executed just as any regular playbooks.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [ ] extend the test coverage
* [x] adjust plugin docstring
* [x] include a release note
