### PR TITLE
Add the `bootc` method for installing packages

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -5,6 +5,16 @@
 ======================
 
 
+tmt-1.47.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When `tmt` works with the image mode images, it now uses native package
+installation method instead of using `rpm-ostree`: `tmt` creates a
+`Containerfile` based on the booted image, adds needed packages there,
+builds the image and reboots the system to use the fresh image with the
+necessary packages.
+
+
 tmt-1.46.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -45,6 +55,7 @@ hardware property has been proposed to allow specifying the desired
 system management interface (e.g., IPMI) when provisioning hardware.
 While not yet implemented, this feature aims to support more precise
 hardware selection in the future.
+
 
 tmt-1.45.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/provision/bootc/data/includes-deps.containerfile
+++ b/tests/provision/bootc/data/includes-deps.containerfile
@@ -1,6 +1,6 @@
 FROM quay.io/fedora/fedora-bootc:41
 
-RUN dnf -y install cloud-init rsync && \
+RUN dnf -y install cloud-init rsync vim && \
     ln -s ../cloud-init.target /usr/lib/systemd/system/default.target.wants && \
     rm /usr/local -rf && ln -sr /var/usrlocal /usr/local && mkdir -p /var/usrlocal/bin && \
     dnf clean all

--- a/tests/provision/bootc/data/plans.fmf
+++ b/tests/provision/bootc/data/plans.fmf
@@ -5,6 +5,8 @@ provision:
     disk: 20
 execute:
     how: tmt
+environment:
+    PATTERN: localhost/tmt/bootc/
 
 
 /image:
@@ -14,16 +16,12 @@ execute:
         provision+:
             add-tmt-dependencies: true
             container-image: localhost/tmt-bootc-needs-deps
-        environment:
-            PATTERN: localhost/tmtmodified
 
     /includes-deps:
         summary: "Image that already includes dependencies"
         provision+:
             add-tmt-dependencies: false
             container-image: localhost/tmt-bootc-includes-deps
-        environment:
-            PATTERN: localhost/tmt-bootc-includes-deps
 
 /containerfile:
 
@@ -32,8 +30,6 @@ execute:
         provision+:
             add-tmt-dependencies: true
             container-file: needs-deps.containerfile
-        environment:
-            PATTERN: localhost/tmtmodified
 
     /includes-deps:
         summary: "Containerfile that already includes dependencies"
@@ -41,5 +37,3 @@ execute:
             how: bootc
             add-tmt-dependencies: false
             container-file: includes-deps.containerfile
-        environment:
-            PATTERN: localhost/tmtbase

--- a/tests/provision/bootc/data/test.fmf
+++ b/tests/provision/bootc/data/test.fmf
@@ -1,2 +1,4 @@
 summary: Check that booted image matches expected pattern
+require:
+  - tree
 test: "bootc status && bootc status | grep $PATTERN"

--- a/tests/provision/bootc/main.fmf
+++ b/tests/provision/bootc/main.fmf
@@ -4,7 +4,7 @@ tag+:
   - provision-bootc
 require:
   - tmt+provision-virtual
-duration: 40m
+duration: 60m
 
 # As for now there is an expected AVC failure:
 # https://github.com/osbuild/bootc-image-builder/issues/645

--- a/tests/provision/bootc/test.sh
+++ b/tests/provision/bootc/test.sh
@@ -17,20 +17,45 @@ rlJournalStart
 
     rlPhaseStartTest "Image that needs dependencies"
         rlRun "podman build . -f needs-deps.containerfile -t $IMAGE_NEEDS_DEPS"
-        rlRun "tmt -vvv run --scratch -i $run plan --name /plans/image/needs-deps"
+        rlRun -s "tmt -vvv run --scratch -i $run plan --name /plans/image/needs-deps"
+        # Testing the output of the bootc package manager
+        rlAssertGrep "building container image with dependencies" $rlRun_LOG
+        rlAssertGrep "STEP 1/2: FROM containers-storage:localhost/tmt/bootc" $rlRun_LOG
+        rlAssertGrep "Successfully tagged localhost/tmt/bootc/" $rlRun_LOG
+        rlAssertGrep "switching to new image localhost/tmt/bootc/" $rlRun_LOG
+        rlAssertGrep "rebooting to apply new image" $rlRun_LOG
+
     rlPhaseEnd
 
     rlPhaseStartTest "Image that already includes dependencies"
         rlRun "podman build . -f includes-deps.containerfile -t $IMAGE_INCLUDES_DEPS"
