### PR TITLE
Honor verbosity options in `tmt * show` commands

### DIFF
--- a/tests/plan/show/test.sh
+++ b/tests/plan/show/test.sh
@@ -203,6 +203,20 @@ rlJournalStart
         rlAssertEquals "script shall be an replaced" "$(grep ' script ' $rlRun_LOG | awk '{print $2}')" "dummy-script"
     rlPhaseEnd
 
+    rlPhaseStartTest "Test whether 'tmt', 'plans' and 'show' accept verbosity option"
+        rlRun -s "tmt    plans    show    /plans/full"
+        rlAssertNotGrep "fmf-id url" $rlRun_LOG
+
+        rlRun -s "tmt    plans    show -v /plans/full"
+        rlAssertGrep "fmf-id url" $rlRun_LOG
+
+        rlRun -s "tmt    plans -v show    /plans/full"
+        rlAssertGrep "fmf-id url" $rlRun_LOG
+
+        rlRun -s "tmt -v plans    show    /plans/full"
+        rlAssertGrep "fmf-id url" $rlRun_LOG
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm $output"

--- a/tests/story/show/test.sh
+++ b/tests/story/show/test.sh
@@ -86,6 +86,20 @@ rlJournalStart
         rlAssertGrep "Invalid name.*$story_name" $rlRun_LOG
     rlPhaseEnd
 
+    rlPhaseStartTest "Test whether 'tmt', 'stories' and 'show' accept verbosity option"
+        rlRun -s "tmt    stories    show    /stories/full"
+        rlAssertNotGrep "fmf-id url" $rlRun_LOG
+
+        rlRun -s "tmt    stories    show -v /stories/full"
+        rlAssertGrep "fmf-id url" $rlRun_LOG
+
+        rlRun -s "tmt    stories -v show    /stories/full"
+        rlAssertGrep "fmf-id url" $rlRun_LOG
+
+        rlRun -s "tmt -v stories    show    /stories/full"
+        rlAssertGrep "fmf-id url" $rlRun_LOG
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
     rlPhaseEnd

--- a/tests/test/show/test.sh
+++ b/tests/test/show/test.sh
@@ -145,6 +145,20 @@ rlJournalStart
         rlAssertGrep    "/tests/disabled02" $rlRun_LOG
     rlPhaseEnd
 
+    rlPhaseStartTest "Test whether 'tmt', 'tests' and 'show' accept verbosity option"
+        rlRun -s "tmt    tests    show    /tests/full"
+        rlAssertNotGrep "fmf-id url" $rlRun_LOG
+
+        rlRun -s "tmt    tests    show -v /tests/full"
+        rlAssertGrep "fmf-id url" $rlRun_LOG
+
+        rlRun -s "tmt    tests -v show    /tests/full"
+        rlAssertGrep "fmf-id url" $rlRun_LOG
+
+        rlRun -s "tmt -v tests    show    /tests/full"
+        rlAssertGrep "fmf-id url" $rlRun_LOG
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
     rlPhaseEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -815,6 +815,9 @@ class Core(
         if self.fmf_id.ref is None or self.fmf_id.url is None:
             return None
 
+        if not self.fmf_sources:
+            return None
+
         # Detect relative path of the last source from the metadata tree root
         relative_path = self.fmf_sources[-1].relative_to(self.node.root)
         relative_path = Path('/') if str(relative_path) == '.' else Path('/') / relative_path

--- a/tmt/cli/_root.py
+++ b/tmt/cli/_root.py
@@ -349,6 +349,9 @@ def tests(context: Context, **kwargs: Any) -> None:
     Convert old metadata into the new fmf format.
     """
 
+    context.obj.logger = context.obj.logger.clone() \
+        .apply_verbosity_options(**kwargs)
+
     # Show overview of available tests
     if context.invoked_subcommand is None:
         tmt.Test.overview(context.obj.tree)
@@ -386,7 +389,11 @@ def tests_show(context: Context, **kwargs: Any) -> None:
     Use '.' to select tests under the current working directory.
     """
     tmt.Test.store_cli_invocation(context)
-    for test in context.obj.tree.tests():
+
+    logger = context.obj.logger.clone() \
+        .apply_verbosity_options(**kwargs)
+
+    for test in context.obj.tree.tests(logger=logger):
         test.show()
         echo()
 
@@ -746,6 +753,9 @@ def plans(context: Context, **kwargs: Any) -> None:
     Explore detailed test step configuration.
     """
 
+    context.obj.logger = context.obj.logger.clone() \
+        .apply_verbosity_options(**kwargs)
+
     # Show overview of available plans
     if context.invoked_subcommand is None:
         tmt.Plan.overview(context.obj.tree)
@@ -786,7 +796,11 @@ def plans_show(context: Context, **kwargs: Any) -> None:
     Use '.' to select plans under the current working directory.
     """
     tmt.Plan.store_cli_invocation(context)
-    for plan in context.obj.tree.plans():
+
+    logger = context.obj.logger.clone() \
+        .apply_verbosity_options(**kwargs)
+
+    for plan in context.obj.tree.plans(logger=logger):
         plan.show()
         echo()
 
@@ -929,6 +943,10 @@ def stories(context: Context, **kwargs: Any) -> None:
     Check available user stories.
     Explore coverage (test, implementation, documentation).
     """
+
+    context.obj.logger = context.obj.logger.clone() \
+        .apply_verbosity_options(**kwargs)
+
     # Show overview of available stories
     if context.invoked_subcommand is None:
         tmt.Story.overview(context.obj.tree)
@@ -990,7 +1008,11 @@ def stories_show(
     Use '.' to select stories under the current working directory.
     """
     tmt.Story.store_cli_invocation(context)
-    for story in context.obj.tree.stories():
+
+    logger = context.obj.logger.clone() \
+        .apply_verbosity_options(**kwargs)
+
+    for story in context.obj.tree.stories(logger=logger):
         if story._match(implemented, verified, documented, covered,
                         unimplemented, unverified, undocumented, uncovered):
             story.show()


### PR DESCRIPTION
The patch fixes it, but it's not perfect, e.g. verbosity inheritance may be incorrect in some cases.

Fixes https://github.com/teemtee/tmt/issues/2364

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage