### PR TITLE
Use the `display` report plugin to display results during execution

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,16 @@
     Releases
 ======================
 
+tmt-1.49.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Output of the :ref:`/plugins/report/internal` and
+:ref:`/plugins/report/display` is changing in this release, to provide
+slightly more details, headers and timestamps. ``execute`` now starts
+using ``display`` for its own progress reporting, providing the unified
+formatting and simplified code.
+
+
 tmt-1.48.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -7,7 +7,7 @@
 tmt-1.49.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Output of the :ref:`/plugins/report/internal` and
+Output of the :ref:`/plugins/report/display` and
 :ref:`/plugins/report/display` is changing in this release, to provide
 slightly more details, headers and timestamps. ``execute`` now starts
 using ``display`` for its own progress reporting, providing the unified

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -7,7 +7,7 @@
 tmt-1.49.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Output of the :ref:`/plugins/report/display` and
+Output of the :ref:`/plugins/execute/tmt` and
 :ref:`/plugins/report/display` is changing in this release, to provide
 slightly more details, headers and timestamps. ``execute`` now starts
 using ``display`` for its own progress reporting, providing the unified

--- a/tests/discover/tests.sh
+++ b/tests/discover/tests.sh
@@ -14,7 +14,9 @@ rlJournalStart
         rlRun -s "tmt run --id $workdir -vvv  $plan"
         rlAssertGrep "package: 1 package requested" "$rlRun_LOG" -F
         rlAssertGrep "test: Concise summary" "$rlRun_LOG" -F
-        rlAssertGrep '00:00:00 pass /first (on default-0) (test failed as expected, original test result: fail) [1/2]' "$rlRun_LOG" -F
+        rlAssertGrep '00:00:00 pass /first (on default-0) [1/2]' "$rlRun_LOG" -F
+        rlAssertGrep "Note: test failed as expected" $rlRun_LOG
+        rlAssertGrep "Note: original test result: fail" $rlRun_LOG
         rlAssertGrep '00:00:00 pass /second (on default-0) [2/2]' "$rlRun_LOG" -F
     rlPhaseEnd
 

--- a/tests/execute/framework/shell.sh
+++ b/tests/execute/framework/shell.sh
@@ -47,7 +47,8 @@ rlJournalStart
         rlAssertGrep "cmd: ./shell.sh 122" $rlRun_LOG
         rlAssertGrep "testing shell with exit code 122" $rlRun_LOG
         rlAssertGrep "warn: Test failed to manage its pidfile." $rlRun_LOG
-        rlAssertGrep "errr /tests/pidlock (pidfile locking)" $rlRun_LOG
+        rlAssertGrep "errr /tests/pidlock" $rlRun_LOG
+        rlAssertGrep "Note: pidfile locking" $rlRun_LOG
         rlRun -s "${extract_results_command} ${run}/plans/execute/results.yaml"
         rlAssertGrep "/tests/pidlock 1 error default-0 pidfile locking" $rlRun_LOG
     rlPhaseEnd
@@ -57,7 +58,8 @@ rlJournalStart
         rlRun -s "${tmt_command} ${testName} >/dev/null" 2 "Testing shell timeout error"
         rlAssertGrep "cmd: ./shell.sh 124" $rlRun_LOG
         rlAssertGrep "testing shell with exit code 124" $rlRun_LOG
-        rlAssertGrep "errr /tests/timeout (timeout)" $rlRun_LOG
+        rlAssertGrep "errr /tests/timeout" $rlRun_LOG
+        rlAssertGrep "Note: timeout" $rlRun_LOG
         rlAssertGrep "Maximum test time '5m' exceeded." $rlRun_LOG
         rlAssertGrep "Adjust the test 'duration' attribute if necessary." $rlRun_LOG
         rlRun -s "${extract_results_command} ${run}/plans/execute/results.yaml"

--- a/tests/execute/ignore-duration/test.sh
+++ b/tests/execute/ignore-duration/test.sh
@@ -11,12 +11,14 @@ rlJournalStart
 
     rlPhaseStartTest "No envvar used"
         rlRun -s "tmt run -vv plan -n /no-option" "2"
-        rlAssertGrep 'errr /demo/test (timeout)' $rlRun_LOG '-F'
+        rlAssertGrep 'errr /demo/test' $rlRun_LOG '-F'
+        rlAssertGrep 'Note: timeout' $rlRun_LOG '-F'
 
         rlRun "tmt run -vv plan -n /via-plan-true" "0"
 
         rlRun "tmt run -vv plan -n /via-plan-false" "2"
-        rlAssertGrep 'errr /demo/test (timeout)' $rlRun_LOG '-F'
+        rlAssertGrep 'errr /demo/test' $rlRun_LOG '-F'
+        rlAssertGrep 'Note: timeout' $rlRun_LOG '-F'
     rlPhaseEnd
 
     rlPhaseStartTest "With IGNORE_DURATION=1"

--- a/tests/execute/reboot/freeze.sh
+++ b/tests/execute/reboot/freeze.sh
@@ -19,7 +19,8 @@ rlJournalStart
     rlPhaseStartTest "Check Report"
         rlRun -s "tmt run --id $run report -v" 2
         rlAssertGrep "pass /tests/one" $rlRun_LOG
-        rlAssertGrep "errr /tests/two (reboot timeout)" $rlRun_LOG
+        rlAssertGrep "errr /tests/two" $rlRun_LOG
+        rlAssertGrep "Note: reboot timeout" $rlRun_LOG
         rlAssertGrep "summary: 1 test passed and 1 error" $rlRun_LOG
     rlPhaseEnd
 

