### PR TITLE
Improve audit events handling in avc check

### DIFF
--- a/tests/test/check/data/main.fmf
+++ b/tests/test/check/data/main.fmf
@@ -42,6 +42,30 @@
                       ls -alZ /root/passwd.log; \
                       rm -f /root/passwd.log" || /bin/true
 
+    /backlog:
+      test: |
+        set -x
+        systemctl status auditd || /bin/true
+        systemctl start auditd
+
+        # Generate a lot of audit events rapidly
+        for i in $(seq 1 100); do
+          # Create temporary files with specific contexts
+          sudo touch /tmp/avctest-$i
+          sudo ls -Z /tmp/avctest-$i
+          # This should generate audit events
+          sudo chmod 600 /tmp/avctest-$i
+          sudo chcon -t httpd_sys_content_t /tmp/avctest-$i 2>/dev/null || true
+        done
+
+        # Now create an AVC denial
+        sudo bash -c "passwd --help &> /root/passwd.log; \
+                      ls -alZ /root/passwd.log; \
+                      rm -f /root/passwd.log" || /bin/true
+
+        # Clean up
+        sudo rm -f /tmp/avctest-*
+
   /timestamp:
     check:
       - how: avc
@@ -60,6 +84,30 @@
         sudo bash -c "passwd --help &> /root/passwd.log; \
                       ls -alZ /root/passwd.log; \
                       rm -f /root/passwd.log" || /bin/true
+
+    /backlog:
+      test: |
+        set -x
+        systemctl status auditd || /bin/true
+        systemctl start auditd
+
+        # Generate a lot of audit events rapidly
+        for i in $(seq 1 100); do
+          # Create temporary files with specific contexts
+          sudo touch /tmp/avctest-$i
+          sudo ls -Z /tmp/avctest-$i
+          # This should generate audit events
+          sudo chmod 600 /tmp/avctest-$i
+          sudo chcon -t httpd_sys_content_t /tmp/avctest-$i 2>/dev/null || true
+        done
+
+        # Now create an AVC denial
+        sudo bash -c "passwd --help &> /root/passwd.log; \
+                      ls -alZ /root/passwd.log; \
+                      rm -f /root/passwd.log" || /bin/true
+
+        # Clean up
+        sudo rm -f /tmp/avctest-*
 
 /watchdog/ping:
   require:


### PR DESCRIPTION
When troubleshooting ausearch --checkpoint failing tests in certain environments, I've observed changes in avc check behaviour when many events are being created for processing. For example `sshd` from tmt ssh connections or `sudo` usage.  
I haven't found a way a better check to find if all events are 'synced' before running ausearch commands, so I'm parsing `auditctl -s` output, which includes: "backlog field tells how many event records are currently queued waiting for auditd to read them" and make sure it is 0 before proceeding.  
Unfortunatelly that's not enough to make it work reliably. 

Using `--just-one` was a bad idea as ausearch always starts from beginning of the log, with no way to start with the last one. Redirecting stdout to /dev/null seems to be just as fast.  
I've also tried to get the event id with `tail -1 audit.log`, and use `auseach -a $id`, but that also didn't solve race conditions(I think) that arise from running all this through ssh. Neither does various --format and --escape options...or any other options for that matter. 
Using `-ts checkpoint` is ultimately the only way I've found in this sunk-cost-fallacy-rabbit-black-hole.  Well, unless we want to have dedicated log file for just avc failures, just for the duration of the test.

Needs tests and I'm not quite happy with the bash script and report. Would mark is as draft, but that would not trigger pipelines.

Pull Request Checklist

* [ ] implement the feature
* [ ] extend the test coverage
