### PR TITLE
tmt-report-result should put test output files into subdirectories

### DIFF
--- a/tests/execute/result/subresults.sh
+++ b/tests/execute/result/subresults.sh
@@ -99,44 +99,44 @@ rlJournalStart
 
 
         # Check the subresults log entries are set in results.yaml
-        rlAssertGrep "- data/.*/extra-tmt-report-result_good_bkr_good_log$" "subresults_beakerlib.yaml"
-        rlAssertGrep "- data/.*/extra-tmt-report-result_bad_bkr_bad_log$" "subresults_beakerlib.yaml"
-        rlAssertGrep "- data/.*/extra-tmt-report-result_weird_bkr_weird_log$" "subresults_beakerlib.yaml"
-        rlAssertGrep "- data/.*/extra-tmt-report-result_skip_bkr_skip_log$" "subresults_beakerlib.yaml"
-        rlAssertGrep "- data/.*/extra-rhts-report-result_bad_bkr_rhts_bad_log$" "subresults_beakerlib.yaml"
+        rlAssertGrep "- data/.*/extra-tmt-report-result_good/bkr_good_log.txt$" "subresults_beakerlib.yaml"
+        rlAssertGrep "- data/.*/extra-tmt-report-result_bad/bkr_bad_log.txt$" "subresults_beakerlib.yaml"
+        rlAssertGrep "- data/.*/extra-tmt-report-result_weird/bkr_weird_log.txt$" "subresults_beakerlib.yaml"
+        rlAssertGrep "- data/.*/extra-tmt-report-result_skip/bkr_skip_log.txt$" "subresults_beakerlib.yaml"
+        rlAssertGrep "- data/.*/extra-rhts-report-result_bad/bkr_rhts_bad_log.txt$" "subresults_beakerlib.yaml"
 
-        rlAssertGrep "- data/.*/fail-subtest_good_good_log$" "subresults_fail.yaml"
-        rlAssertGrep "- data/.*/fail-subtest_fail_fail_log$" "subresults_fail.yaml"
-        rlAssertGrep "- data/.*/fail-subtest_weird_weird_log$" "subresults_fail.yaml"
-        rlAssertGrep "- data/.*/fail-subtest_skip_skip_log$" "subresults_fail.yaml"
-        rlAssertGrep "- data/.*/fail-subtest_fail-rhts_fail-rhts_log$" "subresults_fail.yaml"
+        rlAssertGrep "- data/.*/fail-subtest_good/good_log.txt$" "subresults_fail.yaml"
+        rlAssertGrep "- data/.*/fail-subtest_fail/fail_log.txt$" "subresults_fail.yaml"
+        rlAssertGrep "- data/.*/fail-subtest_weird/weird_log.txt$" "subresults_fail.yaml"
+        rlAssertGrep "- data/.*/fail-subtest_skip/skip_log.txt$" "subresults_fail.yaml"
+        rlAssertGrep "- data/.*/fail-subtest_fail-rhts/fail-rhts_log.txt$" "subresults_fail.yaml"
 
-        rlAssertGrep "- data/.*/skip-subtest_extra-skip2_skip-rhts_log$" "subresults_skip.yaml"
+        rlAssertGrep "- data/.*/skip-subtest_extra-skip2/skip-rhts_log.txt$" "subresults_skip.yaml"
 
-        rlAssertGrep "- data/.*/pass-subtest_good0_good0_log$" "subresults_pass.yaml"
-        rlAssertGrep "- data/.*/pass-subtest_good1_good1_log$" "subresults_pass.yaml"
-        rlAssertGrep "- data/.*/pass-subtest_good2_good2_log$" "subresults_pass.yaml"
-        rlAssertGrep "- data/.*/pass-subtest_good3_good3_log$" "subresults_pass.yaml"
+        rlAssertGrep "- data/.*/pass-subtest_good0/good0_log.txt$" "subresults_pass.yaml"
+        rlAssertGrep "- data/.*/pass-subtest_good1/good1_log.txt$" "subresults_pass.yaml"
+        rlAssertGrep "- data/.*/pass-subtest_good2/good2_log.txt$" "subresults_pass.yaml"
+        rlAssertGrep "- data/.*/pass-subtest_good3/good3_log.txt$" "subresults_pass.yaml"
 
 
         # Check the subresults log files actually exist
         rlRun "log_dir=$run_dir/plan/execute/data/guest/default-0/test"
-        rlAssertExists "$log_dir/shell/pass-3/data/pass-subtest_good0_good0_log"
-        rlAssertExists "$log_dir/shell/pass-3/data/pass-subtest_good1_good1_log"
-        rlAssertExists "$log_dir/shell/pass-3/data/pass-subtest_good2_good2_log"
-        rlAssertExists "$log_dir/shell/pass-3/data/pass-subtest_good3_good3_log"
+        rlAssertExists "$log_dir/shell/pass-3/data/pass-subtest_good0/good0_log.txt"
+        rlAssertExists "$log_dir/shell/pass-3/data/pass-subtest_good1/good1_log.txt"
+        rlAssertExists "$log_dir/shell/pass-3/data/pass-subtest_good2/good2_log.txt"
+        rlAssertExists "$log_dir/shell/pass-3/data/pass-subtest_good3/good3_log.txt"
 