--- a/tests/execute/restraint/compatible/test.sh
+++ b/tests/execute/restraint/compatible/test.sh
@@ -12,10 +12,10 @@ rlJournalStart
 
     rlPhaseStartTest "Test /plans/compatible"
         rlRun -s "tmt run -vvv --id $run plan --name /plans/compatible" 1
-        rlRun "grep -A1 'pass /good-with-log' $rlRun_LOG | grep fine.txt"
-        rlRun "grep -A1 'pass /good-with-var' $rlRun_LOG | grep fine.txt"
-        rlRun "grep -A1 'fail /bad-with-log'  $rlRun_LOG | grep wrong.txt"
-        rlRun "grep -A1 'fail /bad-with-var'  $rlRun_LOG | grep wrong.txt"
+        rlRun "grep -A2 'pass /good-with-log' $rlRun_LOG | grep fine.txt"
+        rlRun "grep -A2 'pass /good-with-var' $rlRun_LOG | grep fine.txt"
+        rlRun "grep -A2 'fail /bad-with-log'  $rlRun_LOG | grep wrong.txt"
+        rlRun "grep -A2 'fail /bad-with-var'  $rlRun_LOG | grep wrong.txt"
     rlPhaseEnd
 
     # In the incompatible mode the OUTPUTFILE variable should be
@@ -24,10 +24,10 @@ rlJournalStart
     for plan in "/plans/default" "/plans/incompatible"; do
         rlPhaseStartTest "Test $plan"
             rlRun -s "tmt run -vvv --id $run plan --name $plan" 1
-            rlRun "grep -A1 'pass /good-with-log' $rlRun_LOG | grep fine.txt"
-            rlRun "grep -A1 'pass /good-with-var' $rlRun_LOG | grep txt" 1
-            rlRun "grep -A1 'fail /bad-with-log'  $rlRun_LOG | grep wrong.txt"
-            rlRun "grep -A1 'fail /bad-with-var'  $rlRun_LOG | grep txt" 1
+            rlRun "grep -A2 'pass /good-with-log' $rlRun_LOG | grep fine.txt"
+            rlRun "grep -A2 'pass /good-with-var' $rlRun_LOG | grep txt" 1
+            rlRun "grep -A2 'fail /bad-with-log'  $rlRun_LOG | grep wrong.txt"
+            rlRun "grep -A2 'fail /bad-with-var'  $rlRun_LOG | grep txt" 1
         rlPhaseEnd
     done
 

--- a/tests/execute/restraint/report-result/test.sh
+++ b/tests/execute/restraint/report-result/test.sh
@@ -70,11 +70,11 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest Output
-        rlRun "grep -A1 'pass /output/separate/good-no-log'   $rlRun_LOG | grep output.txt"
-        rlRun "grep -A1 'pass /output/separate/good-with-log' $rlRun_LOG | grep fine.txt"
-        rlRun "grep -A1 'fail /output/separate/bad-no-log'    $rlRun_LOG | grep output.txt"
-        rlRun "grep -A1 'fail /output/separate/bad-with-log'  $rlRun_LOG | grep wrong.txt"
-        rlRun "grep -A1 'fail /output/single'                 $rlRun_LOG | grep output.txt"
+        rlRun "grep -A2 'pass /output/separate/good-no-log'   $rlRun_LOG | grep output.txt"
+        rlRun "grep -A2 'pass /output/separate/good-with-log' $rlRun_LOG | grep fine.txt"
+        rlRun "grep -A2 'fail /output/separate/bad-no-log'    $rlRun_LOG | grep output.txt"
+        rlRun "grep -A2 'fail /output/separate/bad-with-log'  $rlRun_LOG | grep wrong.txt"
+        rlRun "grep -A2 'fail /output/single'                 $rlRun_LOG | grep output.txt"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/execute/result/check.sh
+++ b/tests/execute/result/check.sh
@@ -9,17 +9,73 @@ rlJournalStart
         rlRun "set -o pipefail"
     rlPhaseEnd
 
+    function test_result () {
+        pattern="$1"
+        extra_lines="$2"
+
+        shift 2
+
+        rlRun "grep -P -A$extra_lines \"\s+\d\d:\d\d:\d\d\s+$pattern\" $run/report.txt > $run/test.txt"
+        rlRun "cat $run/test.txt"
+
+        for i in `seq 1 $extra_lines`; do
+            pattern="$1"
+            shift
+
+            rlRun "grep -P \"\s+$pattern\" $run/test.txt"
+        done
+    }
+
     rlPhaseStartTest "Check Results"
         rlRun "tmt run -av --id $run provision --how $PROVISION_HOW" 1
         rlRun -s "tmt run --id $run report -v" 1
 
