### PR TITLE
Fix version of tmt lint check in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,7 +152,7 @@ repos:
           - '--show-fixes'
 
   - repo: https://github.com/teemtee/tmt.git
-    rev: 1.42.0
+    rev: 1.42.1
     hooks:
     - id: tmt-lint
       additional_dependencies:


### PR DESCRIPTION
1.42.0 is not available, 1.42.1 replacted it.

Pull Request Checklist

* [x] implement the feature