### PR TITLE
Add feature plugin for enabling guest environment profiles

### DIFF
--- a/tests/prepare/feature/data/plans.fmf
+++ b/tests/prepare/feature/data/plans.fmf
@@ -30,3 +30,14 @@ execute:
 
         environment+:
             STATE: disabled
+
+/profile:
+    discover:
+      how: shell
+      tests:
+        - name: test
+          test: /bin/true
+
+    prepare:
+        how: feature
+        profile: testing_farm_profiles.testing_farm

--- a/tests/prepare/feature/test.sh
+++ b/tests/prepare/feature/test.sh
@@ -31,6 +31,16 @@ rlJournalStart
         rlPhaseEnd
     done
 
+    # Environment profiles
+    # TODO: chicken and egg: we need profile to test whether tmt can apply it, and we need tmt
+    # with support for profiles so we could test profiles and start shipping them...
+    # Once we get the tmt, we can continue with profiles and eventually enable the test below.
+    #
+    # rlPhaseStartTest "Enable EPEL on $image"
+    #     rlRun -s "tmt -vvv run -a plan --name '/profile' provision --how container --image fedora"
+    # rlPhaseEnd
+
+
     rlPhaseStartCleanup
         rlRun "popd"
     rlPhaseEnd

--- a/tmt/schemas/prepare/feature.yaml
+++ b/tmt/schemas/prepare/feature.yaml
@@ -25,6 +25,9 @@ properties:
       - enabled
       - disabled
 
+  profile:
+    type: string
+
   name:
     type: string
 

--- a/tmt/steps/prepare/feature/environment_profile.py
+++ b/tmt/steps/prepare/feature/environment_profile.py
@@ -1,0 +1,67 @@
+from typing import Any, Optional
+
+import tmt.log
+import tmt.utils
+from tmt.container import container, field
+from tmt.steps.prepare.feature import Feature, PrepareFeatureData, provides_feature
+from tmt.steps.provision import AnsibleCollectionPlaybook, Guest
+
+# TODO: provide link to said specification once it's created.
+#: The name of a playbook provided by the collection. This name is
+#: part of the Testing Farm profile specification.
+PLAYBOOK_NAME = 'apply'
+
+
+@container
+class ProfileStepData(PrepareFeatureData):
+    profile: Optional[str] = field(
+        default=None,
+        option='--profile',
+        metavar='NAME',
+        help='Apply guest profile.',
+    )
+
+
+@provides_feature('profile')
+class Profile(Feature):
+    """
+    Prepare guest setup with a guest profile.
+
+    .. note::
+
+        Guest profiles are being developed, once there is an agreed upon
+        text we could steal^Wborrow^Wreuse, we shall add it to this
+        docstring.
+
+    Guest profiles represent a particular setup of guest environment as
+    defined by a CI system or service. They are implemented as Ansible
+    roles, and packaged as Ansible collections. The CI systems use
+    profiles to set up guests before testing, and users may use the same
+    profiles to establish the same environment locally when developing
+    tests or reprodcing issues.
+
+    Apply a profile to the guest:
+
+    .. code-block:: yaml
+
+        prepare:
+            how: feature
+            profile: testing_farm.fedora_ci
+
+    .. code-block:: shell
+
+        prepare --how feature --profile testing_farm.fedora_ci
+    """
+
+    NAME = "profile"
+
+    _data_class = ProfileStepData
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def enable(cls, guest: Guest, value: str, logger: tmt.log.Logger) -> None:
+        logger.info('Guest profile', value)
+
+        guest.ansible(AnsibleCollectionPlaybook(f'{value}.{PLAYBOOK_NAME}'))

--- a/tmt/steps/prepare/feature/epel.py
+++ b/tmt/steps/prepare/feature/epel.py
@@ -4,7 +4,7 @@ import tmt.log
 import tmt.steps.prepare
 import tmt.utils
 from tmt.container import container, field
-from tmt.steps.prepare.feature import Feature, PrepareFeatureData, provides_feature
+from tmt.steps.prepare.feature import PrepareFeatureData, ToggleableFeature, provides_feature
 from tmt.steps.provision import Guest
 
 
@@ -19,7 +19,7 @@ class EpelStepData(PrepareFeatureData):
 
 
 @provides_feature('epel')
-class Epel(Feature):
+class Epel(ToggleableFeature):
     NAME = "epel"
 
     _data_class = EpelStepData


### PR DESCRIPTION
Pick a collection, e.g. `testing_farm.testing_farm`, plugin will slap `apply` on top of that, and guest would be set to match a CI system expectations.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] modify the json schema