### PR TITLE
Add more RAM to bootc and virtual provision plans

### DIFF
--- a/plans/provision/bootc.fmf
+++ b/plans/provision/bootc.fmf
@@ -21,7 +21,7 @@ adjust+:
         hardware:
             virtualization:
                 is-supported: true
-            memory: ">= 4 GB"
+            memory: ">= 8 GB"
     when: trigger == commit
 
   - prepare+:

--- a/plans/provision/virtual.fmf
+++ b/plans/provision/virtual.fmf
@@ -46,7 +46,7 @@ adjust+:
         hardware:
             virtualization:
                 is-supported: true
-            memory: ">= 4 GB"
+            memory: ">= 8 GB"
     when: trigger == commit
 
   - prepare+:


### PR DESCRIPTION
Recently Openstack is full and the sad KVM machines we are getting from Beaker do not make it.

Let's try with more RAM.
