### PR TITLE
ReST rendering improved

### DIFF
--- a/tmt/config/models/themes.py
+++ b/tmt/config/models/themes.py
@@ -1,0 +1,103 @@
+from typing import Any, Optional, Union
+
+import click
+
+import tmt.utils
+from tmt._compat.pydantic import ValidationError
+from tmt._compat.typing import TypeAlias
+from tmt.container import MetadataContainer
+
+Color: TypeAlias = Union[int, tuple[int, int, int], str, None]
+
+
+class Style(MetadataContainer):
+    """
+    A collection of parameters accepted by :py:func:`click.style`.
+    """
+
+    fg: Optional[Color] = None
+    bg: Optional[Color] = None
+    bold: Optional[bool] = None
+    dim: Optional[bool] = None
+    underline: Optional[bool] = None
+    italic: Optional[bool] = None
+    blink: Optional[bool] = None
+    strikethrough: Optional[bool] = None
+
+    def apply(self, text: str) -> str:
+        """
+        Apply this style to a given string.
+        """
+
+        return click.style(text, **self.dict())
+
+
+_DEFAULT_STYLE = Style()
+
+
+class Theme(MetadataContainer):
+    """
+    A collection of items tmt uses to colorize various tokens of its CLI.
+    """
+
+    restructuredtext_text: Style = _DEFAULT_STYLE
+
+    restructuredtext_literal: Style = _DEFAULT_STYLE
+    restructuredtext_emphasis: Style = _DEFAULT_STYLE
+    restructuredtext_strong: Style = _DEFAULT_STYLE
+
+    restructuredtext_literalblock: Style = _DEFAULT_STYLE
+    restructuredtext_literalblock_yaml: Style = _DEFAULT_STYLE
+    restructuredtext_literalblock_shell: Style = _DEFAULT_STYLE
+
+    restructuredtext_admonition_note: Style = _DEFAULT_STYLE
+    restructuredtext_admonition_warning: Style = _DEFAULT_STYLE
+
+    def to_spec(self) -> dict[str, Any]:
+        return {key.replace('_', '-'): value for key, value in self.dict().items()}
+
+    def to_minimal_spec(self) -> dict[str, Any]:
+        spec: dict[str, Any] = {}
+
+        for theme_key, style in self.to_spec().items():
+            style_spec = {
+                style_key: value for style_key, value in style.items() if value is not None
+            }
+
+            if style_spec:
+                spec[theme_key] = style_spec
+
+        return spec
+
+    @classmethod
+    def from_spec(cls: type['Theme'], data: Any) -> 'Theme':
+        try:
+            return Theme.parse_obj(data)
+
+        except ValidationError as error:
+            raise tmt.utils.SpecificationError("Invalid theme configuration.") from error
+
+    @classmethod
+    def from_file(cls: type['Theme'], path: tmt.utils.Path) -> 'Theme':
+        return Theme.from_spec(tmt.utils.yaml_to_dict(path.read_text()))
+
+
+class ThemeConfig(MetadataContainer):
+    active_theme: str = 'default'
+
+    @classmethod
+    def load_theme(cls, theme_name: str) -> Theme:
+        try:
+            return Theme.from_file(
+                tmt.utils.resource_files(tmt.utils.Path('config/themes') / f'{theme_name}.yaml')
+            )
+
+        except FileNotFoundError as exc:
+            raise tmt.utils.GeneralError(f"No such theme '{theme_name}'.") from exc
+
+    @classmethod
+    def get_default_theme(cls) -> Theme:
+        return cls.load_theme('default')
+
+    def get_active_theme(self) -> Theme:
+        return self.load_theme(self.active_theme)

--- a/tmt/config/themes/default.yaml
+++ b/tmt/config/themes/default.yaml
@@ -1,0 +1,23 @@
+# restructuredtext-text:
+
+restructuredtext-literal:
+  fg: green
+restructuredtext-emphasis:
+  fg: blue
+restructuredtext-strong:
+  fg: blue
+  bold: true
+
+restructuredtext-literalblock:
+  fg: green
+restructuredtext-literalblock-yaml:
+  fg: cyan
+restructuredtext-literalblock-shell:
+  fg: yellow
+
+restructuredtext-admonition-note:
+  fg: blue
+  bold: true
+restructuredtext-admonition-warning:
+  fg: yellow
+  bold: true

--- a/tmt/config/themes/plain.yaml
+++ b/tmt/config/themes/plain.yaml
@@ -1,0 +1,12 @@
+# restructuredtext-text:
+
+# restructuredtext-literal:
+# restructuredtext-emphasis:
+# restructuredtext-strong:
+
+# restructuredtext-literalblock:
+# restructuredtext-literalblock-yaml:
+# restructuredtext-literalblock-shell:
+
+# restructuredtext-admonition-note:
+# restructuredtext-admonition-warning:

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -82,8 +82,6 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
     # https://tmt.readthedocs.io/en/stable/contribute.html#docs
     #
     """
-    Prepare guest using Ansible.
-
     Run Ansible playbooks against the guest, by running
     ``ansible-playbook`` for all given playbooks.
 

--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -208,8 +208,8 @@ class Try(tmt.utils.Common):
         # Check user config for custom default plans. Search for all
         # plans starting with the default user plan name (there might be
         # more than just one).
-        try:
-            config_tree = tmt.config.Config().fmf_tree
+        config_tree = tmt.config.Config().fmf_tree
+        if config_tree is not None:
             plan_name = re.escape(USER_PLAN_NAME)
             # cast: once fmf is properly annotated, cast() would not be needed.
             # pyright isn't able to infer the type.
@@ -220,8 +220,6 @@ class Try(tmt.utils.Common):
                     self.tree.tree.update(plan_dict)
                 self.debug("Use the default user plan config.")
                 return self.tree.plans(names=[f"^{plan_name}"], run=run)
-        except MetadataError:
-            self.debug("User config tree not found.")
 
         # Use the default plan template otherwise
         plan_name = re.escape(tmt.templates.DEFAULT_PLAN_NAME)

--- a/tmt/utils/jira.py
+++ b/tmt/utils/jira.py
@@ -99,8 +99,6 @@ class JiraInstance:
             link_config = tmt.config.Config().link
         except tmt.utils.SpecificationError:
             raise
-        except tmt.utils.MetadataError:
-            return None
         if not link_config:
             return None
 


### PR DESCRIPTION
Basically sneaking CLI themes in. The patch brings better and cleaner
rendering of various ReST features, simplified code thanks to the use of
`SkipChildren`, and while I was working on that, I connected the dots
and let tmt configuration dictate colors for these ReST directives.

The main benefit as of now is better rendering of help texts on command
line. I hope to provide documentation - we do not seem to have any place
for it yet - with examples, and start using the rendering for hints and
`tmt about`.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