-        rlAssertGrep "pass /test/check-fail-info (check 'dmesg' is informational)" "$rlRun_LOG"
-        rlAssertGrep "fail /test/check-fail-respect (check 'dmesg' failed, original test result: pass)" "$rlRun_LOG"
-        rlAssertGrep "pass /test/check-override (check 'dmesg' failed, test result overridden: pass)" "$rlRun_LOG"
-        rlAssertGrep "pass /test/check-pass" "$rlRun_LOG"
-        rlAssertGrep "fail /test/check-pass-test-xfail (test was expected to fail, original test result: pass)" "$rlRun_LOG"
-        rlAssertGrep "pass /test/check-xfail-fail (check 'dmesg' failed as expected)" "$rlRun_LOG"
-        rlAssertGrep "fail /test/check-xfail-pass (check 'dmesg' did not fail as expected, original test result: pass)" "$rlRun_LOG"
+        rlRun "mv $rlRun_LOG $run/report.txt"
+
+        test_result "pass /test/check-fail-info" \
+                    3 \
+                    "Note: check 'dmesg' is informational" \
+                    "pass dmesg \(before-test check\)" \
+                    "fail dmesg \(after-test check\)"
+
+        test_result "fail /test/check-fail-respect" \
+                    4 \
+                    "Note: check 'dmesg' failed" \
+                    "Note: original test result: pass" \
+                    "pass dmesg \(before-test check\)" \
+                    "fail dmesg \(after-test check\)"
+
+        test_result "pass /test/check-override" \
+                    4 \
+                    "Note: check 'dmesg' failed" \
+                    "Note: test result overridden: pass" \
+                    "pass dmesg \(before-test check\)" \
+                    "fail dmesg \(after-test check\)"
+
+        test_result "pass /test/check-pass" \
+                    2 \
+                    "pass dmesg \(before-test check\)" \
+                    "pass dmesg \(after-test check\)"
+
+        test_result "fail /test/check-pass-test-xfail" \
+                    4 \
+                    "Note: test was expected to fail" \
+                    "Note: original test result: pass" \
+                    "pass dmesg \(before-test check\)" \
+                    "pass dmesg \(after-test check\)"
+
+        test_result "pass /test/check-xfail-fail" \
+                    3 \
+                    "Note: check 'dmesg' failed as expected" \
+                    "pass dmesg \(before-test check\)" \
+                    "fail dmesg \(after-test check\)"
+
+        test_result "fail /test/check-xfail-pass" \
+                    4 \
+                    "Note: check 'dmesg' did not fail as expected" \
+                    "Note: original test result: pass" \
+                    "pass dmesg \(before-test check\)" \
+                    "pass dmesg \(after-test check\)"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -20,13 +20,14 @@ rlJournalStart
         rlAssertGrep "00:00:00 skip /test/custom-results/test/skipped" $rlRun_LOG
         # The duration of the main result is replaced with the duration measured by tmt for the whole test.
         rlAssertGrep "00:00:00 pass /test/custom-results (on default-0) \[1/1\]" $rlRun_LOG
-        rlAssertGrep "00:55:44 pass /test/custom-results/without-leading-slash.*name should start with '/'" $rlRun_LOG
+        rlAssertGrep "00:55:44 pass /test/custom-results/without-leading-slash" $rlRun_LOG
+        rlAssertGrep "Note: custom test result name should start with '/'" $rlRun_LOG
         rlAssertGrep "total: 3 tests passed, 1 test failed and 1 test skipped" $rlRun_LOG
 
-        rlAssertExists "$(sed -n 's/ *pass_log: \(.\+\)/\1/p' $rlRun_LOG)"
-        rlAssertExists "$(sed -n 's/ *fail_log: \(.\+\)/\1/p' $rlRun_LOG)"
-        rlAssertExists "$(sed -n 's/ *another_log: \(.\+\)/\1/p' $rlRun_LOG)"
-        rlAssertExists "$(sed -n 's/ *slash_log: \(.\+\)/\1/p' $rlRun_LOG)"
+        rlAssertExists "$(sed -n 's/ *pass_log (\(.\+\))/\1/p' $rlRun_LOG)"
+        rlAssertExists "$(sed -n 's/ *fail_log (\(.\+\))/\1/p' $rlRun_LOG)"
+        rlAssertExists "$(sed -n 's/ *another_log (\(.\+\))/\1/p' $rlRun_LOG)"
+        rlAssertExists "$(sed -n 's/ *slash_log (\(.\+\))/\1/p' $rlRun_LOG)"
 
         rlRun -s "yq -er '.[] | \"\\(.name) \\(.\"serial-number\") \\(.result) \\(.guest.name)\"' $run/default/plan/execute/results.yaml"
         rlAssertGrep "/test/custom-results/test/passing 1 pass default-0" $rlRun_LOG
@@ -44,9 +45,9 @@ rlJournalStart
         rlAssertGrep "00:00:00 pass /test/custom-json-results .* \[1/1\]" $rlRun_LOG
         rlAssertGrep "total: 2 tests passed and 1 test failed" $rlRun_LOG
 
-        rlAssertExists "$(sed -n 's/ *pass_log: \(.\+\)/\1/p' $rlRun_LOG)"
-        rlAssertExists "$(sed -n 's/ *fail_log: \(.\+\)/\1/p' $rlRun_LOG)"
-        rlAssertExists "$(sed -n 's/ *another_log: \(.\+\)/\1/p' $rlRun_LOG)"
+        rlAssertExists "$(sed -n 's/ *pass_log (\(.\+\))/\1/p' $rlRun_LOG)"
+        rlAssertExists "$(sed -n 's/ *fail_log (\(.\+\))/\1/p' $rlRun_LOG)"
+        rlAssertExists "$(sed -n 's/ *another_log (\(.\+\))/\1/p' $rlRun_LOG)"
     rlPhaseEnd
 
     testName="/test/missing-custom-results"

--- a/tests/report/display/test.sh
+++ b/tests/report/display/test.sh
@@ -31,9 +31,9 @@ rlJournalStart
         rlRun "cp -r faked-subresults-results.yaml $tmp/subresults/execute/results.yaml" 0 "Faking the execute/results.yaml with subresult data"
         rlRun -s "tmt run --last --id $tmp plan -n subresults report -h display -v"
         rlAssertGrep "pass /test$" "$rlRun_LOG"
