### PR TITLE
Fix docstring of Execute.results function

### DIFF
--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1228,7 +1228,7 @@ class Execute(tmt.steps.Step):
         """
         Results from executed tests
 
-        Return a dictionary with test results according to the spec:
+        Return a list with test results according to the spec:
         https://tmt.readthedocs.io/en/latest/spec/plans.html#execute
         """
         return self._results


### PR DESCRIPTION
It returns a list, not a dictionary.