### PR TITLE
Bump release to 1.42.1

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,7 +4,7 @@
     Releases
 ======================
 
-tmt-1.42.0
+tmt-1.42.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``tmt show`` command now prints in verbose mode manual test


### PR DESCRIPTION
Unfortunately we wanted to delete the bogus 1.42 release on PyPI and upload 1.42.0, but it is not possible. One seems to need to bump the release.

Cherry pick of #3502 
