### PR TITLE
Keep container uid the same as host to allow ops on workdir root

### DIFF
--- a/tests/provision/facts/test-guest.sh
+++ b/tests/provision/facts/test-guest.sh
@@ -44,7 +44,7 @@ rlJournalStart
             build_container_image "fedora/41/upstream\:latest"
 
             provision_options="--image localhost/tmt/container/test/fedora/41/upstream:latest"
-            bfu_provision_options="$provision_options --user=nobody"
+            bfu_provision_options="--image localhost/tmt/container/test/fedora/41/unprivileged:latest --user=fedora"
 
             arch="$(arch)"
             distro="Fedora Linux 41 (Container Image)"

--- a/tests/provision/facts/test-guest.sh
+++ b/tests/provision/facts/test-guest.sh
@@ -42,6 +42,7 @@ rlJournalStart
 
         elif [ "$PROVISION_HOW" = "container" ]; then
             build_container_image "fedora/41/upstream\:latest"
+            build_container_image "fedora/41/unprivileged\:latest"
 
             provision_options="--image localhost/tmt/container/test/fedora/41/upstream:latest"
             bfu_provision_options="--image localhost/tmt/container/test/fedora/41/unprivileged:latest --user=fedora"

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -252,6 +252,7 @@ class GuestContainer(tmt.Guest):
             self.execute(
                 ShellScript(
                     f"""
+                    sudo mkdir -p {self.workdir_root};
                     sudo chmod o+rwX {self.workdir_root};
                     sudo setfacl -d -m o:rwX {self.workdir_root}
                     """

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -247,6 +247,7 @@ class GuestContainer(tmt.Guest):
         )
 
     def setup(self) -> None:
+        super().setup()
         if not self.facts.is_superuser:
             self.package_manager.install(FileSystemPath('/usr/bin/setfacl'))
             self.execute(

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -215,9 +215,6 @@ class GuestContainer(tmt.Guest):
                 self._logger,
             )
 
-        # Mount the whole plan directory in the container
-        workdir = self.parent.plan.workdir
-
         self.verbose('name', self.container, 'green')
 
         additional_args = []
@@ -231,10 +228,12 @@ class GuestContainer(tmt.Guest):
             Command(
                 'run',
                 *additional_args,
+                '--userns',
+                'keep-id',
                 '--name',
                 self.container,
                 '-v',
-                f'{workdir}:{workdir}:z',
+                f'{self.workdir_root}:{self.workdir_root}:z',
                 '-itd',
                 '--user',
                 self.user,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -9,7 +9,6 @@ import tmt.steps
 import tmt.steps.provision
 import tmt.utils
 from tmt.container import container, field
-from tmt.options import show_step_method_hints
 from tmt.package_managers import FileSystemPath
 from tmt.steps.provision import GuestCapability
 from tmt.utils import Command, OnProcessStartCallback, Path, ShellScript, retry


### PR DESCRIPTION
Volume mounts on the container are by default read only for non-root users.
This prevents the necessary access for rootless container. The change in this
commit makes the container uid be the same as the host uid so that the user
under which podman runs, which owns the workdir root, is the same user uid on
the container, so the permissions also match.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note

Related: #3252
