### PR TITLE
Enable the `stable` copr repository for building

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -135,7 +135,7 @@ jobs:
         - tmt:
             context:
               how: provision
-        - *tmt-cloud-resources
+          <<: *tmt-cloud-resources
 
   # Test internal plugins
   - <<: *test-base

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,6 +34,8 @@ _:
   # Copr jobs under the packit project
   - &copr-under-packit
     job: copr_build
+    additional_repos:
+      - copr://@teemtee/stable
 
   # Copr jobs under the teemtee project
   - &copr-under-teemtee
@@ -46,6 +48,14 @@ _:
   - &test-base
     job: tests
     trigger: pull_request
+    tf_extra_params:
+      environments:
+        - artifacts:
+            - type: repository-file
+              id: https://copr.fedorainfracloud.org/coprs/g/teemtee/stable/repo/fedora-rawhide/group_teemtee-stable-fedora-rawhide.repo
+            - type: repository-file
+              id: https://copr.fedorainfracloud.org/coprs/g/teemtee/stable/repo/epel-9/group_teemtee-stable-epel-9.repo
+
 
   # Latest fedora & epel targets
   - &latest-targets

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -50,12 +50,12 @@ _:
     trigger: pull_request
     tf_extra_params:
       environments:
-        - artifacts:
+        - &copr-teemtee-stable
+          artifacts:
             - type: repository-file
               id: https://copr.fedorainfracloud.org/coprs/g/teemtee/stable/repo/fedora-rawhide/group_teemtee-stable-fedora-rawhide.repo
             - type: repository-file
               id: https://copr.fedorainfracloud.org/coprs/g/teemtee/stable/repo/epel-9/group_teemtee-stable-epel-9.repo
-
 
   # Latest fedora & epel targets
   - &latest-targets
@@ -70,6 +70,7 @@ _:
     tf_extra_params:
       environments:
         - &tmt-cloud-resources
+          <<: *copr-teemtee-stable
           settings:
             provisioning:
               tags:

--- a/tmt.spec
+++ b/tmt.spec
@@ -9,8 +9,10 @@ Source0:        %{pypi_source tmt}
 
 BuildArch:      noarch
 BuildRequires:  python3-devel
+BuildRequires:  dyd >= 0.22
 
 Requires:       git-core rsync sshpass
+Requires:       dyd >= 0.22
 
 %if 0%{?fedora} < 40
 Obsoletes:      python3-tmt < %{version}-%{release}

--- a/tmt.spec
+++ b/tmt.spec
@@ -9,10 +9,8 @@ Source0:        %{pypi_source tmt}
 
 BuildArch:      noarch
 BuildRequires:  python3-devel
-BuildRequires:  dyd >= 0.22
 
 Requires:       git-core rsync sshpass
-Requires:       dyd >= 0.22
 
 %if 0%{?fedora} < 40
 Obsoletes:      python3-tmt < %{version}-%{release}


### PR DESCRIPTION
This would allow us to test with fresh `fmf` bits as soon as they are released. We would not have to wait until packages reach the stable fedora repositories.