### PR TITLE
Enable the `crb` repo when enabling `epel`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,6 +137,8 @@ repos:
           - --exclude=examples/redis/ansible/tasks/redis.yml
           # redis.yml example requires posix module to be installed
           # in order to be parsed by ansible-lint
+        additional_dependencies:
+          - "ansible"
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.9.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,8 +137,6 @@ repos:
           - --exclude=examples/redis/ansible/tasks/redis.yml
           # redis.yml example requires posix module to be installed
           # in order to be parsed by ansible-lint
-        additional_dependencies:
-          - "ansible"
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.9.8

--- a/tests/prepare/feature/epel/data/plans.fmf
+++ b/tests/prepare/feature/epel/data/plans.fmf
@@ -31,6 +31,17 @@ execute:
         environment+:
             STATE: disabled
 
+/flac:
+    summary: Install flac
+    description: Check that crb repo is enabled
+    prepare:
+      - how: feature
+        epel: enabled
+      - how: install
+        package: flac
+    execute:
+        script: flac --help
+
 /profile:
     discover:
       how: shell

--- a/tests/prepare/feature/epel/test.sh
+++ b/tests/prepare/feature/epel/test.sh
@@ -29,6 +29,10 @@ rlJournalStart
         rlPhaseStartTest "Disable EPEL on $image"
             rlRun -s "tmt -vvv run -a plan --name '/epel/disabled' provision --how container --image $image"
         rlPhaseEnd
+
+        if is_centos_9; then
+            rlRun -s "tmt -vvv run -a plan --name '/flac' provision --how container --image $image"
+        fi
     done
 
     # Environment profiles

--- a/tests/prepare/feature/epel/test.sh
+++ b/tests/prepare/feature/epel/test.sh
@@ -30,8 +30,10 @@ rlJournalStart
             rlRun -s "tmt -vvv run -a plan --name '/epel/disabled' provision --how container --image $image"
         rlPhaseEnd
 
-        if is_centos_9; then
-            rlRun -s "tmt -vvv run -a plan --name '/flac' provision --how container --image $image"
+        if is_centos_stream_9 "$image"; then
+            rlPhaseStartTest "Check CRB on $image"
+                rlRun -s "tmt -vvv run -a plan --name '/flac' provision --how container --image $image"
+            rlPhaseEnd
         fi
     done
 

--- a/tmt/steps/prepare/feature/epel-enable.yaml
+++ b/tmt/steps/prepare/feature/epel-enable.yaml
@@ -87,6 +87,12 @@
         - ansible_distribution == "CentOS"
         - ansible_distribution_major_version | int >= 8
       block:
+        - name: Ensure the crb repository is enabled
+          community.general.dnf_config_manager:
+            name: crb
+            state: enabled
+          when: ansible_distribution_major_version | int >= 9
+
         - name: Install package 'epel-release'
           ansible.builtin.dnf:
             name: epel-release

--- a/tmt/steps/prepare/feature/epel-enable.yaml
+++ b/tmt/steps/prepare/feature/epel-enable.yaml
@@ -64,6 +64,7 @@
 
         - name: Enable the crb repository
           ansible.builtin.command: crb enable
+          register: output
           changed_when: output.rc != 0
 
     - name: Enable EPEL repos on CentOS 7
@@ -124,4 +125,5 @@
 
         - name: Enable the crb repository
           ansible.builtin.command: crb enable
+          register: output
           changed_when: output.rc != 0

--- a/tmt/steps/prepare/feature/epel-enable.yaml
+++ b/tmt/steps/prepare/feature/epel-enable.yaml
@@ -62,6 +62,10 @@
           # Enable for Stream 10 once epel-next is available
           when: ansible_distribution_major_version | int == 9
 
+        - name: Enable the crb repository
+          ansible.builtin.command: crb enable
+          changed_when: output.rc != 0
+
     - name: Enable EPEL repos on CentOS 7
       when:
         - ansible_distribution == "CentOS"
@@ -87,12 +91,6 @@
         - ansible_distribution == "CentOS"
         - ansible_distribution_major_version | int >= 8
       block:
-        - name: Ensure the crb repository is enabled
-          community.general.dnf_config_manager:
-            name: crb
-            state: enabled
-          when: ansible_distribution_major_version | int >= 9
-
         - name: Install package 'epel-release'
           ansible.builtin.dnf:
             name: epel-release
@@ -123,3 +121,7 @@
           # EPEL Next is available for CentOS Stream 9
           # Enable for Stream 10 once epel-next is available
           when: ansible_distribution_major_version | int == 9
+
+        - name: Enable the crb repository
+          ansible.builtin.command: crb enable
+          changed_when: output.rc != 0


### PR DESCRIPTION
The `crb` repository is explicitly included in the official set of steps needed to enable the epel repository:

 * https://docs.fedoraproject.org/en-US/epel/getting-started/

Without it some packages, including `tmt` itself, cannot be installed because of missing dependencies.

Also added `ansible` to the `ansible-lint` check dependencies otherwise it would complain about unknown `community.general` collection.