### PR TITLE
Refactor order of actions in guest reboot implementations

### DIFF
--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -549,21 +549,18 @@ class TestInvocation:
             self.guest.push(self.test_data_path)
 
             try:
-                rebooted = self.guest.reboot(
-                    hard=False,
-                    command=reboot_command,
-                    timeout=timeout)
+                rebooted = self.guest.reboot(hard=False, command=reboot_command, timeout=timeout)
 
             except tmt.utils.RunError:
                 if reboot_command is not None:
                     self.logger.fail(
-                        f"Failed to reboot guest using the custom command '{reboot_command}'.")
+                        f"Failed to reboot guest using the custom command '{reboot_command}'."
+                    )
 
                 raise
 
             except tmt.steps.provision.RebootModeNotSupportedError:
-                self.logger.warning(
-                    "Guest does not support soft reboot, trying hard reboot.")
+                self.logger.warning("Guest does not support soft reboot, trying hard reboot.")
 
                 rebooted = self.guest.reboot(hard=True, timeout=timeout)
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -286,6 +286,29 @@ def format_guest_full_name(name: str, role: Optional[str]) -> str:
     return f'{name} ({role})'
 
 
+class RebootModeNotSupportedError(ProvisionError):
+    """ A requested reboot mode is not supported by the guest """
+
+    def __init__(
+            self,
+            message: Optional[str] = None,
+            guest: Optional['Guest'] = None,
+            hard: bool = False,
+            *args: Any,
+            **kwargs: Any) -> None:
+
+        if message is not None:
+            pass
+
+        elif guest is not None:
+            message = f"Guest '{guest.multihost_name}' does not support {'hard' if hard else 'soft'} reboot."  # noqa: E501
+
+        else:
+            message = f"Guest does not support {'hard' if hard else 'soft'} reboot."
+
+        super().__init__(message, *args, **kwargs)
+
+
 class CheckRsyncOutcome(enum.Enum):
     ALREADY_INSTALLED = 'already-installed'
     INSTALLED = 'installed'
@@ -1540,24 +1563,54 @@ class Guest(tmt.utils.Common):
 
         raise NotImplementedError
 
