### PR TITLE
Build and publish teemtee images via github action

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -12,14 +12,12 @@ jobs:
         id: build-image-tmt
         with:
           image: tmt
-          tags: latest
           containerfiles: ./containers/Containerfile.mini
       - name: Build - tmt-all
         uses: redhat-actions/buildah-build@v2
         id: build-image-tmt-all
         with:
           image: tmt-all
-          tags: latest
           containerfiles: ./containers/Containerfile.full
       - name: Push To quay.io - tmt
         id: push-to-quay-tmt

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,41 @@
+name: publish_images
+on: workflow_dispatch
+
+jobs:
+  publish-images:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build - tmt
+        uses: redhat-actions/buildah-build@v2
+        id: build-image-tmt
+        with:
+          image: tmt
+          tags: latest
+          containerfiles: ./containers/Dockerfile.mini
+      - name: Build - tmt-all
+        uses: redhat-actions/buildah-build@v2
+        id: build-image-tmt-all
+        with:
+          image: tmt-all
+          tags: latest
+          containerfiles: ./containers/Dockerfile.full
+      - name: Push To quay.io - tmt
+        id: push-to-quay-tmt
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image-tmt.outputs.image }}
+          tags: ${{ steps.build-image-tmt.outputs.tags }}
+          registry: quay.io/teemtee/
+          username: teemtee+github_action
+          password: ${{ secrets.QUAY_TEEMTEE_SECRET }}
+      - name: Push To quay.io - tmt-all
+        id: push-to-quay-tmt-all
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image-tmt-all.outputs.image }}
+          tags: ${{ steps.build-image-tmt-all.outputs.tags }}
+          registry: quay.io/teemtee/
+          username: teemtee+github_action
+          password: ${{ secrets.QUAY_TEEMTEE_SECRET }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -13,14 +13,14 @@ jobs:
         with:
           image: tmt
           tags: latest
-          containerfiles: ./containers/Dockerfile.mini
+          containerfiles: ./containers/Containerfile.mini
       - name: Build - tmt-all
         uses: redhat-actions/buildah-build@v2
         id: build-image-tmt-all
         with:
           image: tmt-all
           tags: latest
-          containerfiles: ./containers/Dockerfile.full
+          containerfiles: ./containers/Containerfile.full
       - name: Push To quay.io - tmt
         id: push-to-quay-tmt
         uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           image: ${{ steps.build-image-tmt.outputs.image }}
           tags: ${{ steps.build-image-tmt.outputs.tags }}
-          registry: quay.io/teemtee/
+          registry: quay.io/teemtee
           username: teemtee+github_action
           password: ${{ secrets.QUAY_TEEMTEE_SECRET }}
       - name: Push To quay.io - tmt-all
@@ -34,6 +34,6 @@ jobs:
         with:
           image: ${{ steps.build-image-tmt-all.outputs.image }}
           tags: ${{ steps.build-image-tmt-all.outputs.tags }}
-          registry: quay.io/teemtee/
+          registry: quay.io/teemtee
           username: teemtee+github_action
           password: ${{ secrets.QUAY_TEEMTEE_SECRET }}

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -730,9 +730,8 @@ Create a new `github release`__ based on the tag above
 Finally, if everything went well:
 
 * Close the corresponding release milestone
-* Once the non development `copr build`__ is completed, move the
-  ``quay`` branch to point to the release commit as well to build
-  fresh `container images`__.
+* Once the non development `copr build`__ is completed, run the
+  `publish-images`__ workflow to build fresh container image.
 
 Handle manually what did not went well:
 
@@ -747,7 +746,7 @@ __ https://github.com/teemtee/tmt/releases/
 __ https://tmt.readthedocs.io/en/stable/releases.html
 __ https://src.fedoraproject.org/rpms/tmt/pull-requests
 __ https://copr.fedorainfracloud.org/coprs/g/teemtee/stable/builds/
-__ https://quay.io/repository/teemtee/tmt
+__ https://github.com/teemtee/tmt/actions/workflows/publish-images.yml
 __ https://pypi.org/project/tmt/
 
 


### PR DESCRIPTION
I've put it as a separate action triggered manually because I'm out of ideas how to trigger this automatically during the release process. Containers use `copr @teemtee/stable` to get the builds, and those have to exists at the time we are building the images.

Any ideas?

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