-        rlAssertGrep "pass /test/good$" "$rlRun_LOG"
-        rlAssertGrep "fail /test/fail$" "$rlRun_LOG"
-        rlAssertGrep "warn /test/weird$" "$rlRun_LOG"
+        rlAssertGrep "pass /test/good (subresult)$" "$rlRun_LOG"
+        rlAssertGrep "fail /test/fail (subresult)$" "$rlRun_LOG"
+        rlAssertGrep "warn /test/weird (subresult)$" "$rlRun_LOG"
         rlAssertGrep "skip dmesg (before-test check)$" "$rlRun_LOG"
         rlAssertGrep "summary: 1 test passed$" "$rlRun_LOG"
     rlPhaseEnd

--- a/tests/test/check/data/main.fmf
+++ b/tests/test/check/data/main.fmf
@@ -1,5 +1,5 @@
 /dmesg:
-    test: echo "some text"
+    test: /bin/true
     check: dmesg
 
     /harmless:

--- a/tests/test/check/data/main.fmf
+++ b/tests/test/check/data/main.fmf
@@ -1,8 +1,11 @@
 /dmesg:
-    test: /bin/true
+    test: echo "some text"
     check: dmesg
 
     /harmless:
+        test: bash -c 'sleep 5'
+
+    /harmless2:
 
     /segfault:
         test: echo Some segfault happened > /dev/kmsg

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -2350,7 +2350,7 @@ class Login(Action):
 
     def after_test(
         self,
-        result: 'tmt.base.Result',
+        results: list['tmt.base.Result'],
         cwd: Optional[Path] = None,
         env: Optional[tmt.utils.Environment] = None,
     ) -> None:
@@ -2358,7 +2358,7 @@ class Login(Action):
         Check and login after test execution
         """
 
-        if self._enabled_by_results([result]):
+        if self._enabled_by_results(results):
             self._login(cwd, env)
 
 

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -834,7 +834,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                     else:
                         cwd = self.discover.workdir / test.path.unrooted()
                     self._login_after_test.after_test(
-                        result,
+                        invocation.results,
                         cwd=cwd,
                         env=self._test_environment(
                             invocation=invocation,

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -796,7 +796,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
 
                 ResultRenderer(
                     basepath=self.workdir,
-                    logger=self._logger,
+                    logger=logger,
                     shift=shift,
                     variables={'PROGRESS': f'[{progress}]'},
                 ).print_results(invocation.results)

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -155,7 +155,8 @@ class ResultRenderer:
         """
 
         with open(log) as f:
-            yield from f.readlines()
+            for line in f:
+                yield f'content: {line}'
 
     def render_logs_content(self, result: BaseResult) -> Iterator[str]:
         """

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -81,7 +81,7 @@ class ResultRenderer:
     display_guest: bool = True
 
     #: Additional variables to use when rendering templates.
-    variables: dict[str, Any] = simple_field(default_factory=dict)
+    variables: dict[str, Any] = simple_field(default_factory=dict[str, Any])
 
     result_header_template: str = DEFAULT_RESULT_HEADER_TEMPLATE
     result_check_header_template: str = DEFAULT_RESULT_CHECK_HEADER_TEMPLATE

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -35,7 +35,7 @@ DEFAULT_SUBRESULT_HEADER_TEMPLATE = """
 """  # noqa: E501
 
 DEFAULT_SUBRESULT_CHECK_HEADER_TEMPLATE = """
-{{ RESULT | format_duration | style(fg="cyan") }}{{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }} ({{ RESULT.event.value }} check)
+{{ RESULT | format_duration | style(fg="cyan") }} {{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }} ({{ RESULT.event.value }} check)
 """  # noqa: E501
 
 DEFAULT_NOTE_TEMPLATE = """

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -36,15 +36,15 @@ DEFAULT_RESULT_HEADER_TEMPLATE = """
 """  # noqa: E501
 
 DEFAULT_RESULT_CHECK_HEADER_TEMPLATE = """
-{{ RESULT | format_duration | style(fg="cyan") }}{{ '\u00a0' * 4 }}{{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }} ({{ RESULT.event.value }} check)
+{{ RESULT | format_duration | style(fg="cyan") }}{{ ' ' * 4 }}{{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }} ({{ RESULT.event.value }} check)
 """  # noqa: E501
 
 DEFAULT_SUBRESULT_HEADER_TEMPLATE = """
-{{ RESULT | format_duration | style(fg="cyan") }}{{ '\u00a0' * 4 }}{{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }}
+{{ RESULT | format_duration | style(fg="cyan") }}{{ ' ' * 4 }}{{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }}
 """  # noqa: E501
 
 DEFAULT_SUBRESULT_CHECK_HEADER_TEMPLATE = """
-{{ RESULT | format_duration | style(fg="cyan") }}{{ '\u00a0' * 8 }}{{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }} ({{ RESULT.event.value }} check)
+{{ RESULT | format_duration | style(fg="cyan") }}{{ ' ' * 8 }}{{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }} ({{ RESULT.event.value }} check)
 """  # noqa: E501
 
 

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -41,7 +41,6 @@ DEFAULT_RESULT_CHECK_HEADER_TEMPLATE = """
 
 DEFAULT_SUBRESULT_HEADER_TEMPLATE = """
 {{ RESULT | format_duration | style(fg="cyan") }}{{ '\u00a0' * 4 }}{{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }}
-{%- if CONTEXT.display_guest %} (on {{ RESULT.guest | guest_full_name }}){% endif %}
 """  # noqa: E501
 
 DEFAULT_SUBRESULT_CHECK_HEADER_TEMPLATE = """

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -1,22 +1,52 @@
-from collections.abc import Sequence
-from typing import Optional
+from collections.abc import Iterable, Iterator
+from typing import Any, Optional
 
 import tmt
 import tmt.log
 import tmt.steps
 import tmt.steps.report
