### PR TITLE
Refactoring the file copy operations - reflinks with fallback

### DIFF
--- a/tests/unit/test_filesystem.py
+++ b/tests/unit/test_filesystem.py
@@ -1,0 +1,291 @@
+import os
+import shutil
+import stat
+import tempfile
+import time
+from typing import Optional
+from unittest import TestCase, mock
+
+import pytest
+
+import tmt.log
+import tmt.utils
+import tmt.utils.filesystem
+from tmt._compat.pathlib import Path
+
+
+class TestCopyTree(TestCase):
+    def setUp(self):
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.source_dir = self.temp_dir / "source"
+        self.dest_dir = self.temp_dir / "dest"
+        self.source_dir.mkdir()
+        self.dest_dir.mkdir()
+        self.logger = tmt.log.Logger.create()
+
+        # Create test files in source directory
+        (self.source_dir / ".fmf").mkdir()
+        (self.source_dir / ".fmf" / "version").write_text("1")
+        (self.source_dir / "file1.txt").write_text("content1")
+        (self.source_dir / "file2.txt").write_text("content2")
+        (self.source_dir / "subdir").mkdir()
+        (self.source_dir / "subdir" / "file3.txt").write_text("content3")
+
+        # Create a symlink if the platform supports it
+        try:
+            Path.symlink_to(self.source_dir / "file1.txt", self.source_dir / "symlink.txt")
+        except (OSError, NotImplementedError):
+            self.symlinks_supported = False
+        else:
+            self.symlinks_supported = True
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_copy_tree_basic(self):
+        """Test basic copy operation with default parameters"""
+        tmt.utils.filesystem.copy_tree(self.source_dir, self.dest_dir, self.logger)
+
+        # Check if all files were copied
+        assert (self.dest_dir / ".fmf" / "version").exists()
+        assert (self.dest_dir / "file1.txt").exists()
+        assert (self.dest_dir / "file2.txt").exists()
+        assert (self.dest_dir / "subdir" / "file3.txt").exists()
+
+        # Check file contents
+        assert (self.dest_dir / ".fmf" / "version").read_text() == "1"
+        assert (self.dest_dir / "file1.txt").read_text() == "content1"
+        assert (self.dest_dir / "file2.txt").read_text() == "content2"
+        assert (self.dest_dir / "subdir" / "file3.txt").read_text() == "content3"
+
+        # Check symlink if supported
+        if self.symlinks_supported:
+            assert Path.is_symlink(self.dest_dir / "symlink.txt")
+            target = Path.readlink(self.dest_dir / "symlink.txt")
+            assert Path(target).name == "file1.txt"
+
+    def test_reflink_copy(self):
+        """Test copy outcome when the 'cp' (reflink-aware) strategy is used."""
+        # Note: Verifying reflink specifically without mocking is system-dependent.
+        # This test primarily checks if copy succeeds when reflink is attempted.
+        tmt.utils.filesystem.copy_tree(self.source_dir, self.dest_dir, self.logger)
+
+        # Basic check that files were copied (outcome)
+        assert (self.dest_dir / "file1.txt").exists()
+        assert (self.dest_dir / "subdir" / "file3.txt").exists()
+        if self.symlinks_supported:
+            assert Path.is_symlink(self.dest_dir / "symlink.txt")
+
+    @mock.patch(
+        'tmt.utils.filesystem._copy_tree_shutil', wraps=tmt.utils.filesystem._copy_tree_shutil
+    )
+    @mock.patch('tmt.utils.filesystem._copy_tree_cp')
+    def test_fallback_to_shutil_copy_from_cp_failure(
+        self, mock_copy_tree_cp, mock_copy_tree_shutil
+    ):
+        """Test fallback to shutil.copytree when _copy_tree_cp fails."""
+        # Make _copy_tree_cp return False to trigger fallback
+        mock_copy_tree_cp.return_value = False
+
+        # Execute the function
+        tmt.utils.filesystem.copy_tree(self.source_dir, self.dest_dir, self.logger)
+
+        # Verify _copy_tree_cp was called once
+        mock_copy_tree_cp.assert_called_once_with(self.source_dir, self.dest_dir, self.logger)
+        # Verify _copy_tree_shutil was called
+        mock_copy_tree_shutil.assert_called_once_with(self.source_dir, self.dest_dir, self.logger)
+
+        # Verify files were copied using the fallback approach (shutil.copytree)
+        assert (self.dest_dir / ".fmf" / "version").exists()
+        assert (self.dest_dir / "file1.txt").exists()
+        assert (self.dest_dir / "file2.txt").exists()
+        assert (self.dest_dir / "subdir" / "file3.txt").exists()
+
+    def _assert_permissions_copied(self, src_path: Path, dest_path: Path):
+        """Assert that file/directory permissions are copied."""
+        src_mode = stat.S_IMODE(os.stat(src_path).st_mode)
+        dest_mode = stat.S_IMODE(os.stat(dest_path).st_mode)
+        assert src_mode == dest_mode, (
+            f"Permission mismatch for {dest_path}. Expected {oct(src_mode)}, got {oct(dest_mode)}"
+        )
+
+    def _assert_timestamps_copied(self, src_path: Path, dest_path: Path, delta_seconds=2):
+        """
+        Assert that file/directory timestamps (mtime) are copied.
+        atime is too unreliable to assert precisely in cross-platform unit tests.
+        """
+        src_stat = os.stat(src_path)
+        dest_stat = os.stat(dest_path)
+
+        assert abs(src_stat.st_mtime - dest_stat.st_mtime) <= delta_seconds, (
+            f"mtime mismatch for {dest_path}. Expected {src_stat.st_mtime}, got {dest_stat.st_mtime}"  # noqa: E501
+        )
+
+    def _setup_metadata_test_item(
+        self, name: str, is_dir: bool, mode: int, atime: float, mtime: float
+    ):
+        item_path = self.source_dir / name
+        if is_dir:
+            item_path.mkdir()
+        else:
+            item_path.write_text(f"content of {name}")
+        os.chmod(item_path, mode)
+        os.utime(item_path, (atime, mtime))
+        return item_path
+
+    def _run_metadata_test_for_item(self, src_item: Path, delta_seconds: Optional[int] = None):
+        dest_item = self.dest_dir / src_item.name
+        self._assert_permissions_copied(src_item, dest_item)
+        if delta_seconds is not None:
+            self._assert_timestamps_copied(src_item, dest_item, delta_seconds=delta_seconds)
+        else:
+            self._assert_timestamps_copied(src_item, dest_item)
+
+    def test_metadata_cp_reflink(self):
+        """Test metadata preservation with cp --reflink=auto strategy."""
+        file_mode = 0o640
+        dir_mode = 0o750
+        timestamp = time.time() - 3600  # One hour ago
+
+        test_file = self._setup_metadata_test_item(
+            "meta_file.txt", False, file_mode, timestamp, timestamp
+        )
+        test_dir = self._setup_metadata_test_item("meta_dir", True, dir_mode, timestamp, timestamp)
+
+        tmt.utils.filesystem.copy_tree(self.source_dir, self.dest_dir, self.logger)
+
+        # permissions and mtime should be preserved.
+        self._run_metadata_test_for_item(test_file)
+        self._run_metadata_test_for_item(test_dir)
+
+    @mock.patch(
+        'tmt.utils.filesystem._copy_tree_shutil', wraps=tmt.utils.filesystem._copy_tree_shutil
+    )
+    @mock.patch('tmt.utils.filesystem._copy_tree_cp')
+    def test_metadata_preservation_on_cp_failure_fallback_to_shutil(
+        self, mock_copy_tree_cp, mock_copy_tree_shutil_wrapper
+    ):
+        """Test metadata preservation by shutil.copytree when cp command fails."""
+        # Simulate _copy_tree_cp failing
+        mock_copy_tree_cp.return_value = False
+
+        file_mode = 0o400
+        dir_mode = 0o500
+        timestamp = time.time() - 7200
+
+        # Clear dest_dir to ensure a clean state
+        shutil.rmtree(self.dest_dir)
+        self.dest_dir.mkdir()
+
+        test_file = self._setup_metadata_test_item(
+            "meta_file_shutil_fallback.txt", False, file_mode, timestamp, timestamp
+        )
+        test_dir = self._setup_metadata_test_item(
+            "meta_dir_shutil_fallback", True, dir_mode, timestamp, timestamp
+        )
+        (self.source_dir / "another_file_for_shutil_fallback.txt").write_text(
+            "shutil fallback test"
+        )
+
+        tmt.utils.filesystem.copy_tree(self.source_dir, self.dest_dir, self.logger)
+
+        # Verify _copy_tree_cp was called
+        mock_copy_tree_cp.assert_called_once_with(self.source_dir, self.dest_dir, self.logger)
+        # Verify _copy_tree_shutil (via wrapper) was called
+        mock_copy_tree_shutil_wrapper.assert_called_once_with(
+            self.source_dir, self.dest_dir, self.logger
+        )
+
+        # Verify metadata preservation for the specific items by shutil.copytree
+        self._run_metadata_test_for_item(test_file)
+        self._run_metadata_test_for_item(test_dir)
+        assert (self.dest_dir / "another_file_for_shutil_fallback.txt").exists()
+
+    @mock.patch(
+        'tmt.utils.filesystem._copy_tree_shutil', wraps=tmt.utils.filesystem._copy_tree_shutil
+    )
+    @mock.patch('tmt.utils.filesystem._copy_tree_cp', return_value=False)
+    def test_fallback_to_shutil_copy(self, mock_copy_tree_cp, mock_copy_tree_shutil_actual):
+        """Test fallback to shutil.copytree strategy when cp fails."""
+        # Ensure dest_dir is clean for this test
+        shutil.rmtree(self.dest_dir)
+        self.dest_dir.mkdir()
+
+        # Setup items with metadata to check shutil.copytree's preservation
+        file_mode = 0o660
+        dir_mode = 0o770
+        timestamp = time.time() - 10800
+        test_file = self._setup_metadata_test_item(
+            "shutil_file.txt", False, file_mode, timestamp, timestamp
+        )
+        test_dir = self._setup_metadata_test_item(
+            "shutil_dir", True, dir_mode, timestamp, timestamp
+        )
+
+        tmt.utils.filesystem.copy_tree(self.source_dir, self.dest_dir, self.logger)
+
+        # Verify cp attempt failed
+        mock_copy_tree_cp.assert_called_once_with(self.source_dir, self.dest_dir, self.logger)
+        # Verify shutil.copytree was called
+        mock_copy_tree_shutil_actual.assert_called_once_with(
+            self.source_dir, self.dest_dir, self.logger
+        )
+
+        # Verify files were copied by shutil.copytree
+        assert (self.dest_dir / ".fmf" / "version").exists()
+        assert (self.dest_dir / "file1.txt").exists()
+        assert (self.dest_dir / "shutil_file.txt").exists()
+        assert (self.dest_dir / "shutil_dir").exists()
+
+        # Verify metadata preservation by shutil.copytree (which uses copy2)
+        self._run_metadata_test_for_item(test_file)
+        self._run_metadata_test_for_item(test_dir)
+
+    @mock.patch(
+        'tmt.utils.filesystem._copy_tree_shutil',
+        side_effect=OSError("Simulated shutil.copytree failure"),
+    )
+    @mock.patch('tmt.utils.filesystem._copy_tree_cp', return_value=False)
+    def test_all_strategies_fail(self, mock_copy_tree_cp, mock_copy_tree_shutil_failing):
+        """Test GeneralError is raised when all copy strategies fail."""
+        with pytest.raises(tmt.utils.GeneralError):
+            tmt.utils.filesystem.copy_tree(self.source_dir, self.dest_dir, self.logger)
+
+        # Verify all mocks were called as expected
+        mock_copy_tree_cp.assert_called_once_with(self.source_dir, self.dest_dir, self.logger)
+        mock_copy_tree_shutil_failing.assert_called_once_with(
+            self.source_dir, self.dest_dir, self.logger
+        )
+
+    # The test_basic_copy_metadata_preservation is no longer needed as _copy_tree_basic is removed.
+    # Metadata preservation for shutil.copytree is implicitly tested in
+    # test_metadata_preservation_on_cp_failure_fallback_to_shutil and test_fallback_to_shutil_copy.
+
+    def test_copy_to_existing_destination(self):
+        """Test copying into a destination directory that already contains files."""
+        # Create some pre-existing items in the destination
+        (self.dest_dir / "existing_file.txt").write_text("pre-existing content")
+        (self.dest_dir / "subdir").mkdir(exist_ok=True)  # Ensure subdir exists
+        (self.dest_dir / "subdir" / "existing_in_subdir.txt").write_text("pre-existing in subdir")
+        # This file from source will conflict with a pre-existing file
+        (self.dest_dir / "file1.txt").write_text("old file1 content")
+
+        tmt.utils.filesystem.copy_tree(self.source_dir, self.dest_dir, self.logger)
+
+        # Check that source files were copied and overwrite conflicting ones
+        assert (self.dest_dir / ".fmf" / "version").read_text() == "1"
+        assert (self.dest_dir / "file1.txt").read_text() == "content1"  # Should be overwritten
+        assert (self.dest_dir / "file2.txt").read_text() == "content2"
+        assert (self.dest_dir / "subdir" / "file3.txt").read_text() == "content3"
+
+        # Check that pre-existing non-conflicting files are still there
+        assert (self.dest_dir / "existing_file.txt").read_text() == "pre-existing content"
+        assert (
+            self.dest_dir / "subdir" / "existing_in_subdir.txt"
+        ).read_text() == "pre-existing in subdir"
+
+        # Check symlink if supported
+        if self.symlinks_supported:
+            assert Path.is_symlink(self.dest_dir / "symlink.txt")
+            target = Path.readlink(self.dest_dir / "symlink.txt")
+            assert Path(target).name == "file1.txt"

