### PR TITLE
Remove the two expected `avc` failures on `rawhide`

### DIFF
--- a/tests/run/permissions/main.fmf
+++ b/tests/run/permissions/main.fmf
@@ -13,8 +13,3 @@ adjust+:
   - enabled: true
     when: how == full or trigger == commit
     because: it needs to be executed with root permissions
-  - check:
-      - how: avc
-        result: xfail
-    when: distro == fedora-rawhide
-    because: https://bugzilla.redhat.com/show_bug.cgi?id=2330476

--- a/tests/run/shell/main.fmf
+++ b/tests/run/shell/main.fmf
@@ -6,9 +6,3 @@ tag+:
   - as_root
   - provision-only
   - provision-local
-adjust+:
-  - check:
-      - how: avc
-        result: xfail
-    when: distro == fedora-rawhide
-    because: https://bugzilla.redhat.com/show_bug.cgi?id=2330476


### PR DESCRIPTION
Seems the bug has been fixed, there is no avc any more. This reverts commit 03726d42f2c268430d3fc90004255704dce547c8.