-from tmt.container import container, field
-from tmt.result import BaseResult, CheckResult, Result, SubCheckResult, SubResult
+from tmt.container import container, field, simple_field
+from tmt.result import (
+    RESULT_OUTCOME_COLORS,
+    BaseResult,
+    CheckResult,
+    Result,
+    ResultOutcome,
+    SubResult,
+)
 from tmt.steps.execute import TEST_OUTPUT_FILENAME
-from tmt.utils import Path
+from tmt.utils import INDENT, Path
+from tmt.utils.templates import default_template_environment, render_template
 
 # How much test and test check info should be shifted to the right in the output.
 # We want tests to be shifted by one extra level, with their checks shifted by
 # yet another level.
-TEST_SHIFT = 1
-CHECK_SHIFT = 2
-SUBRESULT_SHIFT = CHECK_SHIFT
+RESULT_SHIFT = 0
+RESULT_CHECK_SHIFT = 1
+SUBRESULT_SHIFT = RESULT_CHECK_SHIFT
 SUBRESULT_CHECK_SHIFT = SUBRESULT_SHIFT + 1
+
+NOTE_SHIFT = 1
+NOTE_PREFIX = (NOTE_SHIFT * INDENT) * ' '
+
+DEFAULT_RESULT_HEADER_TEMPLATE = """
+{{ RESULT | format_duration | style(fg="cyan") }} {{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }}
+{%- if CONTEXT.display_guest %} (on {{ RESULT.guest | guest_full_name }}){% endif %}
+{%- if PROGRESS is defined %} {{ PROGRESS }}{% endif %}
+"""  # noqa: E501
+
+DEFAULT_RESULT_CHECK_HEADER_TEMPLATE = """
+{{ RESULT | format_duration | style(fg="cyan") }}{{ '\u00a0' * 4 }}{{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }} ({{ RESULT.event.value }} check)
+"""  # noqa: E501
+
+DEFAULT_SUBRESULT_HEADER_TEMPLATE = """
+{{ RESULT | format_duration | style(fg="cyan") }}{{ '\u00a0' * 4 }}{{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }}
+{%- if CONTEXT.display_guest %} (on {{ RESULT.guest | guest_full_name }}){% endif %}
+"""  # noqa: E501
+
+DEFAULT_SUBRESULT_CHECK_HEADER_TEMPLATE = """
+{{ RESULT | format_duration | style(fg="cyan") }}{{ '\u00a0' * 8 }}{{ OUTCOME | style(fg=OUTCOME_COLOR) }} {{ RESULT.name }} ({{ RESULT.event.value }} check)
+"""  # noqa: E501
 
 
 @container
