### PR TITLE
Turn hints internally into classes

### DIFF
--- a/docs/templates/plugins.rst.j2
+++ b/docs/templates/plugins.rst.j2
@@ -159,7 +159,7 @@ The following keys are accepted by all plugins of the ``{{ STEP }}`` step.
 {% if plugin_full_id in HINTS %}
 .. note::
 
-{{ HINTS[plugin_full_id] | indent(3, first=true) }}
+{{ HINTS[plugin_full_id].text | indent(3, first=true) }}
 {% endif %}
 
 {% if STEP == 'prepare-feature' %}

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -663,16 +663,16 @@ def create_method_class(methods: MethodDictType) -> type[click.Command]:
                         break
 
             if how and self._method is None:
-                from tmt.utils.hints import print_hint
+                from tmt.utils.hints import print_hints
 
                 # Use run for logging, steps may not be initialized yet
                 assert context.obj.run is not None  # narrow type
                 assert self.name is not None  # narrow type
 
-                print_hint(
-                    id_=f'{self.name}/{how}', ignore_missing=True, logger=context.obj.run._logger
+                print_hints(
+                    f'{self.name}/{how}', ignore_missing=True, logger=context.obj.run._logger
                 )
-                print_hint(id_=self.name, ignore_missing=True, logger=context.obj.run._logger)
+                print_hints(self.name, ignore_missing=True, logger=context.obj.run._logger)
 
                 raise tmt.utils.SpecificationError(f"Unsupported {self.name} method '{how}'.")
 

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -271,9 +271,9 @@ def _import_or_raise(
 
     except tmt.utils.GeneralError as exc:
         if hint_id is not None:
-            from tmt.utils.hints import print_hint
+            from tmt.utils.hints import print_hints
 
-            print_hint(id_=hint_id, logger=logger)
+            print_hints(hint_id, logger=logger)
 
         if exc_message is not None:
             raise exc_class(exc_message) from exc

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -1698,10 +1698,10 @@ class BasePlugin(Phase, Generic[StepDataT, PluginReturnValueT]):
                 assert isinstance(plugin, BasePlugin)
                 return plugin
 
-        from tmt.utils.hints import print_hint
+        from tmt.utils.hints import print_hints
 
-        print_hint(id_=f'{step.name}/{how}', ignore_missing=True, logger=step._logger)
-        print_hint(id_=step.name, ignore_missing=True, logger=step._logger)
+        print_hints(f'{step.name}/{how}', ignore_missing=True, logger=step._logger)
+        print_hints(step.name, ignore_missing=True, logger=step._logger)
 
         # Report invalid method
         if step.plan is None:

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -2295,9 +2295,9 @@ class GuestSsh(Guest):
             )
         except tmt.utils.RunError as exc:
             if "File 'ansible-playbook' not found." in exc.message:
-                from tmt.utils.hints import print_hint
+                from tmt.utils.hints import print_hints
 
-                print_hint(id_='ansible-not-available', logger=self._logger)
+                print_hints('ansible-not-available', logger=self._logger)
             raise exc
 
     @property

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -81,9 +81,9 @@ class GuestLocal(tmt.Guest):
             # fmt: on
         except tmt.utils.RunError as exc:
             if exc.stderr and 'ansible-playbook: command not found' in exc.stderr:
-                from tmt.utils.hints import print_hint
+                from tmt.utils.hints import print_hints
 
-                print_hint(id_='ansible-not-available', logger=self._logger)
+                print_hints('ansible-not-available', logger=self._logger)
             raise exc
 
     def execute(

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -360,9 +360,9 @@ class GuestContainer(tmt.Guest):
             )
         except tmt.utils.RunError as exc:
             if "File 'ansible-playbook' not found." in exc.message:
-                from tmt.utils.hints import print_hint
+                from tmt.utils.hints import print_hints
 
-                print_hint(id_='ansible-not-available', logger=self._logger)
+                print_hints('ansible-not-available', logger=self._logger)
             raise exc
 
     def podman(

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -91,9 +91,9 @@ def import_testcloud(logger: tmt.log.Logger) -> None:
         )
         from testcloud.workarounds import Workarounds
     except ImportError as error:
-        from tmt.utils.hints import print_hint
+        from tmt.utils.hints import print_hints
 
-        print_hint(id_='provision/virtual.testcloud', logger=logger)
+        print_hints('provision/virtual.testcloud', logger=logger)
 
         raise ProvisionError('Could not import testcloud package.') from error
 

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -336,9 +336,9 @@ def make_junit_xml(
         from lxml import etree
 
     except ImportError:
-        from tmt.utils.hints import print_hint
+        from tmt.utils.hints import print_hints
 
-        print_hint(id_='report/junit', logger=phase._logger)
+        print_hints('report/junit', logger=phase._logger)
 
         return xml_data
 


### PR DESCRIPTION
This should bring better API when working with them. While adding better hints and notes to test and check results, I realized there need to be finer API, to better support hints that will not be rendered, and hints that need to present their summary without a wall of text.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
