### PR TITLE
Drop the `Node` alias for the `Core` class

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -25,6 +25,9 @@ the given job group.
 The ``note`` field of tmt :ref:`/spec/plans/results` changes from
 a string to a list of strings, to better accommodate multiple notes.
 
+The ``Node`` alias for the ``Core`` class has been dropped as it
+has been deprecated a long time ago.
+
 
 tmt-1.40.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -1035,9 +1035,6 @@ class Core(
         return self.link.has_link(needle=needle)
 
 
-Node = Core
-
-
 @dataclasses.dataclass(repr=False)
 class Test(
         Core,


### PR DESCRIPTION
The old `Node` class has been deprecated a long time ago. No need to keep it forever.

Fix #781.

Pull Request Checklist

* [x] implement the feature
* [x] include a release note