### PR TITLE
Add --build-disk-image-only option to bootc plugin

### DIFF
--- a/tmt/schemas/provision/bootc.yaml
+++ b/tmt/schemas/provision/bootc.yaml
@@ -74,5 +74,8 @@ properties:
       - xfs
       - btrfs
 
+  build-disk-image-only:
+    type: boolean
+
 required:
   - how


### PR DESCRIPTION
Add --build-disk-image-only option to bootc plugin

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
