### PR TITLE
Fix `tmt test import` error when restraint metadata attributes are empty

### DIFF
--- a/tests/test/import/data/parent/empty-dependencies/metadata
+++ b/tests/test/import/data/parent/empty-dependencies/metadata
@@ -1,0 +1,13 @@
+[General]
+name=/empty_dependencies
+owner=Nobody <nobody@localhost.localdomain>
+description=Empty dependencies
+license=MIT
+confidential=no
+destructive=no
+
+[restraint]
+entry_point=bash -x ./runtest.sh
+dependencies=
+softDependencies=
+max_time=5m

--- a/tests/test/import/data/parent/empty-dependencies/runtest.sh
+++ b/tests/test/import/data/parent/empty-dependencies/runtest.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "A simple test"

--- a/tests/test/import/test.sh
+++ b/tests/test/import/test.sh
@@ -146,6 +146,16 @@ rlJournalStart
         rlRun 'popd'
     rlPhaseEnd
 
+    rlPhaseStartTest "Empty dependencies (Restraint)"
+        rlRun 'pushd $tmp/data/parent/empty-dependencies'
+        rlRun -s 'tmt test import --restraint --no-nitrate --no-purpose' '0'
+        rlAssertExists "main.fmf"
+        rlRun 'cat main.fmf'
+        rlAssertGrep 'require:\s*\[\]' "main.fmf"
+        rlAssertGrep 'recommend:\s*\[\]' "main.fmf"
+        rlRun 'popd'
+    rlPhaseEnd
+
     rlPhaseStartTest "Target run having a single line"
         rlRun 'pushd $tmp/data/parent/single-line-run'
         rlRun -s 'tmt test import --makefile --no-nitrate --no-purpose' '0'

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -336,7 +336,7 @@ def read_datafile(
     if requires:
         data['require'] = [
             sanitize_name(require.strip()) for line in requires
-            for require in line.split(rec_separator)]
+            for require in line.split(rec_separator) if require.strip()]
         echo(style('require: ', fg='green') + ' '.join(data['require']))
 
     # Requires or softDependencies (optional) goes to recommend
@@ -344,7 +344,7 @@ def read_datafile(
     if recommends:
         data['recommend'] = [
             sanitize_name(recommend.strip()) for line in recommends
-            for recommend in line.split(rec_separator)]
+            for recommend in line.split(rec_separator) if recommend.strip()]
         echo(
             style('recommend: ', fg='green') + ' '.join(data['recommend']))
 


### PR DESCRIPTION
This PR fixes the "list index out of range" error that occurs when the `dependencies` or `softDependencies` attribute in restraint metadata is empty.

Resolves #3186

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