+    @overload
     def reboot(
-        self,
-        hard: bool = False,
-        command: Optional[Union[Command, ShellScript]] = None,
-        timeout: Optional[int] = None,
-    ) -> bool:
+            self,
+            hard: Literal[True] = True,
+            command: None = None,
+            timeout: Optional[int] = None,
+            tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+            tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
+        pass
+
+    @overload
+    def reboot(
+            self,
+            hard: Literal[False] = False,
+            command: Optional[Union[Command, ShellScript]] = None,
+            timeout: Optional[int] = None,
+            tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+            tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
+        pass
+
+    def reboot(
+            self,
+            hard: bool = False,
+            command: Optional[Union[Command, ShellScript]] = None,
+            timeout: Optional[int] = None,
+            tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+            tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
         """
-        Reboot the guest, return True if successful
+        Reboot the guest, and wait for the guest to recover.
 
-        Parameter 'hard' set to True means that guest should be
-        rebooted by way which is not clean in sense that data can be
-        lost. When set to False reboot should be done gracefully.
+        .. note::
 
-        Use the 'command' parameter to specify a custom reboot command
-        instead of the default 'reboot'.
+           Custom reboot command can be used only in combination with a
+           soft reboot. If both ``hard`` and ``command`` are set, a hard
+           reboot will be requested, and ``command`` will be ignored.
 
-        Parameter 'timeout' can be used to specify time (in seconds) to
-        wait for the guest to come back up after rebooting.
+        :param hard: if set, force the reboot. This may result in a loss
+            of data. The default of ``False`` will attempt a graceful
+            reboot.
+        :param command: a command to run on the guest to trigger the
+            reboot. If ``hard`` is also set, ``command`` is ignored.
+        :param timeout: amount of time in which the guest must become available
+            again.
+        :param tick: how many seconds to wait between two consecutive attempts
+            of contacting the guest.
+        :param tick_increase: a multiplier applied to ``tick`` after every
+            attempt.
+        :returns: ``True`` if the reboot succeeded, ``False`` otherwise.
         """
 
         raise NotImplementedError
@@ -2341,25 +2394,32 @@ class GuestSsh(Guest):
         # Remove the ssh socket
         self._unlink_ssh_master_socket_path()
 
-    def perform_reboot(
-        self,
-        command: Callable[[], tmt.utils.CommandOutput],
-        timeout: Optional[int] = None,
-        tick: float = tmt.utils.DEFAULT_WAIT_TICK,
-        tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE,
-        hard: bool = False,
-    ) -> bool:
+    def perform_reboot(self,
+                       action: Callable[[], tmt.utils.CommandOutput],
+                       timeout: Optional[int] = None,
+                       tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+                       tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE,
+                       fetch_boot_time: bool = True) -> bool:
         """
         Perform the actual reboot and wait for the guest to recover.
 
-        :param command: a callable running the actual command triggering
-            the reboot.
+        This is the core implementation of the common task of triggering
+        a reboot and waiting for the guest to recover. :py:meth:`reboot`
+        is the public API of guest classes, and feeds
+        :py:meth:`perform_reboot` with the right ``action`` callable.
+
+        :param action: a callable which will trigger the requested reboot.
         :param timeout: amount of time in which the guest must become available
             again.
         :param tick: how many seconds to wait between two consecutive attempts
             of contacting the guest.
         :param tick_increase: a multiplier applied to ``tick`` after every
             attempt.
+        :param fetch_boot_time: if set, the current boot time of the
+            guest would be read first, and used for testing whether the
+            reboot has been performed. This will require communication
+            with the guest, therefore it is recommended to use ``False``
+            with hard reboot of unhealthy guests.
         :returns: ``True`` if the reboot succeeded, ``False`` otherwise.
         """
 
@@ -2378,10 +2438,10 @@ class GuestSsh(Guest):
 
             return int(match.group(1))
 
-        current_boot_time = 0 if hard else get_boot_time()
+        current_boot_time = get_boot_time() if fetch_boot_time else 0
 
         try:
-            command()
+            action()
 
         except tmt.utils.RunError as error:
             # Connection can be closed by the remote host even before the
@@ -2426,6 +2486,26 @@ class GuestSsh(Guest):
         self.debug("Connection to guest succeeded after reboot.")
         return True
 
+    @overload
+    def reboot(
+            self,
+            hard: Literal[True] = True,
+            command: None = None,
+            timeout: Optional[int] = None,
+            tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+            tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
+        pass
+
+    @overload
+    def reboot(
+            self,
+            hard: Literal[False] = False,
+            command: Optional[Union[Command, ShellScript]] = None,
+            timeout: Optional[int] = None,
+            tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+            tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
+        pass
+
     def reboot(
         self,
         hard: bool = False,
@@ -2437,9 +2517,17 @@ class GuestSsh(Guest):
         """
         Reboot the guest, and wait for the guest to recover.
 
-        :param hard: if set, force the reboot. This may result in a loss of
-            data. The default of ``False`` will attempt a graceful reboot.
-        :param command: a command to run on the guest to trigger the reboot.
+        .. note::
+
+           Custom reboot command can be used only in combination with a
+           soft reboot. If both ``hard`` and ``command`` are set, a hard
+           reboot will be requested, and ``command`` will be ignored.
+
+        :param hard: if set, force the reboot. This may result in a loss
+            of data. The default of ``False`` will attempt a graceful
+            reboot.
+        :param command: a command to run on the guest to trigger the
+            reboot. If ``hard`` is also set, ``command`` is ignored.
         :param timeout: amount of time in which the guest must become available
             again.
         :param tick: how many seconds to wait between two consecutive attempts
@@ -2456,15 +2544,13 @@ class GuestSsh(Guest):
 
         actual_command = command or DEFAULT_REBOOT_COMMAND
 
-        self.debug(f"Reboot using the command '{actual_command}'.")
+        self.debug(f"Soft reboot using command '{actual_command}'.")
 
         return self.perform_reboot(
             lambda: self.execute(actual_command),
             timeout=timeout,
             tick=tick,
-            tick_increase=tick_increase,
-            hard=hard,
-        )
+            tick_increase=tick_increase)
 
     def remove(self) -> None:
         """

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -287,16 +287,16 @@ def format_guest_full_name(name: str, role: Optional[str]) -> str:
 
 
 class RebootModeNotSupportedError(ProvisionError):
-    """ A requested reboot mode is not supported by the guest """
+    """A requested reboot mode is not supported by the guest"""
 
     def __init__(
-            self,
-            message: Optional[str] = None,
-            guest: Optional['Guest'] = None,
-            hard: bool = False,
-            *args: Any,
-            **kwargs: Any) -> None:
-
+        self,
+        message: Optional[str] = None,
+        guest: Optional['Guest'] = None,
+        hard: bool = False,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         if message is not None:
             pass
 
@@ -1565,31 +1565,34 @@ class Guest(tmt.utils.Common):
 
     @overload
     def reboot(
-            self,
-            hard: Literal[True] = True,
-            command: None = None,
-            timeout: Optional[int] = None,
-            tick: float = tmt.utils.DEFAULT_WAIT_TICK,
-            tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
+        self,
+        hard: Literal[True] = True,
+        command: None = None,
+        timeout: Optional[int] = None,
+        tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+        tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE,
+    ) -> bool:
         pass
 
     @overload
     def reboot(
-            self,
-            hard: Literal[False] = False,
-            command: Optional[Union[Command, ShellScript]] = None,
-            timeout: Optional[int] = None,
-            tick: float = tmt.utils.DEFAULT_WAIT_TICK,
-            tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
+        self,
+        hard: Literal[False] = False,
+        command: Optional[Union[Command, ShellScript]] = None,
+        timeout: Optional[int] = None,
+        tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+        tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE,
+    ) -> bool:
         pass
 
     def reboot(
-            self,
-            hard: bool = False,
-            command: Optional[Union[Command, ShellScript]] = None,
-            timeout: Optional[int] = None,
-            tick: float = tmt.utils.DEFAULT_WAIT_TICK,
-            tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
+        self,
+        hard: bool = False,
+        command: Optional[Union[Command, ShellScript]] = None,
+        timeout: Optional[int] = None,
+        tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+        tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE,
+    ) -> bool:
         """
         Reboot the guest, and wait for the guest to recover.
 
@@ -2394,12 +2397,14 @@ class GuestSsh(Guest):
         # Remove the ssh socket
         self._unlink_ssh_master_socket_path()
 
-    def perform_reboot(self,
-                       action: Callable[[], Any],
-                       timeout: Optional[int] = None,
-                       tick: float = tmt.utils.DEFAULT_WAIT_TICK,
-                       tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE,
-                       fetch_boot_time: bool = True) -> bool:
+    def perform_reboot(
+        self,
+        action: Callable[[], Any],
+        timeout: Optional[int] = None,
+        tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+        tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE,
+        fetch_boot_time: bool = True,
+    ) -> bool:
         """
         Perform the actual reboot and wait for the guest to recover.
 
@@ -2488,22 +2493,24 @@ class GuestSsh(Guest):
 
     @overload
     def reboot(
-            self,
-            hard: Literal[True] = True,
-            command: None = None,
-            timeout: Optional[int] = None,
-            tick: float = tmt.utils.DEFAULT_WAIT_TICK,
-            tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
+        self,
+        hard: Literal[True] = True,
+        command: None = None,
+        timeout: Optional[int] = None,
+        tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+        tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE,
+    ) -> bool:
         pass
 
     @overload
     def reboot(
-            self,
-            hard: Literal[False] = False,
-            command: Optional[Union[Command, ShellScript]] = None,
-            timeout: Optional[int] = None,
-            tick: float = tmt.utils.DEFAULT_WAIT_TICK,
-            tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
+        self,
+        hard: Literal[False] = False,
+        command: Optional[Union[Command, ShellScript]] = None,
+        timeout: Optional[int] = None,
+        tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+        tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE,
+    ) -> bool:
         pass
 
     def reboot(
@@ -2550,7 +2557,8 @@ class GuestSsh(Guest):
             lambda: self.execute(actual_command),
             timeout=timeout,
             tick=tick,
-            tick_increase=tick_increase)
+            tick_increase=tick_increase,
+        )
 
     def remove(self) -> None:
         """

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -2395,7 +2395,7 @@ class GuestSsh(Guest):
         self._unlink_ssh_master_socket_path()
 
     def perform_reboot(self,
-                       action: Callable[[], tmt.utils.CommandOutput],
+                       action: Callable[[], Any],
                        timeout: Optional[int] = None,
                        tick: float = tmt.utils.DEFAULT_WAIT_TICK,
                        tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE,

--- a/tmt/steps/provision/bootc.py
+++ b/tmt/steps/provision/bootc.py
@@ -198,6 +198,10 @@ class ProvisionBootc(tmt.steps.provision.ProvisionPlugin[BootcData]):
     The bootc disk creation requires running podman as root. The plugin will
     automatically check if the current podman connection is rootless. If it is,
     a podman machine will be spun up and used to build the bootc disk.
+
+    To trigger hard reboot of a guest, plugin uses testcloud API. It is
+    also used to trigger soft reboot unless a custom reboot command was
+    specified via ``tmt-reboot -c ...``.
     """
 
     _data_class = BootcData

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -134,12 +134,12 @@ class GuestConnect(tmt.steps.provision.GuestSsh):
             # ignore[union-attr]: mypy still considers `self.hard_reboot` as possibly
             # being `None`, missing the explicit check above.
             return self.perform_reboot(
-                lambda: self._run_guest_command(
-                    self.hard_reboot.to_shell_command()),  # type: ignore[union-attr]
+                lambda: self._run_guest_command(self.hard_reboot.to_shell_command()),  # type: ignore[union-attr]
                 timeout=timeout,
                 tick=tick,
                 tick_increase=tick_increase,
-                fetch_boot_time=False)
+                fetch_boot_time=False,
+            )
 
         if command is not None:
             return super().reboot(
@@ -147,7 +147,8 @@ class GuestConnect(tmt.steps.provision.GuestSsh):
                 command=command,
                 timeout=timeout,
                 tick=tick,
-                tick_increase=tick_increase)
+                tick_increase=tick_increase,
+            )
 
         if self.soft_reboot is not None:
             self.debug(f"Soft reboot using the soft reboot command '{self.soft_reboot}'.")
@@ -155,17 +156,13 @@ class GuestConnect(tmt.steps.provision.GuestSsh):
             # ignore[union-attr]: mypy still considers `self.soft_reboot` as possibly
             # being `None`, missing the explicit check above.
             return self.perform_reboot(
-                lambda: self._run_guest_command(
-                    self.soft_reboot.to_shell_command()),  # type: ignore[union-attr]
+                lambda: self._run_guest_command(self.soft_reboot.to_shell_command()),  # type: ignore[union-attr]
                 timeout=timeout,
                 tick=tick,
-                tick_increase=tick_increase)
+                tick_increase=tick_increase,
+            )
 
-        return super().reboot(
-            hard=False,
-            timeout=timeout,
-            tick=tick,
-            tick_increase=tick_increase)
+        return super().reboot(hard=False, timeout=timeout, tick=tick, tick_increase=tick_increase)
 
     def start(self) -> None:
         """

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -96,14 +96,26 @@ class GuestConnect(tmt.steps.provision.GuestSsh):
         """
         Reboot the guest, and wait for the guest to recover.
 
+        .. note::
+
+           Custom reboot command can be used only in combination with a
+           soft reboot. If both ``hard`` and ``command`` are set, a hard
+           reboot will be requested, and ``command`` will be ignored.
+
         :param hard: if set, force the reboot. This may result in a loss of
             data. The default of ``False`` will attempt a graceful reboot.
-        :param command: a command to run on the guest to trigger the reboot.
+
+            Plugin will use :py:attr:`ConnectGuestData.hard_reboot`,
+            set via ``hard-reboot`` key. Unlike ``command``, this command
+            would be executed on the runner, **not** on the guest.
+        :param command: a command to run on the guest to trigger the
+            reboot. If ``hard`` is also set, ``command`` is ignored.
+
             If not set, plugin would try to use
-            :py:attr:`ConnectGuestData.soft_reboot` or
-            :py:attr:`ConnectGuestData.hard_reboot` (``--soft-reboot`` and
-            ``--hard-reboot``, respectively), if specified. Unlike ``command``,
-            these would be executed on the runner, **not** on the guest.
+            :py:attr:`ConnectGuestData.soft_reboot`, set via
+            ``soft-reboot`` key. Unlike ``command``,
+            this command would be executed on the runner, **not** on the
+            guest.
         :param timeout: amount of time in which the guest must become available
             again.
         :param tick: how many seconds to wait between two consecutive attempts
@@ -113,35 +125,47 @@ class GuestConnect(tmt.steps.provision.GuestSsh):
         :returns: ``True`` if the reboot succeeded, ``False`` otherwise.
         """
 
-        if not command:
-            if hard and self.hard_reboot is not None:
-                self.debug(f"Reboot using the hard reboot command '{self.hard_reboot}'.")
+        if hard:
+            if self.hard_reboot is None:
+                raise tmt.steps.provision.RebootModeNotSupportedError(guest=self, hard=True)
 
-                # ignore[union-attr]: mypy still considers `self.hard_reboot` as possibly
-                # being `None`, missing the explicit check above.
-                return self.perform_reboot(
-                    lambda: self._run_guest_command(self.hard_reboot.to_shell_command()),  # type: ignore[union-attr]
-                    timeout=timeout,
-                    tick=tick,
-                    tick_increase=tick_increase,
-                    hard=True,
-                )
+            self.debug(f"Hard reboot using the hard reboot command '{self.hard_reboot}'.")
 
-            if not hard and self.soft_reboot is not None:
-                self.debug(f"Reboot using the soft reboot command '{self.soft_reboot}'.")
+            # ignore[union-attr]: mypy still considers `self.hard_reboot` as possibly
+            # being `None`, missing the explicit check above.
+            return self.perform_reboot(
+                lambda: self._run_guest_command(
+                    self.hard_reboot.to_shell_command()),  # type: ignore[union-attr]
+                timeout=timeout,
+                tick=tick,
+                tick_increase=tick_increase,
+                fetch_boot_time=False)
 
-                # ignore[union-attr]: mypy still considers `self.soft_reboot` as possibly
-                # being `None`, missing the explicit check above.
-                return self.perform_reboot(
-                    lambda: self._run_guest_command(self.soft_reboot.to_shell_command()),  # type: ignore[union-attr]
-                    timeout=timeout,
-                    tick=tick,
-                    tick_increase=tick_increase,
-                )
+        if command is not None:
+            return super().reboot(
+                hard=False,
+                command=command,
+                timeout=timeout,
+                tick=tick,
+                tick_increase=tick_increase)
+
+        if self.soft_reboot is not None:
+            self.debug(f"Soft reboot using the soft reboot command '{self.soft_reboot}'.")
+
+            # ignore[union-attr]: mypy still considers `self.soft_reboot` as possibly
+            # being `None`, missing the explicit check above.
+            return self.perform_reboot(
+                lambda: self._run_guest_command(
+                    self.soft_reboot.to_shell_command()),  # type: ignore[union-attr]
+                timeout=timeout,
+                tick=tick,
+                tick_increase=tick_increase)
 
         return super().reboot(
-            hard=hard, command=command, timeout=timeout, tick=tick, tick_increase=tick_increase
-        )
+            hard=False,
+            timeout=timeout,
+            tick=tick,
+            tick_increase=tick_increase)
 
     def start(self) -> None:
         """
@@ -187,6 +211,24 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin[ProvisionConnectData]
         provision:
             how: connect
             guest: host.example.org
+
+    To trigger a hard reboot of a guest, ``hard-reboot`` must be set to
+    an executable command or script. Without this key set, hard reboot
+    will remain unsupported and result in an error. In comparison,
+    ``soft-reboot`` is optional, it will be preferred over the default
+    soft reboot command, ``reboot``:
+
+    .. code-block:: yaml
+
+        provision:
+          how: connect
+          hard-reboot: virsh reboot my-example-vm
+          soft-reboot: shutdown -r now
+
+    .. warning::
+
+        Both ``hard-reboot`` and ``soft-reboot`` commands are executed
+        on the runner, not on the guest.
     """
 
     _data_class = ProvisionConnectData

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -220,7 +220,7 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin[ProvisionConnectData]
         provision:
           how: connect
           hard-reboot: virsh reboot my-example-vm
-          soft-reboot: shutdown -r now
+          soft-reboot: ssh root@my-example-vm 'shutdown -r now'
 
     .. warning::
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -145,15 +145,13 @@ class GuestLocal(tmt.Guest):
         self.debug(f"Doing nothing to stop guest '{self.primary_address}'.")
 
     def reboot(
-        self,
-        hard: bool = False,
-        command: Optional[Union[Command, ShellScript]] = None,
-        timeout: Optional[int] = None,
-    ) -> bool:
-        """
-        Reboot the guest, return True if successful
-        """
-
+            self,
+            hard: bool = False,
+            command: Optional[Union[Command, ShellScript]] = None,
+            timeout: Optional[int] = None,
+            tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+            tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
+        # No localhost reboot allowed!
         self.debug(f"Doing nothing to reboot guest '{self.primary_address}'.")
 
         return False
@@ -206,6 +204,10 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin[ProvisionLocalData]):
     Note that ``tmt run`` is expected to be executed under a regular user.
     If there are admin rights required (for example in the prepare step)
     you might be asked for a ``sudo`` password.
+
+    .. note:
+
+        Neither hard nor soft reboot is supported.
     """
 
     _data_class = ProvisionLocalData

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -205,7 +205,7 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin[ProvisionLocalData]):
     If there are admin rights required (for example in the prepare step)
     you might be asked for a ``sudo`` password.
 
