### PR TITLE
Update container images to latest packages

### DIFF
--- a/containers/alpine/Containerfile
+++ b/containers/alpine/Containerfile
@@ -8,5 +8,7 @@ FROM docker.io/library/alpine:3.19
 
     # Populate apk cache
 RUN    apk update \
+    # Make sure the image is built with the latest packages
+    && apk upgrade \
     # Inject `bash` which is unavoidably required by tmt
     && apk add --no-cache bash

--- a/containers/alpine/Containerfile.upstream
+++ b/containers/alpine/Containerfile.upstream
@@ -7,4 +7,6 @@
 FROM docker.io/library/alpine:3.19
 
     # Populate apk cache
-RUN apk update
+RUN    apk update \
+    # Make sure the image is built with the latest packages
+    && apk upgrade

--- a/containers/centos/7/Containerfile
+++ b/containers/centos/7/Containerfile
@@ -12,4 +12,6 @@ RUN cd /etc/yum.repos.d/ \
     && sed 's|#baseurl=http://mirror.centos.org/centos/$releasever|baseurl=https://vault.centos.org/7.9.2009|' -i *repo
 
     # Populate yum cache
-RUN yum makecache
+RUN    yum makecache \
+    # Make sure the image is built with the latest packages
+    && yum update -y

--- a/containers/centos/7/Containerfile.upstream
+++ b/containers/centos/7/Containerfile.upstream
@@ -12,4 +12,6 @@ RUN cd /etc/yum.repos.d/ \
     && sed 's|#baseurl=http://mirror.centos.org/centos/$releasever|baseurl=https://vault.centos.org/7.9.2009|' -i *repo
 
     # Populate yum cache
-RUN yum makecache
+RUN    yum makecache \
+    # Make sure the image is built with the latest packages
+    && yum update -y

--- a/containers/centos/stream10/Containerfile
+++ b/containers/centos/stream10/Containerfile
@@ -7,4 +7,6 @@
 FROM quay.io/centos/centos:stream10
 
     # Populate dnf cache
-RUN dnf makecache
+RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y

--- a/containers/centos/stream10/Containerfile.upstream
+++ b/containers/centos/stream10/Containerfile.upstream
@@ -7,4 +7,6 @@
 FROM quay.io/centos/centos:stream10
 
     # Populate dnf cache
-RUN dnf makecache
+RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y

--- a/containers/centos/stream9/Containerfile
+++ b/containers/centos/stream9/Containerfile
@@ -7,4 +7,6 @@
 FROM quay.io/centos/centos:stream9
 
     # Populate dnf cache
-RUN dnf makecache
+RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y

--- a/containers/centos/stream9/Containerfile.upstream
+++ b/containers/centos/stream9/Containerfile.upstream
@@ -7,4 +7,6 @@
 FROM quay.io/centos/centos:stream9
 
     # Populate dnf cache
-RUN dnf makecache
+RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y

--- a/containers/debian/12.7/Containerfile.upstream
+++ b/containers/debian/12.7/Containerfile.upstream
@@ -7,4 +7,6 @@
 FROM docker.io/library/debian:12.7
 
     # Populate apt cache
-RUN apt update
+RUN    apt update \
+    # Make sure the image is built with the latest packages
+    && apt upgrade -y

--- a/containers/fedora/39/Containerfile
+++ b/containers/fedora/39/Containerfile
@@ -8,6 +8,8 @@ FROM quay.io/fedora/fedora:39
 
     # Populate dnf cache
 RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y \
     # Inject `dnf5` to make things more complicated for `dnf` family of
     # package manager implementations
     && dnf install -y dnf5

--- a/containers/fedora/39/Containerfile.unprivileged
+++ b/containers/fedora/39/Containerfile.unprivileged
@@ -8,6 +8,8 @@ FROM quay.io/fedora/fedora:39
 
     # Populate dnf cache
 RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y \
     # Create unprivileged user and setup sudo for it
     && dnf install -y /usr/sbin/useradd \
     && useradd fedora \

--- a/containers/fedora/39/Containerfile.upstream
+++ b/containers/fedora/39/Containerfile.upstream
@@ -7,4 +7,6 @@
 FROM quay.io/fedora/fedora:39
 
     # Populate dnf cache
-RUN dnf makecache
+RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y

--- a/containers/fedora/40/Containerfile
+++ b/containers/fedora/40/Containerfile
@@ -8,6 +8,8 @@ FROM quay.io/fedora/fedora:40
 
     # Populate dnf cache
 RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y \
     # Inject `dnf5` to make things more complicated for `dnf` family of
     # package manager implementations
     && dnf install -y dnf5

--- a/containers/fedora/40/Containerfile.unprivileged
+++ b/containers/fedora/40/Containerfile.unprivileged
@@ -8,6 +8,8 @@ FROM quay.io/fedora/fedora:40
 
     # Populate dnf cache
 RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y \
     # Create unprivileged user and setup sudo for it
     && dnf install -y /usr/sbin/useradd \
     && useradd fedora \

--- a/containers/fedora/40/Containerfile.upstream
+++ b/containers/fedora/40/Containerfile.upstream
@@ -7,4 +7,6 @@
 FROM quay.io/fedora/fedora:40
 
     # Populate dnf cache
-RUN dnf makecache
+RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y

