### PR TITLE
Save remote ansible playbooks to correct directory

### DIFF
--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -186,10 +186,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
             lowercased_playbook = _playbook.lower()
 
             def normalize_remote_playbook(raw_playbook: str) -> Path:
-                assert self.step.plan.my_run is not None  # narrow type
-                assert self.step.plan.my_run.tree is not None  # narrow type
-                assert self.step.plan.my_run.tree.root is not None  # narrow type
-                root_path = self.step.plan.my_run.tree.root
+                root_path = self.step.plan.anchor_path
 
                 try:
                     with retry_session(

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -186,7 +186,8 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
             lowercased_playbook = _playbook.lower()
 
             def normalize_remote_playbook(raw_playbook: str) -> Path:
-                root_path = self.step.plan.anchor_path
+                assert self.step.workdir is not None  # narrow type
+                root_path = self.step.workdir
 
                 try:
                     with retry_session(
@@ -225,8 +226,11 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
                 return AnsibleCollectionPlaybook(raw_playbook)
 
             playbook: AnsibleApplicable
+            playbook_root = self.step.plan.anchor_path
 
             if lowercased_playbook.startswith(('http://', 'https://')):
+                assert self.step.workdir is not None  # narrow type
+                playbook_root = self.step.workdir
                 playbook = normalize_remote_playbook(lowercased_playbook)
 
             elif lowercased_playbook.startswith('file://'):
@@ -240,7 +244,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
 
             guest.ansible(
                 playbook,
-                playbook_root=self.step.plan.anchor_path,
+                playbook_root=playbook_root,
                 extra_args=self.data.extra_args,
             )
 


### PR DESCRIPTION
This PR changes the location where remote ansible playbooks are saved. Previously, they were saved in the plan's directory, but now they are saved in the workdir (`/var/tmp/tmt/...`) to ensure that tmt does not modify the plan directory.

This change also resolves the issue with remote ansible playbooks not functioning correctly when used with imported plans.

Fixes: #3237
Fixes: #3349


Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
