### PR TITLE
Shut down SSH master process when leaving tmt

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -13,6 +13,13 @@ slightly more details, headers and timestamps. ``execute`` now starts
 using ``display`` for its own progress reporting, providing the unified
 formatting and simplified code.
 
+When the login step was called in a separate command after the guest
+has been provisioned, the connection seemed to be stuck. This has been
+caused by the SSH master process not being terminated together with tmt,
+new tmt command would then spawn its own and conflict with the forgotten
+one. tmt no longer leaves the SSH master process running, preventing the
+issue.
+
 
 tmt-1.48.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/provision/ssh-multiplexing/main.fmf
+++ b/tests/provision/ssh-multiplexing/main.fmf
@@ -5,4 +5,5 @@ tag+:
   - provision-virtual
 
 require+:
+  - expect
   - procps-ng

--- a/tests/provision/ssh-multiplexing/main.fmf
+++ b/tests/provision/ssh-multiplexing/main.fmf
@@ -3,3 +3,6 @@ tag+:
   - provision-only
   - provision-connect
   - provision-virtual
+
+require+:
+  - procps-ng

--- a/tests/provision/ssh-multiplexing/test.exp
+++ b/tests/provision/ssh-multiplexing/test.exp
@@ -1,7 +1,7 @@
 #!/usr/bin/expect -f
 
 set timeout 300
-spawn tmt -vvvvdddd run -i RUN login
+spawn tmt -vv run -i RUN login
 expect "root@default-0 tree"
 send -- "exit\r"
 expect eof

--- a/tests/provision/ssh-multiplexing/test.exp
+++ b/tests/provision/ssh-multiplexing/test.exp
@@ -1,0 +1,7 @@
+#!/usr/bin/expect -f
+
+set timeout 300
+spawn tmt -vvvvdddd run -i RUN login
+expect "root@default-0 tree"
+send -- "exit\r"
+expect eof

--- a/tests/provision/ssh-multiplexing/test.sh
+++ b/tests/provision/ssh-multiplexing/test.sh
@@ -20,6 +20,18 @@ rlJournalStart
         rlAssertGrep "The SSH master process cannot be terminated because it is disabled." "$long_run/log.txt"
     rlPhaseEnd
 
+    if [ "$PROVISION_HOW" = "virtual" ]; then
+        rlPhaseStartTest "Make sure SSH multiplexing does not block reuse of guests (#3520)"
+            rlRun "tmt -vv run -i $run --scratch provision -h $PROVISION_HOW"
+
+            rlRun -s "tmt -vv run -i $run login < /dev/null"
+            rlAssertGrep "login: Starting interactive shell" $rlRun_LOG
+            rlAssertGrep "login: Interactive shell finished" $rlRun_LOG
+
+            rlRun "tmt -vv run -i $run finish"
+        rlPhaseEnd
+    fi
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $run" 0 "Remove run directory"

--- a/tests/provision/ssh-multiplexing/test.sh
+++ b/tests/provision/ssh-multiplexing/test.sh
@@ -15,7 +15,6 @@ rlJournalStart
         rlRun "pushd data"
     rlPhaseEnd
 
-    if false; then
     rlPhaseStartTest "SSH multiplexing should be enabled by default ($PROVISION_HOW)"
         rlRun "tmt -vv run -i $run -a provision -h $PROVISION_HOW"
         rlAssertGrep "Spawning the SSH master process" "$run/log.txt"
@@ -26,7 +25,6 @@ rlJournalStart
         rlAssertGrep "warn: SSH multiplexing will not be used because the SSH master socket path '.*' is too long." "$long_run/log.txt"
         rlAssertGrep "The SSH master process cannot be terminated because it is disabled." "$long_run/log.txt"
     rlPhaseEnd
-    fi
 
     if [ "$PROVISION_HOW" = "virtual" ]; then
         rlPhaseStartTest "Make sure SSH multiplexing does not block reuse of guests (#3520)"

--- a/tests/provision/ssh-multiplexing/test.sh
+++ b/tests/provision/ssh-multiplexing/test.sh
@@ -32,11 +32,11 @@ rlJournalStart
         rlPhaseStartTest "Make sure SSH multiplexing does not block reuse of guests (#3520)"
             rlRun "tmt -vv run -i $run --scratch provision -h $PROVISION_HOW"
 
