### PR TITLE
Simplify workdir pruning implementation

### DIFF
--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -540,7 +540,7 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
     @property
     def _preserved_workdir_members(self) -> set[str]:
         """
-        A set of members of the step workdir that should not be removed.
+        A set of members of the step workdir that should not be removed during pruning.
         """
 
         return {'step.yaml'}

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -162,6 +162,43 @@ PHASE_OPTIONS = tmt.options.create_options_decorator(
 )
 
 
+def prune_directory(path: Path, preserved_members: set[str], logger: tmt.log.Logger) -> set[str]:
+    """
+    Remove content of a given directory while preserving selected members.
+
+    :param path: a directory to prune.
+    :param preserved_members: names of directory entries that should not
+        be removed.
+    :param logger: used for logging.
+    :returns: names of members that were actually preserved, i.e. members
+        that exist in the directory, and were not removed.
+    """
+
+    actual_preserved_members: set[str] = set()
+
+    for member in path.iterdir():
+        if member.name in preserved_members:
+            logger.debug(f"Preserve '{member.relative_to(path)}'.", level=3)
+
+            actual_preserved_members = {*actual_preserved_members, member.name}
+
+            continue
+
+        logger.debug(f"Remove '{member}'.", level=3)
+
+        try:
+            if member.is_file() or member.is_symlink():
+                member.unlink()
+
+            else:
+                shutil.rmtree(member)
+
+        except OSError as error:
+            logger.warning(f"Unable to remove '{member}': {error}")
+
+    return actual_preserved_members
+
+
 class DefaultNameGenerator:
     """
     Generator of names for that do not have any.
@@ -446,11 +483,6 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
     #: by :py:meth:`_normalize_data`.
     _raw_data: list[_RawStepData]
 
-    # The step has pruning capability to remove all irrelevant files. All
-    # important file and directory names located in workdir should be specified
-    # in the list below to avoid deletion during pruning.
-    _preserved_workdir_members: list[str] = ['step.yaml']
-
     def __init__(
         self,
         *,
@@ -504,6 +536,14 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
     @property
     def _cli_invocation_logger(self) -> tmt.log.LoggingFunction:
         return functools.partial(self.debug, level=4, topic=tmt.log.Topic.CLI_INVOCATIONS)
+
+    @property
+    def _preserved_workdir_members(self) -> set[str]:
+        """
+        A set of members of the step workdir that should not be removed.
+        """
+
+        return {'step.yaml'}
 
     def _check_duplicate_names(self, raw_data: list[_RawStepData]) -> None:
         """
@@ -1237,29 +1277,17 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
         logger = logger.descend()
 
         # Collect all workdir members that shall not be removed
-        preserved_members: list[str] = self._preserved_workdir_members[:]
+        preserved_members: set[str] = self._preserved_workdir_members
 
         # Do not prune plugin workdirs, each plugin decides what should
         # be pruned from the workdir and what should be kept there
         plugins = self.phases(classes=BasePlugin)
         for plugin in plugins:
             if plugin.workdir is not None:
-                preserved_members.append(plugin.workdir.name)
+                preserved_members = {*preserved_members, plugin.workdir.name}
             plugin.prune(logger)
 
-        # Prune everything except for the preserved files
-        for member in self.workdir.iterdir():
-            if member.name in preserved_members:
-                logger.debug(f"Preserve '{member.relative_to(self.workdir)}'.", level=3)
-                continue
-            logger.debug(f"Remove '{member}'.", level=3)
-            try:
-                if member.is_file() or member.is_symlink():
-                    member.unlink()
-                else:
-                    shutil.rmtree(member)
-            except OSError as error:
-                logger.warning(f"Unable to remove '{member}': {error}")
+        prune_directory(self.workdir, preserved_members, self._logger)
 
 
 class Method:
@@ -1406,8 +1434,6 @@ class BasePlugin(Phase, Generic[StepDataT, PluginReturnValueT]):
 
     _data_class: type[StepDataT]
 
