### PR TITLE
Move hints to their own place, with API and unicorns

### DIFF
--- a/docs/_static/tmt-custom.css
+++ b/docs/_static/tmt-custom.css
@@ -7,3 +7,11 @@
 .logo {
     padding: 10px 50px !important;
 }
+
+.rst-content .note .admonition-title {
+  display: block !important;
+}
+
+.rst-content .warning .admonition-title {
+  display: block !important;
+}

--- a/docs/scripts/generate-plugins.py
+++ b/docs/scripts/generate-plugins.py
@@ -18,6 +18,7 @@ import tmt.steps.prepare
 import tmt.steps.provision
 import tmt.steps.report
 import tmt.utils
+import tmt.utils.hints
 from tmt.container import ContainerClass
 from tmt.utils import Path
 from tmt.utils.templates import render_template_file
@@ -222,6 +223,7 @@ def main() -> None:
             STEP=step_name,
             PLUGINS=plugin_generator,
             REVIEWED_PLUGINS=REVIEWED_PLUGINS,
+            HINTS=tmt.utils.hints.HINTS,
             is_enum=is_enum,
             container_fields=tmt.container.container_fields,
             container_field=tmt.container.container_field,

--- a/docs/templates/plugins.rst.j2
+++ b/docs/templates/plugins.rst.j2
@@ -84,6 +84,12 @@ The following keys are accepted by all plugins of the ``{{ STEP }}`` step.
 {{ PLUGIN.__doc__ | dedent | trim }}
 {% endif %}
 
+{% if plugin_full_id in HINTS %}
+.. note::
+
+{{ HINTS[plugin_full_id] | indent(3, first=true) }}
+{% endif %}
+
 {% set intrinsic_fields = container_intrinsic_fields(PLUGIN_DATA_CLASS) | sort %}
 
 {% if intrinsic_fields %}

--- a/tests/unit/provision/testcloud/test_hw.py
+++ b/tests/unit/provision/testcloud/test_hw.py
@@ -17,7 +17,7 @@ from tmt.steps.provision.testcloud import (
     import_testcloud,
     )
 
-import_testcloud()
+import_testcloud(Logger.get_bootstrap_logger())
 
 # These must be imported *after* importing testcloud
 from tmt.steps.provision.testcloud import TPM_CONFIG_ALLOWS_VERSIONS, \

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -4431,8 +4431,7 @@ class Clean(tmt.utils.Common):
         self.info('images', color='blue')
         successful = True
         for method in tmt.steps.provision.ProvisionPlugin.methods():
