### PR TITLE
Replace WikiChip link with CPU World in hardware specification

### DIFF
--- a/spec/hardware/cpu.fmf
+++ b/spec/hardware/cpu.fmf
@@ -65,9 +65,9 @@ description: |
     See e.g. https://virtual-dba.com/blog/sockets-cores-and-threads/ for the
     socket, core and thread distinction.
 
-    See e.g. https://www.cpu-world.com/index.html for information on family,
-    model, stepping and corresponding names. ``/proc/cpuinfo`` and ``lscpu``
-    are also useful resources.
+    See e.g. https://www.cpu-world.com/ for information on family, model,
+    stepping and corresponding names. ``/proc/cpuinfo`` and ``lscpu`` are
+    also useful resources.
 
     .. versionchanged:: 1.39
        ``beaker`` plugins supports ``family`` and ``frequency``

--- a/spec/hardware/cpu.fmf
+++ b/spec/hardware/cpu.fmf
@@ -65,7 +65,7 @@ description: |
     See e.g. https://virtual-dba.com/blog/sockets-cores-and-threads/ for the
     socket, core and thread distinction.
 
-    See e.g. https://en.wikichip.org/wiki/WikiChip for information on family,
+    See e.g. https://www.cpu-world.com/index.html for information on family,
     model, stepping and corresponding names. ``/proc/cpuinfo`` and ``lscpu``
     are also useful resources.
 


### PR DESCRIPTION
It seems that WikiChip site is dead, which ruins our documentation checks.

Pull Request Checklist

* [x] implement the feature