### PR TITLE
Switch to hadolint-py and add shellcheck-py

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -26,9 +26,10 @@ jobs:
         name: Differential ShellCheck
         uses: redhat-plumbers-in-action/differential-shellcheck@v4
         with:
+          # Keep exclusions in sync with shellcheck-py hook in .pre-commit-config.yaml
           exclude-path: |
             tests/**
-            examples/**/test.sh
+            examples/**
             tmt/steps/execute/scripts/*.sh.j2
             tmt/templates/**
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -188,19 +188,13 @@ repos:
           - single-statement-per-line
           - "--"
 
-  - repo: https://github.com/hadolint/hadolint
-    rev: v2.13.1-beta
+  - repo: https://github.com/AleksaC/hadolint-py
+    rev: v2.12.1b3
     hooks:
-      # * hadolint-docker depends hard on Docker, ignores podman
-      # * pre-commit check does not install hadolint binary,
-      #   see https://github.com/hadolint/hadolint/issues/886
-      #
-      # As of now, installing hadolint "manually" is the only viable
-      # option. It is required to exist on developer's workstation,
-      # and it is installed by a dedicated step in Github pre-commit
-      # action (.github/workflows/pre-commit.yml).
+
       - id: hadolint
         files: ^containers/.*
+
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -201,3 +201,15 @@ repos:
       # action (.github/workflows/pre-commit.yml).
       - id: hadolint
         files: ^containers/.*
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        # Local shellcheck for developers - keep exclusions in sync with .github/workflows/shellcheck.yml
+        exclude: |
+          (?x)^(
+            tests/.*|
+            examples/.*|
+            tmt/steps/execute/scripts/.*\.sh\.j2|
+            tmt/templates/.*
+          )$

--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/debian/1
 ## Development
 ##
 develop: _deps  ## Install development requirements
-	sudo dnf install -y expect gcc git python3-nitrate {libvirt,krb5,libpq,python3}-devel jq podman buildah hadolint /usr/bin/python3.9
+	sudo dnf install -y expect gcc git python3-nitrate {libvirt,krb5,libpq,python3}-devel jq podman buildah /usr/bin/python3.9
 
 # Git vim tags and cleanup
 tags:

--- a/tmt/steps/execute/scripts/tmt-reboot
+++ b/tmt/steps/execute/scripts/tmt-reboot
@@ -31,7 +31,7 @@ if [ $efi = True ]; then
         fi
         if [[ -n "$os_boot_entry" ]] ; then
             logger -s "efibootmgr -n $os_boot_entry"
-            efibootmgr -n $os_boot_entry
+            efibootmgr -n "$os_boot_entry"
         else
             logger -s "Could not determine value for BootNext!"
         fi


### PR DESCRIPTION
> See: https://pre-commit.ci/
> 
> In order for it to work, it requires adding pre-commit.ci in gh organization settings. (not doing that without consensus)  
> 
> Can go hand-in-hand with https://github.com/teemtee/tmt/pull/2923
> 
> One motivation is to keep the checks autoupdated, for example https://github.com/teemtee/tmt/pull/3544#issuecomment-2713452237
> 
> GitHub action:
> >this action is in maintenance-only mode and will not be accepting new features.
> generally you want to use [pre-commit.ci](https://pre-commit.ci/) which is faster and has more features.
> 
> > pre-commit.ci will always be free for open source repositories.
> Also adding shellcheck.py while keeping the shellcheck action - Closes https://github.com/teemtee/tmt/issues/2271

pre-commit.ci doesn't play ball with pyright. For now, reverting to github workflow. Keeping hadolint-py and shellcheck-py
