### PR TITLE
Polish docker/podman images

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,8 +13,7 @@ jobs:
     steps:
     # Required because of https://github.com/hadolint/hadolint/issues/886
     - run: |
-        wget -O /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
-        chmod +x /usr/local/bin/hadolint
+        dnf install -y hadolint
     - uses: actions/checkout@v4
       with:
         persist-credentials: false

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
     # Required because of https://github.com/hadolint/hadolint/issues/886
     - run: |
-        dnf install -y hadolint
+        wget -O /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/latest/hadolint-Linux-x86_64
+        chmod +x /usr/local/bin/hadolint
     - uses: actions/checkout@v4
       with:
         persist-credentials: false

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,10 @@ jobs:
     env:
       SKIP: no-commit-to-branch
     steps:
+    # Required because of https://github.com/hadolint/hadolint/issues/886
+    - run: |
+        wget -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+        chmod +x /bin/hadolint
     - uses: actions/checkout@v4
       with:
         persist-credentials: false

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     # Required because of https://github.com/hadolint/hadolint/issues/886
     - run: |
-        wget -O /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/latest/hadolint-Linux-x86_64
+        wget -O /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
         chmod +x /usr/local/bin/hadolint
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
     # Required because of https://github.com/hadolint/hadolint/issues/886
     - run: |
-        wget -O /bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
-        chmod +x /bin/hadolint
+        wget -O /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+        chmod +x /usr/local/bin/hadolint
     - uses: actions/checkout@v4
       with:
         persist-credentials: false

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,13 @@
+# See https://github.com/hadolint/hadolint?tab=readme-ov-file#configure
+failure-threshold: style
+format: tty
+ignored:
+  # Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag.
+  - DL3007
+  # Pin versions in apk add
+  - DL3018
+  # Specify version with dnf install -y <package>-<version>
+  - DL3041
+strict-labels: true
+disable-ignore-pragma: false
+trustedRegistries: []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -195,5 +195,13 @@ repos:
   - repo: https://github.com/hadolint/hadolint
     rev: v2.12.0
     hooks:
+      # * hadolint-docker depends hard on Docker, ignores podman
+      # * pre-commit check does not install hadolint binary,
+      #   see https://github.com/hadolint/hadolint/issues/886
+      #
+      # As of now, installing hadolint "manually" is the only viable
+      # option. It is required to exist on developer's workstation,
+      # and it is installed by a dedicated step in Github pre-commit
+      # action (.github/workflows/pre-commit.yml).
       - id: hadolint
         files: ^containers/.*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -191,3 +191,9 @@ repos:
           - jinja-variable-lower-case
           - single-statement-per-line
           - "--"
+
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint
+        files: ^containers/.*

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ images/test/bases:  ## Download base images for custom test images
 
 # Build a single container: <image name> <containerfile>
 define do-build-container-image =
-@ echo "$(ccgreen)Building $(ccred)${1}$(ccend) $(ccgreen)image...$(ccend)"
+@ echo "$(ccgreen)Building$(ccend) $(ccred)${1}$(ccend) $(ccgreen)image...$(ccend)"
 podman build --squash -t ${1} -f ./containers/${2} .
 @ echo
 endef

--- a/Makefile
+++ b/Makefile
@@ -82,14 +82,33 @@ ver2spec:
 ##
 ## Containers
 ##
-images:  ## Build tmt images for podman/docker
-	podman build -t tmt --squash -f ./containers/Containerfile.mini .
-	podman build -t tmt-all --squash -f ./containers/Containerfile.full .
 
+# Base images of our tmt container images, collected from `FROM ...` directives in Containerfiles.
+TMT_DISTRO_IMAGE_BASES = $(shell grep -h 'FROM ' containers/Containerfile.* | cut -d' ' -f2 | sort | uniq)
+
+# All tmt image targets will begin with this string.
+TMT_DISTRO_IMAGE_TARGET_PREFIX = images
+
+# All tmt container images will begin with this string.
+TMT_DISTRO_CONTAINER_IMAGE_NAME_PREFIX = tmt/container
+
+# The list of tmt container images.
+TMT_DISTRO_CONTAINER_IMAGES := $(TMT_DISTRO_CONTAINER_IMAGE_NAME_PREFIX)/tmt:latest \
+                               $(TMT_DISTRO_CONTAINER_IMAGE_NAME_PREFIX)/tmt-all:latest
+
+# The list of targets building individual tmt images.
+TMT_DISTRO_IMAGES_TARGETS := $(foreach image,$(TMT_DISTRO_CONTAINER_IMAGES),images/$(subst :,\:,$(image)))
+
+# Base images of our test images, collected from `FROM ...` directives in Containerfiles
 TMT_TEST_IMAGE_BASES = $(shell grep -rh 'FROM ' containers/ | cut -d' ' -f2 | sort | uniq)
