### PR TITLE
Save console logs as a file in `testcloud`

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,14 @@
     Releases
 ======================
 
+
+tmt-1.48.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The console log content is now available for guests provisioned by
+the :ref:`/plugins/provision/virtual.testcloud` plugin.
+
+
 tmt-1.47.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -38,13 +46,6 @@ The default unit of the ``memory`` hardware requirement is now
 
 The steps documentation was deduplicated, and all information
 from the specs was moved to the ``plugins`` section.
-
-
-tmt-1.47.0
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The console log content is now available for guests provisioned by
-the :ref:`/plugins/provision/virtual.testcloud` plugin.
 
 
 tmt-1.46.0

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -40,6 +40,13 @@ The steps documentation was deduplicated, and all information
 from the specs was moved to the ``plugins`` section.
 
 
+tmt-1.47.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The console log content is now available for guests provisioned by
+the :ref:`/plugins/provision/virtual.testcloud` plugin.
+
+
 tmt-1.46.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ provision-beaker = [
     "mrack>=1.23.1",
     ]
 provision-virtual = [
-    "testcloud>=0.11.3",
+    "testcloud>=0.11.7",
     ]
 provision-container = []
 provision-bootc = []

--- a/tests/provision/virtual.testcloud/test.sh
+++ b/tests/provision/virtual.testcloud/test.sh
@@ -48,11 +48,9 @@ rlJournalStart
             rlAssertGrep "disk\\[0\\].size: set to '11 GB' because of 'disk\\[0\\].size: == 11 GB'" "$run/log.txt"
             rlAssertGrep "final domain memory: 2049000" "$run/log.txt"
             rlAssertGrep "final domain root disk size: 11" "$run/log.txt"
-            rpmdev-vercmp "$(rpm -q --qf '%{V}' testcloud)" 0.11.4 > /dev/null; testcloud_cmp_code=$?
-            VERSION_NEWER_CODE=11
-            if [[ $testcloud_cmp_code == "$VERSION_NEWER_CODE" ]]; then
-                rlAssertGrep "\\[    0.000000\\] Linux version" "$run/default/plan/provision/default-0/console.log"
-            fi
+            # TODO Enable once the testcloud change is merged and released
+            # https://github.com/teemtee/testcloud/pull/7
+            # rlAssertGrep "\\[    0.000000\\] Linux version" "$run/default/plan/provision/default-0/console.log"
         fi
     rlPhaseEnd
 

--- a/tests/provision/virtual.testcloud/test.sh
+++ b/tests/provision/virtual.testcloud/test.sh
@@ -48,9 +48,7 @@ rlJournalStart
             rlAssertGrep "disk\\[0\\].size: set to '11 GB' because of 'disk\\[0\\].size: == 11 GB'" "$run/log.txt"
             rlAssertGrep "final domain memory: 2049000" "$run/log.txt"
             rlAssertGrep "final domain root disk size: 11" "$run/log.txt"
-            # TODO Enable once the testcloud change is merged and released
-            # https://github.com/teemtee/testcloud/pull/7
-            # rlAssertGrep "\\[    0.000000\\] Linux version" "$run/default/plan/provision/default-0/console.log"
+            rlAssertGrep "\\[    0.000000\\] Linux version" "$run/default/plan/provision/default-0/console.txt"
         fi
     rlPhaseEnd
 

--- a/tests/provision/virtual.testcloud/test.sh
+++ b/tests/provision/virtual.testcloud/test.sh
@@ -48,6 +48,11 @@ rlJournalStart
             rlAssertGrep "disk\\[0\\].size: set to '11 GB' because of 'disk\\[0\\].size: == 11 GB'" "$run/log.txt"
             rlAssertGrep "final domain memory: 2049000" "$run/log.txt"
             rlAssertGrep "final domain root disk size: 11" "$run/log.txt"
+            rpmdev-vercmp "$(rpm -q --qf '%{V}' testcloud)" 0.11.4 > /dev/null; testcloud_cmp_code=$?
+            VERSION_NEWER_CODE=11
+            if [[ $testcloud_cmp_code == "$VERSION_NEWER_CODE" ]]; then
+                rlAssertGrep "\\[    0.000000\\] Linux version" "$run/default/plan/provision/default-0/console.log"
+            fi
         fi
     rlPhaseEnd
 

--- a/tests/provision/virtual.testcloud/test.sh
+++ b/tests/provision/virtual.testcloud/test.sh
@@ -48,7 +48,7 @@ rlJournalStart
             rlAssertGrep "disk\\[0\\].size: set to '11 GB' because of 'disk\\[0\\].size: == 11 GB'" "$run/log.txt"
             rlAssertGrep "final domain memory: 2049000" "$run/log.txt"
             rlAssertGrep "final domain root disk size: 11" "$run/log.txt"