--- a/tests/unit/test_filesystem.py
+++ b/tests/unit/test_filesystem.py
@@ -33,7 +33,7 @@ class TestCopyTree(TestCase):
 
         # Create a symlink if the platform supports it
         try:
-            Path.symlink_to(self.source_dir / "file1.txt", self.source_dir / "symlink.txt")
+            (self.source_dir / "symlink.txt").symlink_to(self.source_dir / "file1.txt")
         except (OSError, NotImplementedError):
             self.symlinks_supported = False
         else:

--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -1,5 +1,4 @@
 import re
-import shutil
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Optional, Union, cast
 
@@ -9,6 +8,7 @@ import tmt
 import tmt.base
 import tmt.log
 import tmt.utils
+import tmt.utils.filesystem
 import tmt.utils.git
 from tmt.base import DependencyFmfId, DependencySimple, FmfId
 from tmt.convert import write
@@ -351,7 +351,7 @@ class BeakerLib(Library):
                         self.parent.debug(f"Failed to find library {self} at {self.url}")
                         raise LibraryError
                     self.parent.debug(f"Library {self} is copied into {directory}")
-                    shutil.copytree(library_path, local_library_path, dirs_exist_ok=True)
+                    tmt.utils.filesystem.copy_tree(library_path, local_library_path, self._logger)
 
                     fake_library_id = (
                         self.identifier
@@ -388,12 +388,16 @@ class BeakerLib(Library):
                         ) from error
 
                     # Copy fmf metadata
