### PR TITLE
Check disk space for `/tests/provision/bootc`

### DIFF
--- a/tests/provision/bootc/test.sh
+++ b/tests/provision/bootc/test.sh
@@ -12,6 +12,7 @@ rlJournalStart
         rlRun "mkdir -p /var/tmp/tmt"
         rlRun "run=\$(mktemp -d --tmpdir=/var/tmp/tmt)" 0 "Create run directory"
         rlRun "pushd data"
+        rlRun "df -h" 0 "Check available disk space"
     rlPhaseEnd
 
     rlPhaseStartTest "Image that needs dependencies"


### PR DESCRIPTION
The test started to fail recently with the following error:

    qemu-img: error while writing at byte 6421348352:
    No space left on device

Let's investigate the problem and adjust hardware requirements accordingly if needed.