-TMT_TEST_IMAGE_TARGET_PREFIX = images-tests
-TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX = tmt/tests/container
 
+# All tmt test image targets will begin with this string.
+TMT_TEST_IMAGE_TARGET_PREFIX = images/test
+
+# All tmt test container images will begin with this string.
+TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX = tmt/container/test
+
+# The list of tmt test container images.
 TMT_TEST_CONTAINER_IMAGES := $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/alpine:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/alpine/upstream:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/centos/7:latest \
@@ -116,23 +135,50 @@ TMT_TEST_CONTAINER_IMAGES := $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/alpine:late
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/ubuntu/22.04/upstream:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/debian/12.7/upstream:latest
 
-TMT_TEST_IMAGES_TARGETS := $(foreach image,$(TMT_TEST_CONTAINER_IMAGES),images-tests/$(subst :,\:,$(image)))
+# The list of targets building individual tmt test images.
+TMT_TEST_IMAGES_TARGETS := $(foreach image,$(TMT_TEST_CONTAINER_IMAGES),images/test/$(subst :,\:,$(image)))
 
-images-tests: $(TMT_TEST_IMAGES_TARGETS)  ## Build customized images for tests
+images: $(TMT_DISTRO_IMAGES_TARGETS)  ## Build tmt images for podman/docker
+	podman images | grep 'localhost/$(TMT_DISTRO_CONTAINER_IMAGE_NAME_PREFIX)/' | sort
+
+images/test: $(TMT_TEST_IMAGES_TARGETS)  ## Build customized images for tests
 	podman images | grep 'localhost/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/' | sort
 
-images-tests-bases:  ## Download base images for custom test images
+images/test/bases:  ## Download base images for custom test images
 	podman pull $(TMT_TEST_IMAGE_BASES)
 
+# Build a single container: <image name> <containerfile>
+define do-build-container-image =
+@ echo "$(ccgreen)Building $(ccred)${1}$(ccend) $(ccgreen)image...$(ccend)"
+podman build --squash -t ${1} -f ./containers/${2} .
+@ echo
+endef
+
+# Return an image name from the given target: <image target>
+define container-image-target-to-name =
+$(subst $(TMT_DISTRO_IMAGE_TARGET_PREFIX)/,,${1})
+endef
+
+# Return a test image name from the given target: <image target>
 define test-container-image-target-to-name =
 $(subst $(TMT_TEST_IMAGE_TARGET_PREFIX)/,,${1})
 endef
 
-define build-test-container-image =
-@ echo "$(ccgreen)Building $(ccred)$(call test-container-image-target-to-name,$@)$(ccend) $(ccgreen)image...$(ccend)"
-podman build -t $(call test-container-image-target-to-name,${1}) -f ./containers/${2} .
-@ echo
+# Build tmt image: <image name> <containerfile>
+define build-container-image =
+$(call do-build-container-image,$(call container-image-target-to-name,${1}),${2})
 endef
+
+# Build tmt test image: <image name> <containerfile>
+define build-test-container-image =
+$(call do-build-container-image,$(call test-container-image-target-to-name,${1}),${2})
+endef
+
+$(TMT_DISTRO_IMAGE_TARGET_PREFIX)/$(TMT_DISTRO_CONTAINER_IMAGE_NAME_PREFIX)/tmt\:latest:
+	$(call build-container-image,$@,Containerfile.mini)
+
+$(TMT_DISTRO_IMAGE_TARGET_PREFIX)/$(TMT_DISTRO_CONTAINER_IMAGE_NAME_PREFIX)/tmt-all\:latest:
+	$(call build-container-image,$@,Containerfile.full)
 
 $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/alpine\:latest:
 	$(call build-test-container-image,$@,alpine/Containerfile)
@@ -231,7 +277,12 @@ clean:  ## Remove all temporary files, packaging artifacts and docs
 	rm -rf examples/convert/{main.fmf,test.md,Manual} Manual
 	rm -f tests/full/repo_copy.tgz
 
-clean-test-images:  ## Remove all custom images built for tests
+clean/images:  ## Remove tmt images
+	for image in $(TMT_DISTRO_CONTAINER_IMAGES); do \
+	    podman rmi -i "$$image"; \
+	done
+
+clean/images/test:  ## Remove all custom images built for tests
 	for image in $(TMT_TEST_CONTAINER_IMAGES); do \
 	    podman rmi -i "$$image"; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/debian/1
 ## Development
 ##
 develop: _deps  ## Install development requirements
