### PR TITLE
Add distro variants for the newly added distros

### DIFF
--- a/tmt/steps/provision/mrack/mrack-provisioning-config.yaml
+++ b/tmt/steps/provision/mrack/mrack-provisioning-config.yaml
@@ -87,6 +87,8 @@ beaker:
         Fedora-38%: Server
         Fedora-39%: Server
         Fedora-40%: Server
+        Fedora-41%: Server
+        Fedora-42%: Server
 
     distro_tags:
         RHEL-9.0%:


### PR DESCRIPTION
The `mrack` config requires the `distro_variants` section to be updated as well to make it actually working. Relates to #3488.