### PR TITLE
Add `check` key to the `shell` discover step

### DIFF
--- a/tmt/schemas/discover/shell.yaml
+++ b/tmt/schemas/discover/shell.yaml
@@ -72,6 +72,10 @@ properties:
         author:
           $ref: "/schemas/core#/definitions/author"
 
+        # https://tmt.readthedocs.io/en/stable/spec/tests.html#check
+        check:
+          $ref: "/schemas/test#/properties/check"
+
         # https://tmt.readthedocs.io/en/stable/spec/tests.html#component
         component:
           $ref: "/schemas/test#/properties/component"
@@ -99,6 +103,10 @@ properties:
         # https://tmt.readthedocs.io/en/stable/spec/tests.html#framework
         framework:
           $ref: "/schemas/test#/properties/framework"
+
+        # https://tmt.readthedocs.io/en/stable/spec/core.html#id
+        id:
+          $ref: "/schemas/core#/definitions/id"
 
         # https://tmt.readthedocs.io/en/stable/spec/core.html#link
         link:
@@ -147,6 +155,10 @@ properties:
         # https://tmt.readthedocs.io/en/stable/spec/tests.html#tier
         tier:
           $ref: "/schemas/test#/properties/tier"
+
+        # https://tmt.readthedocs.io/en/stable/spec/tests.html#tty
+        tty:
+          $ref: "/schemas/test#/properties/tty"
 
       patternProperties:
         ^extra-:

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -7,6 +7,7 @@ import fmf
 
 import tmt
 import tmt.base
+import tmt.checks
 import tmt.log
 import tmt.steps
 import tmt.steps.discover
@@ -136,6 +137,15 @@ class TestDescription(
         unserialize=lambda serialized: tmt.utils.Environment.from_fmf_spec(serialized),
         exporter=lambda environment: environment.to_fmf_spec(),
     )
+    check: list[tmt.checks.Check] = field(
+        default_factory=list,
+        normalize=tmt.checks.normalize_test_checks,
+        serialize=lambda checks: [check.to_spec() for check in checks],
+        unserialize=lambda serialized: [
+            tmt.checks.Check.from_spec(**check) for check in serialized
+        ],
+        exporter=lambda value: [check.to_minimal_spec() for check in value],
+    )
     duration: str = '1h'
     result: str = 'respect'
 
@@ -163,6 +173,7 @@ class TestDescription(
         data['link'] = self.link.to_spec() if self.link else None
         data['require'] = [require.to_spec() for require in self.require]
         data['recommend'] = [recommend.to_spec() for recommend in self.recommend]
+        data['check'] = [check.to_spec() for check in self.check]
         data['test'] = str(self.test)
 
         return data


### PR DESCRIPTION
This PR adds the missing `check` key to the `shell` discover step and also adds the previously missing `id` and `tty` keys to the schema.

Fixes: #3620 

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [x] modify the json schema
* [ ] mention the version
* [ ] include a release note