-    .. note:
+    .. note::
 
         Neither hard nor soft reboot is supported.
     """

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -145,12 +145,13 @@ class GuestLocal(tmt.Guest):
         self.debug(f"Doing nothing to stop guest '{self.primary_address}'.")
 
     def reboot(
-            self,
-            hard: bool = False,
-            command: Optional[Union[Command, ShellScript]] = None,
-            timeout: Optional[int] = None,
-            tick: float = tmt.utils.DEFAULT_WAIT_TICK,
-            tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
+        self,
+        hard: bool = False,
+        command: Optional[Union[Command, ShellScript]] = None,
+        timeout: Optional[int] = None,
+        tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+        tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE,
+    ) -> bool:
         # No localhost reboot allowed!
         self.debug(f"Doing nothing to reboot guest '{self.primary_address}'.")
 

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1384,7 +1384,8 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
                 timeout=timeout,
                 tick=tick,
                 tick_increase=tick_increase,
-                fetch_boot_time=False)
+                fetch_boot_time=False,
+            )
 
         return super().reboot(
             hard=False,

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1350,12 +1350,21 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
         """
         Reboot the guest, and wait for the guest to recover.
 
-        :param hard: if set, force the reboot. This may result in a loss of
-            data. The default of ``False`` will attempt a graceful reboot.
-        :param command: a command to run on the guest to trigger the reboot.
-            If not set, plugin would try to use ``bkr system-power`` for hard
-            reboot. Unlike ``command``, this would be executed on the runner,
-            **not** on the guest.
+        .. note::
+
+           Custom reboot command can be used only in combination with a
+           soft reboot. If both ``hard`` and ``command`` are set, a hard
+           reboot will be requested, and ``command`` will be ignored.
+
+        :param hard: if set, force the reboot. This may result in a loss
+            of data. The default of ``False`` will attempt a graceful
+            reboot.
+
+            Plugin will use ``bkr system-power`` command to trigger the
+            hard reboot. Unlike ``command``, this command would be
+            executed on the runner, **not** on the guest.
+        :param command: a command to run on the guest to trigger the
+            reboot. If ``hard`` is also set, ``command`` is ignored.
         :param timeout: amount of time in which the guest must become available
             again.
         :param tick: how many seconds to wait between two consecutive attempts
