### PR TITLE
Sort plugin docs by plugin id

### DIFF
--- a/docs/scripts/generate-plugins.py
+++ b/docs/scripts/generate-plugins.py
@@ -138,7 +138,7 @@ def _create_step_plugin_iterator(registry: tmt.plugins.PluginRegistry[tmt.steps.
     """
 
     def plugin_iterator():
-        for plugin_id in registry.iter_plugin_ids():
+        for plugin_id in sorted(registry.iter_plugin_ids()):
             plugin = registry.get_plugin(plugin_id).class_
 
             if hasattr(plugin, 'get_data_class'):
@@ -156,7 +156,7 @@ def _create_feature_plugin_iterator(
     """Create iterator over plugins of a feature plugin registry"""
 
     def plugin_iterator():
-        for plugin_id in registry.iter_plugin_ids():
+        for plugin_id in sorted(registry.iter_plugin_ids()):
             plugin = registry.get_plugin(plugin_id)
 
             yield plugin_id, plugin, plugin._data_class
@@ -170,7 +170,7 @@ def _create_test_check_plugin_iterator(registry: tmt.plugins.PluginRegistry[tmt.
     """
 
     def plugin_iterator():
-        for plugin_id in registry.iter_plugin_ids():
+        for plugin_id in sorted(registry.iter_plugin_ids()):
             plugin = registry.get_plugin(plugin_id)
 
             yield plugin_id, plugin, plugin._check_class


### PR DESCRIPTION
Sorted is nice, `beaker` belongs before `connect`, not otherwise.

Pull Request Checklist

* [x] implement the feature