@@ -31,6 +61,239 @@ class ReportDisplayData(tmt.steps.report.ReportStepData):
              (default), always, or never.
              """,
     )
+
+
+@container
+class ResultRenderer:
+    """
+    A rendering engine for turning results into printable representation.
+    """
+
+    #: A base path for all log references.
+    basepath: Path
+
+    logger: tmt.log.Logger
+
+    #: Default shift of all rendered lines.
+    shift: int
+
+    #: When 2 or more, log info - name and path - would be printed out.
+    #: When 3 or more, og output would be printed out as well.
+    verbosity: int = 0
+    #: Whether guest from which results originated should be printed out.
+    display_guest: bool = True
+
+    #: Additional variables to use when rendering templates.
+    variables: dict[str, Any] = simple_field(default_factory=dict)
+
+    result_header_template: str = DEFAULT_RESULT_HEADER_TEMPLATE
+    result_check_header_template: str = DEFAULT_RESULT_CHECK_HEADER_TEMPLATE
+    subresult_header_template: str = DEFAULT_SUBRESULT_HEADER_TEMPLATE
+    subresult_check_header_template: str = DEFAULT_SUBRESULT_CHECK_HEADER_TEMPLATE
+
+    def __post_init__(self) -> None:
+        self.environment = default_template_environment()
+
+    @staticmethod
+    def _indent(level: int, iterable: Iterable[str]) -> Iterator[str]:
+        """
+        Indent each string from iterable by the given indentation levels.
+        """
+
+        for item in iterable:
+            if not item:
+                yield item
+
+            else:
+                for line in item.splitlines():
+                    yield f'{(INDENT * level) * " "}{line}'
+
+    @staticmethod
+    def render_note(note: str) -> Iterator[str]:
+        """
+        Render a single result note.
+        """
+
+        note_lines = note.splitlines()
+
+        yield f'{NOTE_PREFIX}* Note: {note_lines.pop(0)}'
+
+        for note_line in note_lines:
+            yield f'{NOTE_PREFIX}        {note_line}'
+
+    @classmethod
+    def render_notes(cls, result: BaseResult) -> Iterator[str]:
+        """
+        Render result notes.
+        """
+
+        for note in result.note:
+            yield from cls.render_note(note)
+
+    @staticmethod
+    def render_log_info(log: Path) -> Iterator[str]:
+        """
+        Render info about a single log.
+        """
+
+        yield f'{log.name} ({log})'
+
+    def render_logs_info(self, result: BaseResult, shift: int) -> Iterator[str]:
+        """
+        Render info about result logs.
+        """
+
+        yield from self._indent(shift, ['logs:'])
+
+        for log in result.log:
+            yield from self._indent(shift + 1, self.render_log_info(self.basepath / log))
+
+    @staticmethod
+    def render_log_content(log: Path) -> Iterator[str]:
+        """
+        Render log info and content of a single log.
+        """
+
+        with open(log) as f:
+            yield from f.readlines()
+
+    def render_logs_content(self, result: BaseResult, shift: int) -> Iterator[str]:
+        """
+        Render log info and content of result logs.
+        """
+
+        yield from self._indent(shift, ['logs (with content):'])
+
+        for log in result.log:
+            yield from self._indent(shift + 1, self.render_log_info(self.basepath / log))
+
+            if log.name == TEST_OUTPUT_FILENAME:
+                yield from self._indent(shift + 2, self.render_log_content(self.basepath / log))
+
+    def render_check_result(self, result: CheckResult, shift: int, template: str) -> Iterator[str]:
+        """
+        Render a single test check result.
+        """
+
+        outcome = 'errr' if result.result == ResultOutcome.ERROR else result.result.value
+
+        yield render_template(
+            template,
+            environment=self.environment,
+            CONTEXT=self,
+            RESULT=result,
+            OUTCOME=outcome,
+            OUTCOME_COLOR=RESULT_OUTCOME_COLORS[result.result],
+            **self.variables,
+        )
+
+        yield from self._indent(shift + 1, self.render_notes(result))
+
+    def render_check_results(
+        self, results: Iterable[CheckResult], shift: int, template: str
+    ) -> Iterator[str]:
+        """
+        Render test check results.
+        """
+
+        for result in results:
+            yield from self.render_check_result(result, shift, template)
+
+    def render_subresult(self, result: SubResult) -> Iterator[str]:
+        """
+        Render a single subresult.
+        """
+
+        outcome = 'errr' if result.result == ResultOutcome.ERROR else result.result.value
+
+        yield render_template(
+            self.subresult_header_template,
+            environment=self.environment,
+            CONTEXT=self,
+            RESULT=result,
+            OUTCOME=outcome,
+            OUTCOME_COLOR=RESULT_OUTCOME_COLORS[result.result],
+            INDENT=INDENT * ' ',
+            **self.variables,
+        )
+
+        yield from self._indent(SUBRESULT_SHIFT + 1, self.render_notes(result))
+
+        # With verbosity increased to `-vvv` or more, display content of the main test log
+        if self.verbosity > 2:
+            yield from self.render_logs_content(result, SUBRESULT_SHIFT + 1)
+
+        # With verbosity increased to `-vv`, display the list of logs
+        elif self.verbosity > 1:
+            yield from self.render_logs_info(result, SUBRESULT_SHIFT + 1)
+
+        yield from self.render_check_results(
+            result.check, SUBRESULT_CHECK_SHIFT, self.subresult_check_header_template
+        )
+
+    def render_subresults(self, results: Iterable[SubResult]) -> Iterator[str]:
+        """
+        Render subresults.
+        """
+
+        for result in results:
+            yield from self.render_subresult(result)
+
+    def render_result(self, result: Result) -> Iterator[str]:
+        """
+        Render a single test result.
+        """
+
+        outcome = 'errr' if result.result == ResultOutcome.ERROR else result.result.value
+
+        yield render_template(
+            self.result_header_template,
+            environment=self.environment,
+            CONTEXT=self,
+            RESULT=result,
+            OUTCOME=outcome,
+            OUTCOME_COLOR=RESULT_OUTCOME_COLORS[result.result],
+            **self.variables,
+        )
+
+        yield from self._indent(RESULT_SHIFT + 1, self.render_notes(result))
+
+        # With verbosity increased to `-vvv` or more, display content of the main test log
+        if self.verbosity > 2:
+            yield from self.render_logs_content(result, RESULT_SHIFT + 1)
+
+        # With verbosity increased to `-vv`, display the list of logs
+        elif self.verbosity > 1:
+            yield from self.render_logs_info(result, RESULT_SHIFT + 1)
+
+        yield from self.render_check_results(
+            result.check, RESULT_CHECK_SHIFT, self.result_check_header_template
+        )
+        yield from self.render_subresults(result.subresult)
+
+    def render_results(self, results: Iterable[Result]) -> Iterator[str]:
+        """
+        Render test results.
+        """
+
+        for result in results:
+            yield from self.render_result(result)
+
+    def print_result(self, result: Result) -> None:
+        """
+        Print out a single rendered test result.
+        """
+
+        for line in self.render_result(result):
+            self.logger.verbose(line, shift=self.shift)
+
+    def print_results(self, results: Iterable[Result]) -> None:
+        """
+        Print out rendered test results.
+        """
+
+        for line in self.render_results(results):
+            self.logger.verbose(line, shift=self.shift)
 
 
 @tmt.steps.provides_method('display')
@@ -50,126 +313,6 @@ class ReportDisplay(tmt.steps.report.ReportPlugin[ReportDisplayData]):
     """
 
     _data_class = ReportDisplayData