-	sudo dnf install -y expect gcc git python3-nitrate {libvirt,krb5,libpq,python3}-devel jq podman buildah /usr/bin/python3.9
+	sudo dnf install -y expect gcc git python3-nitrate {libvirt,krb5,libpq,python3}-devel jq podman buildah hadolint /usr/bin/python3.9
 
 # Git vim tags and cleanup
 tags:

--- a/containers/Containerfile.full
+++ b/containers/Containerfile.full
@@ -1,6 +1,5 @@
 FROM registry.fedoraproject.org/fedora:latest
 
-# hadolint ignore=DL3040
 RUN <<EOF
 set -ex
 
@@ -13,6 +12,7 @@ dnf install -y dnf-plugins-core
 dnf copr enable -y @teemtee/stable
 dnf install -y tmt+all-[0-9].[0-9][0-9].[0-9]* beakerlib
 dnf autoremove -y
+dnf clean all
 
 # Prepare a directory for experimenting
 mkdir /tmt

--- a/containers/Containerfile.full
+++ b/containers/Containerfile.full
@@ -1,20 +1,24 @@
-FROM registry.fedoraproject.org/fedora
+FROM registry.fedoraproject.org/fedora:latest
+
+# hadolint ignore=DL3040
+RUN <<EOF
+set -ex
 
 # Adjust system defaults
-RUN set -x && \
-    sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf && \
-    echo "Set disable_coredump false" >> /etc/sudo.conf
+sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf
+echo "Set disable_coredump false" >> /etc/sudo.conf
 
 # Install necessary packages
-RUN set -x && \
-    dnf install -y dnf-plugins-core && \
-    dnf copr enable -y @teemtee/stable && \
-    dnf install -y tmt+all-[0-9].[0-9][0-9].[0-9]* beakerlib && \
-    dnf autoremove -y && \
-    dnf clean all
+dnf install -y dnf-plugins-core
+dnf copr enable -y @teemtee/stable
+dnf install -y tmt+all-[0-9].[0-9][0-9].[0-9]* beakerlib
+dnf autoremove -y
+
+# Prepare a directory for experimenting
+mkdir /tmt
+EOF
 
 # Prepare files for experimenting
-RUN mkdir /tmt
 COPY .fmf /tmt/.fmf
 COPY tests /tmt/tests
 COPY plans /tmt/plans
@@ -22,4 +26,4 @@ COPY stories /tmt/stories
 
 # Run all plans under the regular user by default
 WORKDIR /tmt
-CMD tmt run -av provision -h local
+CMD ["tmt", "run", "-av", "provision", "-h", "local"]

--- a/containers/Containerfile.mini
+++ b/containers/Containerfile.mini
@@ -1,20 +1,24 @@
-FROM registry.fedoraproject.org/fedora
+FROM registry.fedoraproject.org/fedora:latest
+
+RUN <<EOF
+set -ex
 
 # Adjust system defaults
-RUN set -x && \
-    sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf && \
-    echo "Set disable_coredump false" >> /etc/sudo.conf
+sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf
+echo "Set disable_coredump false" >> /etc/sudo.conf
 
 # Install necessary packages
-RUN set -x && \
-    dnf install -y dnf-plugins-core && \
-    dnf copr enable -y @teemtee/stable && \
-    dnf install -y tmt-[0-9].[0-9][0-9].[0-9]* && \
-    dnf autoremove -y && \
-    dnf clean all
+dnf install -y dnf-plugins-core
+dnf copr enable -y @teemtee/stable
+dnf install -y tmt-[0-9].[0-9][0-9].[0-9]*
+dnf autoremove -y
+dnf clean all
+
+# Prepare a directory for experimenting
+mkdir /tmt
+EOF
 
 # Prepare files for experimenting
-RUN mkdir /tmt
 COPY .fmf /tmt/.fmf
 COPY tests /tmt/tests
 COPY plans/main.fmf /tmt/plans/main.fmf
@@ -22,4 +26,4 @@ COPY plans/features/core.fmf /tmt/plans/core.fmf
 
 # Run all plans under the regular user by default
 WORKDIR /tmt
-CMD tmt run -av provision -h local
+CMD ["tmt", "run", "-av", "provision", "-h", "local"]

--- a/containers/alpine/Containerfile
+++ b/containers/alpine/Containerfile
@@ -6,9 +6,15 @@
 
 FROM docker.io/library/alpine:3.19
 
-    # Populate apk cache
-RUN    apk update \
-    # Make sure the image is built with the latest packages
-    && apk upgrade \
-    # Inject `bash` which is unavoidably required by tmt
-    && apk add --no-cache bash
+RUN <<EOF
+set -ex
+
+# Populate apk cache
+apk update
+
+# Make sure the image is built with the latest packages
+apk upgrade
+
+# Inject `bash` which is unavoidably required by tmt
+apk add --no-cache bash
+EOF

