### PR TITLE
Continue after prepare failure in `tmt try`

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,12 +4,6 @@
     Releases
 ======================
 
-tmt-1.44.0
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When running ``tmt try`` failure in ``prepare`` phase drops the user
-to the menu to be able to login to the machine and possibly try it again.
-
 
 tmt-1.45.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -18,6 +12,9 @@ When pruning a repository with a specified ``path``, the ``discover``
 step now saves the data to the correct temporary directory and
 respects the structure of the original repository. This ensures
 that the test attributes have correct paths.
+
+When running ``tmt try`` failure in ``prepare`` phase drops the user
+to the menu to be able to login to the machine and possibly try it again.
 
 
 tmt-1.44.0

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -6,6 +6,7 @@
 
 tmt-1.44.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 When running ``tmt try`` failure in ``prepare`` phase drops the user
 to the menu to be able to login to the machine and possibly try it again.
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,11 @@
     Releases
 ======================
 
+tmt-1.44.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When running ``tmt try`` failure in ``prepare`` phase drops the user
+to the menu to be able to login to the machine and possibly try it again.
+
 
 tmt-1.45.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -348,7 +348,11 @@ class Try(tmt.utils.Common):
         try:
             plan.prepare.go()
         except GeneralError as error:
-            self.print(click.style(f"\n{error}.", fg="red"))
+            tmt.utils.show_exception(
+                error,
+                traceback_verbosity=tmt.utils.TracebackVerbosity.DEFAULT,
+                include_logfiles=True,
+            )
             return
         plan.execute.go()
 
@@ -363,7 +367,11 @@ class Try(tmt.utils.Common):
         try:
             plan.prepare.go()
         except GeneralError as error:
-            self.print(click.style(f"\n{error}.", fg="red"))
+            tmt.utils.show_exception(
+                error,
+                traceback_verbosity=tmt.utils.TracebackVerbosity.DEFAULT,
+                include_logfiles=True,
+            )
             return
         assert plan.login is not None  # Narrow type
         plan.login.go(force=True)
@@ -464,7 +472,11 @@ class Try(tmt.utils.Common):
         try:
             plan.prepare.go(force=True)
         except GeneralError as error:
-            self.print(click.style(f"\n{error}.", fg="red"))
+            tmt.utils.show_exception(
+                error,
+                traceback_verbosity=tmt.utils.TracebackVerbosity.DEFAULT,
+                include_logfiles=True,
+            )
 
     def action_execute(self, plan: Plan) -> None:
         """

--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -142,6 +142,17 @@ class Try(tmt.utils.Common):
             options={"interactive": True},
         )
 
+    def _show_exception(self, exc: Exception) -> None:
+        """
+        A little helper for consistent exception reporting.
+        """
+
+        tmt.utils.show_exception(
+            exc,
+            traceback_verbosity=tmt.utils.TracebackVerbosity.DEFAULT,
+            include_logfiles=True,
+        )
+
     def check_tree(self) -> None:
         """
         Make sure there is a sane metadata tree
@@ -348,11 +359,7 @@ class Try(tmt.utils.Common):
         try:
             plan.prepare.go()
         except GeneralError as error:
-            tmt.utils.show_exception(
-                error,
-                traceback_verbosity=tmt.utils.TracebackVerbosity.DEFAULT,
-                include_logfiles=True,
-            )
+            self._show_exception(error)
             return
         plan.execute.go()
 
@@ -367,11 +374,7 @@ class Try(tmt.utils.Common):
         try:
             plan.prepare.go()
         except GeneralError as error:
-            tmt.utils.show_exception(
-                error,
-                traceback_verbosity=tmt.utils.TracebackVerbosity.DEFAULT,
-                include_logfiles=True,
-            )
+            self._show_exception(error)
             return
         assert plan.login is not None  # Narrow type
         plan.login.go(force=True)
@@ -472,11 +475,7 @@ class Try(tmt.utils.Common):
         try:
             plan.prepare.go(force=True)
         except GeneralError as error:
-            tmt.utils.show_exception(
-                error,
-                traceback_verbosity=tmt.utils.TracebackVerbosity.DEFAULT,
-                include_logfiles=True,
-            )
+            self._show_exception(error)
 
     def action_execute(self, plan: Plan) -> None:
         """

--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -345,7 +345,11 @@ class Try(tmt.utils.Common):
 
         plan.discover.go()
         plan.provision.go()
-        plan.prepare.go()
+        try:
+            plan.prepare.go()
+        except GeneralError as error:
+            self.print(click.style(f"\n{error}.", fg="red"))
+            return
         plan.execute.go()
 
     def action_start_login(self, plan: Plan) -> None:
@@ -356,7 +360,11 @@ class Try(tmt.utils.Common):
         self.action_start(plan)
 
         plan.provision.go()
-        plan.prepare.go()
+        try:
+            plan.prepare.go()
+        except GeneralError as error:
+            self.print(click.style(f"\n{error}.", fg="red"))
+            return
         assert plan.login is not None  # Narrow type
         plan.login.go(force=True)
 
@@ -453,7 +461,10 @@ class Try(tmt.utils.Common):
         Prepare the guest
         """
 
-        plan.prepare.go(force=True)
+        try:
+            plan.prepare.go(force=True)
+        except GeneralError as error:
+            self.print(click.style(f"\n{error}.", fg="red"))
 
     def action_execute(self, plan: Plan) -> None:
         """

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -2837,6 +2837,7 @@ def render_exception(
 
 def show_exception(
     exception: BaseException,
+    traceback_verbosity: Optional[TracebackVerbosity] = None,
     include_logfiles: bool = True,
 ) -> None:
     """
@@ -2849,7 +2850,7 @@ def show_exception(
 
     from tmt.cli import EXCEPTION_LOGGER
 
-    traceback_verbosity = TracebackVerbosity.from_env()
+    traceback_verbosity = traceback_verbosity or TracebackVerbosity.from_env()
 
     def _render_exception(traceback_verbosity: TracebackVerbosity) -> Iterator[str]:
         yield ''


### PR DESCRIPTION
Useful if machine needs tweaks before prepare can work, e.g. enable repos.
Fix: #2685

WDYT ? Error message needs tweaks (e.g write it in red...) but any objections against this behaviour change?

I often hit this if test requires something from beaker task library or crb isn't enabled in the image.


Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] include a release note
