### PR TITLE
Refactor and document test wrapper scripts

### DIFF
--- a/tests/try/investigate/test.sh
+++ b/tests/try/investigate/test.sh
@@ -11,7 +11,8 @@ rlJournalStart
     rlPhaseStartTest "Interactive Investigation"
         rlRun -s "LANG=en_US ./investigate.exp" 0 "Try interactive investigation"
         rlAssertGrep "2 tests executed" $rlRun_LOG
-        rlAssertGrep "tmt-test-wrapper.sh" $rlRun_LOG
+        rlAssertGrep "tmt-test-wrapper-inner.sh" $rlRun_LOG
+        rlAssertGrep "tmt-test-wrapper-outer.sh" $rlRun_LOG
         rlAssertGrep "everything bad done" $rlRun_LOG
         rlAssertGrep "fail /tests/bad" $rlRun_LOG
         rlAssertGrep "everything good done" $rlRun_LOG

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -68,8 +68,8 @@ def effective_pidfile_root() -> Path:
 # the test. Test script may be a single command, but also a multiline,
 # complicated shell script. To avoid issues with quotes and escaping
 # things here and there, tmt saves the test script into the inner
-# wrapper, and then the outer wrapper can work with just a single a
-# single executable shell script.
+# wrapper, and then the outer wrapper can work with just a single
+# executable shell script.
 #
 # For the duration of the test, the outer wrapper creates so-called
 # "test pidfile". The pidfile contains outer wrapper PID and path to the


### PR DESCRIPTION
Yes, there is more than one, and the documentation comments were speaking just about one of them. So, giving them the names, adding more comments on why they exist, and changing the implementation to better reuse code when creating these wrappers.

Pull Request Checklist

* [x] implement the feature