### PR TITLE
Add `system.management-interface` hardware property

### DIFF
--- a/spec/hardware/system.fmf
+++ b/spec/hardware/system.fmf
@@ -26,11 +26,17 @@ description: |
                # String, name of the management interface protocol
                protocol: IPMI
 
-               # Integer or string, management interface vendor name or id
-               vendor: "~ MontaVista Software, Inc."
+               # Number or string, an ID of the management interface vendor.
+               vendor: "0x04b3"
 
-               # Integer or string, management interface product name or id
-               product: 0x4010
+               # String, a name of the management interface vendor.
+               vendor-name: "~ MontaVista Software, Inc."
+
+               # Number or string, an ID of the management interface device (product).
+               device: "0x04b3"
+
+               # String, a name of the management interface device (product).
+               device-name: "~ Some device name"
 
     .. versionchanged:: 1.45
        added ``management-interface`` specification

--- a/spec/hardware/system.fmf
+++ b/spec/hardware/system.fmf
@@ -20,6 +20,21 @@ description: |
            # Integer or string, required number of NUMA nodes.
            numa-nodes: 2|">= 2"
 
+           # System management interface
+           management-interface:
+
+               # String, name of the management interface protocol
+               protocol: IPMI
+
+               # Integer or string, management interface vendor name or id
+               vendor: "~ MontaVista Software, Inc."
+
+               # Integer or string, management interface product name or id
+               product: 0x4010
+
+    .. versionchanged:: 1.45
+       added ``management-interface`` specification
+
     .. versionchanged:: 1.39
        ``beaker`` plugin supports ``vendor-name``
 
@@ -43,6 +58,12 @@ example:
         vendor-name: "~ HPE"
         numa-nodes: ">= 4"
 
+  - |
+    # Select any system with available Intelligent Platform Management Interface (IPMI).
+    system:
+        management-interface:
+            protocol: IPMI
+
 link:
   - implemented-by: /tmt/steps/provision/mrack.py
-    note: "``system.vendor`` and ``system.model`` not implemented yet"
+    note: "``system.vendor``, ``system.model`` and ``management-interface`` not implemented yet"

--- a/spec/hardware/system.fmf
+++ b/spec/hardware/system.fmf
@@ -38,7 +38,7 @@ description: |
                # String, a name of the management interface device (product).
                device-name: "~ Some device name"
 
-    .. versionchanged:: 1.45
+    .. versionchanged:: 1.46
        added ``management-interface`` specification
 
     .. versionchanged:: 1.39

--- a/spec/hardware/system.fmf
+++ b/spec/hardware/system.fmf
@@ -20,8 +20,8 @@ description: |
            # Integer or string, required number of NUMA nodes.
            numa-nodes: 2|">= 2"
 
-           # System management interface
-           management-interface:
+           # System management controller
+           management-controller:
 
                # String, name of the management interface protocol
                protocol: IPMI
@@ -39,7 +39,7 @@ description: |
                device-name: "~ Some device name"
 
     .. versionchanged:: 1.46
-       added ``management-interface`` specification
+       added ``management-controller`` specification
 
     .. versionchanged:: 1.39
        ``beaker`` plugin supports ``vendor-name``
@@ -67,9 +67,9 @@ example:
   - |
     # Select any system with available Intelligent Platform Management Interface (IPMI).
     system:
-        management-interface:
+        management-controller:
             protocol: IPMI
 
 link:
   - implemented-by: /tmt/steps/provision/mrack.py
-    note: "``system.vendor``, ``system.model`` and ``management-interface`` not implemented yet"
+    note: "``system.vendor``, ``system.model`` and ``management-controller`` not implemented yet"

--- a/tmt/schemas/provision/hardware.yaml
+++ b/tmt/schemas/provision/hardware.yaml
@@ -310,7 +310,7 @@ definitions:
           - type: string
           - type: integer
 
-      management-interface:
+      management-controller:
         type: object
 
         properties:

--- a/tmt/schemas/provision/hardware.yaml
+++ b/tmt/schemas/provision/hardware.yaml
@@ -310,6 +310,23 @@ definitions:
           - type: string
           - type: integer
 
+      management-interface:
+        type: object
+
+        properties:
+          protocol:
+            type: string
+
+          product:
+            anyOf:
+              - type: string
+              - type: integer
+
+          vendor:
+            anyOf:
+              - type: string
+              - type: integer
+
     additionalProperties: false
 
     # enforce at least one property

--- a/tmt/schemas/provision/hardware.yaml
+++ b/tmt/schemas/provision/hardware.yaml
@@ -317,15 +317,21 @@ definitions:
           protocol:
             type: string
 
-          product:
+          device:
             anyOf:
               - type: string
               - type: integer
+
+          device-name:
+            type: string
 
           vendor:
             anyOf:
               - type: string
               - type: integer
+
+          vendor-name:
+            type: string
 
     additionalProperties: false
 


### PR DESCRIPTION
Users wanting to select a system with available system management interface can use this field.

Being added to be able to select Beaker machines with `IPMI`.

```
provision:
  hardware:
    system:
      management-interface: IPMI
```

Seems there are other management interfaces which could have in the future, like:

```
Redfish
Intel Active Management Technology (AMT)
Dell iDRAC (Integrated Dell Remote Access Controller)
HP iLO (Integrated Lights-Out)
Lenovo XClarity
Supermicro IPMI/BMC
OpenBMC
Cisco UCS Manager
SMASH (System Management Architecture for Server Hardware)
```

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
