### PR TITLE
Enable `PermitRootLogin` for `RHCOS` in `testcloud`

### DIFF
--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -137,20 +137,16 @@ passwd:
     - name: ${user_name}
       ssh_authorized_keys:
         - ${public_key}
-systemd:
-  units:
-    - name: ssh_root_login.service
-      enabled: true
-      contents: |
-        [Unit]
-        Before=sshd.service
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/bin/sed -i \
-                  "s|^PermitRootLogin no$|PermitRootLogin yes|g" \
-                  /etc/ssh/sshd_config
-        [Install]
-        WantedBy=multi-user.target
+storage:
+  files:
+    - path: /etc/ssh/sshd_config.d/20-enable-root-login.conf
+      mode: 0644
+      contents:
+        inline: |
+          # CoreOS disables root SSH login by default.
+          # Enable it.
+          # This file must sort before 40-rhcos-defaults.conf.
+          PermitRootLogin yes
 """
 
 # VM defaults


### PR DESCRIPTION
Currently, tmt fails to provision RHCOS because RHCOS e.g. RHCOS-4.17.2
don't have "PermitRootLogin no" in /etc/ssh/sshd_config but disable
PermitRootLogin 40-rhcos-defaults.conf. As a result, tmt can't connect
to the guest machine.

Follow [1] to permit root to login by SSH pubkey.

Note FCOS e.g. fedora-coreos-41.20250130.3.0 doesn't have
"PermitRootLogin no" so it actually permits root to have ssh login. So
ssh_root_login.service is unneeded.

[1] https://docs.fedoraproject.org/en-US/fedora-coreos/authentication/#_enabling_ssh_password_authentication