-        rlAssertExists "$log_dir/shell/fail-2/data/fail-subtest_fail_fail_log"
-        rlAssertExists "$log_dir/shell/fail-2/data/fail-subtest_good_good_log"
-        rlAssertExists "$log_dir/shell/fail-2/data/fail-subtest_skip_skip_log"
-        rlAssertExists "$log_dir/shell/fail-2/data/fail-subtest_weird_weird_log"
-        rlAssertExists "$log_dir/shell/fail-2/data/fail-subtest_fail-rhts_fail-rhts_log"
+        rlAssertExists "$log_dir/shell/fail-2/data/fail-subtest_fail/fail_log.txt"
+        rlAssertExists "$log_dir/shell/fail-2/data/fail-subtest_good/good_log.txt"
+        rlAssertExists "$log_dir/shell/fail-2/data/fail-subtest_skip/skip_log.txt"
+        rlAssertExists "$log_dir/shell/fail-2/data/fail-subtest_weird/weird_log.txt"
+        rlAssertExists "$log_dir/shell/fail-2/data/fail-subtest_fail-rhts/fail-rhts_log.txt"
 
-        rlAssertExists "$log_dir/beakerlib-1/data/extra-tmt-report-result_bad_bkr_bad_log"
-        rlAssertExists "$log_dir/beakerlib-1/data/extra-tmt-report-result_good_bkr_good_log"
-        rlAssertExists "$log_dir/beakerlib-1/data/extra-tmt-report-result_skip_bkr_skip_log"
-        rlAssertExists "$log_dir/beakerlib-1/data/extra-tmt-report-result_weird_bkr_weird_log"
-        rlAssertExists "$log_dir/beakerlib-1/data/extra-rhts-report-result_bad_bkr_rhts_bad_log"
+        rlAssertExists "$log_dir/beakerlib-1/data/extra-tmt-report-result_bad/bkr_bad_log.txt"
+        rlAssertExists "$log_dir/beakerlib-1/data/extra-tmt-report-result_good/bkr_good_log.txt"
+        rlAssertExists "$log_dir/beakerlib-1/data/extra-tmt-report-result_skip/bkr_skip_log.txt"
+        rlAssertExists "$log_dir/beakerlib-1/data/extra-tmt-report-result_weird/bkr_weird_log.txt"
+        rlAssertExists "$log_dir/beakerlib-1/data/extra-rhts-report-result_bad/bkr_rhts_bad_log.txt"
         rlAssertExists "$log_dir/beakerlib-1/data/journal.xml"
     rlPhaseEnd
 

--- a/tmt/steps/execute/scripts/tmt-report-result
+++ b/tmt/steps/execute/scripts/tmt-report-result
@@ -36,14 +36,15 @@ copy_outputfile_to_data_dir () {
     # Cut first char if underscore.
     [[ ${fileprefix:0:1} == '_' ]] && fileprefix=$(echo "$fileprefix" | cut -c 2-)
     # Construct the final outputfile.
-    finalOutputFile="${TMT_TEST_DATA}/${fileprefix}/${filename}.txt"
+    relativeFinalOutputFile="${fileprefix}/${filename}.txt"
+    finalOutputFile="${TMT_TEST_DATA}/${relativeFinalOutputFile}"
     # make sure the directory exists.
     mkdir -p "$(dirname "$finalOutputFile")"
     # Copy outputfile to data dir.
     cp -f "$outputFile" "$finalOutputFile"
     # Make sure that the log file is readable for guest.pull()
     chmod a+r "$finalOutputFile"
-    outputFile="$finalOutputFile"
+    outputFile="${relativeFinalOutputFile}"
 }
 
 position=

--- a/tmt/steps/execute/scripts/tmt-report-result
+++ b/tmt/steps/execute/scripts/tmt-report-result
@@ -35,11 +35,15 @@ copy_outputfile_to_data_dir () {
     fileprefix=$(echo "$TESTNAME" | tr / _ | tr ' ' _)
     # Cut first char if underscore.
     [[ ${fileprefix:0:1} == '_' ]] && fileprefix=$(echo "$fileprefix" | cut -c 2-)
-    # Copy outputfile to data dir. Prefix with underscored test name.
-    cp -f "$outputFile" "${TMT_TEST_DATA}/${fileprefix}_${filename}"
+    # Construct the final outputfile.
+    finalOutputFile="${TMT_TEST_DATA}/${fileprefix}/${filename}.txt"
+    # make sure the directory exists.
+    mkdir -p "$(dirname "$finalOutputFile")"
+    # Copy outputfile to data dir.
+    cp -f "$outputFile" "$finalOutputFile"
     # Make sure that the log file is readable for guest.pull()
-    chmod a+r "${TMT_TEST_DATA}/${fileprefix}_${filename}"
-    outputFile="$fileprefix"_"$filename"
+    chmod a+r "$finalOutputFile"
+    outputFile="$finalOutputFile"
 }
 
 position=


### PR DESCRIPTION
Instead of using `fileprefix` as a prefix of filenames, use it to construct a directory, and put files into it. This should present files organized by their `$TESTNAME` rather thana  flat structure, which becomes hard to navigate in case of tests with many phases and logs.

Pull Request Checklist

* [x] implement the feature