-        rlRun "tmt -vvv run --scratch -i $run plan --name /plans/image/includes-deps"
+        rlRun -s "tmt -vvv run --scratch -i $run plan --name /plans/image/includes-deps"
+        # Testing the output of the bootc package manager
+        rlAssertGrep "building container image with dependencies" $rlRun_LOG
+        rlAssertGrep "STEP 1/2: FROM containers-storage:localhost/tmt-bootc-includes-deps" $rlRun_LOG
+        rlAssertGrep "Successfully tagged localhost/tmt/bootc/" $rlRun_LOG
+        rlAssertGrep "switching to new image localhost/tmt/bootc/" $rlRun_LOG
+        rlAssertGrep "rebooting to apply new image" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Containerfile that needs dependencies"
-        rlRun "tmt -vvv run --scratch -i $run plan --name /plans/containerfile/needs-deps"
+        rlRun -s "tmt -vvv run --scratch -i $run plan --name /plans/containerfile/needs-deps"
+        # Testing the output of the bootc package manager
+        rlAssertGrep "building container image with dependencies" $rlRun_LOG
+        rlAssertGrep "STEP 1/2: FROM containers-storage:localhost/tmtmodified" $rlRun_LOG
+        rlAssertGrep "Successfully tagged localhost/tmt/bootc/" $rlRun_LOG
+        rlAssertGrep "switching to new image localhost/tmt/bootc/" $rlRun_LOG
+        rlAssertGrep "rebooting to apply new image" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Containerfile that already includes dependencies"
-        rlRun "tmt -vvv run --scratch -i $run plan --name /plans/containerfile/includes-deps"
+        rlRun -s "tmt -vvv run --scratch -i $run plan --name /plans/containerfile/includes-deps"
+        # Testing the output of the bootc package manager
+        rlAssertGrep "building container image with dependencies" $rlRun_LOG
+        rlAssertGrep "STEP 1/2: FROM containers-storage:localhost/tmtbase-" $rlRun_LOG
+        rlAssertGrep "Successfully tagged localhost/tmt/bootc/" $rlRun_LOG
+        rlAssertGrep "switching to new image localhost/tmt/bootc/" $rlRun_LOG
+        rlAssertGrep "rebooting to apply new image" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -1,0 +1,264 @@
+import json
+import re
+import uuid
+from typing import Any, Optional, cast
+
+import tmt.utils
+from tmt.package_managers import (
+    FileSystemPath,
+    Installable,
+    Options,
+    PackageManager,
+    PackageManagerEngine,
+    dnf,
+    provides_package_manager,
+)
+from tmt.utils import Command, CommandOutput, GeneralError, Path, RunError, ShellScript
+
+
+class BootcEngine(PackageManagerEngine):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize bootc engine for package management"""
+        super().__init__(*args, **kwargs)
+
+        self.aux_engine = dnf.DnfEngine(*args, **kwargs)
+
+        self.initialize_containerfile_directives()
+
+    def initialize_containerfile_directives(self) -> None:
+        """Initialize containerfile directives"""
+        self.containerfile_directives = self._get_base_containerfile_directives()
+
+    def prepare_command(self) -> tuple[Command, Command]:
+        """
+        Prepare installation command for bootc
+        """
+        command = Command()
+
+        if self.guest.facts.is_superuser is False:
+            command += Command('sudo')
+
+        command += Command('bootc')
+        return (command, Command(''))
+
+    def _get_current_bootc_image(self) -> str:
+        """Get the current bootc image running on the system"""
+
+        command, _ = self.prepare_command()
+        command += Command('status', '--json')
+        output = self.guest.execute(command, silent=True)
+
+        if not output.stdout:
+            raise tmt.utils.PrepareError("Failed to get current bootc status: empty output.")
+
+        try:
+            image_status = json.loads(output.stdout)
+        except json.JSONDecodeError as error:
+            raise tmt.utils.PrepareError(f"Failed to parse bootc status JSON: {error}")
+
+        if not image_status:
+            raise tmt.utils.PrepareError("Failed to get current bootc status: empty JSON.")
+
+        # Extract nested information with clear error messages for each missing key
+        try:
+            booted = image_status.get('status', {}).get('booted', {})
+            if not booted:
+                raise KeyError("'booted' key")
+
+            image_info = booted.get('image')
+            if not image_info:
+                raise KeyError("'image' key in booted status")
+
+            image_data = image_info.get('image', {})
+
+            base_image = cast(str, image_data.get('image', ''))
+            if not base_image:
+                raise KeyError("'image' name in image data")
+
+            return base_image
+        except KeyError as error:
+            raise tmt.utils.PrepareError(f"Failed to extract bootc image info: missing {error}")
+
+    def _get_base_containerfile_directives(self) -> list[str]:
+        return [f'FROM containers-storage:{self._get_current_bootc_image()}']
+
+    def check_presence(self, *installables: Installable) -> ShellScript:
+        script = self.aux_engine.check_presence(*installables)
+        self.containerfile_directives.append(f'RUN {script}')
+        return script
+
+    def install(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> ShellScript:
+        script = self.aux_engine.install(*installables, options=options)
+        self.containerfile_directives.append(f'RUN {script}')
+        return script
+
+    def reinstall(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> ShellScript:
+        script = self.aux_engine.reinstall(*installables, options=options)
+        self.containerfile_directives.append(f'RUN {script}')
+        return script
+
+    def install_debuginfo(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> ShellScript:
+        script = self.aux_engine.install_debuginfo(*installables, options=options)
+        self.containerfile_directives.append(f'RUN {script}')
+        return script
+
+    def refresh_metadata(self) -> ShellScript:
+        script = self.aux_engine.refresh_metadata()
+        self.containerfile_directives.append(f'RUN {script}')
+        return script
+
+
+@provides_package_manager('bootc')
+class Bootc(PackageManager[BootcEngine]):
+    NAME = 'bootc'
+
+    _engine_class = BootcEngine
+
+    # Invoke e.g. `bootc status`, and check if it returns "Booted image".
+    probe_command = ShellScript(
+        "type bootc && sudo bootc status && ((sudo bootc status --format yaml | grep -e 'booted: null' -e 'image: null') && exit 1 || exit 0)"  # noqa: E501
+    ).to_shell_command()
+
+    # Needs to be bigger than priorities of `yum`, `dnf`, `dnf5` and `rpm-ostree`.
+    probe_priority = 130
+
+    def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
+        script = self.engine.check_presence(*installables)
+
+        if len(installables) == 1 and isinstance(installables[0], FileSystemPath):
+            try:
+                self.guest.execute(script)
+
+            except RunError as exc:
+                if exc.returncode == 1:
+                    return {installables[0]: False}
+
+                raise exc
+
+            return {installables[0]: True}
+
+        try:
+            output = self.guest.execute(script)
+            stdout = output.stdout
+
+        except RunError as exc:
+            stdout = exc.stdout
+
+        if stdout is None:
+            raise GeneralError("rpm presence check provided no output")
+
+        results: dict[Installable, bool] = {}
+
+        for line, installable in zip(stdout.strip().splitlines(), installables):
+            match = re.match(rf'package {re.escape(str(installable))} is not installed', line)
+            if match is not None:
+                results[installable] = False
+                continue
+
+            match = re.match(rf'no package provides {re.escape(str(installable))}', line)
+            if match is not None:
+                results[installable] = False
+                continue
+
+            results[installable] = True
+
+        return results
+
+    def build_container(self) -> None:
+        image_tag = f"localhost/tmt/bootc/{uuid.uuid4()}"
+
+        # Write the final Containerfile
+        with self.guest.mkdtemp() as containerfile_dir:
+            containerfile_path = Path(containerfile_dir, 'Containerfile')
+
+            containerfile = '\n'.join(self.engine.containerfile_directives)
+
+            base_image = self.engine._get_current_bootc_image()
+
+            try:
+                # First try if image is available in container registries.
+                # Next try the local container storage.
+                # As the last resort, copy the booted image to the local container storage.
+                # Note that the last method will be used when `bootc` provision plugin
+                # is used, where the container image is built on the machine running `tmt`.
+                # We cannot use the last method by default because it does not preserve
+                # all the container image layers, see
+                # https://github.com/bootc-dev/bootc/issues/1259 for more information.
+                self.guest.execute(
+                    ShellScript(
+                        f'( podman pull {base_image} || podman pull containers-storage:{base_image} ) || bootc image copy-to-storage --target {base_image}'  # noqa: E501
+                    )
+                )
+                self.guest.execute(
+                    ShellScript(f'cat <<EOF > {containerfile_path!s} \n{containerfile} \nEOF')
+                )
+
+                self.debug(f"containerfile content: {containerfile}")
+                # Build the container image
+                self.info("package", "building container image with dependencies", "green")
+                self.guest.execute(
+                    Command('podman', 'build', '-t', image_tag, '-f', str(containerfile_path), '.')
+                )
+
+                # Switch to the new image for next boot
+                self.info("package", f"switching to new image {image_tag}", "green")
+
+                bootc_command, _ = self.engine.prepare_command()
+                bootc_command += Command('switch', '--transport', 'containers-storage', image_tag)
+                self.guest.execute(bootc_command)
+
+                # Reboot into the new image
+                self.info("package", "rebooting to apply new image", "green")
+                self.guest.reboot()
+
+            finally:
+                # Re-initialize containerfile directives
+                self.engine.initialize_containerfile_directives()
+
+    def refresh_metadata(self) -> CommandOutput:
+        self.engine.refresh_metadata()
+
+        self.build_container()
+        return CommandOutput(stdout=None, stderr=None)
+
+    def install(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> CommandOutput:
+        self.engine.install(*installables, options=options)
+
+        self.build_container()
+        return CommandOutput(stdout=None, stderr=None)
+
+    def reinstall(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> CommandOutput:
+        self.engine.reinstall(*installables, options=options)
+
+        self.build_container()
+        return CommandOutput(stdout=None, stderr=None)
+
+    def install_debuginfo(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> CommandOutput:
+        self.engine.install_debuginfo(*installables, options=options)
+
+        self.build_container()
+        return CommandOutput(stdout=None, stderr=None)


### PR DESCRIPTION
Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [x] include a release note
  * When `tmt` works with the image mode images, it now uses native package installation method instead of using `rpm-ostree`: `tmt` creates a `Containerfile` based on the booted image, adds needed packages there, builds the image and reboot a system to use the fresh image with needed packages.