### PR TITLE
Add a trivial handler for `:ref:` role when rendering CLI help

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -1185,7 +1185,8 @@ class Method:
 
         self.name = name
         self.class_ = class_
-        self.doc = tmt.utils.rest.render_rst(doc, tmt.log.Logger.get_bootstrap_logger())
+        self.doc = tmt.utils.rest.render_rst(doc, tmt.log.Logger.get_bootstrap_logger()) \
+            if tmt.utils.rest.REST_RENDERING_ALLOWED else doc
         self.order = order
 
         # Parse summary and description from provided doc string

--- a/tmt/utils/rest.py
+++ b/tmt/utils/rest.py
@@ -6,6 +6,7 @@ help texts.
 """
 
 import functools
+import sys
 from collections.abc import Mapping, Sequence
 from typing import Any, Optional
 
@@ -20,6 +21,16 @@ import docutils.utils
 import tmt.log
 from tmt.log import Logger
 from tmt.utils import GeneralError
+
+# We may be sharing parser structures with Sphinx, when it's generating
+# docs. And that lead to problems, our roles conflicting with those
+# registered by Sphinx, or parser calling Sphinx roles in our context.
+# Both Sphinx and docutils rely on global mutable states, and
+# monkeypatching it around our calls to parser does not work. To avoid
+# issues, ReST renderign is disabled when we know our code runs under
+# the control of Sphinx.
+REST_RENDERING_ALLOWED = ('sphinx-build' not in sys.argv[0])
+
 
 #: Special string representing a new-line in the stack of rendered
 #: paragraphs.

--- a/tmt/utils/rest.py
+++ b/tmt/utils/rest.py
@@ -276,8 +276,8 @@ def role_ref(
     text: str,
     lineno: int,
     inliner: docutils.parsers.rst.states.Inliner,
-    options: Mapping[str, Any],
-    content: Sequence[str]) \
+    options: Optional[Mapping[str, Any]] = None,
+    content: Optional[Sequence[str]] = None) \
         -> tuple[Sequence[docutils.nodes.reference], Sequence[docutils.nodes.reference]]:
     """
     A handler for ``:ref:`` role.


### PR DESCRIPTION
Sphinx takes care of it when building (HTML) docs, but for CLI help, we need to provide a handler of our own. But even a simple one is enough.

Pull Request Checklist

* [x] implement the feature
* [ ] extend the test coverage