### PR TITLE
Extend `yamllint` coverage to prepare/feature playbooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,7 +125,7 @@ repos:
     rev: v1.35.1
     hooks:
       - id: yamllint
-        files: ^tmt/schemas/.*\.yaml
+        files: ^tmt/(?:schemas|steps/prepare/feature)/.*\.yaml
 
   - repo: https://github.com/ansible-community/ansible-lint.git
     rev: v24.10.0

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,35 @@
+---
+
+# The following settings are recommended by ansible-lint project. They
+# may conflict with our other YAML files, but as of now, we test only
+# a very small subset of all YAML files in the repository. Once we start
+# extending the coverage, it may become a problem, and we will need to
+# resolve it, but the settings below seem reasonable enough that any
+# YAML file could comply.
+
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+
+  comments-indentation: false
+
+  braces:
+    max-spaces-inside: 1
+
+  line-length:
+    max: 100
+
+  octal-values:
+    forbid-implicit-octal: true
+    forbid-explicit-octal: true
+
+  truthy:
+    level: error
+
+    allowed-values:
+      - "true"
+      - "false"
+
+    check-keys: true

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -1,3 +1,5 @@
+---
+
 - name: Install packages
   hosts: all
   tasks:

--- a/examples/ansible/test.yml
+++ b/examples/ansible/test.yml
@@ -1,3 +1,5 @@
+---
+
 - name: A simple test
   hosts: localhost
   tasks:

--- a/examples/redis/ansible/tasks/redis_variables.yml
+++ b/examples/redis/ansible/tasks/redis_variables.yml
@@ -1,3 +1,5 @@
+---
+
 - name: Set variables into redis database
   ansible.builtin.command: |
     redis-cli set key value1

--- a/tests/finish/ansible/data/playbook.yml
+++ b/tests/finish/ansible/data/playbook.yml
@@ -1,3 +1,5 @@
+---
+
 - name: A simple playbook in finish phase
   hosts: all
   vars:

--- a/tests/run/worktree/data/ansible/playbook.yml
+++ b/tests/run/worktree/data/ansible/playbook.yml
@@ -1,3 +1,5 @@
+---
+
 - name: Copy and check test file
   hosts: all
   tasks:

--- a/tmt/steps/prepare/feature/epel-disable.yaml
+++ b/tmt/steps/prepare/feature/epel-disable.yaml
@@ -1,8 +1,12 @@
+---
+
 - name: Disable EPEL repositories
   hosts: all
   tasks:
     - name: Disable EPEL repos on RHEL 7 or CentOS 7
-      when: ansible_distribution in ["RedHat", "CentOS"] and ansible_distribution_major_version | int == 7
+      when:
+        - ansible_distribution in ["RedHat", "CentOS"]
+        - ansible_distribution_major_version | int == 7
       block:
         - name: Install package 'yum-utils'
           ansible.builtin.dnf:
@@ -22,7 +26,9 @@
           changed_when: output.rc != 0
 
     - name: Disable EPEL and EPEL-Next repos on RHEL 8+ or CentOS Stream 8+
-      when: ansible_distribution in ["RedHat", "CentOS"] and ansible_distribution_major_version | int >= 8
+      when:
+        - ansible_distribution in ["RedHat", "CentOS"]
+        - ansible_distribution_major_version | int >= 8
       block:
         - name: Install 'dnf config-manager'
           ansible.builtin.command: dnf -y install 'dnf-command(config-manager)'
@@ -49,6 +55,7 @@
 
         - name: Disable EPEL-Next repos
           when: result.rc == 0
-          ansible.builtin.command: dnf config-manager --disable epel-next epel-next-debuginfo epel-next-source
+          ansible.builtin.command: |
+            dnf config-manager --disable epel-next epel-next-debuginfo epel-next-source
           register: output
           changed_when: output.rc != 0

--- a/tmt/steps/prepare/feature/epel-enable.yaml
+++ b/tmt/steps/prepare/feature/epel-enable.yaml
@@ -1,12 +1,16 @@
+---
+
 - name: Enable EPEL repositories
   hosts: all
   tasks:
     - name: Enable EPEL repos on RHEL 7
-      when: ansible_distribution == "RedHat" and ansible_distribution_major_version | int == 7
+      when:
+        - ansible_distribution == "RedHat"
+        - ansible_distribution_major_version | int == 7
       block:
         - name: Install package 'epel-release'
           ansible.builtin.dnf:
-            name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+            name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"  # yamllint disable rule:line-length
             disable_gpg_check: true
             state: present
 
@@ -29,13 +33,13 @@
       block:
         - name: Install package 'epel-release'
           ansible.builtin.dnf:
-            name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+            name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"  # yamllint disable rule:line-length
             disable_gpg_check: true
             state: present
 
         - name: Install package 'epel-next-release'
           ansible.builtin.dnf:
-            name: "https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+            name: "https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"  # yamllint disable rule:line-length
             disable_gpg_check: true
             state: present
           # EPEL Next is available for CentOS Stream 9 and newer only
@@ -59,7 +63,9 @@
           when: ansible_distribution_major_version | int >= 9
 
     - name: Enable EPEL repos on CentOS 7
-      when: ansible_distribution == "CentOS" and ansible_distribution_major_version | int == 7
+      when:
+        - ansible_distribution == "CentOS"
+        - ansible_distribution_major_version | int == 7
       block:
         - name: Install package 'epel-release'
           ansible.builtin.dnf:


### PR DESCRIPTION
These playbooks are not examples or test-only playbooks, but user-facing playbooks tmt and other tools may use in real workflows. They are covered by ansible-lint, let's add also yamllint to the mix because Ansible playbooks should be valid YAML files, and yamllint takes a slightly different view and reports slightly different set of issues. Whatever passes ansible-lint should be perfectly valid YAML file, but not necessarily nicely formatted, presentable, maintainable, readable, and/or consistent with the rest of playbooks shipped with tmt. yamllint should improve this side of the picture.

Pull Request Checklist

* [x] implement the feature