### PR TITLE
Fix incorrect directory in /tests/unit/with-development-packages/basic

### DIFF
--- a/tests/unit/test.sh
+++ b/tests/unit/test.sh
@@ -54,7 +54,8 @@ rlJournalStart
         rlPhaseEnd
     else
         rlPhaseStartTest "Unit tests"
-            rlRun "hatch -v run $HATCH_ENVIRONMENT:$PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK tests/unit"
+            # Note: we're not in the root directory!
+            rlRun "hatch -v run $HATCH_ENVIRONMENT:$PYTEST_COMMAND $PYTEST_PARALLELIZE $PYTEST_MARK ."
         rlPhaseEnd
     fi
 


### PR DESCRIPTION
It seems to be broken for some time, but since the test was part of CI on Fedora 39 only, and that the CI does not run on Fedora 39 for some time already, we simply did not know.

Pull Request Checklist

* [x] implement the feature