### PR TITLE
Update copr links to point to the stable repo

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -746,7 +746,7 @@ Handle manually what did not went well:
 __ https://github.com/teemtee/tmt/releases/
 __ https://tmt.readthedocs.io/en/stable/releases.html
 __ https://src.fedoraproject.org/rpms/tmt/pull-requests
-__ https://copr.fedorainfracloud.org/coprs/g/teemtee/tmt/builds/
+__ https://copr.fedorainfracloud.org/coprs/g/teemtee/stable/builds/
 __ https://quay.io/repository/teemtee/tmt
 __ https://pypi.org/project/tmt/
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -750,7 +750,7 @@ Releases:
 https://tmt.readthedocs.io/en/stable/releases.html
 
 Copr:
-https://copr.fedorainfracloud.org/coprs/g/teemtee/tmt/
+https://copr.fedorainfracloud.org/coprs/g/teemtee/stable/
 
 PIP:
 https://pypi.org/project/tmt/

--- a/docs/toolbelt-catalog.yaml
+++ b/docs/toolbelt-catalog.yaml
@@ -27,7 +27,7 @@ metadata:
       - title: pypi
         url: https://pypi.org/project/tmt
       - title: copr
-        url: https://copr.fedorainfracloud.org/coprs/g/teemtee/tmt/
+        url: https://copr.fedorainfracloud.org/coprs/g/teemtee/stable/
       - title: "#tmt"
         url: https://app.slack.com/client/E030G10V24F/C04LRPNDZ4Y
         icon: chat


### PR DESCRIPTION
The original copr repository is no more used. Let's point users to the `stable` one.

Pull Request Checklist

* [x] write the documentation