### PR TITLE
Save data to the correct directory when pruning with `path` specified

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -5,6 +5,15 @@
 ======================
 
 
+tmt-1.45.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When pruning a repository with a specified ``path``, the ``discover``
+step now saves the data to the correct temporary directory and
+respects the structure of the original repository. This ensures
+that the test attributes have correct paths.
+
+
 tmt-1.44.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/discover/prune.sh
+++ b/tests/discover/prune.sh
@@ -8,17 +8,19 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Discover local"
-        rlRun -s "tmt run -i $run discover plans --name plan tests --name test1"
+        rlRun -s "tmt run --scratch -i $run discover plans --name plan tests --name test1"
         rlAssertExists "$run/plan/discover/default-0/tests/test1"
         rlAssertNotExists "$run/plan/discover/default-0/tests/test2"
         rlAssertNotExists "$run/plan/discover/default-0/tests/some-file"
     rlPhaseEnd
 
     rlPhaseStartTest "Discover remote with path"
-        rlRun -s "tmt run -i $run discover plans --name nested tests --name file"
-        rlAssertExists "$run/nested/discover/default-0/tests/file/test.sh"
+        rlRun -s "tmt run --scratch -i $run discover plans --name nested tests --name file"
+        rlAssertExists "$run/nested/discover/default-0/tests/nested/file/test.sh"
+        rlAssertExists "$run/nested/discover/default-0/tests/nested/file/lib.sh"
         rlAssertExists "$run/nested/discover/default-0/tests/scripts/random_file.sh"
-        rlAssertNotExists "$run/nested/discover/default-0/tests/dir-without-fmf"
+        rlAssertNotExists "$run/nested/discover/default-0/tests/nested/dir-without-fmf"
+        rlAssertNotExists "$run/nested/discover/default-0/tests/requre"
     rlPhaseEnd
 
     rlPhaseStartCleanup


### PR DESCRIPTION
When pruning a repository with a specified `path`, the discover step now saves the data to the correct temporary directory and respects the structure of the original repository. This ensures that the test attributes have correct paths.

Fixes: #3589 

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [x] include a release note