-
-    def details(self, result: tmt.Result, verbosity: int, display_guest: bool) -> None:
-        """
-        Print result details.
-
-        :param result: a test result to display.
-        :param verbosity: how verbose should the report be. Generally equal to
-            number of  ``--verbose``/``-v`` options given on command line.
-            For ``1``, display only test name and its result, ``2`` will add
-            log paths, and ``3`` or more would show the test output as well.
-        :param display_guest: if set, guest multihost name would be part of the
-            report.
-        """
-
-        def _display_log_info(log: Path, shift: int) -> None:
-            """
-            Display info about a single result log
-            """
-
-            # TODO: are we sure it cannot be None?
-            assert self.step.plan.execute.workdir is not None
-
-            self.verbose(
-                log.name, self.step.plan.execute.workdir / log, color='yellow', shift=shift
-            )
-
-        def _display_log_content(log: Path, shift: int) -> None:
-            """
-            Display content of a single result log
-            """
-
-            # TODO: are we sure it cannot be None?
-            assert self.step.plan.execute.workdir is not None
-
-            self.verbose(
-                'content',
-                self.read(self.step.plan.execute.workdir / log),
-                color='yellow',
-                shift=shift,
-            )
-
-        def display_outcome(result: BaseResult) -> None:
-            """
-            Display a single result outcome
-            """
-
-            if isinstance(result, SubCheckResult):
-                self.verbose(
-                    f'{result.show()} ({result.event.value} check)', shift=SUBRESULT_CHECK_SHIFT
-                )
-
-            elif isinstance(result, CheckResult):
-                self.verbose(f'{result.show()} ({result.event.value} check)', shift=CHECK_SHIFT)
-
-            elif isinstance(result, SubResult):
-                self.verbose(result.show(), shift=SUBRESULT_SHIFT)
-
-            elif isinstance(result, Result):
-                self.verbose(result.show(display_guest=display_guest), shift=TEST_SHIFT)
-
-        def display_log_info(result: BaseResult) -> None:
-            """
-            Display info about result logs
-            """
-
-            # TODO: are we sure it cannot be None?
-            assert self.step.plan.execute.workdir is not None
-
-            shift = (TEST_SHIFT + 1) if isinstance(result, Result) else (CHECK_SHIFT + 1)
-
-            for log in result.log:
-                _display_log_info(log, shift)
-
-        def display_log_content(result: BaseResult) -> None:
-            """
-            Display content of interesting result logs
-            """
-
-            # TODO: are we sure it cannot be None?
-            assert self.step.plan.execute.workdir is not None
-
-            shift = (TEST_SHIFT + 1) if isinstance(result, Result) else (CHECK_SHIFT + 1)
-
-            for log in result.log:
-                _display_log_info(log, shift)
-
-                if log.name == TEST_OUTPUT_FILENAME:
-                    _display_log_content(log, shift)
-
-        def display_subresults(results: Sequence[BaseResult]) -> None:
-            """
-            Display subresults, checks and subresult checks
-            """
-
-            for subresult in results:
-                display_outcome(subresult)
-
-                if verbosity > 2:
-                    display_log_content(subresult)
-
-                elif verbosity > 1:
-                    display_log_info(subresult)
-
-                # Recursively show also all the results of subresult checks
-                if isinstance(subresult, SubResult):
-                    display_subresults(subresult.check)
-
-        # Always show the result outcome
-        display_outcome(result)
-
-        # With verbosity increased to `-vvv` or more, display content of the main test log
-        if verbosity > 2:
-            display_log_content(result)
-
-        # With verbosity increased to `-vv`, display the list of logs
-        elif verbosity > 1:
-            display_log_info(result)
-
-        display_subresults(result.check)
-        display_subresults(result.subresult)
 
     def go(self, *, logger: Optional[tmt.log.Logger] = None) -> None:
         """
@@ -192,5 +335,12 @@ class ReportDisplay(tmt.steps.report.ReportPlugin[ReportDisplayData]):
 
             display_guest = len(seen_guests) > 1
 
-        for result in self.step.plan.execute.results():
-            self.details(result, self.verbosity_level, display_guest)
+        assert self.step.plan.execute.workdir is not None
+
+        ResultRenderer(
+            basepath=self.step.plan.execute.workdir,
+            logger=self._logger,
+            shift=1,
+            verbosity=self.verbosity_level,
+            display_guest=display_guest,
+        ).print_results(self.step.plan.execute.results())

--- a/tmt/utils/templates.py
+++ b/tmt/utils/templates.py
@@ -10,12 +10,14 @@ import shlex
 import textwrap
 from re import Match
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Optional,
     cast,
 )
 
+import click
 import fmf
 import fmf.utils
 import jinja2
@@ -23,6 +25,10 @@ import jinja2.exceptions
 
 from tmt.utils import GeneralError, Path
 from tmt.utils.git import web_git_url
+
+if TYPE_CHECKING:
+    from tmt.result import BaseResult
+    from tmt.steps.provision import Guest
 
 
 def _template_filter_basename(  # type: ignore[reportUnusedFunction,unused-ignore]
@@ -324,6 +330,75 @@ def _template_filter_shell_quote(  # type: ignore[reportUnusedFunction,unused-ig
     """
 
     return shlex.quote(s)