@@ -1365,8 +1374,8 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
         :returns: ``True`` if the reboot succeeded, ``False`` otherwise.
         """
 
-        if not command and hard:
-            self.debug("Reboot using the reboot command 'bkr system-power --action reboot'.")
+        if hard:
+            self.debug("Hard reboot using the reboot command 'bkr system-power --action reboot'.")
 
             reboot_script = ShellScript(f'bkr system-power --action reboot {self.primary_address}')
 
@@ -1375,11 +1384,10 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
                 timeout=timeout,
                 tick=tick,
                 tick_increase=tick_increase,
-                hard=True,
-            )
+                fetch_boot_time=False)
 
         return super().reboot(
-            hard=hard,
+            hard=False,
             command=command,
             timeout=timeout,
             tick=tick,
@@ -1400,6 +1408,13 @@ class ProvisionBeaker(tmt.steps.provision.ProvisionPlugin[ProvisionBeakerData]):
             how: beaker
             image: fedora
 
+    To trigger a hard reboot of a guest, ``bkr system-power --action reboot``
+    command is executed.
+
+    .. warning::
+
+        ``bkr system-power`` command is executed on the runner, not
+        on the guest.
     """
 
     _data_class = ProvisionBeakerData

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -243,12 +243,14 @@ class GuestContainer(tmt.Guest):
             )
         )
 
