### PR TITLE
Add "latest Fedora" container image for tests to use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,9 @@ TMT_TEST_CONTAINER_IMAGES := $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/alpine:late
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/centos/stream10/upstream:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/coreos:stable \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/coreos/ostree:stable \
+                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/latest:latest \
+                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/latest/upstream:latest \
+                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/latest/unprivileged:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/rawhide:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/rawhide/upstream:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/rawhide/unprivileged:latest \
@@ -215,6 +218,15 @@ $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/r
 
 $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/rawhide/unprivileged\:latest:
 	$(call build-test-container-image,$@,fedora/rawhide/Containerfile.unprivileged)
+
+$(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/latest\:latest:
+	$(call build-test-container-image,$@,fedora/latest/Containerfile)
+
+$(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/latest/upstream\:latest:
+	$(call build-test-container-image,$@,fedora/latest/Containerfile.upstream)
+
+$(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/latest/unprivileged\:latest:
+	$(call build-test-container-image,$@,fedora/latest/Containerfile.unprivileged)
 
 $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/41\:latest:
 	$(call build-test-container-image,$@,fedora/41/Containerfile)

--- a/containers/fedora/latest/Containerfile
+++ b/containers/fedora/latest/Containerfile
@@ -15,8 +15,4 @@ dnf makecache
 
 # Make sure the image is built with the latest packages
 dnf update -y
-
-# Inject `dnf5` to make things more complicated for `dnf` family of
-# package manager implementations
-dnf install -y dnf5
 EOF

--- a/containers/fedora/latest/Containerfile
+++ b/containers/fedora/latest/Containerfile
@@ -1,0 +1,22 @@
+#
+# A latest Fedora image tailored for tmt test suite
+#
+# tmt/tests/fedora/latest:latest
+#
+
+FROM quay.io/fedora/fedora:latest
+
+# hadolint ignore=DL3040
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+
+# Inject `dnf5` to make things more complicated for `dnf` family of
+# package manager implementations
+dnf install -y dnf5
+EOF

--- a/containers/fedora/latest/Containerfile.unprivileged
+++ b/containers/fedora/latest/Containerfile.unprivileged
@@ -1,0 +1,26 @@
+#
+# A latest Fedora image tailored for tmt test suite, with unprivileged account & password-less sudo
+#
+# tmt/tests/fedora/latest/unprivileged:latest
+#
+
+FROM quay.io/fedora/fedora:latest
+
+# hadolint ignore=DL3040
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+
+# Create unprivileged user and setup sudo for it
+dnf install -y /usr/sbin/useradd
+useradd fedora
+usermod -aG wheel fedora
+printf "fedora\tALL=(ALL)\tNOPASSWD: ALL" >> /etc/sudoers
+EOF
+
+USER fedora

--- a/containers/fedora/latest/Containerfile.upstream
+++ b/containers/fedora/latest/Containerfile.upstream
@@ -1,0 +1,17 @@
+#
+# A latest Fedora image tailored for tmt test suite
+#
+# tmt/tests/fedora/latest/upstream:latest
+#
+
+FROM quay.io/fedora/fedora:latest
+
+RUN <<EOF
+set -ex
+
+# Populate dnf cache
+dnf makecache
+
+# Make sure the image is built with the latest packages
+dnf update -y
+EOF


### PR DESCRIPTION
To avoid hardcoding `fedora/41` or `fedora/rawhide`, we can use `fedora/latest` and have the released Fedora at our disposal.

Pull Request Checklist

* [x] implement the feature