### PR TITLE
Reset AVC denials after building test images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@
 # Prepare variables
 TMP = $(CURDIR)/tmp
 
-ccred=$(shell tput setaf 1)
-ccgreen=$(shell tput setaf 2)
-ccend=$(shell tput sgr0)
+ccred=$(shell env TERM="$${TERM:-linux}" tput setaf 1)
+ccgreen=$(shell env TERM="$${TERM:-linux}" tput setaf 2)
+ccend=$(shell env TERM="$${TERM:-linux}" tput sgr0)
 
 # Define special targets
 .DEFAULT_GOAL := help
@@ -146,9 +146,9 @@ images/test/bases:  ## Download base images for custom test images
 
 # Build a single container: <image name> <containerfile>
 define do-build-container-image =
-@ echo "$(ccgreen)Building$(ccend) $(ccred)${1}$(ccend) $(ccgreen)image...$(ccend)"
+@ echo "$(ccred)$$(date '+%x %T')$(ccend) $(ccgreen)Building$(ccend) $(ccred)${1}$(ccend) $(ccgreen)image...$(ccend)"
 podman build ${3} -t ${1} -f ./containers/${2} .
-@ echo
+@ echo "$(ccred)$$(date '+%x %T')$(ccend) $(ccgreen)Building$(ccend) $(ccred)${1}$(ccend) $(ccgreen)image done$(ccend)"
 endef
 
 # Return an image name from the given target: <image target>

--- a/Makefile
+++ b/Makefile
@@ -146,9 +146,9 @@ images/test/bases:  ## Download base images for custom test images
 
 # Build a single container: <image name> <containerfile>
 define do-build-container-image =
-@ echo "$(ccred)$$(date '+%x %T')$(ccend) $(ccgreen)Building$(ccend) $(ccred)${1}$(ccend) $(ccgreen)image...$(ccend)"
+@ echo "$(ccred)$$(date '+%Y-%m-%d %H:%M:%S')$(ccend) $(ccgreen)Building$(ccend) $(ccred)${1}$(ccend) $(ccgreen)image...$(ccend)"
 podman build ${3} -t ${1} -f ./containers/${2} .
-@ echo "$(ccred)$$(date '+%x %T')$(ccend) $(ccgreen)Building$(ccend) $(ccred)${1}$(ccend) $(ccgreen)image done$(ccend)"
+@ echo "$(ccred)$$(date '+%Y-%m-%d %H:%M:%S')$(ccend) $(ccgreen)Building$(ccend) $(ccred)${1}$(ccend) $(ccgreen)image done$(ccend)"
 endef
 
 # Return an image name from the given target: <image target>

--- a/tests/images.sh
+++ b/tests/images.sh
@@ -157,6 +157,14 @@ function build_container_image () {
     # https://github.com/teemtee/tmt/issues/2063
     build="make -C $_MAKEFILE_DIR images/test/tmt/container/test/$1"
     rlWaitForCmd "$build" -m 5 -d 5 -t 3600 || rlDie "Unable to prepare the image"
+
+    # TODO: temporarily silencing AVC checks during image builds. The call
+    # to tmt-check-avc-mark should do the trick, but it's not available
+    # in TF yet.
+    #
+    # tmt-check-avc-mark
+    sleep 1
+    LC_ALL=C bash -c 'echo "export AVC_SINCE=\"$(date "+%x %H:%M:%S")\""' > "$(dirname $TMT_TEST_DATA)/checks/avc-mark.txt"
 }
 
 
@@ -170,4 +178,12 @@ function build_container_images () {
     # https://github.com/teemtee/tmt/issues/2063
     build="make -C $_MAKEFILE_DIR images/test"
     rlWaitForCmd "$build" -m 5 -d 5 -t 3600 || rlDie "Unable to prepare the images"
+
+    # TODO: temporarily silencing AVC checks during image builds. The call
+    # to tmt-check-avc-mark should do the trick, but it's not available
+    # in TF yet.
+    #
+    # tmt-check-avc-mark
+    sleep 1
+    LC_ALL=C bash -c 'echo "export AVC_SINCE=\"$(date "+%x %H:%M:%S")\""' > "$(dirname $TMT_TEST_DATA)/checks/avc-mark.txt"
 }

--- a/tests/test/check/test-avc.sh
+++ b/tests/test/check/test-avc.sh
@@ -36,12 +36,7 @@ rlJournalStart
 
             rlAssertGrep "<no matches>" "$avc_log"
             rlAssertGrep "## mark" "$avc_log"
-
-            if [ "$method" = "checkpoint" ]; then
-                /bin/true
-            else
-                rlAssertGrep "export 'AVC_SINCE=[[:digit:]]{2}/[[:digit:]]{2}/[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}'" "$avc_log" -E
-            fi
+            rlAssertGrep "## ausearch" "$avc_log"
         rlPhaseEnd
 
         rlPhaseStartTest "Test nasty AVC check with $PROVISION_HOW ($method method)"
@@ -54,12 +49,7 @@ rlJournalStart
             rlAssertGrep "avc:  denied" "$avc_log"
             rlAssertGrep "path=/root/passwd.log" "$avc_log"
             rlAssertGrep "## mark" "$avc_log"
-
-            if [ "$method" = "checkpoint" ]; then
-                /bin/true
-            else
-                rlAssertGrep "export 'AVC_SINCE=[[:digit:]]{2}/[[:digit:]]{2}/[[:digit:]]{2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}'" "$avc_log" -E
-            fi
+            rlAssertGrep "## ausearch" "$avc_log"
         rlPhaseEnd
     done
 


### PR DESCRIPTION
Also add timestamps to image building logging.

This should help identify which images cause trouble with AVC denials,
and let us build images whose base images we don't control and can break
our tests.

Pull Request Checklist

* [x] implement the feature