-            rlRun "ps xa | grep ssh"
+            rlRun "pgrep --full 'ssh .* -i $run/plan/provision/default-0/id_ecdsa'" 1 "Check whether the SSH master process is still running"
 
             rlRun -s "$tmpdir/test.exp"
-            rlAssertGrep "login: Starting interactive shell" $rlRun_LOG
-            rlAssertGrep "login: Interactive shell finished" $rlRun_LOG
+            rlAssertGrep "Starting interactive shell" $rlRun_LOG
+            rlAssertGrep "Interactive shell finished" $rlRun_LOG
 
             rlRun "tmt -vv run -i $run finish"
         rlPhaseEnd

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -2868,6 +2868,9 @@ class Plan(
                     self._source_plan_environment_file()
         # Make sure we run 'report' and 'finish' steps always if enabled
         finally:
+            for step in self.steps(skip=['finish', 'report']):
+                step.suspend()
+
             if not abort:
                 if self.report.enabled and self.report.status() != "done":
                     self.report.go()

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -907,6 +907,16 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
 
         self._raw_data = raw_data
 
+    def suspend(self) -> None:
+        """
+        Suspend the step.
+
+        Perform any actions necessary before quitting the step and tmt.
+        The step may be revisited by future tmt invocations.
+        """
+
+        self.debug(f"Suspending step '{self.name}'.")
+
     def _apply_cli_invocations(self, raw_data: list[_RawStepData]) -> list[_RawStepData]:
         # Override step data with command line options
         #

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1321,6 +1321,16 @@ class Guest(tmt.utils.Common):
 
         self.debug(f"Doing nothing to wake up guest '{self.primary_address}'.")
 
+    def suspend(self) -> None:
+        """
+        Suspend the guest.
+
+        Perform any actions necessary before quitting step and tmt. The
+        guest may be reused by future tmt invocations.
+        """
+
+        self.debug(f"Suspending guest '{self.name}'.")
+
     def start(self) -> None:
         """
         Start the guest
@@ -2650,6 +2660,22 @@ class GuestSsh(Guest):
                 )
                 raise
 
+    def suspend(self) -> None:
+        """
+        Suspend the guest.
+
+        Perform any actions necessary before quitting step and tmt. The
+        guest may be reused by future tmt invocations.
+        """
+
+        super().suspend()
+
+        # Close the master ssh connection
+        self._cleanup_ssh_master_process()
+
+        # Remove the ssh socket
+        self._unlink_ssh_master_socket_path()
+
     def stop(self) -> None:
         """
         Stop the guest
@@ -2659,11 +2685,7 @@ class GuestSsh(Guest):
         necessary to store the instance status to disk.
         """
 
-        # Close the master ssh connection
-        self._cleanup_ssh_master_process()
-
-        # Remove the ssh socket
-        self._unlink_ssh_master_socket_path()
+        self.suspend()
 
     def perform_reboot(
         self,
@@ -3249,6 +3271,12 @@ class Provision(tmt.steps.Step):
         else:
             self.status('todo')
             self.save()
+
+    def suspend(self) -> None:
+        super().suspend()
+
+        for guest in self.guests:
+            guest.suspend()
 
     def summary(self) -> None:
         """


### PR DESCRIPTION
The SSH master process and master socket may nto stay active in sutiations when tmt is invoked multiple times and reusing the guest. Each new invocation will try to start its own SSH master process, with the same socket path, and this new SSH process will be stuck.

Plus, it's simply a resource leak: tmt quits and leaves a SSH process running.

Patch adds a counterpart of `wake()` methods, `suspend()`, as in "prepare for quitting, but you may be revisited later". It is a softer version of what finish do - we want to release resources with runtime lifespan, but not all of them.

There is an idea that tmt should split `finish` into two parts, running `finish` phases and "cleanup" for taking care of resources. Once that finalizes, the release of SSH master socket should moved into the "cleanup" step, although even there it would need to remain a softer version of the resource cleanup. In other words, the method will probably stay with us, it just would be called from a slightly different part of tmt.

Fixes #3520.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] include a release note