-            # FIXME: ignore[union-attr]: https://github.com/teemtee/tmt/issues/1599
-            if not method.class_.clean_images(  # type: ignore[union-attr]
+            if not method.class_.clean_images(  # type: ignore[attr-defined]
                 self, self.is_dry_run, self.workdir_root
             ):
                 successful = False

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -535,75 +535,6 @@ def create_options_decorator(options: list[ClickOptionDecoratorType]) -> Callabl
     return common_decorator
 
 
-def show_step_method_hints(
-    step_name: str,
-    how: str,
-    logger: tmt.log.Logger,
-) -> None:
-    """
-    Show hints about available step methods' installation
-
-    The logger will be used to output the hints to the terminal, hence
-    it must be an instance of a subclass of tmt.utils.Common (info method
-    must be available).
-    """
-
-    if how == 'ansible':
-        logger.info(
-            'hint',
-            "Install 'ansible-core' to prepare guests using ansible playbooks.",
-            color='blue',
-        )
-    elif step_name == 'provision':
-        if how == 'virtual':
-            logger.info(
-                'hint',
-                "Install 'tmt+provision-virtual' to run tests in a virtual machine.",
-                color='blue',
-            )
-        if how == 'container':
-            logger.info(
-                'hint',
-                "Install 'tmt+provision-container' to run tests in a container.",
-                color='blue',
-            )
-        if how == 'minute':
-            logger.info(
-                'hint',
-                "Install 'tmt-redhat-provision-minute' "
-                "to run tests in 1minutetip OpenStack backend. "
-                "(Available only from the internal COPR repository.)",
-                color='blue',
-            )
-        logger.info(
-            'hint',
-            "Use the 'local' method to execute tests directly on your localhost.",
-            color='blue',
-        )
-        logger.info(
-            'hint',
-            "See 'tmt run provision --help' for all available provision options.",
-            color='blue',
-        )
-    elif step_name == 'report':
-        if how == 'junit':
-            logger.info(
-                'hint',
-                "Install 'tmt+report-junit' to write results in JUnit format.",
-                color='blue',
-            )
-        logger.info(
-            'hint',
-            "Use the 'display' method to show test results on the terminal.",
-            color='blue',
-        )
-        logger.info(
-            'hint',
-            "See 'tmt run report --help' for all available report options.",
-            color='blue',
-        )
-
-
 def create_method_class(methods: MethodDictType) -> type[click.Command]:
     """
     Create special class to handle different options for each method
@@ -732,10 +663,17 @@ def create_method_class(methods: MethodDictType) -> type[click.Command]:
                         break
 
             if how and self._method is None:
+                from tmt.utils.hints import print_hint
+
                 # Use run for logging, steps may not be initialized yet
                 assert context.obj.run is not None  # narrow type
                 assert self.name is not None  # narrow type
-                show_step_method_hints(self.name, how, context.obj.run._logger)
+
+                print_hint(
+                    id_=f'{self.name}/{how}', ignore_missing=True, logger=context.obj.run._logger
+                )
+                print_hint(id_=self.name, ignore_missing=True, logger=context.obj.run._logger)
+
                 raise tmt.utils.SpecificationError(f"Unsupported {self.name} method '{how}'.")
 
         def parse_args(  # type: ignore[override]

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -44,7 +44,7 @@ import tmt.steps.provision
 import tmt.utils
 from tmt.container import SerializableContainer, container, field, key_to_option
 from tmt.log import Logger
-from tmt.options import option, show_step_method_hints
+from tmt.options import option
 from tmt.package_managers import FileSystemPath, Package, PackageManagerClass
 from tmt.plugins import PluginRegistry
 from tmt.steps import Action, ActionTask, PhaseQueue
@@ -2111,7 +2111,9 @@ class GuestSsh(Guest):
             )
         except tmt.utils.RunError as exc:
             if "File 'ansible-playbook' not found." in exc.message:
-                show_step_method_hints('plugin', 'ansible', self._logger)
+                from tmt.utils.hints import print_hint
+
+                print_hint(id_='ansible-not-available', logger=self._logger)
             raise exc
 
     @property

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -7,7 +7,6 @@ import tmt.steps
 import tmt.steps.provision
 import tmt.utils
 from tmt.container import container
-from tmt.options import show_step_method_hints
 from tmt.utils import Command, OnProcessStartCallback, Path, ShellScript
 
 
@@ -82,7 +81,9 @@ class GuestLocal(tmt.Guest):
             # fmt: on
         except tmt.utils.RunError as exc:
             if exc.stderr and 'ansible-playbook: command not found' in exc.stderr:
-                show_step_method_hints('plugin', 'ansible', self._logger)
+                from tmt.utils.hints import print_hint
+
+                print_hint(id_='ansible-not-available', logger=self._logger)
             raise exc
 
     def execute(

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -9,7 +9,6 @@ import tmt.steps
 import tmt.steps.provision
 import tmt.utils
 from tmt.container import container, field
-from tmt.options import show_step_method_hints
 from tmt.steps.provision import GuestCapability
 from tmt.utils import Command, OnProcessStartCallback, Path, ShellScript, retry
 
@@ -361,7 +360,9 @@ class GuestContainer(tmt.Guest):
             )
         except tmt.utils.RunError as exc:
             if "File 'ansible-playbook' not found." in exc.message:
-                show_step_method_hints('plugin', 'ansible', self._logger)
+                from tmt.utils.hints import print_hint
+
+                print_hint(id_='ansible-not-available', logger=self._logger)
             raise exc
 
     def podman(
@@ -544,7 +545,22 @@ class GuestContainer(tmt.Guest):
                     raise err
 
 
-@tmt.steps.provides_method('container')
+@tmt.steps.provides_method(
+    'container',
+    installation_hint="""
+        Make sure ``podman`` is installed and configured, it is required for container-backed
+        guests provided by ``provision/container`` plugin.
+
+        To quickly test ``podman`` functionality, you can try running ``podman images`` or
+        ``podman run --rm -it fedora:latest``.
+
+        * Users who installed tmt from system repositories should install
+          ``tmt+provision-container`` package.
+        * Users who installed tmt from PyPI should also install ``tmt+provision-container``
+          package, as it will install required system dependencies. After doing so, they should
+          install ``tmt[provision-container]`` extra.
+    """,
+)
 class ProvisionPodman(tmt.steps.provision.ProvisionPlugin[ProvisionPodmanData]):
     """
     Create a new container using ``podman``.

--- a/tmt/utils/hints.py
+++ b/tmt/utils/hints.py
@@ -1,0 +1,181 @@
+"""
+Hints for users when facing installation-related issues.
+
+Plugins, steps, and tmt code in general can register hints to be shown
+to user when an important (or optional, but interesting) package is not
+available.
+
+Hints are shown when importing plugins fails, and rendered as part of
+both their CLI help and HTML documentation.
+"""
+
+# NOTE (happz): in my plan, this module would be an unfinished, staging
+# area for hints; eventually, I would like them to be managed under the
+# umbrella of `tmt about` subcommand. `print_hint()` would still exist,
+# but `tmt about` would be responsible for handling hints, therefore the
+# code below may change, the concept should not. And hints would cover
+# wider area, e.g. describing common errors and issues, not just when
+# a package is missing. They would be coupled with exceptions tmt
+# raises, providing more info on command-line and in HTML docs.
+
+import textwrap
+from collections.abc import Iterator
+from typing import Optional
+
+import tmt.log
+import tmt.utils
+import tmt.utils.rest
+
+HINTS: dict[str, str] = {
+    # Hints must be dedented & stripped of leading/trailing white space.
+    # For hints registered by plugins, this is done by `register_hint()`.
+    _hint_id: textwrap.dedent(_hint).strip()
+    for _hint_id, _hint in {
+        'provision': """
+            You can use the ``local`` method to execute tests directly on your localhost.
+
+            See ``tmt run provision --help`` for all available ``provision`` options.
+            """,
+        "report": """
+            You can use the ``display`` method to show test results on the terminal.
+
+            See ``tmt run report --help`` for all available report options.
+            """,
+        'ansible-not-available': """
+            Make sure ``ansible-playbook`` is installed, it is required for preparing guests using
+            Ansible playbooks.
+
+            To quickly test ``ansible-playbook`` presence, you can try running
+            ``ansible-playbook --help``.
+
+            * Users who installed tmt from system repositories should install ``ansible-core``
+            package.
+            * Users who installed tmt from PyPI should install ``tmt[ansible]`` extra.
+            """,
+        # TODO: once `minute` plugin provides its own hints, we can drop
+        # this hint and move it to the plugin.
+        'provision/minute': """
+            Make sure ``tmt-redhat-provision-minute`` package is installed, it is required for
+            guests backed by 1minutetip OpenStack as provided by ``provision/minute`` plugin. The
+            package is available from the internal COPR repository only.
+            """,
+    }.items()
+}
+
+
+def register_hint(id_: str, hint: str) -> None:
+    """
+    Register a hint for users.
+
+    :param id_: step name for step-specific hints,
+        ``<step name>/< plugin name>`` for plugin-specific hints,
+        or an arbitrary string.
+    :param hint: a hint to register.
+    """
+
+    if id_ in HINTS:
+        raise tmt.utils.GeneralError(
+            "Registering hint '{id_}' collides with an already registered hint."
+        )
+
+    HINTS[id_] = textwrap.dedent(hint).strip()
+
+
+def render_hint(
+    *, id_: str, ignore_missing: bool = False, logger: tmt.log.Logger
+) -> Optional[str]:
+    """
+    Render a given hint to be printable.
+
+    :param id_: id of the hint to render.
+    :param ignore_missing: if not set, non-existent hints will
+        raise an exception.
+    :param logger: to use for logging.
+    :returns: a printable representation of the hint. If the hint ID
+        does not exist and ``ignore_missing`` is set, ``None`` is
+        returned.
+    """
+
+    def _render_single_hint(hint: str) -> str:
+        if tmt.utils.rest.REST_RENDERING_ALLOWED:
+            return tmt.utils.rest.render_rst(hint, logger)
+
+        return hint
+
+    if ignore_missing:
+        hint = HINTS.get(id_)
+
+        if hint is None:
+            return None
+
+        return _render_single_hint(hint)
+
+    hint = HINTS.get(id_)
+
+    if hint is None:
+        raise tmt.utils.GeneralError("Could not find hint '{id_}'.")
+
+    return _render_single_hint(hint)
+
+
+def render_hints(*ids: str, ignore_missing: bool = False, logger: tmt.log.Logger) -> str:
+    """
+    Render multiple hints into a single screen of text.
+
+    :param ids: ids of hints to render.
+    :param ignore_missing: if not set, non-existent hints will
+        raise an exception. Otherwise, non-existent hints will
+        be skipped.
+    :param logger: to use for logging.
+    :returns: a printable representation of hints.
+    """
+
+    def _render_single_hint(hint: str) -> str:
+        if tmt.utils.rest.REST_RENDERING_ALLOWED:
+            return tmt.utils.rest.render_rst(hint, logger)
+
+        return hint
+
+    if ignore_missing:
+
+        def _render_optional_hints() -> Iterator[str]:
+            for id_ in ids:
+                hint = HINTS.get(id_)
+
+                if hint is None:
+                    continue
+
+                yield _render_single_hint(hint)
+
+        return '\n'.join(_render_optional_hints())
+
+    def _render_mandatory_hints() -> Iterator[str]:
+        for id_ in ids:
+            hint = HINTS.get(id_)
+
+            if hint is None:
+                raise tmt.utils.GeneralError("Could not find hint '{id_}'.")
+
+            yield _render_single_hint(hint)
+
+    return '\n'.join(_render_mandatory_hints())
+
+
+def print_hint(*, id_: str, ignore_missing: bool = False, logger: tmt.log.Logger) -> None:
+    """
+    Display a given hint by printing it as a warning.
+
+    :param id_: id of the hint to render.
+    :param ignore_missing: if not set, non-existent hints will
+        raise an exception.
+    :param logger: to use for logging.
+    """
+
+    hint = render_hint(id_=id_, ignore_missing=ignore_missing, logger=logger)
+
+    if hint is None:
+        return
+
+    logger.info(
+        'hint', render_hint(id_=id_, ignore_missing=ignore_missing, logger=logger), color='blue'
+    )

--- a/tmt/utils/hints.py
+++ b/tmt/utils/hints.py
@@ -68,14 +68,14 @@ def register_hint(id_: str, hint: str) -> None:
     Register a hint for users.
 
     :param id_: step name for step-specific hints,
-        ``<step name>/< plugin name>`` for plugin-specific hints,
+        ``<step name>/<plugin name>`` for plugin-specific hints,
         or an arbitrary string.
     :param hint: a hint to register.
     """
 
     if id_ in HINTS:
         raise tmt.utils.GeneralError(
-            "Registering hint '{id_}' collides with an already registered hint."
+            f"Registering hint '{id_}' collides with an already registered hint."
         )
 
     HINTS[id_] = textwrap.dedent(hint).strip()
@@ -113,7 +113,7 @@ def render_hint(
     hint = HINTS.get(id_)
 
     if hint is None:
-        raise tmt.utils.GeneralError("Could not find hint '{id_}'.")
+        raise tmt.utils.GeneralError(f"Could not find hint '{id_}'.")
 
     return _render_single_hint(hint)
 
@@ -154,7 +154,7 @@ def render_hints(*ids: str, ignore_missing: bool = False, logger: tmt.log.Logger
             hint = HINTS.get(id_)
 
             if hint is None:
-                raise tmt.utils.GeneralError("Could not find hint '{id_}'.")
+                raise tmt.utils.GeneralError(f"Could not find hint '{id_}'.")
 
             yield _render_single_hint(hint)
 

--- a/tmt/utils/jira.py
+++ b/tmt/utils/jira.py
@@ -8,6 +8,7 @@ import tmt.base
 import tmt.config
 import tmt.log
 import tmt.utils
+import tmt.utils.hints
 from tmt.config.models.link import IssueTracker, IssueTrackerType
 from tmt.plugins import ModuleImporter
 
@@ -19,9 +20,20 @@ TmtObject = Union['tmt.base.Test', 'tmt.base.Plan', 'tmt.base.Story']
 
 
 import_jira: ModuleImporter['jira'] = ModuleImporter(  # type: ignore[valid-type]
+    'jira', tmt.utils.ReportError, 'jira'
+)
+
+
+tmt.utils.hints.register_hint(
     'jira',
-    tmt.utils.ReportError,
-    "Install 'tmt+link-jira' to use the Jira linking.",
+    """
+    For linking tests, plans and stories to Jira, ``jira`` package is required by tmt.
+
+    To quickly test ``jira`` presence, you can try running ``python -c 'import jira'``.
+
+    * Users who installed tmt from system repositories should install ``tmt+link-jira`` package.
+    * Users who installed tmt from PyPI should install ``tmt[link-jira]`` extra.
+    """,
 )
 
 


### PR DESCRIPTION
I wanted to change a couple of things about "hints" tmt shows to users when when a package is missing and functionality is limited:

* Static, stored in a single function. That made them detached from their origin, and 3rd party plugins would have no chance to add their own hints.
* A bit confined text of hints did not cover all possible venues. PyPI installation was ignored by some, other hints spoke just about using `pip install`.
* Hints are interesting and useful, but visible only when error strikes.

The patch turns the function into a "registry", a simple dictionary storing them. Plugins and tmt code in general can "register" their hints, and a nice tools are available for showing them.

Hints wow have IDs, and there are dedicated IDs for step-specific (``report``, ...) and plugin-specific (``report/foo``) hints, allowing tmt core to print them when step or plugins crashes on import.

Plugin-specific hints are now rendered both in their CLI and HTML documentation.

In the future, I would like to provide hints not just as "a package foo is missing, install it" guide, but also explaining various errors and issues tmt would report, e.g. pairing them with exceptions, "To learn more, run `tmt about E1234`".

Pull Request Checklist

* [x] implement the feature
* [ ] extend the test coverage - I plan to connect these to `tmt about`, together with listing all discovered plugins it should give me enough tools to test the features
