### PR TITLE
Tests that abort or fail (with `exit-first`) will skip remaining tests

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -21,6 +21,13 @@ subset of plans, commands such as ``tmt run --last report`` will
 load the respective plans only instead of all available plans to
 save disk space and speed up the execution.
 
+Aborted tests and tests that failed when
+:ref:`/spec/plans/execute/exit-first` was enabled did not skip all
+remaining tests, only tests from the current ``discover`` phase. Plans
+with multiple ``discover`` phases would start ``execute`` step for
+remaining ``discover`` phases. This is now fixed, aborted test and
+:ref:`/spec/plans/execute/exit-first` will skip **all** remaining tests.
+
 
 tmt-1.44.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/execute/exit-first/test.sh
+++ b/tests/execute/exit-first/test.sh
@@ -18,7 +18,7 @@ rlJournalStart
         rlAssertGrep "warn /test/warn" $rlRun_LOG
         rlAssertGrep "pass /test/pass" $rlRun_LOG
         rlAssertGrep "pass /test/another-pass" $rlRun_LOG
-        rlAssertNotGrep "warn: Test .* stopping execution." $rlRun_LOG
+        rlAssertNotGrep "fail: Test .* stopping execution." $rlRun_LOG
         rlAssertGrep "summary: 4 tests executed" $rlRun_LOG
         rlAssertGrep "total: 2 tests passed, 1 info and 1 warn" $rlRun_LOG
     rlPhaseEnd
@@ -29,7 +29,7 @@ rlJournalStart
         rlAssertGrep "pass /test/pass" $rlRun_LOG
         rlAssertGrep "fail /test/fail" $rlRun_LOG
         rlAssertNotGrep "pass /test/another-pass" $rlRun_LOG
-        rlAssertGrep "warn: Test /test/fail failed, stopping execution." $rlRun_LOG
+        rlAssertGrep "fail: Test /test/fail failed, stopping execution." $rlRun_LOG
         rlAssertGrep "summary: 2 tests executed" $rlRun_LOG
         rlAssertGrep "total: 1 test passed, 1 test failed and 1 pending" $rlRun_LOG
     rlPhaseEnd
@@ -40,7 +40,7 @@ rlJournalStart
         rlAssertGrep "pass /test/pass" $rlRun_LOG
         rlAssertGrep "errr /test/error" $rlRun_LOG
         rlAssertNotGrep "pass /test/another-pass" $rlRun_LOG
-        rlAssertGrep "warn: Test /test/error failed, stopping execution." $rlRun_LOG
+        rlAssertGrep "fail: Test /test/error failed, stopping execution." $rlRun_LOG
         rlAssertGrep "summary: 2 tests executed" $rlRun_LOG
         rlAssertGrep "total: 1 test passed, 1 error and 1 pending" $rlRun_LOG
     rlPhaseEnd

--- a/tests/execute/restraint/tmt-abort/data/do-not-run.fmf
+++ b/tests/execute/restraint/tmt-abort/data/do-not-run.fmf
@@ -1,3 +1,8 @@
 summary: Should not be run
 framework: shell
-test: echo "This should not be executed either."
+
+/1:
+  test: echo "This should not be executed either."
+
+/2:
+  test: echo "And neither should this."

--- a/tests/execute/restraint/tmt-abort/data/plan.fmf
+++ b/tests/execute/restraint/tmt-abort/data/plan.fmf
@@ -1,9 +1,13 @@
 discover:
-    how: fmf
+  - how: fmf
     test:
      - abort
-     - do-not-run
+     - do-not-run/1
+  - how: fmf
+    test:
+     - do-not-run/2
 provision:
     how: container
+    image: localhost/tmt/container/test/fedora/rawhide:latest
 execute:
     how: tmt

--- a/tests/execute/restraint/tmt-abort/main.fmf
+++ b/tests/execute/restraint/tmt-abort/main.fmf
@@ -6,3 +6,4 @@ contact: Philip Daly <pdaly@redhat.com>
 tag+:
   - beakerlib
   - provision-container
+  - provision-only

--- a/tests/execute/restraint/tmt-abort/main.fmf
+++ b/tests/execute/restraint/tmt-abort/main.fmf
@@ -3,4 +3,6 @@ description:
     Verify that the tmt-abort functionality
     can be executed successfully.
 contact: Philip Daly <pdaly@redhat.com>
-tag+: [beakerlib]
+tag+:
+  - beakerlib
+  - provision-container

--- a/tests/execute/restraint/tmt-abort/test.sh
+++ b/tests/execute/restraint/tmt-abort/test.sh
@@ -11,11 +11,20 @@ rlJournalStart
         rlRun -s "tmt run -vvv --id \${run}" 2 "Expect error from execution to tmt-abort."
         # 2 tests discovered but only one is executed due to abort
         rlAssertGrep "1 test executed" $rlRun_LOG
+        rlAssertGrep "total: 1 error and 2 pending" $rlRun_LOG
+
+        rlAssertGrep "errr /default-0/abort" $rlRun_LOG
+        rlAssertGrep "pending /default-0/do-not-run/1" $rlRun_LOG
+        rlAssertGrep "pending /default-1/do-not-run/2" $rlRun_LOG
+
         rlAssertNotGrep "This test should not be executed." $rlRun_LOG
         rlAssertNotGrep "This should not be executed either." $rlRun_LOG
-
+        rlAssertNotGrep "And neither should this." $rlRun_LOG
 
         rlAssertGrep "result: error" "${run}/plan/execute/results.yaml"
+        rlAssertEquals "check expected outcomes" \
+            "$(yq -r '[sort_by(.name) | .[] | "\(.name):\(.result)"] | join(" ")' ${run}/plan/execute/results.yaml)" \
+            "/default-0/abort:error /default-0/do-not-run/1:pending /default-1/do-not-run/2:pending"
         rlAssertEquals "results should record the test aborted" \
             "$(yq -r '.[] | .note | join(", ")' ${run}/plan/execute/results.yaml)" \
             "beakerlib: State 'started', aborted"

--- a/tests/execute/restraint/tmt-abort/test.sh
+++ b/tests/execute/restraint/tmt-abort/test.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 . /usr/share/beakerlib/beakerlib.sh || exit 1
+. ../../../images.sh || exit 1
 
 rlJournalStart
     rlPhaseStartSetup
         rlRun "run=\$(mktemp -d)" 0 "Create run directory"
         rlRun "pushd data"
+
+        build_container_image "fedora/rawhide\:latest"
     rlPhaseEnd
 
     rlPhaseStartTest

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -287,7 +287,7 @@ ExecuteStepDataT = TypeVar('ExecuteStepDataT', bound=ExecuteStepData)
 
 class AbortExecute(tmt.utils.GeneralError):
     """
-    Raised by ``execute`` phases to when the whole step should abort.
+    Raised by ``execute`` phases when the entire step should abort.
     """
 
     pass


### PR DESCRIPTION
Before the patch, an aborted test or a failed test with `exit-first` would skip tests remaining in the current `discover` phase. Tests from remaining `discover` phases would still be executed.

The patch adds a signal for `execute` plugins to notify the step queue to not continue by running more phases. It's implemented by raising an exception, but that may change in the future, once we teach plugins and steps to return values instead of using object attributes to communicate results.

Fixes https://github.com/teemtee/tmt/issues/3573

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [x] include a release note