### PR TITLE
Drop explicit version pattern from container files

### DIFF
--- a/containers/Containerfile.full
+++ b/containers/Containerfile.full
@@ -9,7 +9,7 @@ RUN set -x && \
 RUN set -x && \
     dnf install -y dnf-plugins-core && \
     dnf copr enable -y @teemtee/stable && \
-    dnf install -y tmt+all-[0-9].[0-9][0-9].[0-9]* beakerlib && \
+    dnf install -y tmt+all beakerlib && \
     dnf autoremove -y && \
     dnf clean all
 

--- a/containers/Containerfile.mini
+++ b/containers/Containerfile.mini
@@ -9,7 +9,7 @@ RUN set -x && \
 RUN set -x && \
     dnf install -y dnf-plugins-core && \
     dnf copr enable -y @teemtee/stable && \
-    dnf install -y tmt-[0-9].[0-9][0-9].[0-9]* && \
+    dnf install -y tmt && \
     dnf autoremove -y && \
     dnf clean all
 


### PR DESCRIPTION
This was needed when both development and stable packages were hosted in the same copr repository. As now there is a separate `stable` repo we can drop the explicit version hack.