-            rlAssertGrep "\\[    0.000000\\] Linux version" "$run/default/plan/provision/default-0/console.txt"
+            rlAssertGrep "\\[    0.000000\\] Linux version" "$run/plan/provision/default-0/logs/console.txt"
         fi
     rlPhaseEnd
 

--- a/tmt.spec
+++ b/tmt.spec
@@ -76,7 +76,7 @@ Provides:       tmt-provision-virtual == %{version}-%{release}
 Obsoletes:      tmt-provision-virtual < %{version}-%{release}
 %endif
 Requires:       tmt == %{version}-%{release}
-Requires:       python3-testcloud >= 0.11.3
+Requires:       python3-testcloud >= 0.11.7
 Requires:       libvirt-daemon-config-network
 Requires:       openssh-clients
 # Recommend qemu system emulators for supported arches

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -2791,7 +2791,13 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin[ProvisionStepDataT, None]):
     # TODO: Generics would provide a better type, https://github.com/teemtee/tmt/issues/1437
     _guest: Optional[Guest] = None
 
-    _preserved_workdir_members = {'logs'}
+    @property
+    def _preserved_workdir_members(self) -> set[str]:
+        """
+        A set of members of the step workdir that should not be removed.
+        """
+
+        return {*super()._preserved_workdir_members, "logs"}
 
     @classmethod
     def base_command(

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1036,7 +1036,11 @@ class GuestData(SerializableContainer):
 
 @container
 class GuestLog:
+    # Log file name
     name: str
+
+    # Linked guest
+    guest: "Guest"
 
     def fetch(self, logger: tmt.log.Logger) -> Optional[str]:
         """
@@ -1794,8 +1798,17 @@ class Guest(tmt.utils.Common):
     def logdir(self) -> Optional[Path]:
         """
         Path to store logs
+
+        Create the directory if it does not exist yet.
         """
-        return self.workdir / 'logs' if self.workdir else None
+
+        if not self.workdir:
+            return None
+
+        dirpath = self.workdir / 'logs'
+        dirpath.mkdir(parents=True, exist_ok=True)
+
+        return dirpath
 
     def fetch_logs(
         self,

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -1383,7 +1383,9 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin[ProvisionTestcloudD
         return successful
 
     def prune(self, logger: tmt.log.Logger) -> None:
-        """ Do not prune console logs """
+        """
+        Do not prune console logs.
+        """
         assert self.workdir is not None  # narrow type
         _console_log = self.workdir / 'console.log'
         if _console_log.exists():

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -4,6 +4,7 @@ import itertools
 import os
 import platform
 import re
+import shutil
 import threading
 import types
 from collections.abc import Iterator
@@ -993,6 +994,9 @@ class GuestTestcloud(tmt.GuestSsh):
         # Prepare DomainConfiguration object before Instance object
         self._domain = DomainConfiguration(self.instance_name)
 
+        assert self.workdir is not None  # narrow type
+        self._domain.console_log_file = self.workdir / 'console.log'
+
         # Prepare Workarounds object
         self._workarounds = Workarounds(defaults=True)
         for cmd in TESTCLOUD_WORKAROUNDS:
@@ -1377,3 +1381,23 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin[ProvisionTestcloudD
                     clean.fail(f"Failed to remove '{image}'.", shift=2)
                     successful = False
         return successful
+
+    def prune(self, logger: tmt.log.Logger) -> None:
+        """ Do not prune console logs """
+        assert self.workdir is not None  # narrow type
+        _console_log = self.workdir / 'console.log'
+        if _console_log.exists():
+            for member in self.workdir.iterdir():
+                if member.name == "console.log":
+                    logger.debug(f"Preserve '{member.relative_to(self.workdir)}'.", level=3)
+                    continue
+                logger.debug(f"Remove '{member}'.", level=3)
+                try:
+                    if member.is_file() or member.is_symlink():
+                        member.unlink()
+                    else:
+                        shutil.rmtree(member)
+                except OSError as error:
+                    logger.warning(f"Unable to remove '{member}': {error}")
+        else:
+            super().prune(logger)

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -994,7 +994,15 @@ class GuestTestcloud(tmt.GuestSsh):
         # Prepare DomainConfiguration object before Instance object
         self._domain = DomainConfiguration(self.instance_name)
 
+        # Make sure that the workdir has the right selinux type set
+        # and set the 'console.log' file destination path
         assert self.workdir is not None  # narrow type
+        assert self.parent is not None  # narrow type
+        if self.parent.plan.my_run.runner.facts.has_selinux:
+            self._run_guest_command(
+                Command("chcon", "--type=virt_tmp_t", self.workdir),
+                silent=True,
+            )
         self._domain.console_log_file = self.workdir / 'console.log'
 
         # Prepare Workarounds object

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -1092,6 +1092,7 @@ class GuestTestcloud(tmt.GuestSsh):
 
         # Boot the virtual machine
         self.info('progress', 'booting...', 'cyan')
+        self.verbose("console", console_log.testcloud_symlink_path, level=2, color="cyan")
         assert libvirt is not None
 
         try:
@@ -1251,6 +1252,9 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin[ProvisionTestcloudD
             # in GB
             disk: 30
 
+    Images
+    ^^^^^^
+
     As the image use ``fedora`` for the latest released Fedora compose,
     ``fedora-rawhide`` for the latest Rawhide compose, short aliases such as
     ``fedora-32``, ``f-32`` or ``f32`` for specific release or a full url to
@@ -1283,9 +1287,22 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin[ProvisionTestcloudD
     In addition to the qcow2 format, Vagrant boxes can be used as well,
     testcloud will take care of unpacking the image for you.
 
+    Reboot
+    ^^^^^^
+
     To trigger hard reboot of a guest, plugin uses testcloud API. It is
     also used to trigger soft reboot unless a custom reboot command was
     specified via ``tmt-reboot -c ...``.
+
+    Console
+    ^^^^^^^
+
+    The full console log is available, after the guest is booted, in the
+    ``logs`` directory under the provision step workdir, for example:
+    ``plan/provision/client/logs/console.txt``. Enable verbose mode
+    using ``-vv`` to get the full path printed to the terminal for easy
+    investigation.
+
     """
 
     _data_class = ProvisionTestcloudData
@@ -1406,7 +1423,7 @@ class ConsoleLog(tmt.steps.provision.GuestLog):
 
     def prepare(self, logger: tmt.log.Logger) -> None:
         """
-        Prepare temporary directory for the console log
+        Prepare temporary directory for the console log.
 
         Special directory is needed for console logs with the right
         selinux context so that virtlogd is able to write there.
@@ -1422,7 +1439,7 @@ class ConsoleLog(tmt.steps.provision.GuestLog):
 
     def cleanup(self, logger: tmt.log.Logger) -> None:
         """
-        Remove the temporary directory
+        Remove the temporary directory.
         """
 
         if self.exchange_directory is None:
@@ -1440,7 +1457,7 @@ class ConsoleLog(tmt.steps.provision.GuestLog):
 
     def fetch(self, logger: tmt.log.Logger) -> Optional[str]:
         """
-        Read the content of the symlink target prepared by testcloud
+        Read the content of the symlink target prepared by testcloud.
         """
 
         text = None

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -994,15 +994,7 @@ class GuestTestcloud(tmt.GuestSsh):
         # Prepare DomainConfiguration object before Instance object
         self._domain = DomainConfiguration(self.instance_name)
 
-        # Make sure that the workdir has the right selinux type set
-        # and set the 'console.log' file destination path
         assert self.workdir is not None  # narrow type
-        assert self.parent is not None  # narrow type
-        if self.parent.plan.my_run.runner.facts.has_selinux:
-            self._run_guest_command(
-                Command("chcon", "--type=virt_tmp_t", self.workdir),
-                silent=True,
-            )
         self._domain.console_log_file = self.workdir / 'console.log'
 
         # Prepare Workarounds object

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -994,17 +994,13 @@ class GuestTestcloud(tmt.GuestSsh):
         # Prepare DomainConfiguration object before Instance object
         self._domain = DomainConfiguration(self.instance_name)
 
-        assert self.workdir is not None  # narrow type
-        assert isinstance(self.parent, tmt.steps.Step)  # narrow type
-        assert self.parent.plan.my_run is not None  # narrow type
-
         # Make sure that the workdir has the right selinux type set
         # and set the 'console.log' file destination path
+        assert self.workdir is not None  # narrow type
+        assert self.parent is not None  # narrow type
         if self.parent.plan.my_run.runner.facts.has_selinux:
-            policy = self.workdir / "policy.cil"
-            policy.write_text("( allow virtlogd_t user_tmp_t ( dir ( search )))")
             self._run_guest_command(
-                Command("semodule", "--install", policy),
+                Command("chcon", "--type=virt_tmp_t", self.workdir),
                 silent=True,
             )
         self._domain.console_log_file = self.workdir / 'console.log'


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/KEX-189

Partially fixes: https://github.com/teemtee/tmt/issues/2624

Console logs are crucial are debugging tests involving a kernel panic/crash as it's the only way to know what happens after a kernel panic/crash. tmt will make use testcloud's new feature [1] to save console logs to {plan.workdir}/{guest_name}_console.log.

[1] https://github.com/teemtee/testcloud/pull/7

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [x] include a release note