-    _preserved_workdir_members: set[str] = set()
-
     @classmethod
     def get_data_class(cls) -> type[StepDataT]:
         """
@@ -1459,6 +1485,14 @@ class BasePlugin(Phase, Generic[StepDataT, PluginReturnValueT]):
         # all keys are not known at the time of the class definition
         self.data = data
         self.step = step
+
+    @property
+    def _preserved_workdir_members(self) -> set[str]:
+        """
+        A set of members of the step workdir that should not be removed.
+        """
+
+        return set()
 
     @functools.cached_property
     def safe_name(self) -> str:
@@ -1913,25 +1947,14 @@ class BasePlugin(Phase, Generic[StepDataT, PluginReturnValueT]):
 
         if self.workdir is None:
             return
-        preservable_members = [
-            member
-            for member in self.workdir.iterdir()
-            if member.name in self._preserved_workdir_members
-        ]
-        removable_members = [
-            member for member in self.workdir.iterdir() if member not in preservable_members
-        ]
-        if preservable_members:
-            for member in removable_members:
-                logger.debug(f"Remove '{member}'.", level=3)
-                try:
-                    if member.is_file() or member.is_symlink():
-                        member.unlink()
-                    else:
-                        shutil.rmtree(member)
-                except OSError as error:
-                    logger.warning(f"Unable to remove '{member}': {error}")
-        else:
+
+        preserved_members = prune_directory(
+            self.workdir, self._preserved_workdir_members, self._logger
+        )
+
+        # If no member was preserved in our workdir, we can remove the whole
+        # directory.
+        if not preserved_members:
             logger.debug(f"Remove '{self.name}' workdir '{self.workdir}'.", level=3)
             try:
                 shutil.rmtree(self.workdir)

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -218,7 +218,6 @@ class Discover(tmt.steps.Step):
     """
 
     _plugin_base_class = DiscoverPlugin
