### PR TITLE
Split package manager code into scripts and execution

### DIFF
--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1910,14 +1910,11 @@ def _parametrize_test_install_debuginfo() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree')),
-                r"debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",
+                r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| dnf5 install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",  # noqa: E501
                 None,
             )
 
-        elif (
-            package_manager_class is tmt.package_managers.dnf.Dnf
-            or package_manager_class is tmt.package_managers.dnf.Yum
-        ):
+        elif package_manager_class is tmt.package_managers.dnf.Dnf:
             if 'centos' in container.url:
                 yield pytest.param(
                     container,
@@ -1935,7 +1932,7 @@ def _parametrize_test_install_debuginfo() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dconf'), Package('libpng')),
-                    r"debuginfo-install -y  dconf libpng && rpm -q dconf-debuginfo libpng-debuginfo",  # noqa: E501
+                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dconf libpng && rpm -q dconf-debuginfo libpng-debuginfo",  # noqa: E501
                     None,
                 )
 
@@ -1944,7 +1941,38 @@ def _parametrize_test_install_debuginfo() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dos2unix'), Package('tree')),
+                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",  # noqa: E501
+                    None,
+                )
+
+        elif package_manager_class is tmt.package_managers.dnf.Yum:
+            if 'centos' in container.url:
+                yield pytest.param(
+                    container,
+                    package_manager_class,
+                    (Package('dos2unix'), Package('tree')),
                     r"debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",  # noqa: E501
+                    None,
+                    marks=pytest.mark.skip(
+                        reason='centos comes without debuginfo repos, we do not enable them yet'
+                    ),
+                )
+
+            elif 'ubi/8' in container.url:
+                yield (
+                    container,
+                    package_manager_class,
+                    (Package('dconf'), Package('libpng')),
+                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y  dconf libpng && rpm -q dconf-debuginfo libpng-debuginfo",  # noqa: E501
+                    None,
+                )
+
+            else:
+                yield (
+                    container,
+                    package_manager_class,
+                    (Package('dos2unix'), Package('tree')),
+                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",  # noqa: E501
                     None,
                 )
 
@@ -2006,16 +2034,30 @@ def _parametrize_test_install_debuginfo_nonexistent() -> Iterator[
     tuple[Container, PackageManagerClass, tuple[Package, Package], str, Optional[str]]
 ]:
     for container, package_manager_class in CONTAINER_BASE_MATRIX:
-        if (
-            package_manager_class is tmt.package_managers.dnf.Dnf5
-            or package_manager_class is tmt.package_managers.dnf.Dnf
-            or package_manager_class is tmt.package_managers.dnf.Yum
-        ):
+        if package_manager_class is tmt.package_managers.dnf.Dnf5:
             yield (
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                r"debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                r"rpm -q --whatprovides /usr/bin/debuginfo-install || dnf5 install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                None,
+            )
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf:
+            yield (
+                container,
+                package_manager_class,
+                (Package('dos2unix'), Package('tree-but-spelled-wrong')),
+                r"rpm -q --whatprovides /usr/bin/debuginfo-install || dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                None,
+            )
+
+        elif package_manager_class is tmt.package_managers.dnf.Yum:
+            yield (
+                container,
+                package_manager_class,
+                (Package('dos2unix'), Package('tree-but-spelled-wrong')),
+                r"rpm -q --whatprovides /usr/bin/debuginfo-install || yum install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
                 None,
             )
 
@@ -2097,14 +2139,11 @@ def _parametrize_test_install_debuginfo_nonexistent_skip() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                r"debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",
+                r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| dnf5 install -y  /usr/bin/debuginfo-install && debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",  # noqa: E501
                 None,
             )
 