--- a/containers/alpine/Containerfile.upstream
+++ b/containers/alpine/Containerfile.upstream
@@ -6,7 +6,12 @@
 
 FROM docker.io/library/alpine:3.19
 
-    # Populate apk cache
-RUN    apk update \
-    # Make sure the image is built with the latest packages
-    && apk upgrade
+RUN <<EOF
+set -ex
+
+# Populate apk cache
+apk update
+
+# Make sure the image is built with the latest packages
+apk upgrade
+EOF

--- a/containers/centos/7/Containerfile
+++ b/containers/centos/7/Containerfile
@@ -6,12 +6,21 @@
 
 FROM quay.io/centos/centos:7
 
-# Use latest vault repos, mirrors are gone after centos EOL
-RUN cd /etc/yum.repos.d/ \
-    && sed '/mirrorlist/d' -i *repo \
-    && sed 's|#baseurl=http://mirror.centos.org/centos/$releasever|baseurl=https://vault.centos.org/7.9.2009|' -i *repo
+# hadolint ignore=SC2016
+RUN <<EOF
+set -ex
 
-    # Populate yum cache
-RUN    yum makecache \
-    # Make sure the image is built with the latest packages
-    && yum update -y
+# Use latest vault repos, mirrors are gone after centos EOL
+sed '/mirrorlist/d' -i /etc/yum.repos.d/*repo
+sed 's|#baseurl=http://mirror.centos.org/centos/$releasever|baseurl=https://vault.centos.org/7.9.2009|' -i /etc/yum.repos.d/*repo
+EOF
+
+RUN <<EOF
+set -ex
+
+# Populate yum cache
+yum makecache
+
+# Make sure the image is built with the latest packages
+yum update -y
+EOF

--- a/containers/centos/7/Containerfile.upstream
+++ b/containers/centos/7/Containerfile.upstream
@@ -6,12 +6,21 @@
 
 FROM quay.io/centos/centos:7
 
-# Use latest vault repos, mirrors are gone after centos EOL
-RUN cd /etc/yum.repos.d/ \
-    && sed '/mirrorlist/d' -i *repo \
-    && sed 's|#baseurl=http://mirror.centos.org/centos/$releasever|baseurl=https://vault.centos.org/7.9.2009|' -i *repo
+# hadolint ignore=SC2016
+RUN <<EOF
+set -ex
 
-    # Populate yum cache
-RUN    yum makecache \
-    # Make sure the image is built with the latest packages
-    && yum update -y
+# Use latest vault repos, mirrors are gone after centos EOL
+sed '/mirrorlist/d' -i /etc/yum.repos.d/*repo
+sed 's|#baseurl=http://mirror.centos.org/centos/$releasever|baseurl=https://vault.centos.org/7.9.2009|' -i /etc/yum.repos.d/*repo
+EOF
+
+RUN <<EOF
+set -ex
+
+# Populate yum cache
+yum makecache
+
+# Make sure the image is built with the latest packages
+yum update -y
+EOF

--- a/containers/centos/stream10/Containerfile
+++ b/containers/centos/stream10/Containerfile
@@ -6,7 +6,12 @@
 
 FROM quay.io/centos/centos:stream10
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+EOF

--- a/containers/centos/stream10/Containerfile.upstream
+++ b/containers/centos/stream10/Containerfile.upstream
@@ -6,7 +6,12 @@
 
 FROM quay.io/centos/centos:stream10
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+EOF

--- a/containers/centos/stream9/Containerfile
+++ b/containers/centos/stream9/Containerfile
@@ -6,7 +6,12 @@
 
 FROM quay.io/centos/centos:stream9
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+EOF

--- a/containers/centos/stream9/Containerfile.upstream
+++ b/containers/centos/stream9/Containerfile.upstream
@@ -6,7 +6,12 @@
 
 FROM quay.io/centos/centos:stream9
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+EOF

--- a/containers/debian/12.7/Containerfile.upstream
+++ b/containers/debian/12.7/Containerfile.upstream
@@ -6,7 +6,13 @@
 
 FROM docker.io/library/debian:12.7
 
-    # Populate apt cache
-RUN    apt update \
-    # Make sure the image is built with the latest packages
-    && apt upgrade -y
+# hadolint ignore=DL3009
+RUN <<EOF
+set -ex
+
+# Populate apt cache
+apt-get update
+
+# Make sure the image is built with the latest packages
+apt-get upgrade -y
+EOF

--- a/containers/fedora/39/Containerfile
+++ b/containers/fedora/39/Containerfile
@@ -6,10 +6,17 @@
 
 FROM quay.io/fedora/fedora:39
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y \
-    # Inject `dnf5` to make things more complicated for `dnf` family of
-    # package manager implementations
-    && dnf install -y dnf5
+# hadolint ignore=DL3040
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+
+# Inject `dnf5` to make things more complicated for `dnf` family of
+# package manager implementations
+dnf install -y dnf5
+EOF

--- a/containers/fedora/39/Containerfile.unprivileged
+++ b/containers/fedora/39/Containerfile.unprivileged
@@ -6,14 +6,21 @@
 
 FROM quay.io/fedora/fedora:39
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y \
-    # Create unprivileged user and setup sudo for it
-    && dnf install -y /usr/sbin/useradd \
-    && useradd fedora \
-    && usermod -aG wheel fedora \
-    && echo -e 'fedora\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
+# hadolint ignore=DL3040
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+
+# Create unprivileged user and setup sudo for it
+dnf install -y /usr/sbin/useradd
+useradd fedora
+usermod -aG wheel fedora
+printf "fedora\tALL=(ALL)\tNOPASSWD: ALL" >> /etc/sudoers
+EOF
 
 USER fedora

--- a/containers/fedora/39/Containerfile.upstream
+++ b/containers/fedora/39/Containerfile.upstream
@@ -6,7 +6,12 @@
 
 FROM quay.io/fedora/fedora:39
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+EOF

--- a/containers/fedora/40/Containerfile
+++ b/containers/fedora/40/Containerfile
@@ -6,10 +6,17 @@
 
 FROM quay.io/fedora/fedora:40
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y \
-    # Inject `dnf5` to make things more complicated for `dnf` family of
-    # package manager implementations
-    && dnf install -y dnf5
+# hadolint ignore=DL3040
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+
+# Inject `dnf5` to make things more complicated for `dnf` family of
+# package manager implementations
+dnf install -y dnf5
+EOF

--- a/containers/fedora/40/Containerfile.unprivileged
+++ b/containers/fedora/40/Containerfile.unprivileged
@@ -6,14 +6,21 @@
 
 FROM quay.io/fedora/fedora:40
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y \
-    # Create unprivileged user and setup sudo for it
-    && dnf install -y /usr/sbin/useradd \
-    && useradd fedora \
-    && usermod -aG wheel fedora \
-    && echo -e 'fedora\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
+# hadolint ignore=DL3040
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+
+# Create unprivileged user and setup sudo for it
+dnf install -y /usr/sbin/useradd
+useradd fedora
+usermod -aG wheel fedora
+printf "fedora\tALL=(ALL)\tNOPASSWD: ALL" >> /etc/sudoers
+EOF
 
 USER fedora

--- a/containers/fedora/40/Containerfile.upstream
+++ b/containers/fedora/40/Containerfile.upstream
@@ -6,7 +6,12 @@
 
 FROM quay.io/fedora/fedora:40
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+EOF

--- a/containers/fedora/41/Containerfile
+++ b/containers/fedora/41/Containerfile
@@ -6,10 +6,17 @@
 
 FROM quay.io/fedora/fedora:41
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y \
-    # Inject `dnf5` to make things more complicated for `dnf` family of
-    # package manager implementations
-    && dnf install -y dnf5
+# hadolint ignore=DL3040
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+
+# Inject `dnf5` to make things more complicated for `dnf` family of
+# package manager implementations
+dnf install -y dnf5
+EOF

--- a/containers/fedora/41/Containerfile.unprivileged
+++ b/containers/fedora/41/Containerfile.unprivileged
@@ -6,14 +6,21 @@
 
 FROM quay.io/fedora/fedora:41
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y \
-    # Create unprivileged user and setup sudo for it
-    && dnf install -y /usr/sbin/useradd \
-    && useradd fedora \
-    && usermod -aG wheel fedora \
-    && echo -e 'fedora\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
+# hadolint ignore=DL3040
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+
+# Create unprivileged user and setup sudo for it
+dnf install -y /usr/sbin/useradd
+useradd fedora
+usermod -aG wheel fedora
+printf "fedora\tALL=(ALL)\tNOPASSWD: ALL" >> /etc/sudoers
+EOF
 
 USER fedora

--- a/containers/fedora/41/Containerfile.upstream
+++ b/containers/fedora/41/Containerfile.upstream
@@ -6,7 +6,12 @@
 
 FROM quay.io/fedora/fedora:41
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+EOF

--- a/containers/fedora/coreos/Containerfile
+++ b/containers/fedora/coreos/Containerfile
@@ -6,10 +6,16 @@
 
 FROM quay.io/fedora/fedora-coreos:stable
 
-    # Inject `dnf` to make things more complicated for `rpm-ostree` package
-    # manager implementation
-RUN    rpm-ostree install dnf5 \
-    # Populate dnf cache
-    && dnf5 makecache \
-    # Make sure the image is built with the latest packages
-    && dnf5 update -y
+RUN <<EOF
+set -ex
+
+# Inject `dnf` to make things more complicated for `rpm-ostree` package
+# manager implementation
+rpm-ostree install dnf5
+
+# Populate dnf cache
+dnf5 makecache
+
+# Make sure the image is built with the latest packages
+dnf5 update -y
+EOF

--- a/containers/fedora/coreos/ostree/Containerfile
+++ b/containers/fedora/coreos/ostree/Containerfile
@@ -8,12 +8,19 @@
 
 FROM quay.io/fedora/fedora-coreos:stable
 
-    # Inject `dnf` to make things more complicated for `rpm-ostree` package
-    # manager implementation
-RUN    rpm-ostree install dnf5 \
-    # Populate dnf cache
-    && dnf5 makecache \
-    # Make sure the image is built with the latest packages
-    && dnf5 update -y \
-    # Simulate ostree-booted environment
-    && touch /run/ostree-booted
+RUN <<EOF
+set -ex
+
+# Inject `dnf` to make things more complicated for `rpm-ostree` package
+# manager implementation
+rpm-ostree install dnf5
+
+# Populate dnf cache
+dnf5 makecache
+
+# Make sure the image is built with the latest packages
+dnf5 update -y
+
+# Simulate ostree-booted environment
+touch /run/ostree-booted
+EOF

--- a/containers/fedora/rawhide/Containerfile
+++ b/containers/fedora/rawhide/Containerfile
@@ -6,10 +6,17 @@
 
 FROM quay.io/fedora/fedora:rawhide
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y \
-    # Inject `dnf5` to make things more complicated for `dnf` family of
-    # package manager implementations
-    && dnf install -y dnf5
+# hadolint ignore=DL3040
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+
+# Inject `dnf5` to make things more complicated for `dnf` family of
+# package manager implementations
+dnf install -y dnf5
+EOF

--- a/containers/fedora/rawhide/Containerfile.unprivileged
+++ b/containers/fedora/rawhide/Containerfile.unprivileged
@@ -6,14 +6,21 @@
 
 FROM quay.io/fedora/fedora:rawhide
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y \
-    # Create unprivileged user and setup sudo for it
-    && dnf install -y /usr/sbin/useradd \
-    && useradd fedora \
-    && usermod -aG wheel fedora \
-    && echo -e 'fedora\tALL=(ALL)\tNOPASSWD: ALL' >> /etc/sudoers
+# hadolint ignore=DL3040
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+
+# Create unprivileged user and setup sudo for it
+dnf install -y /usr/sbin/useradd
+useradd fedora
+usermod -aG wheel fedora
+printf "fedora\tALL=(ALL)\tNOPASSWD: ALL" >> /etc/sudoers
+EOF
 
 USER fedora

--- a/containers/fedora/rawhide/Containerfile.upstream
+++ b/containers/fedora/rawhide/Containerfile.upstream
@@ -6,7 +6,12 @@
 
 FROM quay.io/fedora/fedora:rawhide
 
-    # Populate dnf cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y \
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+EOF

--- a/containers/ubi/8/Containerfile.upstream
+++ b/containers/ubi/8/Containerfile.upstream
@@ -6,7 +6,12 @@
 
 FROM registry.access.redhat.com/ubi8:latest
 
-    # Populate yum cache
-RUN    dnf makecache \
-    # Make sure the image is built with the latest packages
-    && dnf update -y
+RUN <<EOF
+set -ex
+
+# Populate yum cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+EOF

--- a/containers/ubuntu/22.04/Containerfile.upstream
+++ b/containers/ubuntu/22.04/Containerfile.upstream
@@ -6,7 +6,13 @@
 
 FROM docker.io/library/ubuntu:22.04
 
-    # Populate apt cache
-RUN    apt update \
-    # Make sure the image is built with the latest packages
-    && apt upgrade -y
+# hadolint ignore=DL3009
+RUN <<EOF
+set -ex
+
+# Populate apt cache
+apt-get update
+
+# Make sure the image is built with the latest packages
+apt-get upgrade -y
+EOF

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -312,17 +312,17 @@ For example, the following images can be found:
 .. code-block::
 
     # Latest Alpine, with added Bash to simulate proper essential setup:
-    localhost/tmt/tests/container/alpine
+    localhost/tmt/container/test/alpine
 
     # Various CentOS releases:
-    localhost/tmt/tests/container/centos/7
-    localhost/tmt/tests/container/centos/stream9
+    localhost/tmt/container/test/centos/7
+    localhost/tmt/container/test/centos/stream9
 
     # Fedora rawhide, with dnf5 pre-installed:
-    localhost/tmt/tests/container/fedora/rawhide
+    localhost/tmt/container/test/fedora/rawhide
 
     # Same, but with password-less sudo set up:
-    localhost/tmt/tests/container/fedora/rawhide/unprivileged
+    localhost/tmt/container/test/fedora/rawhide/unprivileged
 
 __ https://ostreedev.github.io/ostree/
 
@@ -331,17 +331,17 @@ To build these images, run the following:
 .. code-block:: shell
 
     # Build all images...
-    make images-tests
+    make images/test
 
     # ... or just a single one:
-    make images-tests/tmt/tests/container/fedora/rawhide:latest
+    make images/test/tmt/container/test/fedora/rawhide:latest
 
 Tests that need to use various container images should trigger this
 command before running the actual test cases:
 
 .. code-block:: bash
 
-    rlRun "make -C images-tests"
+    rlRun "make -C images/test"
 
 To list built container images, run the following:
 
@@ -353,7 +353,7 @@ To remove these images from your local system, run the following:
 
 .. code-block:: shell
 
-    make clean-test-images
+    make clean/images/test
 
 
 .. _docs:

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -108,15 +108,6 @@ your commits to the project:
 
     pre-commit install
 
-.. note::
-
-    One of the pre-commit checks, ``hadolint``, suffers from `a bug`__
-    and does not install the necessary ``hadolint`` binary. To make the
-    pre-commit fully functional, please download the binary from its
-    `project page`__.
-
-    __ https://github.com/hadolint/hadolint/issues/886
-    __ https://github.com/hadolint/hadolint/releases
 
 Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -108,6 +108,15 @@ your commits to the project:
 
     pre-commit install
 
+.. note::
+
+    One of the pre-commit checks, ``hadolint``, suffers from `a bug`__
+    and does not install the necessary ``hadolint`` binary. To make the
+    pre-commit fully functional, please download the binary from its
+    `project page`__.
+
+    __ https://github.com/hadolint/hadolint/issues/886
+    __ https://github.com/hadolint/hadolint/releases
 
 Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ lint = ["autopep8 {args:.}", "ruff --fix {args:.}"]
 type = ["mypy {args:tmt}"]
 check = ["lint", "type"]
 
-unit = "make images-tests && pytest -vvv -ra --showlocals -n 0 tests/unit"
+unit = "make images/test && pytest -vvv -ra --showlocals -n 0 tests/unit"
 smoke = "pytest -vvv -ra --showlocals -n 0 tests/unit/test_cli.py"
 cov = [
     "coverage run --source=tmt -m pytest -vvv -ra --showlocals -n 0 tests",

--- a/tests/images.sh
+++ b/tests/images.sh
@@ -6,7 +6,7 @@
 #
 
 # A preix shared by all images built for tests.
-TEST_IMAGE_PREFIX="localhost/tmt/tests/container"
+TEST_IMAGE_PREFIX="localhost/tmt/container/test"
 
 # Directory where the top-level Makefile lives. It might be possible to
 # rely on tmt, but sometimes one might want to run a test directly,
@@ -164,7 +164,7 @@ function build_container_image () {
 
     # Try several times to build the container
     # https://github.com/teemtee/tmt/issues/2063
-    build="make -C $_MAKEFILE_DIR images-tests/tmt/tests/container/$1"
+    build="make -C $_MAKEFILE_DIR images/test/tmt/container/test/$1"
     rlWaitForCmd "$build" -m 5 -d 5 -t 3600 || rlDie "Unable to prepare the image"
 }
 
@@ -177,6 +177,6 @@ function build_container_images () {
 
     # Try several times to build the container
     # https://github.com/teemtee/tmt/issues/2063
-    build="make -C $_MAKEFILE_DIR images-tests"
+    build="make -C $_MAKEFILE_DIR images/test"
     rlWaitForCmd "$build" -m 5 -d 5 -t 3600 || rlDie "Unable to prepare the images"
 }

--- a/tests/prepare/ansible/main.fmf
+++ b/tests/prepare/ansible/main.fmf
@@ -10,3 +10,10 @@ tag+:
   - provision-local
   - provision-virtual
 duration: 30m
+
+adjust+:
+  - check:
+      - how: avc
+        result: xfail
+    when: provision_how == container
+    because: https://bugzilla.redhat.com/show_bug.cgi?id=2342247

--- a/tests/provision/become/data/main.fmf
+++ b/tests/provision/become/data/main.fmf
@@ -8,7 +8,7 @@ adjust:
     - when: provisiontest == container
       provision+:
         how: container
-        image: localhost/tmt/tests/container/fedora/rawhide/unprivileged:latest
+        image: localhost/tmt/container/test/fedora/rawhide/unprivileged:latest
 
 execute:
     how: tmt

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -37,33 +37,33 @@ logger.add_console_handler()
 # Explore available plugins
 tmt.plugins.explore(logger)
 
-# Local images created via `make images-tests`, reference to local registry
+# Local images created via `make images/test`, reference to local registry
 CONTAINER_FEDORA_RAWHIDE = Container(
-    url='containers-storage:localhost/tmt/tests/container/fedora/rawhide/upstream:latest')
+    url='containers-storage:localhost/tmt/container/test/fedora/rawhide/upstream:latest')
 CONTAINER_FEDORA_41 = Container(
-    url='containers-storage:localhost/tmt/tests/container/fedora/41/upstream:latest')
+    url='containers-storage:localhost/tmt/container/test/fedora/41/upstream:latest')
 CONTAINER_FEDORA_40 = Container(
-    url='containers-storage:localhost/tmt/tests/container/fedora/40/upstream:latest')
+    url='containers-storage:localhost/tmt/container/test/fedora/40/upstream:latest')
 CONTAINER_FEDORA_39 = Container(
-    url='containers-storage:localhost/tmt/tests/container/fedora/39/upstream:latest')
+    url='containers-storage:localhost/tmt/container/test/fedora/39/upstream:latest')
 CONTAINER_CENTOS_STREAM_10 = Container(
-    url='containers-storage:localhost/tmt/tests/container/centos/stream10/upstream:latest')
+    url='containers-storage:localhost/tmt/container/test/centos/stream10/upstream:latest')
 CONTAINER_CENTOS_STREAM_9 = Container(
-    url='containers-storage:localhost/tmt/tests/container/centos/stream9/upstream:latest')
+    url='containers-storage:localhost/tmt/container/test/centos/stream9/upstream:latest')
 CONTAINER_CENTOS_7 = Container(
-    url='containers-storage:localhost/tmt/tests/container/centos/7/upstream:latest')
+    url='containers-storage:localhost/tmt/container/test/centos/7/upstream:latest')
 CONTAINER_UBI_8 = Container(
-    url='containers-storage:localhost/tmt/tests/container/ubi/8/upstream:latest')
+    url='containers-storage:localhost/tmt/container/test/ubi/8/upstream:latest')
 CONTAINER_UBUNTU_2204 = Container(
-    url='containers-storage:localhost/tmt/tests/container/ubuntu/22.04/upstream:latest')
+    url='containers-storage:localhost/tmt/container/test/ubuntu/22.04/upstream:latest')
 CONTAINER_DEBIAN_127 = Container(
-    url='containers-storage:localhost/tmt/tests/container/debian/12.7/upstream:latest')
+    url='containers-storage:localhost/tmt/container/test/debian/12.7/upstream:latest')
 CONTAINER_FEDORA_COREOS = Container(
-    url='containers-storage:localhost/tmt/tests/container/fedora/coreos:stable')
+    url='containers-storage:localhost/tmt/container/test/fedora/coreos:stable')
 CONTAINER_FEDORA_COREOS_OSTREE = Container(
-    url='containers-storage:localhost/tmt/tests/container/fedora/coreos/ostree:stable')
+    url='containers-storage:localhost/tmt/container/test/fedora/coreos/ostree:stable')
 CONTAINER_ALPINE = Container(
-    url='containers-storage:localhost/tmt/tests/container/alpine:latest')
+    url='containers-storage:localhost/tmt/container/test/alpine:latest')
 
 PACKAGE_MANAGER_DNF5 = tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.get_plugin('dnf5')
 PACKAGE_MANAGER_DNF = tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.get_plugin('dnf')


### PR DESCRIPTION
After the question about indentation in containerfiles has been raised several times, it's time to do something about it. And can't stop with just one issue, so touching several parts of the image building process:

* adding a linter to pre-commit for containerimages, and fixing issues reported by it.
* using heredoc + `RUN` instead of often weirdly aligned multiline `RUN`.
* renamed `make` targets: `images`, `images/test`, `images/test/bases`, `clean`, `clean/images`, `clean/images/test`
* renamed images as well, to have a nice namespace for container images and regular container images, not the test ones, etc.: `tmt/container/tmt-all`, `tmt/container/tmt`, `tmt/container/test/alpine`, ...
* simplified coe building images in `Makefile` to use same path for both test and tmt images.

Pull Request Checklist

* [x] implement the feature