-                    shutil.copytree(clone_dir / '.fmf', directory / '.fmf', dirs_exist_ok=True)
+                    tmt.utils.filesystem.copy_tree(
+                        clone_dir / '.fmf',
+                        directory / '.fmf',
+                        self._logger,
+                    )
                     if self.path:
-                        shutil.copytree(
+                        tmt.utils.filesystem.copy_tree(
                             clone_dir / self.path.unrooted() / '.fmf',
                             directory / self.path.unrooted() / '.fmf',
-                            dirs_exist_ok=True,
+                            self._logger,
                         )
                 else:
                     # Either url or path must be defined
@@ -408,13 +412,15 @@ class BeakerLib(Library):
                         f"Copy local library '{self.fmf_node_path}' to '{directory}'.", level=3
                     )
                     # Copy only the required library
-                    shutil.copytree(
-                        library_path, local_library_path, symlinks=True, dirs_exist_ok=True
-                    )
+                    tmt.utils.filesystem.copy_tree(library_path, local_library_path, self._logger)
                     # Remove metadata file(s) and create one with full data
                     self._merge_metadata(library_path, local_library_path)
                     # Copy fmf metadata
-                    shutil.copytree(self.path / '.fmf', directory / '.fmf', dirs_exist_ok=True)
+                    tmt.utils.filesystem.copy_tree(
+                        self.path / '.fmf',
+                        directory / '.fmf',
+                        self._logger,
+                    )
             except (tmt.utils.RunError, tmt.utils.RetryError, tmt.utils.GitUrlError) as error:
                 assert self.url is not None
                 # Fallback to install during the prepare step if in rpm format

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -541,7 +541,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             if not dist_git_source or dist_git_merge:
                 self.debug(f"Copy '{directory}' to '{self.testdir}'.")
                 if not self.is_dry_run:
