### PR TITLE
Force multiline docstrings to start on the second line

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,6 +340,8 @@ select = [
     "FURB",  # refurb
     "RUF",  # ruff
     "D",    # pydocstyle
+    # Override docstring convention
+    "D213", # multi-line-summary-second-line
     ]
 ignore = [
     "B904",  # Within an `except` clause, raise exceptions with `raise ... from err` or `raise ...

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -60,7 +60,8 @@ class Path(click.ParamType):
         param: Optional[click.Parameter],
         ctx: Optional[click.Context],
     ) -> Optional[tmt.utils.Path]:
-        """Convert the value to the correct type. This is not called if
+        """
+        Convert the value to the correct type. This is not called if
         the value is ``None`` (the missing value).
 
         This must accept string values from the command line, as well as


### PR DESCRIPTION
We enable all D* checks, but our selected convention disables some of
them again. Adding D213 to the list of enabled checks does the trick.
    
This will not affect singleline docstrings :/

Pull Request Checklist

* [x] implement the feature