-    def reboot(self,
-               hard: bool = False,
-               command: Optional[Union[Command, ShellScript]] = None,
-               timeout: Optional[int] = None,
-               tick: float = tmt.utils.DEFAULT_WAIT_TICK,
-               tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE) -> bool:
+    def reboot(
+        self,
+        hard: bool = False,
+        command: Optional[Union[Command, ShellScript]] = None,
+        timeout: Optional[int] = None,
+        tick: float = tmt.utils.DEFAULT_WAIT_TICK,
+        tick_increase: float = tmt.utils.DEFAULT_WAIT_TICK_INCREASE,
+    ) -> bool:
         """
         Reboot the guest, and wait for the guest to recover.
 
@@ -285,17 +287,18 @@ class GuestContainer(tmt.Guest):
             self.podman(Command('container', 'restart', self.container))
 
             return self.reconnect(
-                timeout=timeout or CONNECTION_TIMEOUT,
-                tick=tick,
-                tick_increase=tick_increase)
+                timeout=timeout or CONNECTION_TIMEOUT, tick=tick, tick_increase=tick_increase
+            )
 
         if command:
             raise tmt.utils.ProvisionError(
-                "Custom reboot command not supported in podman provision.")
+                "Custom reboot command not supported in podman provision."
+            )
 
         raise tmt.steps.provision.RebootModeNotSupportedError(
             f"Guest '{self.multihost_name}' does not support soft reboot."
-            " Containers can only be stopped and started again (hard reboot).")
+            " Containers can only be stopped and started again (hard reboot)."
+        )
 
     def _run_ansible(
         self,

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -1170,14 +1170,13 @@ class GuestTestcloud(tmt.GuestSsh):
                 timeout=timeout,
                 tick=tick,
                 tick_increase=tick_increase,
-                fetch_boot_time=False)
+                fetch_boot_time=False,
+            )
 
         if command:
             return super().reboot(
-                command=command,
-                timeout=timeout,
-                tick=tick,
-                tick_increase=tick_increase)
+                command=command, timeout=timeout, tick=tick, tick_increase=tick_increase
+            )
 
         if self._instance is None:
             raise tmt.utils.ProvisionError("No instance initialized.")
@@ -1188,7 +1187,8 @@ class GuestTestcloud(tmt.GuestSsh):
             lambda: self._instance.reboot(soft=True),  # type: ignore[union-attr]
             timeout=timeout,
             tick=tick,
-            tick_increase=tick_increase)
+            tick_increase=tick_increase,
+        )
 
 
 @tmt.steps.provides_method('virtual.testcloud')

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -1175,7 +1175,7 @@ class GuestTestcloud(tmt.GuestSsh):
 
         if command:
             return super().reboot(
-                command=command, timeout=timeout, tick=tick, tick_increase=tick_increase
+                hard=False, command=command, timeout=timeout, tick=tick, tick_increase=tick_increase
             )
 
         if self._instance is None:

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -1175,7 +1175,11 @@ class GuestTestcloud(tmt.GuestSsh):
 
         if command:
             return super().reboot(
-                hard=False, command=command, timeout=timeout, tick=tick, tick_increase=tick_increase
+                hard=False,
+                command=command,
+                timeout=timeout,
+                tick=tick,
+                tick_increase=tick_increase,
             )
 
         if self._instance is None:


### PR DESCRIPTION
Things worked, but the code was not easy to understand and follow:

* it wasn't obvious custom reboot `command` and hard reboots are not compatible;
* it wasn't obvious that custom reboot command can come only from reboot request data stored by `tmt-reboot`;
* the ordering of hard, soft and soft-with-custom-command was unclear,
* `command` of `reboot()` was not the same as `command` of `perform_reboot()`;
* the relationship between `reboot()` and `perform_reboot()` was unclear;
* often all known arguments were passed to `super().reboot()` or `perform_reboot()`, which was not incorrect, but harder for humans and linters to reason about;
* docstrings of `reboot()` methods were incomplete or outdated,
* plugins did not mention their special behavior in docstrings of `reboot()` method.

To hopefully improve the situation, the patch makes the following changes:

* uses `@overload` to clearly mark that `hard=True` means no custom reboot command;
* it makes reboot handling in `TestInvocation` code more verbose to make the distinction between hard and soft reboots which should make the custom reboot command clearly attached to soft reboots only;
* all `reboot()` methods now follow the same order of actions: handling hard reboot first, soft reboots second, with less dense code;
* `perform_reboot()` now accepts "action" callback, not "command", and it is responsibility of `reboot()` to feed `perform_reboot()` wit the proper action (running remote command, local command, or calling testcloud API, and so on);
* reduces "blind" passing of known values: `super().reboot(hard=hard)` is correct, but impossible for a type checker to map to the "hard or custom command" split; using `hard=True|False` helps linters narrow the situation;
* cleans up docstrings, makes them as same as possible with plugin-specific additions and notes where necessary;
* and mention reboot support levels in plugin docstrings.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] adjust plugin docstring