-    _preserved_workdir_members = ['step.yaml', 'tests.yaml']
 
     def __init__(
         self,
@@ -239,6 +238,14 @@ class Discover(tmt.steps.Step):
 
         # Test will be (re)discovered in other phases/steps
         self.extract_tests_later: bool = False
+
+    @property
+    def _preserved_workdir_members(self) -> set[str]:
+        """
+        A set of members of the step workdir that should not be removed.
+        """
+
+        return {*super()._preserved_workdir_members, 'tests.yaml'}
 
     def load(self) -> None:
         """

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1155,8 +1155,6 @@ class Execute(tmt.steps.Step):
 
     _plugin_base_class = ExecutePlugin
 
-    _preserved_workdir_members = ['step.yaml', 'results.yaml', 'data']
-
     def __init__(
         self,
         *,
@@ -1172,6 +1170,14 @@ class Execute(tmt.steps.Step):
         # List of Result() objects representing test results
         self._results: list[tmt.Result] = []
         self._old_results: list[tmt.Result] = []
+
+    @property
+    def _preserved_workdir_members(self) -> set[str]:
+        """
+        A set of members of the step workdir that should not be removed.
+        """
+
+        return {*super()._preserved_workdir_members, 'data', 'results.yaml'}
 
     def load(self) -> None:
         """

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -97,10 +97,13 @@ class Finish(tmt.steps.Step):
 
     _plugin_base_class = FinishPlugin
 
-    _preserved_workdir_members = [
-        *tmt.steps.Step._preserved_workdir_members,
-        'results.yaml',
-    ]
+    @property
+    def _preserved_workdir_members(self) -> set[str]:
+        """
+        A set of members of the step workdir that should not be removed.
+        """
+
+        return {*super()._preserved_workdir_members, 'results.yaml'}
 
     def wake(self) -> None:
         """

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -153,10 +153,13 @@ class Prepare(tmt.steps.Step):
 
     _plugin_base_class = PreparePlugin
 
-    _preserved_workdir_members = [
-        *tmt.steps.Step._preserved_workdir_members,
-        'results.yaml',
-    ]
+    @property
+    def _preserved_workdir_members(self) -> set[str]:
+        """
+        A set of members of the step workdir that should not be removed.
+        """
+
+        return {*super()._preserved_workdir_members, 'results.yaml'}
 
     def __init__(
         self,

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -3047,8 +3047,6 @@ class Provision(tmt.steps.Step):
 
     _plugin_base_class = ProvisionPlugin
 
-    _preserved_workdir_members = ['step.yaml', 'guests.yaml']
-
     #: All known guests.
     #:
     #: .. warning::
@@ -3102,6 +3100,14 @@ class Provision(tmt.steps.Step):
 
         self.guests = []
         self._guest_data: dict[str, GuestData] = {}
+
+    @property
+    def _preserved_workdir_members(self) -> set[str]:
+        """
+        A set of members of the step workdir that should not be removed.
+        """
+
+        return {*super()._preserved_workdir_members, 'guests.yaml'}
 
     @property
     def is_multihost(self) -> bool:

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -15,6 +15,8 @@ from tmt.utils import Path
 
 HTML_TEMPLATE_PATH = tmt.utils.resource_files('steps/report/html/template.html.j2')
 
+DEFAULT_FILENAME = 'index.html'
+
 
 @container
 class ReportHtmlData(tmt.steps.report.ReportStepData):
@@ -71,10 +73,13 @@ class ReportHtml(tmt.steps.report.ReportPlugin[ReportHtmlData]):
 
     _data_class = ReportHtmlData
 
-    def prune(self, logger: tmt.log.Logger) -> None:
+    @property
+    def _preserved_workdir_members(self) -> set[str]:
         """
-        Do not prune generated html report
+        A set of members of the step workdir that should not be removed.
         """
+
+        return {DEFAULT_FILENAME}
 
     def go(self, *, logger: Optional[tmt.log.Logger] = None) -> None:
         """
@@ -117,7 +122,7 @@ class ReportHtml(tmt.steps.report.ReportPlugin[ReportHtmlData]):
             display_guest = len(seen_guests) > 1
 
         # Write the report
-        filename = Path('index.html')
+        filename = Path(DEFAULT_FILENAME)
 
         self.write(
             filename,

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     XMLElement: TypeAlias = Any
 
 
-DEFAULT_NAME = 'junit.xml'
+DEFAULT_FILENAME = 'junit.xml'
 DEFAULT_FLAVOR_NAME = 'default'
 CUSTOM_FLAVOR_NAME = 'custom'
 
@@ -515,10 +515,18 @@ class ReportJUnit(tmt.steps.report.ReportPlugin[ReportJUnitData]):
                 "The '--template-path' can be used only with '--flavor=custom'."
             )
 
-    def prune(self, logger: tmt.log.Logger) -> None:
+    @property
+    def _preserved_workdir_members(self) -> set[str]:
         """
-        Do not prune generated junit report
+        A set of members of the step workdir that should not be removed.
         """
+
+        members = super()._preserved_workdir_members
+
+        if self.data.file is None:
+            members = {*members, DEFAULT_FILENAME}
+
+        return members
 
     def go(self, *, logger: Optional[tmt.log.Logger] = None) -> None:
         """
@@ -530,7 +538,7 @@ class ReportJUnit(tmt.steps.report.ReportPlugin[ReportJUnitData]):
         self.check_options()
 
         assert self.workdir is not None
-        f_path = self.data.file or self.workdir / DEFAULT_NAME
+        f_path = self.data.file or self.workdir / DEFAULT_FILENAME
 
         xml_data = make_junit_xml(
             phase=self,

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -13,7 +13,7 @@ from tmt.utils import Path
 
 from .junit import ResultsContext, make_junit_xml
 
-DEFAULT_NAME = 'xunit.xml'
+DEFAULT_FILENAME = 'xunit.xml'
 
 
 @container
@@ -268,10 +268,18 @@ class ReportPolarion(tmt.steps.report.ReportPlugin[ReportPolarionData]):
 
     _data_class = ReportPolarionData
 
-    def prune(self, logger: tmt.log.Logger) -> None:
+    @property
+    def _preserved_workdir_members(self) -> set[str]:
         """
-        Do not prune generated xunit report
+        A set of members of the step workdir that should not be removed.
         """
+
+        members = super()._preserved_workdir_members
+
+        if self.data.file is None:
+            members = {*members, DEFAULT_FILENAME}
+
+        return members
 
     def go(self, *, logger: Optional[tmt.log.Logger] = None) -> None:
         """
@@ -417,7 +425,7 @@ class ReportPolarion(tmt.steps.report.ReportPlugin[ReportPolarionData]):
             results_context=results_context,
         )
 
-        f_path = self.data.file or self.workdir / DEFAULT_NAME
+        f_path = self.data.file or self.workdir / DEFAULT_FILENAME
 
         try:
             f_path.write_text(xml_data)


### PR DESCRIPTION
* some plugins used no-op `prune()` do prevent removing report files they created,
* several pieces implementing the removal were repeated.

Patch

* changes the "preserved members" attribute to a property plugins can easily override and extend with names known in runtime,
* adds a helper for the "prune directory except for these members" action.

Pull Request Checklist

* [x] implement the feature