### PR TITLE
Add Testing Farm As GitHub action to template ini

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -3709,6 +3709,14 @@ class Tree(tmt.utils.Common):
                 dry=dry,
                 logger=logger,
             )
+            tmt.Plan.create(
+                names=['/plans/example'],
+                template='tfaga',
+                path=path,
+                force=force,
+                dry=dry,
+                logger=logger,
+            )
         elif template == 'base':
             tmt.Test.create(
                 names=['/tests/example'],

--- a/tmt/templates/plan/tfaga.j2
+++ b/tmt/templates/plan/tfaga.j2
@@ -1,0 +1,29 @@
+name: Tests by GitHub Action at Testing Farm
+
+on:
+  issue_comment:
+    types:
+      - created
+jobs:
+  build:
+    name: Tests by GitHub Action on Testing Farm service
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: "refs/pull/${{ github.event.issue.number }}/head"
+
+      # https://github.com/sclorg/testing-farm-as-github-action
+      - name: Schedule tests on Testing Farm by Testing-Farm-as-github-action
+        id: github_action
+        uses: sclorg/testing-farm-as-github-action@main
+        with:
+          api_key: "<Testing Farm API key>"
+          git_url: "<An url to the repository with tmt metadata>"
+          git_ref: "<A tmt tests branch, tag or commit specifying the desired git revision which will be used for tests>"
+          tf_scope: "<Define the scope of Testing Farm. Possible options are 'public' or 'private'>"
+          update_pull_request_status: true
+          create_issue_comment: true
+          pull_request_status_name: "<GitHub pull request status name is also used as the name of the test in the Job Summary and in comments>"
+          compose: "<Compose to run tests on>"


### PR DESCRIPTION
so the user can easily integrate their project
into GitHub Pipelines by GitHub Actions.

The reference to Testing Farm as GitHub Action is here: https://github.com/sclorg/testing-farm-as-github-action

Pull Request Checklist

* [ x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