-        elif (
-            package_manager_class is tmt.package_managers.dnf.Dnf
-            or package_manager_class is tmt.package_managers.dnf.Yum
-        ):
+        elif package_manager_class is tmt.package_managers.dnf.Dnf:
             if 'centos' in container.url:
                 yield pytest.param(
                     container,
@@ -2122,7 +2161,29 @@ def _parametrize_test_install_debuginfo_nonexistent_skip() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dos2unix'), Package('tree-but-spelled-wrong')),
+                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",  # noqa: E501
+                    None,
+                )
+
+        elif package_manager_class is tmt.package_managers.dnf.Yum:
+            if 'centos' in container.url:
+                yield pytest.param(
+                    container,
+                    package_manager_class,
+                    (Package('dos2unix'), Package('tree-but-spelled-wrong')),
                     r"debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",
+                    None,
+                    marks=pytest.mark.skip(
+                        reason='centos comes without debuginfo repos, we do not enable them yet'
+                    ),
+                )
+
+            else:
+                yield (
+                    container,
+                    package_manager_class,
+                    (Package('dos2unix'), Package('tree-but-spelled-wrong')),
+                    r"rpm -q --whatprovides /usr/bin/debuginfo-install || yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",  # noqa: E501
                     None,
                 )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -381,8 +381,8 @@ def _parametrize_test_install() -> Iterator[
                 package_manager_class,
                 Package('tree'),
                 r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y  \$installable_packages.*",  # noqa: E501
-                'Setting up tree'
-              )
+                'Setting up tree',
+            )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
             yield (
@@ -437,7 +437,7 @@ def test_install(
 
     assert_log(
         caplog,
-        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'")
+        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
     )
 
     assert_output(expected_output, output.stdout, output.stderr)
@@ -590,7 +590,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 container,
                 package_manager_class,
                 r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y  \$installable_packages.*",  # noqa: E501
-                'E: Unable to locate package tree-but-spelled-wrong'
+                'E: Unable to locate package tree-but-spelled-wrong',
             )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
@@ -634,8 +634,10 @@ def test_install_nonexistent(
     with pytest.raises(tmt.utils.RunError) as excinfo:
         package_manager.install(Package('tree-but-spelled-wrong'))
 
-    assert_log(caplog, message=MATCH(
-        rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+    assert_log(
+        caplog,
+        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
+    )
 
     assert excinfo.type is tmt.utils.RunError
     assert excinfo.value.returncode != 0
@@ -699,10 +701,12 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
                 )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:
-            yield container, \
-                package_manager_class, \
-                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y --ignore-missing \$installable_packages.*", \
-                'E: Unable to locate package tree-but-spelled-wrong'  # noqa: E501
+            yield (
+                container,
+                package_manager_class,
+                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y --ignore-missing \$installable_packages.*",  # noqa: E501
+                'E: Unable to locate package tree-but-spelled-wrong',
+            )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
             yield (
@@ -746,8 +750,10 @@ def test_install_nonexistent_skip(
         Package('tree-but-spelled-wrong'), options=Options(skip_missing=True)
     )
 
-    assert_log(caplog, message=MATCH(
-        rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+    assert_log(
+        caplog,
+        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
+    )
 
     assert_output(expected_output, output.stdout, output.stderr)
 
@@ -797,11 +803,13 @@ def _parametrize_test_install_dont_check_first() -> Iterator[
                 )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:
-            yield container, \
-                package_manager_class, \
-                Package('tree'), \
-                r".*?/bin/false \\\n^\|\| apt install -y  \$installable_packages.*", \
-                'Setting up tree'
+            yield (
+                container,
+                package_manager_class,
+                Package('tree'),
+                r".*?/bin/false \\\n^\|\| apt install -y  \$installable_packages.*",
+                'Setting up tree',
+            )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
             yield (
@@ -854,8 +862,10 @@ def test_install_dont_check_first(
 
     output = package_manager.install(package, options=Options(check_first=False))
 
-    assert_log(caplog, message=MATCH(
-        rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+    assert_log(
+        caplog,
+        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
+    )
 
     assert_output(expected_output, output.stdout, output.stderr)
 
@@ -906,12 +916,14 @@ def _parametrize_test_reinstall() -> Iterator[
             )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:
-            yield container, \
-                package_manager_class, \
-                Package('tar'), \
-                True, \
-                r".*?dpkg-query --show \$installable_packages \\\n^&& apt reinstall -y  \$installable_packages.*", \
-                'Setting up tar'  # noqa: E501
+            yield (
+                container,
+                package_manager_class,
+                Package('tar'),
+                True,
+                r".*?dpkg-query --show \$installable_packages \\\n^&& apt reinstall -y  \$installable_packages.*",  # noqa: E501
+                'Setting up tar',
+            )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
             yield container, package_manager_class, Package('tar'), False, None, None
@@ -964,8 +976,10 @@ def test_reinstall(
 
         output = package_manager.reinstall(package)
 
-        assert_log(caplog, message=MATCH(
-            rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+        assert_log(
+            caplog,
+            message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
+        )
 
     else:
         with pytest.raises(tmt.utils.GeneralError) as excinfo:
@@ -1028,11 +1042,13 @@ def _generate_test_reinstall_nonexistent_matrix() -> Iterator[
                 )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:
-            yield container, \
-                package_manager_class, \
-                True, \
-                r".*?dpkg-query --show \$installable_packages \\\n^&& apt reinstall -y  \$installable_packages.*", \
-                'dpkg-query: no packages found matching tree-but-spelled-wrong'  # noqa: E501
+            yield (
+                container,
+                package_manager_class,
+                True,
+                r".*?dpkg-query --show \$installable_packages \\\n^&& apt reinstall -y  \$installable_packages.*",  # noqa: E501
+                'dpkg-query: no packages found matching tree-but-spelled-wrong',
+            )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
             yield container, package_manager_class, False, None, None
@@ -1075,8 +1091,10 @@ def test_reinstall_nonexistent(
         with pytest.raises(tmt.utils.RunError) as excinfo:
             package_manager.reinstall(Package('tree-but-spelled-wrong'))
 
-        assert_log(caplog, message=MATCH(
-            rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+        assert_log(
+            caplog,
+            message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
+        )
 
         assert excinfo.type is tmt.utils.RunError
         assert excinfo.value.returncode != 0
@@ -1294,26 +1312,32 @@ def _generate_test_check_presence() -> Iterator[
                 )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:
-            yield container, \
-                package_manager_class, \
-                Package('util-linux'), \
-                True, \
-                r".*?echo \"PRESENCE-TEST:util-linux:util-linux:\$\(dpkg-query --show util-linux\).*?", \
-                r'\s+out:\s+PRESENCE-TEST:util-linux:util-linux:util-linux'  # noqa: E501
+            yield (
+                container,
+                package_manager_class,
+                Package('util-linux'),
+                True,
+                r".*?echo \"PRESENCE-TEST:util-linux:util-linux:\$\(dpkg-query --show util-linux\).*?",  # noqa: E501
+                r'\s+out:\s+PRESENCE-TEST:util-linux:util-linux:util-linux',
+            )
 
-            yield container, \
-                package_manager_class, \
-                Package('tree-but-spelled-wrong'), \
-                False, \
-                r".*?echo \"PRESENCE-TEST:tree-but-spelled-wrong:tree-but-spelled-wrong:\$\(dpkg-query --show tree-but-spelled-wrong\).*?", \
-                r'\s+err:\s+dpkg-query: no packages found matching tree-but-spelled-wrong'  # noqa: E501
+            yield (
+                container,
+                package_manager_class,
+                Package('tree-but-spelled-wrong'),
+                False,
+                r".*?echo \"PRESENCE-TEST:tree-but-spelled-wrong:tree-but-spelled-wrong:\$\(dpkg-query --show tree-but-spelled-wrong\).*?",  # noqa: E501
+                r'\s+err:\s+dpkg-query: no packages found matching tree-but-spelled-wrong',
+            )
 
-            yield container, \
-                package_manager_class, \
-                FileSystemPath('/usr/bin/flock'), \
-                True, \
-                r".*?echo \"PRESENCE-TEST:/usr/bin/flock:\$\{fs_path_package\}:\$\(dpkg-query --show \$fs_path_package\)\".*?", \
-                r'\s+out:\s+PRESENCE-TEST:/usr/bin/flock:util-linux:util-linux'  # noqa: E501
+            yield (
+                container,
+                package_manager_class,
+                FileSystemPath('/usr/bin/flock'),
+                True,
+                r".*?echo \"PRESENCE-TEST:/usr/bin/flock:\$\{fs_path_package\}:\$\(dpkg-query --show \$fs_path_package\)\".*?",  # noqa: E501
+                r'\s+out:\s+PRESENCE-TEST:/usr/bin/flock:util-linux:util-linux',
+            )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
             yield (
@@ -1417,8 +1441,10 @@ def test_check_presence(
 
     assert package_manager.check_presence(installable) == {installable: expected_result}
 
-    assert_log(caplog, message=MATCH(
-        rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+    assert_log(
+        caplog,
+        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
+    )
 
     if expected_output:
         assert_log(caplog, remove_colors=True, message=MATCH(expected_output))
@@ -1466,11 +1492,13 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                 )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:
-            yield container, \
-                package_manager_class, \
-                FileSystemPath('/usr/bin/dos2unix'), \
-                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y  \$installable_packages.*", \
-                "Setting up dos2unix"  # noqa: E501
+            yield (
+                container,
+                package_manager_class,
+                FileSystemPath('/usr/bin/dos2unix'),
+                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y  \$installable_packages.*",  # noqa: E501
+                "Setting up dos2unix",
+            )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
             yield (
@@ -1523,8 +1551,10 @@ def test_install_filesystempath(
 
     output = package_manager.install(installable)
 
-    assert_log(caplog, message=MATCH(
-        rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+    assert_log(
+        caplog,
+        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
+    )
 
     assert_output(expected_output, output.stdout, output.stderr)
 
@@ -1599,11 +1629,13 @@ def _parametrize_test_install_multiple() -> Iterator[
             )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:
-            yield container, \
-                package_manager_class, \
-                (Package('tree'), Package('nano')), \
-                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y  \$installable_packages.*", \
-                'Setting up tree'  # noqa: E501
+            yield (
+                container,
+                package_manager_class,
+                (Package('tree'), Package('nano')),
+                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y  \$installable_packages.*",  # noqa: E501
+                'Setting up tree',
+            )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
             yield (
@@ -1656,8 +1688,10 @@ def test_install_multiple(
 
     output = package_manager.install(*packages)
 
-    assert_log(caplog, message=MATCH(
-        rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+    assert_log(
+        caplog,
+        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
+    )
 
     assert_output(expected_output, output.stdout, output.stderr)
 
@@ -1848,8 +1882,10 @@ def test_install_downloaded(
     else:
         output = package_manager.install(*installables, options=Options(check_first=False))
 
-    assert_log(caplog, message=MATCH(
-        rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"))
+    assert_log(
+        caplog,
+        message=MATCH(rf"(?sm)Run command: podman exec .+? /bin/bash -c '{expected_command}'"),
+    )
 
     assert_output(expected_output, output.stdout, output.stderr)
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -471,7 +471,7 @@ def _parametrize_test_refresh_metadata() -> Iterator[
                 container,
                 package_manager_class,
                 r"export DEBIAN_FRONTEND=noninteractive; apt update",
-                'Fetched',
+                'Reading package list',
             )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -380,7 +380,7 @@ def _parametrize_test_install() -> Iterator[
                 container,
                 package_manager_class,
                 Package('tree'),
-                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y  \$installable_packages.*",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'Setting up tree',
             )
 
@@ -471,7 +471,7 @@ def _parametrize_test_refresh_metadata() -> Iterator[
                 container,
                 package_manager_class,
                 r"export DEBIAN_FRONTEND=noninteractive; apt update",
-                'packages',
+                'Fetched',
             )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
@@ -589,7 +589,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y  \$installable_packages.*",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'E: Unable to locate package tree-but-spelled-wrong',
             )
 
@@ -704,7 +704,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y --ignore-missing \$installable_packages.*",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y --ignore-missing \$installable_packages\s+exit 0",  # noqa: E501
                 'E: Unable to locate package tree-but-spelled-wrong',
             )
 
@@ -807,7 +807,7 @@ def _parametrize_test_install_dont_check_first() -> Iterator[
                 container,
                 package_manager_class,
                 Package('tree'),
-                r".*?/bin/false \\\n^\|\| apt install -y  \$installable_packages.*",
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree\"\s+/bin/false \\\s+\|\| apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'Setting up tree',
             )
 
@@ -921,7 +921,7 @@ def _parametrize_test_reinstall() -> Iterator[
                 package_manager_class,
                 Package('tar'),
                 True,
-                r".*?dpkg-query --show \$installable_packages \\\n^&& apt reinstall -y  \$installable_packages.*",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tar\"\s+dpkg-query --show \$installable_packages \\\s+&& apt reinstall -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'Setting up tar',
             )
 
@@ -1046,7 +1046,7 @@ def _generate_test_reinstall_nonexistent_matrix() -> Iterator[
                 container,
                 package_manager_class,
                 True,
-                r".*?dpkg-query --show \$installable_packages \\\n^&& apt reinstall -y  \$installable_packages.*",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+dpkg-query --show \$installable_packages \\\s+&& apt reinstall -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'dpkg-query: no packages found matching tree-but-spelled-wrong',
             )
 
@@ -1317,7 +1317,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('util-linux'),
                 True,
-                r".*?echo \"PRESENCE-TEST:util-linux:util-linux:\$\(dpkg-query --show util-linux\).*?",  # noqa: E501
+                r".*?echo \"PRESENCE-TEST:util-linux:util-linux:\$\(dpkg-query --show util-linux\)\".*?",  # noqa: E501
                 r'\s+out:\s+PRESENCE-TEST:util-linux:util-linux:util-linux',
             )
 
@@ -1326,7 +1326,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('tree-but-spelled-wrong'),
                 False,
-                r".*?echo \"PRESENCE-TEST:tree-but-spelled-wrong:tree-but-spelled-wrong:\$\(dpkg-query --show tree-but-spelled-wrong\).*?",  # noqa: E501
+                r".*?echo \"PRESENCE-TEST:tree-but-spelled-wrong:tree-but-spelled-wrong:\$\(dpkg-query --show tree-but-spelled-wrong\)\".*?",  # noqa: E501
                 r'\s+err:\s+dpkg-query: no packages found matching tree-but-spelled-wrong',
             )
 
@@ -1335,7 +1335,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 FileSystemPath('/usr/bin/flock'),
                 True,
-                r".*?echo \"PRESENCE-TEST:/usr/bin/flock:\$\{fs_path_package\}:\$\(dpkg-query --show \$fs_path_package\)\".*?",  # noqa: E501
+                r".*?set -x\s+export DEBIAN_FRONTEND=noninteractive\s+fs_path_package=\"\$\(apt-file search --package-only /usr/bin/flock\)\".*echo \"PRESENCE-TEST:/usr/bin/flock:\$\{fs_path_package\}:\$\(dpkg-query --show \$fs_path_package\)\".*?",  # noqa: E501
                 r'\s+out:\s+PRESENCE-TEST:/usr/bin/flock:util-linux:util-linux',
             )
 
@@ -1496,7 +1496,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                 container,
                 package_manager_class,
                 FileSystemPath('/usr/bin/dos2unix'),
-                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y  \$installable_packages.*",  # noqa: E501
+                r".*?set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"\"\s+fs_path_package=\"\$\(apt-file search --package-only /usr/bin/dos2unix\)\"\s+\[ -z \"\$fs_path_package\" \] && echo \"No package found for path /usr/bin/dos2unix\" && exit 1\s+installable_packages=\"\$installable_packages \$fs_path_package\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y\s+\$installable_packages\s+exit \$\?",  # noqa: E501
                 "Setting up dos2unix",
             )
 
@@ -1633,7 +1633,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('tree'), Package('nano')),
-                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y  \$installable_packages.*",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree nano\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'Setting up tree',
             )
 

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -1,26 +1,19 @@
 import re
 from typing import Optional
 
-import tmt.package_managers
-import tmt.utils
 from tmt.package_managers import (
     FileSystemPath,
     Installable,
     Options,
+    PackageManager,
+    PackageManagerEngine,
     escape_installables,
     provides_package_manager,
 )
 from tmt.utils import Command, CommandOutput, GeneralError, RunError, ShellScript
 
 
-@provides_package_manager('rpm-ostree')
-class RpmOstree(tmt.package_managers.PackageManager):
-    NAME = 'rpm-ostree'
-
-    probe_command = Command('stat', '/run/ostree-booted')
-    # Needs to be bigger than priorities of `yum`, `dnf` and `dnf5`.
-    probe_priority = 100
-
+class RpmOstreeEngine(PackageManagerEngine):
     def prepare_command(self) -> tuple[Command, Command]:
         """
         Prepare installation command for rpm-ostree
@@ -43,10 +36,99 @@ class RpmOstree(tmt.package_managers.PackageManager):
 
         return ShellScript(f'rpm -q --whatprovides {" ".join(escape_installables(*installables))}')
 
+    def check_presence(self, *installables: Installable) -> ShellScript:
+        if len(installables) == 1 and isinstance(installables[0], FileSystemPath):
+            return ShellScript(f'rpm -qf {installables[0]}')
+
+        return ShellScript(f'rpm -q --whatprovides {" ".join(escape_installables(*installables))}')
+
+    def _extra_options(self, options: Options) -> Command:
+        extra_options = Command()
+
+        for package in options.excluded_packages:
+            self.warn(
+                "There is no support for rpm-ostree exclude,"
+                f" package '{package}' may still be installed."
+            )
+
+        if options.install_root is not None:
+            extra_options += Command(f'--installroot={options.install_root}')
+
+        if options.release_version is not None:
+            extra_options += Command(f'--releasever={options.release_version}')
+
+        return extra_options
+
+    def refresh_metadata(self) -> ShellScript:
+        self.guest.warn("Metadata refresh is not supported with rpm-ostree.")
+
+        return ShellScript('/bin/true')
+
+        # The following should work, but it hits some ostree issue:
+        #
+        #   System has not been booted with systemd as init system (PID 1). Can't operate.
+        #   Failed to connect to bus: Host is down
+        #   System has not been booted with systemd as init system (PID 1). Can't operate.
+        #   Failed to connect to bus: Host is down
+        #   error: Loading sysroot: exit status: 1
+        #
+        # script = ShellScript(f'{self.command.to_script()} refresh-md --force')
+        # return self.guest.execute(script)
+
+    def install(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> ShellScript:
+        options = options or Options()
+
+        extra_options = self._extra_options(options)
+
+        script = ShellScript(
+            f'{self.command.to_script()} install '
+            f'{self.options.to_script()} {extra_options} '
+            f'{" ".join(escape_installables(*installables))}'
+        )
+
+        if options.check_first:
+            script = self._construct_presence_script(*installables) | script
+
+        if options.skip_missing:
+            script = script | ShellScript('/bin/true')
+
+        return script
+
+    def reinstall(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> ShellScript:
+        raise GeneralError("rpm-ostree does not support reinstall operation.")
+
+    def install_debuginfo(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> ShellScript:
+        raise GeneralError("rpm-ostree does not support debuginfo packages.")
+
+
+@provides_package_manager('rpm-ostree')
+class RpmOstree(PackageManager[RpmOstreeEngine]):
+    NAME = 'rpm-ostree'
+
+    _engine_class = RpmOstreeEngine
+
+    probe_command = Command('stat', '/run/ostree-booted')
+    # Needs to be bigger than priorities of `yum`, `dnf` and `dnf5`.
+    probe_priority = 100
+
     def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
+        script = self.engine.check_presence(*installables)
+
         if len(installables) == 1 and isinstance(installables[0], FileSystemPath):
             try:
-                self.guest.execute(ShellScript(f'rpm -qf {installables[0]}'))
+                self.guest.execute(script)
 
             except RunError as exc:
                 if exc.returncode == 1:
@@ -57,11 +139,7 @@ class RpmOstree(tmt.package_managers.PackageManager):
             return {installables[0]: True}
 
         try:
-            output = self.guest.execute(
-                ShellScript(
-                    f'rpm -q --whatprovides {" ".join(escape_installables(*installables))}'
-                )
-            )
+            output = self.guest.execute(script)
             stdout = output.stdout
 
         except RunError as exc:
@@ -87,23 +165,6 @@ class RpmOstree(tmt.package_managers.PackageManager):
 
         return results
 
-    def _extra_options(self, options: Options) -> Command:
-        extra_options = Command()
-
-        for package in options.excluded_packages:
-            self.warn(
-                "There is no support for rpm-ostree exclude,"
-                f" package '{package}' may still be installed."
-            )
-
-        if options.install_root is not None:
-            extra_options += Command(f'--installroot={options.install_root}')
-
-        if options.release_version is not None:
-            extra_options += Command(f'--releasever={options.release_version}')
-
-        return extra_options
-
     def refresh_metadata(self) -> CommandOutput:
         self.guest.warn("Metadata refresh is not supported with rpm-ostree.")
 
@@ -119,29 +180,6 @@ class RpmOstree(tmt.package_managers.PackageManager):
         #
         # script = ShellScript(f'{self.command.to_script()} refresh-md --force')
         # return self.guest.execute(script)
-
-    def install(
-        self,
-        *installables: Installable,
-        options: Optional[Options] = None,
-    ) -> CommandOutput:
-        options = options or Options()
-
-        extra_options = self._extra_options(options)
-
-        script = ShellScript(
-            f'{self.command.to_script()} install '
-            f'{self.options.to_script()} {extra_options} '
-            f'{" ".join(escape_installables(*installables))}'
-        )
-
-        if options.check_first:
-            script = self._construct_presence_script(*installables) | script
-
-        if options.skip_missing:
-            script = script | ShellScript('/bin/true')
-
-        return self.guest.execute(script)
 
     def reinstall(
         self,

--- a/tmt/steps/prepare/distgit.py
+++ b/tmt/steps/prepare/distgit.py
@@ -253,7 +253,7 @@ class PrepareDistGit(tmt.steps.prepare.PreparePlugin[DistGitData]):
                 raise tmt.utils.PrepareError('No src.rpm file created by the `rpmbuild -br` call.')
             # Install build requires
             # Create the package manager command
-            cmd, _ = guest.package_manager.prepare_command()
+            cmd, _ = guest.package_manager.engine.prepare_command()
             # Can't set 'cwd' as the check for its existence fails for local workdir
             cmd += Command("builddep", "-y", f"SRPMS/{src_rpm_name}")
             guest.execute(command=cmd, cwd=Path(source_dir))

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -281,10 +281,12 @@ class Copr(tmt.utils.Common):
         if not repositories:
             return
 
+        package_manager = self.guest.package_manager
+
         # Try to install copr plugin
         self.debug('Make sure the copr plugin is available.')
         try:
-            self.guest.package_manager.install(Package(self.copr_plugin))
+            package_manager.install(Package(self.copr_plugin))
 
         # Enable repositories manually for epel6
         except tmt.utils.RunError:
@@ -299,8 +301,8 @@ class Copr(tmt.utils.Common):
 
                 self.guest.execute(
                     ShellScript(
-                        f"{self.guest.package_manager.command.to_script()} copr "
-                        f"{self.guest.package_manager.options.to_script()} enable -y {repository}"
+                        f"{package_manager.engine.command.to_script()} copr "
+                        f"{package_manager.engine.options.to_script()} enable -y {repository}"
                     )
                 )
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -45,7 +45,11 @@ import tmt.utils
 from tmt.container import SerializableContainer, container, field, key_to_option
 from tmt.log import Logger
 from tmt.options import option
-from tmt.package_managers import FileSystemPath, Package, PackageManagerClass
+from tmt.package_managers import (
+    FileSystemPath,
+    Package,
+    PackageManagerClass,
+)
 from tmt.plugins import PluginRegistry
 from tmt.steps import Action, ActionTask, PhaseQueue
 from tmt.utils import (
@@ -548,7 +552,9 @@ class GuestFacts(SerializableContainer):
         # one available. Collect them, and sort them by their priorities
         # to find the most suitable one.
 
-        discovered_package_managers: list[PackageManagerClass] = []
+        discovered_package_managers: list[
+            PackageManagerClass[tmt.package_managers.PackageManagerEngine]
+        ] = []
 
         for (
             _,
@@ -1141,7 +1147,9 @@ class Guest(tmt.utils.Common):
         raise NotImplementedError
 
     @functools.cached_property
-    def package_manager(self) -> 'tmt.package_managers.PackageManager':
+    def package_manager(
+        self,
+    ) -> 'tmt.package_managers.PackageManager[tmt.package_managers.PackageManagerEngine]':
         if not self.facts.package_manager:
             raise tmt.utils.GeneralError(
                 f"Package manager was not detected on guest '{self.name}'."


### PR DESCRIPTION
Current package manager classes were given a guest, and then were responsible for running commands on the guest to install stuff. To support delayed running of these commands - I'm looking at you, image mode! - we would like to use the existing implementations, use the existing code preparing commands like `dnf install foo`, we just don't want to run them on the guest.

Package manager classes are now split into two parts: "engine" that is pretty much what package managers are now, i.e. prepares commands that would reaize the requested action, and the "package manager" whose job is to urn these commands. Each package manager has its own engine. The effect is, we can now can access an engine we pick, and use it to construct the commands without actually running them. We can put them into Containerfiles, or run them in a special SSH session, and so on. And it will use the same code as the usual "install me a package *now*" workflow of regular testing, preventing duplication and exceptions.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
