### PR TITLE
Execute must not use discover phases disabled by their `when`

### DIFF
--- a/tests/steps/when/data/plan.fmf
+++ b/tests/steps/when/data/plan.fmf
@@ -1,32 +1,52 @@
 execute:
   how: tmt
 
-discover:
-  how: shell
-  tests:
-    - name: /
-      test: touch $TMT_PLAN_DATA/when-in-discover
-  when: trigger == commit
-
 provision:
   how: local
 
-prepare:
-  - how: shell
-    script: touch $TMT_PLAN_DATA/when-prepare-always
-  - how: shell
-    script: touch $TMT_PLAN_DATA/when-prepare-fedora
-    when: distro == fedora
+/sanity:
+  discover:
+    how: shell
+    tests:
+      - name: /
+        test: touch $TMT_PLAN_DATA/when-in-discover
+    when: trigger == commit
 
-finish:
-  - how: shell
-    script: touch $TMT_PLAN_DATA/when-finish-no-distro
-    when:
-    - initiator == human
-    - distro is not defined
+  prepare:
+    - how: shell
+      script: touch $TMT_PLAN_DATA/when-prepare-always
+    - how: shell
+      script: touch $TMT_PLAN_DATA/when-prepare-fedora
+      when: distro == fedora
 
-report:
-  - how: junit
-    file: $TMT_PLAN_DATA/when-report-fedora
-    when: distro == fedora
-  - how: display
+  finish:
+    - how: shell
+      script: touch $TMT_PLAN_DATA/when-finish-no-distro
+      when:
+      - initiator == human
+      - distro is not defined
+
+  report:
+    - how: junit
+      file: $TMT_PLAN_DATA/when-report-fedora
+      when: distro == fedora
+    - how: display
+
+/execute-must-obey:
+  link:
+    - verifies: https://github.com/teemtee/tmt/issues/3492
+
+  discover:
+      - how: shell
+        name: shell-not-run
+        tests:
+         - name: nope
+           test: echo
+        when: flag == on
+
+      - how: shell
+        name: shell-run
+        tests:
+         - name: yes
+           test: echo
+        when: flag is not defined

--- a/tests/steps/when/test.sh
+++ b/tests/steps/when/test.sh
@@ -12,27 +12,33 @@ rlJournalStart
 
     rlPhaseStartTest
         # No tests discovered
-        rlRun -s "tmt run --id $tmp/no-context" "3"
+        rlRun -s "tmt run --id $tmp/no-context plan -n '/sanity'" "3"
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun -s "tmt -c distro=fedora -c trigger=commit run --id $tmp/distro-trigger-context"
-        rlAssertExists "$tmp/distro-trigger-context/plan/data/when-in-discover"
-        rlAssertExists "$tmp/distro-trigger-context/plan/data/when-prepare-always"
-        rlAssertExists "$tmp/distro-trigger-context/plan/data/when-prepare-fedora"
-        rlAssertExists "$tmp/distro-trigger-context/plan/data/when-report-fedora"
-        rlAssertNotExists "$tmp/distro-trigger-context/plan/data/when-finish-no-distro"
+        rlRun -s "tmt -c distro=fedora -c trigger=commit run --id $tmp/distro-trigger-context plan -n '/sanity'"
+        rlAssertExists "$tmp/distro-trigger-context/plan/sanity/data/when-in-discover"
+        rlAssertExists "$tmp/distro-trigger-context/plan/sanity/data/when-prepare-always"
+        rlAssertExists "$tmp/distro-trigger-context/plan/sanity/data/when-prepare-fedora"
+        rlAssertExists "$tmp/distro-trigger-context/plan/sanity/data/when-report-fedora"
+        rlAssertNotExists "$tmp/distro-trigger-context/plan/sanity/data/when-finish-no-distro"
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun -s "tmt -c trigger=commit run --id $tmp/trigger-context"
-        rlAssertExists "$tmp/trigger-context/plan/data/when-in-discover"
-        rlAssertExists "$tmp/trigger-context/plan/data/when-prepare-always"
-        rlAssertNotExists "$tmp/trigger-context/plan/data/when-prepare-fedora"
-        rlAssertNotExists "$tmp/trigger-context/plan/data/when-report-fedora"
-        rlAssertExists "$tmp/trigger-context/plan/data/when-finish-no-distro"
+        rlRun -s "tmt -c trigger=commit run --id $tmp/trigger-context plan -n '/sanity'"
+        rlAssertExists "$tmp/trigger-context/plan/sanity/data/when-in-discover"
+        rlAssertExists "$tmp/trigger-context/plan/sanity/data/when-prepare-always"
+        rlAssertNotExists "$tmp/trigger-context/plan/sanity/data/when-prepare-fedora"
+        rlAssertNotExists "$tmp/trigger-context/plan/sanity/data/when-report-fedora"
+        rlAssertExists "$tmp/trigger-context/plan/sanity/data/when-finish-no-distro"
     rlPhaseEnd
 
+    rlPhaseStartTest
+        rlRun -s "tmt run --id $tmp/execute-must-obey plan -n '/execute-must-obey'"
+        rlAssertExists "$tmp/execute-must-obey/plan/execute-must-obey/execute/data/guest/default-0/shell-run"
+        rlAssertExists "$tmp/execute-must-obey/plan/execute-must-obey/execute/data/guest/default-0/shell-run/yes-1/output.txt"
+        rlAssertNotExists "$tmp/execute-must-obey/plan/execute-must-obey/execute/data/guest/default-0/shell-not-run"
+    rlPhaseEnd
 
     rlPhaseStartCleanup
         rlRun "popd"

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1171,6 +1171,9 @@ class Execute(tmt.steps.Step):
                 # plugin, so we could point it to that discover phase rather than
                 # let is "see" all tests, or test in different discover phase.
                 for discover in self.plan.discover.phases(classes=(DiscoverPlugin,)):
+                    if not discover.enabled_by_when:
+                        continue
+
                     phase_copy = cast(ExecutePlugin[ExecuteStepData], copy.copy(phase))
                     phase_copy.discover_phase = discover.name
 


### PR DESCRIPTION
This seems to be an omission from when `when` was added: it is evaluated by tmt, not by fmf, disabled phases are still present in the tree of steps and phases. Most places already ignore them, but `execute` did not. `execute` runs its single phase with all `discover` phases in sequence, and must make sure it does not try to run the disabled ones.

Fixes #3492.

Pull Request Checklist

* [x] implement the feature