### PR TITLE
Use custom option type for workdir root to deliver `Path` instances

### DIFF
--- a/tmt/cli/_root.py
+++ b/tmt/cli/_root.py
@@ -229,13 +229,11 @@ def main(
 @verbosity_options
 @force_dry_options
 @again_option
-def run(context: Context, id_: Optional[str], _workdir_root: Optional[str], **kwargs: Any) -> None:
+def run(context: Context, id_: Optional[str], workdir_root: Optional[Path], **kwargs: Any) -> None:
     """ Run test steps. """
     # Initialize
     logger = context.obj.logger.descend(logger_name='run', extra_shift=0)
     logger.apply_verbosity_options(**kwargs)
-
-    workdir_root = Path(_workdir_root) if _workdir_root is not None else None
 
     run = tmt.Run(
         id_=Path(id_) if id_ is not None else None,
@@ -1257,7 +1255,7 @@ def clean(context: Context,
           id_: tuple[str, ...],
           keep: Optional[int],
           skip: list[str],
-          _workdir_root: Optional[str],
+          workdir_root: Optional[Path],
           **kwargs: Any) -> None:
     """
     Clean workdirs, guests or images.
@@ -1274,7 +1272,6 @@ def clean(context: Context,
     if last and id_:
         raise tmt.utils.GeneralError(
             "Options --last and --id cannot be used together.")
-    workdir_root = Path(_workdir_root) if _workdir_root is not None else None
     if workdir_root and not workdir_root.exists():
         raise tmt.utils.GeneralError(f"Path '{workdir_root}' doesn't exist.")
 
@@ -1354,7 +1351,7 @@ def perform_clean(
 @dry_options
 def clean_runs(
         context: Context,
-        _workdir_root: Optional[str],
+        workdir_root: Optional[Path],
         last: bool,
         id_: tuple[str, ...],
         keep: Optional[int],
@@ -1370,7 +1367,6 @@ def clean_runs(
             "Options --last, --id and --keep cannot be used together.")
     if keep is not None and keep < 0:
         raise tmt.utils.GeneralError("--keep must not be a negative number.")
-    workdir_root = Path(_workdir_root) if _workdir_root is not None else None
     if workdir_root and not workdir_root.exists():
         raise tmt.utils.GeneralError(f"Path '{workdir_root}' doesn't exist.")
 
@@ -1407,7 +1403,7 @@ def clean_runs(
 @dry_options
 def clean_guests(
         context: Context,
-        _workdir_root: Optional[str],
+        workdir_root: Optional[Path],
         last: bool,
         id_: tuple[str, ...],
         keep: Optional[int],
@@ -1420,7 +1416,6 @@ def clean_guests(
     if last and bool(id_):
         raise tmt.utils.GeneralError(
             "Options --last and --id cannot be used together.")
-    workdir_root = Path(_workdir_root) if _workdir_root is not None else None
     if workdir_root and not workdir_root.exists():
         raise tmt.utils.GeneralError(f"Path '{workdir_root}' doesn't exist.")
 

--- a/tmt/cli/status.py
+++ b/tmt/cli/status.py
@@ -27,7 +27,7 @@ from tmt.utils import Path, effective_workdir_root
 @verbosity_options
 def status(
         context: Context,
-        _workdir_root: Optional[str],
+        workdir_root: Optional[Path],
         abandoned: bool,
         active: bool,
         finished: bool,
@@ -50,7 +50,6 @@ def status(
             "Options --abandoned, --active and --finished cannot be "
             "used together.")
 
-    workdir_root = Path(_workdir_root) if _workdir_root is not None else None
     if workdir_root and not workdir_root.exists():
         raise tmt.utils.GeneralError(f"Path '{workdir_root}' doesn't exist.")
     status_obj = tmt.Status(

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -238,7 +238,7 @@ FIX_OPTIONS: list[ClickOptionDecoratorType] = [
 
 WORKDIR_ROOT_OPTIONS: list[ClickOptionDecoratorType] = [
     option(
-        '--workdir-root', '_workdir_root',
+        '--workdir-root',
         metavar='PATH',
         envvar='TMT_WORKDIR_ROOT',
         default=tmt.utils.WORKDIR_ROOT,

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import dataclasses
+import pathlib
 import re
 import textwrap
 from collections.abc import Sequence
@@ -44,6 +45,60 @@ class Deprecated:
             message = f'{message}, {self.hint}'
 
         return f'{message}.'
+
+
+class Path(click.ParamType):
+    name = 'path'
+
+    def convert(
+            self,
+            value: Any,
+            param: Optional[click.Parameter],
+            ctx: Optional[click.Context]
+            ) -> Optional[tmt.utils.Path]:
+        """Convert the value to the correct type. This is not called if
+        the value is ``None`` (the missing value).
+
+        This must accept string values from the command line, as well as
+        values that are already the correct type. It may also convert
+        other compatible types.
+
+        The ``param`` and ``ctx`` arguments may be ``None`` in certain
+        situations, such as when converting prompt input.
+
+        If the value cannot be converted, call :meth:`fail` with a
+        descriptive message.
+
+        :param value: The value to convert.
+        :param param: The parameter that is using this type to convert
+            its value. May be ``None``.
+        :param ctx: The current context that arrived at this value. May
+            be ``None``.
+        """
+
+        if value is None:
+            return None
+
+        if isinstance(value, str):
+            return tmt.utils.Path(value)
+
+        if isinstance(value, tmt.utils.Path):
+            return value
+
+        if isinstance(value, pathlib.Path):  # noqa: TID251
+            return tmt.utils.Path(str(value))
+
+        if param is None:
+            self.fail(
+                f"A path-like string was expected, '{type(value).__name__}' found.",
+                param=param,
+                ctx=ctx)
+
+        # RET503: ruff does not recognize NoReturn annotation of `self.fail`.
+        self.fail(  # noqa: RET503
+            f"Field '{param.name}' must be a path-like string, '{type(value).__name__}' found.",
+            param=param,
+            ctx=ctx)
 
 
 MethodDictType = dict[str, click.core.Command]
@@ -187,6 +242,7 @@ WORKDIR_ROOT_OPTIONS: list[ClickOptionDecoratorType] = [
         metavar='PATH',
         envvar='TMT_WORKDIR_ROOT',
         default=tmt.utils.WORKDIR_ROOT,
+        type=Path(),
         help=f"""
              Path to root directory containing run workdirs.
              Defaults to '{tmt.utils.WORKDIR_ROOT}'.


### PR DESCRIPTION
Instead of strings needing to convert to paths "manually", we can ask to Click to use a custom type that would do the conversion for us, delivering `Path` instances to our commands.

Pull Request Checklist

* [x] implement the feature