--- a/containers/fedora/41/Containerfile
+++ b/containers/fedora/41/Containerfile
@@ -8,6 +8,8 @@ FROM quay.io/fedora/fedora:41
 
     # Populate dnf cache
 RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y \
     # Inject `dnf5` to make things more complicated for `dnf` family of
     # package manager implementations
     && dnf install -y dnf5

--- a/containers/fedora/41/Containerfile.unprivileged
+++ b/containers/fedora/41/Containerfile.unprivileged
@@ -8,6 +8,8 @@ FROM quay.io/fedora/fedora:41
 
     # Populate dnf cache
 RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y \
     # Create unprivileged user and setup sudo for it
     && dnf install -y /usr/sbin/useradd \
     && useradd fedora \

--- a/containers/fedora/41/Containerfile.upstream
+++ b/containers/fedora/41/Containerfile.upstream
@@ -7,4 +7,6 @@
 FROM quay.io/fedora/fedora:41
 
     # Populate dnf cache
-RUN dnf makecache
+RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y

--- a/containers/fedora/coreos/Containerfile
+++ b/containers/fedora/coreos/Containerfile
@@ -10,4 +10,6 @@ FROM quay.io/fedora/fedora-coreos:stable
     # manager implementation
 RUN    rpm-ostree install dnf5 \
     # Populate dnf cache
-    && dnf5 makecache
+    && dnf5 makecache \
+    # Make sure the image is built with the latest packages
+    && dnf5 update -y

--- a/containers/fedora/coreos/ostree/Containerfile
+++ b/containers/fedora/coreos/ostree/Containerfile
@@ -13,5 +13,7 @@ FROM quay.io/fedora/fedora-coreos:stable
 RUN    rpm-ostree install dnf5 \
     # Populate dnf cache
     && dnf5 makecache \
+    # Make sure the image is built with the latest packages
+    && dnf5 update -y \
     # Simulate ostree-booted environment
     && touch /run/ostree-booted

--- a/containers/fedora/rawhide/Containerfile
+++ b/containers/fedora/rawhide/Containerfile
@@ -8,6 +8,8 @@ FROM quay.io/fedora/fedora:rawhide
 
     # Populate dnf cache
 RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y \
     # Inject `dnf5` to make things more complicated for `dnf` family of
     # package manager implementations
     && dnf install -y dnf5

--- a/containers/fedora/rawhide/Containerfile.unprivileged
+++ b/containers/fedora/rawhide/Containerfile.unprivileged
@@ -8,6 +8,8 @@ FROM quay.io/fedora/fedora:rawhide
 
     # Populate dnf cache
 RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y \
     # Create unprivileged user and setup sudo for it
     && dnf install -y /usr/sbin/useradd \
     && useradd fedora \

--- a/containers/fedora/rawhide/Containerfile.upstream
+++ b/containers/fedora/rawhide/Containerfile.upstream
@@ -7,4 +7,6 @@
 FROM quay.io/fedora/fedora:rawhide
 
     # Populate dnf cache
-RUN dnf makecache
+RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y \

--- a/containers/ubi/8/Containerfile.upstream
+++ b/containers/ubi/8/Containerfile.upstream
@@ -7,4 +7,6 @@
 FROM registry.access.redhat.com/ubi8:latest
 
     # Populate yum cache
-RUN dnf makecache
+RUN    dnf makecache \
+    # Make sure the image is built with the latest packages
+    && dnf update -y

--- a/containers/ubuntu/22.04/Containerfile.upstream
+++ b/containers/ubuntu/22.04/Containerfile.upstream
@@ -7,4 +7,6 @@
 FROM docker.io/library/ubuntu:22.04
 
     # Populate apt cache
-RUN apt update
+RUN    apt update \
+    # Make sure the image is built with the latest packages
+    && apt upgrade -y

--- a/tests/finish/ansible/main.fmf
+++ b/tests/finish/ansible/main.fmf
@@ -11,3 +11,9 @@ tag+:
   - provision-local
   - provision-virtual
 duration: 30m
+adjust+:
+  - check:
+      - how: avc
+        result: xfail
+    when: provision_how == container
+    because: https://bugzilla.redhat.com/show_bug.cgi?id=2342247

--- a/tests/prepare/install/main.fmf
+++ b/tests/prepare/install/main.fmf
@@ -12,3 +12,10 @@ tag+:
 
 # TODO: what test cases are safe enough to be executed against the localhost?
 #  - provision-local
+
+adjust+:
+  - check:
+      - how: avc
+        result: xfail
+    when: provision_how == container
+    because: https://bugzilla.redhat.com/show_bug.cgi?id=2342247

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -37,6 +37,11 @@ require+:
 
         enabled: true
 
+      - check:
+          - how: avc
+            result: xfail
+        because: https://bugzilla.redhat.com/show_bug.cgi?id=2342247
+
     /basic:
         summary: Basic unit tests (development packages)
         tier: 0
@@ -65,6 +70,11 @@ require+:
         because: Enable in CI only
 
         enabled: true
+
+      - check:
+          - how: avc
+            result: xfail
+        because: https://bugzilla.redhat.com/show_bug.cgi?id=2342247
 
     /basic:
         summary: Basic unit tests (system packages)


### PR DESCRIPTION
The tests rely on images to be up-to-date and looks recently on Rawhide the images are outdated, causing issues for the tests, which expect the `grep` and `tar` to match what is installed.

The packages were updated to new versions on 17th/19th January.