+
+
+def _template_filter_style(  # type: ignore[reportUnusedFunction,unused-ignore]
+    s: str,
+    fg: Optional[str] = None,
+    bg: Optional[str] = None,
+    bold: Optional[bool] = None,
+    dim: Optional[bool] = None,
+    underline: Optional[bool] = None,
+    overline: Optional[bool] = None,
+    italic: Optional[bool] = None,
+    blink: Optional[bool] = None,
+    reverse: Optional[bool] = None,
+    strikethrough: Optional[bool] = None,
+    reset: bool = True,
+) -> str:
+    """
+    Evaluate terminal-style colorization tags supported by Click.
+
+    Implemented by passing all arguments to :py:func:`click.style`.
+    """
+
+    kwargs = locals().copy()
+    kwargs.pop('s')
+
+    return click.style(s, **kwargs)
+
+
+def _template_filter_guest_full_name(  # type: ignore[reportUnusedFunction,unused-ignore]
+    guest: 'Guest',
+) -> str:
+    """
+    Render guest's "full name".
+
+    Implemented by calling :py:func:`format_guest_full_name`.
+
+    .. code-block:: jinja
+
+        # {"name": "foo", "role": None, ...} -> 'foo'
+        {{ {"name": "foo", "role": None, ...} | guest_full_name }}
+
+        # {"name": "foo", "role": "bar", ...} -> 'foo (bar)'
+        {{ {"name": "foo", "role": "bar", ...} | guest_full_name }}
+    """
+
+    from tmt.steps.provision import format_guest_full_name
+
+    return format_guest_full_name(guest.name, guest.role)
+
+
+def _template_filter_format_duration(  # type: ignore[reportUnusedFunction,unused-ignore]
+    result: 'BaseResult',
+) -> str:
+    """
+    Render result duration in the ``hh:mm:ss`` format.
+
+    .. code-block:: jinja
+
+        # {"duration": None, ...} -> '    '
+        {{ {"duration": None, ...} | format_duration }}
+
+        # {"duration": "12:34:56", ...} -> '12:34:56'
+        {{ {"duration": "12:34:56", ...} | format_duration }}
+
+    """
+
+    # If test duration information is missing, print 8 spaces to keep indentation
+
+    return result.duration if result.duration else 6 * ' '
 
 
 TEMPLATE_FILTERS: dict[str, Callable[..., Any]] = {

--- a/tmt/utils/templates.py
+++ b/tmt/utils/templates.py
@@ -368,11 +368,11 @@ def _template_filter_guest_full_name(  # type: ignore[reportUnusedFunction,unuse
 
     .. code-block:: jinja
 
-        # {"name": "foo", "role": None, ...} -> 'foo'
-        {{ {"name": "foo", "role": None, ...} | guest_full_name }}
+        # {"name": "foo", "role": None} -> 'foo'
+        {{ {"name": "foo", "role": None} | guest_full_name }}
 
-        # {"name": "foo", "role": "bar", ...} -> 'foo (bar)'
-        {{ {"name": "foo", "role": "bar", ...} | guest_full_name }}
+        # {"name": "foo", "role": "bar"} -> 'foo (bar)'
+        {{ {"name": "foo", "role": "bar"} | guest_full_name }}
     """
 
     from tmt.steps.provision import format_guest_full_name
@@ -388,12 +388,11 @@ def _template_filter_format_duration(  # type: ignore[reportUnusedFunction,unuse
 
     .. code-block:: jinja
 
-        # {"duration": None, ...} -> '    '
-        {{ {"duration": None, ...} | format_duration }}
+        # {"duration": None} -> '    '
+        {{ {"duration": None} | format_duration }}
 
-        # {"duration": "12:34:56", ...} -> '12:34:56'
-        {{ {"duration": "12:34:56", ...} | format_duration }}
-
+        # {"duration": "12:34:56"} -> '12:34:56'
+        {{ {"duration": "12:34:56"} | format_duration }}
     """
 
     # If test duration information is missing, print 8 spaces to keep indentation

--- a/tmt/utils/templates.py
+++ b/tmt/utils/templates.py
@@ -376,16 +376,16 @@ def _template_filter_format_duration(  # type: ignore[reportUnusedFunction,unuse
     """
     Render result duration in the ``hh:mm:ss`` format.
 
+    If the duration is not defined, return a placeholder marker instead.
+
     .. code-block:: jinja
 
-        # {"duration": None} -> '    '
+        # {"duration": None} -> '..:..:..'
         {{ {"duration": None} | format_duration }}
 
         # {"duration": "12:34:56"} -> '12:34:56'
         {{ {"duration": "12:34:56"} | format_duration }}
     """
-
-    # If test duration information is missing, print 8 spaces to keep indentation
 
     return result.duration if result.duration else '..:..:..'
 

--- a/tmt/utils/templates.py
+++ b/tmt/utils/templates.py
@@ -17,7 +17,6 @@ from typing import (
     cast,
 )
 
-import click
 import fmf
 import fmf.utils
 import jinja2
@@ -335,16 +334,8 @@ def _template_filter_shell_quote(  # type: ignore[reportUnusedFunction,unused-ig
 def _template_filter_style(  # type: ignore[reportUnusedFunction,unused-ignore]
     s: str,
     fg: Optional[str] = None,
-    bg: Optional[str] = None,
     bold: Optional[bool] = None,
-    dim: Optional[bool] = None,
     underline: Optional[bool] = None,
-    overline: Optional[bool] = None,
-    italic: Optional[bool] = None,
-    blink: Optional[bool] = None,
-    reverse: Optional[bool] = None,
-    strikethrough: Optional[bool] = None,
-    reset: bool = True,
 ) -> str:
     """
     Evaluate terminal-style colorization tags supported by Click.
@@ -352,10 +343,9 @@ def _template_filter_style(  # type: ignore[reportUnusedFunction,unused-ignore]
     Implemented by passing all arguments to :py:func:`click.style`.
     """
 
-    kwargs = locals().copy()
-    kwargs.pop('s')
+    from tmt.utils.themes import style
 
-    return click.style(s, **kwargs)
+    return style(s, fg=fg, bold=bold, underline=underline)
 
 
 def _template_filter_guest_full_name(  # type: ignore[reportUnusedFunction,unused-ignore]
@@ -397,7 +387,7 @@ def _template_filter_format_duration(  # type: ignore[reportUnusedFunction,unuse
 
     # If test duration information is missing, print 8 spaces to keep indentation
 
-    return result.duration if result.duration else 6 * ' '
+    return result.duration if result.duration else '..:..:..'
 
 
 TEMPLATE_FILTERS: dict[str, Callable[..., Any]] = {


### PR DESCRIPTION
`execute/tmt` is using very, very similar output format - test, duration, check results, subresults. The patch changes `display` to be reusable from other places, and changes `execute/tmt` to use `display` instad of its custom code. With a bit of templating, what gets rendered how should now be easier to follow, and we are reusing existing code.

Pull Request Checklist

* [x] implement the feature