### PR TITLE
Logger's print() no longer shifts the output

### DIFF
--- a/tmt/log.py
+++ b/tmt/log.py
@@ -767,7 +767,6 @@ class Logger:
         self,
         text: str,
         color: Optional[str] = None,
-        shift: int = 0,
     ) -> str:
         """
         Format the given text in a way suitable for :py:meth:`print`
@@ -777,7 +776,7 @@ class Logger:
             text,
             # Always apply colors - message can be decolorized later.
             color=color,
-            level=shift + self._base_shift,
+            level=0,
             labels=self.labels,
             labels_padding=self.labels_padding,
         )
@@ -788,12 +787,11 @@ class Logger:
         self,
         text: str,
         color: Optional[str] = None,
-        shift: int = 0,
         file: Optional[TextIO] = None,
     ) -> None:
         file = file or sys.stdout
 
-        print(self.print_format(text, color=color, shift=shift), file=file)
+        print(self.print_format(text, color=color), file=file)
 
     def info(
         self,

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1280,7 +1280,6 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
                     job.toxml(prettyxml=True),
                     flags=re.MULTILINE,
                 ),
-                shift=-2,
             )
             return
 

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1922,7 +1922,6 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         self,
         text: str,
         color: Optional[str] = None,
-        shift: int = 0,
     ) -> None:
         """
         Print out an output.
@@ -1935,7 +1934,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         **logging** but not the actual command output.
         """
 
-        self._logger.print(text, color=color, shift=shift)
+        self._logger.print(text, color=color)
 
     def info(
         self,


### PR DESCRIPTION
As discussed offline, `print()` will no longer shift the output depending on `shift` or `level` parameters. It will remain focused on the output rather than logging - and logging is the tree-like pattern when emitted by tmt, while output should not be indented this way.

If a particular callsite wishes to indent (part of) its output, e.g. to improve readability of the output, it needs to do it on its own.

Pull Request Checklist

* [x] implement the feature