### PR TITLE
Update the latest fedora alias in `mrack` config

### DIFF
--- a/tmt/steps/provision/mrack/mrack-provisioning-config.yaml
+++ b/tmt/steps/provision/mrack/mrack-provisioning-config.yaml
@@ -63,8 +63,10 @@ beaker:
         fedora-38: Fedora-38%
         fedora-39: Fedora-39%
         fedora-40: Fedora-40%
-        fedora-latest: Fedora-40%
-        fedora: Fedora-40%
+        fedora-41: Fedora-41%
+        fedora-42: Fedora-42%
+        fedora-latest: Fedora-41%
+        fedora: Fedora-41%
         fedora-rawhide: Fedora-Rawhide-%
 
     distro_variants:


### PR DESCRIPTION
As for now this has to be done manually. Would be nice to find some automated solution for the latest image.

Pull Request Checklist

* [x] implement the feature