-                    assert isinstance(self.run, tmt.Run)  # Needed for mypy check
                     tmt.utils.filesystem.copy_tree(directory, self.testdir, self._logger)
 
         # Prepare path of the dynamic reference
@@ -581,7 +580,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 )
                 # Copy rest of files so TMT_SOURCE_DIR has patches, sources and spec file
                 # FIXME 'worktree' could be used as sourcedir when 'url' is not set
-                assert isinstance(self.run, tmt.Run)  # Needed for mypy check
                 tmt.utils.filesystem.copy_tree(
                     self.testdir if ref else git_root,
                     sourcedir,
@@ -721,7 +719,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             # Save fmf metadata
             clonedir = self.clone_dirpath / 'tests'
             clone_tree_path = clonedir / path.unrooted()
-            assert isinstance(self.run, tmt.Run)  # Needed for mypy check
             for file_path in tmt.utils.filter_paths(tree_path, [r'\.fmf']):
                 tmt.utils.filesystem.copy_tree(
                     file_path,
@@ -738,7 +735,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 shutil.copymode(tree_path / upgrade_path, clone_tree_path / upgrade_path)
 
         # Prefix tests and handle library requires
-        assert isinstance(self.run, tmt.Run)  # Needed for mypy check
         for test in self._tests:
             # Propagate `where` key
             test.where = cast(tmt.steps.discover.DiscoverStepData, self.data).where
@@ -783,7 +779,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             # Clean self.testdir and copy back only required tests and files from clonedir
             # This is to have correct paths in tests
             shutil.rmtree(self.testdir, ignore_errors=True)
-            assert isinstance(self.run, tmt.Run)  # Needed for mypy check
             tmt.utils.filesystem.copy_tree(clonedir, self.testdir, self._logger)
 
         # Cleanup clone directories
@@ -861,7 +856,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 copy_these = [dist_git_extract.relative_to(sourcedir)]
             else:
                 copy_these = [top_fmf_root.relative_to(sourcedir)]
-            assert isinstance(self.run, tmt.Run)  # Needed for mypy check
             for to_copy in copy_these:
                 src = sourcedir / to_copy
                 if src.is_dir():

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -849,7 +849,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                     git_root = self.get_git_root(Path(self.step.plan.node.root))
                     self.debug(f"Copy '{git_root}' to '{self.testdir}'.")
                     if not self.is_dry_run:
-                        shutil.copytree(git_root, self.testdir, symlinks=True, dirs_exist_ok=True)
+                        tmt.utils.filesystem.copy_tree(git_root, self.testdir, self._logger)
 
         # Copy extracted sources into testdir
         if not self.is_dry_run:

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -16,6 +16,7 @@ import tmt.options
 import tmt.steps
 import tmt.steps.discover
 import tmt.utils
+import tmt.utils.filesystem
 import tmt.utils.git
 from tmt.base import _RawAdjustRule
 from tmt.container import container, field
@@ -540,7 +541,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             if not dist_git_source or dist_git_merge:
                 self.debug(f"Copy '{directory}' to '{self.testdir}'.")
                 if not self.is_dry_run:
-                    shutil.copytree(directory, self.testdir, symlinks=True)
+                    assert isinstance(self.run, tmt.Run)  # Needed for mypy check
+                    tmt.utils.filesystem.copy_tree(directory, self.testdir, self._logger)
 
         # Prepare path of the dynamic reference
         try:
@@ -579,11 +581,11 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 )
                 # Copy rest of files so TMT_SOURCE_DIR has patches, sources and spec file
                 # FIXME 'worktree' could be used as sourcedir when 'url' is not set
-                shutil.copytree(
+                assert isinstance(self.run, tmt.Run)  # Needed for mypy check
+                tmt.utils.filesystem.copy_tree(
                     self.testdir if ref else git_root,
                     sourcedir,
-                    symlinks=True,
-                    dirs_exist_ok=True,
+                    self._logger,
                 )
                 # patch & rediscover will happen later in the prepare step
                 if not self.get('dist-git-download-only'):
@@ -719,22 +721,24 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             # Save fmf metadata
             clonedir = self.clone_dirpath / 'tests'
             clone_tree_path = clonedir / path.unrooted()
+            assert isinstance(self.run, tmt.Run)  # Needed for mypy check
             for file_path in tmt.utils.filter_paths(tree_path, [r'\.fmf']):
-                shutil.copytree(
+                tmt.utils.filesystem.copy_tree(
                     file_path,
                     clone_tree_path / file_path.relative_to(tree_path),
-                    dirs_exist_ok=True,
+                    self._logger,
                 )
 
             # Save upgrade plan
             upgrade_path = self.get('upgrade_path')
             if upgrade_path:
                 upgrade_path = f"{upgrade_path.lstrip('/')}.fmf"
-                (clone_tree_path / upgrade_path).parent.mkdir()
+                (clone_tree_path / upgrade_path).parent.mkdir(parents=True, exist_ok=True)
                 shutil.copyfile(tree_path / upgrade_path, clone_tree_path / upgrade_path)
                 shutil.copymode(tree_path / upgrade_path, clone_tree_path / upgrade_path)
 
         # Prefix tests and handle library requires
+        assert isinstance(self.run, tmt.Run)  # Needed for mypy check
         for test in self._tests:
             # Propagate `where` key
             test.where = cast(tmt.steps.discover.DiscoverStepData, self.data).where
@@ -743,10 +747,10 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 # Save only current test data
                 assert test.path is not None  # narrow type
                 relative_test_path = test.path.unrooted()
-                shutil.copytree(
+                tmt.utils.filesystem.copy_tree(
                     tree_path / relative_test_path,
                     clone_tree_path / relative_test_path,
-                    dirs_exist_ok=True,
+                    self._logger,
                 )
 
                 # Copy all parent main.fmf files
@@ -754,6 +758,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 while parent_dir.resolve() != Path.cwd().resolve():
                     parent_dir = parent_dir.parent
                     if (tree_path / parent_dir / 'main.fmf').exists():
+                        # Ensure parent directory exists
+                        (clone_tree_path / parent_dir).mkdir(parents=True, exist_ok=True)
                         shutil.copyfile(
                             tree_path / parent_dir / 'main.fmf',
                             clone_tree_path / parent_dir / 'main.fmf',
@@ -777,7 +783,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             # Clean self.testdir and copy back only required tests and files from clonedir
             # This is to have correct paths in tests
             shutil.rmtree(self.testdir, ignore_errors=True)
-            shutil.copytree(clonedir, self.testdir)
+            assert isinstance(self.run, tmt.Run)  # Needed for mypy check
+            tmt.utils.filesystem.copy_tree(clonedir, self.testdir, self._logger)
 
         # Cleanup clone directories
         if self.clone_dirpath.exists():
@@ -854,14 +861,14 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 copy_these = [dist_git_extract.relative_to(sourcedir)]
             else:
                 copy_these = [top_fmf_root.relative_to(sourcedir)]
+            assert isinstance(self.run, tmt.Run)  # Needed for mypy check
             for to_copy in copy_these:
                 src = sourcedir / to_copy
                 if src.is_dir():
-                    shutil.copytree(
+                    tmt.utils.filesystem.copy_tree(
                         sourcedir / to_copy,
                         self.testdir if flatten else self.testdir / to_copy,
-                        symlinks=True,
-                        dirs_exist_ok=True,
+                        self._logger,
                     )
                 else:
                     shutil.copyfile(src, self.testdir / to_copy)

--- a/tmt/utils/filesystem.py
+++ b/tmt/utils/filesystem.py
@@ -65,6 +65,7 @@ def copy_tree(
     Copy directory efficiently, trying different strategies.
 
     Attempts strategies in order:
+
     #. ``cp -a --reflink=auto`` (copy-on-write, with ``cp``'s own
        fallback).
 

--- a/tmt/utils/filesystem.py
+++ b/tmt/utils/filesystem.py
@@ -72,10 +72,26 @@ def copy_tree(
 
     Attempts strategies in order:
     1. 'cp -a --reflink=auto' (copy-on-write, with cp's own fallback).
+       - Reflinks provide fast, space-efficient copies that behave like normal copies
+       - They don't use additional storage space unless the file is modified
+       - Supported on btrfs (Fedora default since F33) and XFS (CentOS Stream 8+)
+       - Using '--reflink=auto' means 'cp' automatically falls back to standard copy
+         if reflinks aren't supported by the filesystem
     2. shutil.copytree as a final fallback.
+       - Used if the 'cp' command fails for any reason
+       - Maintains symlinks (symlinks=True)
+       - Merges with existing destination directories (dirs_exist_ok=True)
 
     Symlinks are always preserved. The destination directory `dst` and its
-    parents will be created if they do not exist.
+    parents will be created if they do not exist. File permissions and timestamps
+    are preserved in all copy strategies.
+
+    Example usage:
+        # Copy a directory tree with all its content
+        copy_tree(Path("/path/to/source"), Path("/path/to/destination"), logger)
+
+        # Copy with relative paths
+        copy_tree(workdir / "original", workdir / "backup", logger)
 
     :param src: Source directory path. Must exist and be a directory.
     :param dst: Destination directory path.

--- a/tmt/utils/filesystem.py
+++ b/tmt/utils/filesystem.py
@@ -1,0 +1,116 @@
+"""
+Utility functions for filesystem operations.
+"""
+
+import shutil
+
+import tmt.log
+from tmt._compat.pathlib import Path
+from tmt.utils import Command, GeneralError, RunError
+
+
+def _copy_tree_cp(
+    src: Path,
+    dst: Path,
+    logger: tmt.log.Logger,
+) -> bool:
+    """
+    Attempt to copy directory using 'cp -a --reflink=auto'.
+
+    The 'cp' command itself will fall back to a standard copy if reflink is
+    not supported by the filesystem.
+    Returns True if successful, False if `cp` command fails with `RunError`.
+    """
+    cmd = ['cp', '-a', '--reflink=auto']
+
+    logger.debug(f"Attempting copy from '{src}' to '{dst}' with {cmd}")
+
+    try:
+        # The '/./' at the end of the source path tells cp to copy the *contents* of the directory
+        # rather than creating a new subdirectory in the destination
+        Command(*cmd, f"{src}/./", str(dst)).run(cwd=None, logger=logger, join=True, silent=True)
+        return True
+    except RunError as error:
+        logger.debug(f"cp copy command failed: {error}, falling back")
+        return False
+    # Let other exceptions (e.g. permissions, disk full) propagate
+
+
+def _copy_tree_shutil(
+    src: Path,
+    dst: Path,
+    logger: tmt.log.Logger,
+) -> None:
+    """
+    Perform copy using shutil.copytree.
+
+    This is typically a fallback strategy. It ensures that the destination
+    directory `dst` and its parents exist before attempting the copy.
+    """
+    logger.debug(f"Performing shutil.copytree from '{src}' to '{dst}'")
+
+    # Ensure destination directory `dst` and its parents exist.
+    # shutil.copytree with dirs_exist_ok=True will then copy contents into `dst`,
+    # merging if `dst` already contains files (e.g. from a previous failed attempt).
+    dst.mkdir(parents=True, exist_ok=True)
+
+    shutil.copytree(
+        src,
+        dst,
+        symlinks=True,
+        dirs_exist_ok=True,
+    )
+
+
+def copy_tree(
+    src: Path,
+    dst: Path,
+    logger: tmt.log.Logger,
+) -> None:
+    """
+    Copy directory efficiently, trying different strategies.
+
+    Attempts strategies in order:
+    1. 'cp -a --reflink=auto' (copy-on-write, with cp's own fallback).
+    2. shutil.copytree as a final fallback.
+
+    Symlinks are always preserved. The destination directory `dst` and its
+    parents will be created if they do not exist.
+
+    :param src: Source directory path. Must exist and be a directory.
+    :param dst: Destination directory path.
+    :param logger: Logger to use for debug messages.
+    :raises GeneralError: when copying fails using all strategies, or if `src`
+                         does not exist or is not a directory.
+    """
+    logger.debug(f"Copying directory tree from '{src}' to '{dst}'")
+
+    if not src.is_dir():
+        # Add an explicit check for src, as 'cp' or 'shutil.copytree' might give
+        # less clear or varied errors. This ensures a consistent error message.
+        raise GeneralError(f"Source '{src}' for copy_tree is not a directory or does not exist.")
+
+    # Ensure destination directory `dst` and its parents exist.
+    # This is crucial for `cp` and helpful for `shutil.copytree` (as it creates parent dirs).
+    dst.mkdir(parents=True, exist_ok=True)
+
+    # 1. Try 'cp -a --reflink=auto' copy.
+    #    'cp' itself handles fallback from reflink to standard copy if reflink=auto is used.
+    if _copy_tree_cp(src, dst, logger):
+        logger.debug(
+            "Copy finished using 'cp -a --reflink=auto' strategy (or its internal fallback)."
+        )
+        return
+
+    # 2. Fallback to shutil.copytree
+    logger.debug("Falling back to shutil.copytree strategy.")
+    try:
+        _copy_tree_shutil(src, dst, logger)
+        logger.debug("Copy finished using shutil.copytree strategy.")
+    except Exception as error:
+        # Catching a broad Exception here because shutil.copytree can raise various errors
+        # (e.g., OSError, FileExistsError if dst is a file after mkdir, etc.)
+        # and we want to wrap them all in GeneralError.
+        raise GeneralError(
+            f"Failed to copy directory tree from '{src}' to '{dst}' using all strategies."
+        ) from error

--- a/tmt/utils/filesystem.py
+++ b/tmt/utils/filesystem.py
@@ -15,11 +15,13 @@ def _copy_tree_cp(
     logger: tmt.log.Logger,
 ) -> bool:
     """
-    Attempt to copy directory using 'cp -a --reflink=auto'.
+    Attempt to copy directory using ``cp -a --reflink=auto``.
 
-    The 'cp' command itself will fall back to a standard copy if reflink is
-    not supported by the filesystem.
-    Returns True if successful, False if `cp` command fails with `RunError`.
+    The ``cp`` command itself will fall back to a standard copy if
+    reflink is not supported by the filesystem.
+
+    :returns: ``True`` if successful, ``False`` if ``cp`` command fails
+        with :py:class:`RunError`.
     """
     try:
         # The '/./' at the end of the source path tells cp to copy the *contents* of the directory
@@ -63,22 +65,32 @@ def copy_tree(
     Copy directory efficiently, trying different strategies.
 
     Attempts strategies in order:
-    1. 'cp -a --reflink=auto' (copy-on-write, with cp's own fallback).
-       - Reflinks provide fast, space-efficient copies that behave like normal copies
-       - They don't use additional storage space unless the file is modified
-       - Supported on btrfs (Fedora default since F33) and XFS (CentOS Stream 8+)
-       - Using '--reflink=auto' means 'cp' automatically falls back to standard copy
-         if reflinks aren't supported by the filesystem
-    2. shutil.copytree as a final fallback.
-       - Used if the 'cp' command fails for any reason
-       - Maintains symlinks (symlinks=True)
-       - Merges with existing destination directories (dirs_exist_ok=True)
+    #. ``cp -a --reflink=auto`` (copy-on-write, with ``cp``'s own
+       fallback).
+
+       * Reflinks provide fast, space-efficient copies that behave like
+         normal copies
+       * They don't use additional storage space unless the file is
+         modified
+       * Supported on btrfs (Fedora default since F33) and XFS (CentOS
+         Stream 8+)
+       * Using ``--reflink=auto`` means ``cp`` automatically falls back
+         to standard copy if reflink isn't supported by the filesystem
+
+    #. :py:func:`shutil.copytree` as a final fallback.
+
+       * Used if the ``cp`` command fails for any reason
+       * Maintains symlinks (``symlinks=True``)
+       * Merges with existing destination directories (``dirs_exist_ok=True``)
 
     Symlinks are always preserved. The destination directory `dst` and its
     parents will be created if they do not exist. File permissions and timestamps
     are preserved in all copy strategies.
 
     Example usage:
+
+    .. code-block:: python
+
         # Copy a directory tree with all its content
         copy_tree(Path("/path/to/source"), Path("/path/to/destination"), logger)
 
@@ -88,8 +100,8 @@ def copy_tree(
     :param src: Source directory path. Must exist and be a directory.
     :param dst: Destination directory path.
     :param logger: Logger to use for debug messages.
-    :raises GeneralError: when copying fails using all strategies, or if `src`
-                         does not exist or is not a directory.
+    :raises GeneralError: when copying fails using all strategies, or if
+        ``src`` does not exist or is not a directory.
     """
     logger.debug(f"Copying directory tree from '{src}' to '{dst}'")
 


### PR DESCRIPTION
More or less follow-up on https://github.com/teemtee/tmt/pull/2791  
The way tmt is copying files appears to be quite a performance bottleneck in some scenarios and can cause issues like https://github.com/teemtee/tmt/issues/3558 (well, reflinks wouldn't help with running out of inodes there). 

What makes `reflinks` interesting, is that it behaves the same as normal `cp` operation, but doesn't take additional storage space, unless the file is changed.

They do need to be supported by the underlying filesystem. Notably:
✅ [Btrfs](https://btrfs.readthedocs.io/en/latest/Reflink.html) - Fedora default since F33
✅ XFS - reflinks supported since CentOS Stream 8

:x: ext4 - Ubuntu GitHub action runners
:x: EFS - AWS 

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] mention the version
* [ ] include a release note
