### PR TITLE
Add `when` field to inherited fields of all plugins

### DIFF
--- a/docs/scripts/generate-plugins.py
+++ b/docs/scripts/generate-plugins.py
@@ -57,7 +57,7 @@ def _is_inherited(
 
     # TODO: for now, it's a list, but inspecting the actual tree of classes
     # would be more generic. It's good enough for now.
-    return field.name in ('name', 'where', 'order', 'summary', 'enabled', 'result')
+    return field.name in ('name', 'where', 'when', 'order', 'summary', 'enabled', 'result')
 
 
 def container_ignored_fields(container: ContainerClass) -> list[str]:


### PR DESCRIPTION
Added recently, this field is accepted for all phases, and sice we do not detect inherited fields but use a static list, the list needs to be extended to avoid showing the field in every plugin's docs.

Pull Request Checklist

* [x] implement the feature