### PR TITLE
Switch AVC check requirements to use packages

### DIFF
--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -301,9 +301,11 @@ class AvcDenials(CheckPlugin[Check]):
         # Avoid circular imports
         import tmt.base
 
+        # Note: yes, this will most likely explode in any distro outside
+        # of Fedora, CentOS and RHEL.
         return [
-            tmt.base.DependencySimple('/usr/sbin/sestatus'),
-            tmt.base.DependencySimple('/usr/sbin/ausearch')
+            tmt.base.DependencySimple('audit'),
+            tmt.base.DependencySimple('policycoreutils')
             ]
 
     @classmethod


### PR DESCRIPTION
Fedora Rawhide moved files under `/usr/bin`, therefore paths no longer work. Let's hope packages will work, everywhere, and that the required files are not shipped by some other packages on an obscure distro release.

Pull Request Checklist

* [x] implement the feature