### PR TITLE
Ignore cpu docs page during the `linkcheck`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -312,7 +312,10 @@ linkcheck_ignore = [
     # Github "source code line" anchors are apparently too dynamic for linkcheck
     # to detect correctly. The link exists, a browser can open it, but linkcheck
     # reports a broken link.
-    r'https://github.com/packit/packit/blob/main/packit/utils/logging.py#L10'
+    r'https://github.com/packit/packit/blob/main/packit/utils/logging.py#L10',
+
+    # The site repeatedly refuses to serve pages to github
+    r'https://www.cpu-world.com.*',
     ]
 
 


### PR DESCRIPTION
Seems that the site is too alergic to github as it repeatedly refuses to serve the pages when request from there with this:

    403 Client Error: Forbidden for url: https://www.cpu-world.com/

Let's just ignore it.