### PR TITLE
Replace `click.style()` with our own styling code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -434,6 +434,7 @@ builtins-ignorelist = ["help", "format", "input", "filter", "copyright", "max"]
 # "builtins.open".msg = "Use Path.{write_text,append_text,read_text,write_bytes,read_bytes} instead."
 "dataclasses.dataclass".msg = "Use tmt.container.container instead."
 "dataclasses.field".msg = "Use tmt.container.field instead."
+"click.style".msg = "Use tmt.log.style instead."
 
 [tool.ruff.lint.flake8-type-checking]
 runtime-evaluated-base-classes = ["tmt.config.models.BaseConfig"]

--- a/tmt/base.py
+++ b/tmt/base.py
@@ -31,7 +31,7 @@ import fmf
 import fmf.base
 import fmf.utils
 import jsonschema
-from click import confirm, echo, style
+from click import confirm, echo
 from fmf.utils import listed
 from ruamel.yaml.error import MarkedYAMLError
 
@@ -81,6 +81,7 @@ from tmt.utils import (
     normalize_shell_script,
     verdict,
 )
+from tmt.utils.themes import style
 
 if TYPE_CHECKING:
     import tmt.cli

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -11,6 +11,7 @@ import tmt.steps.execute
 import tmt.steps.provision
 import tmt.utils
 import tmt.utils.templates
+import tmt.utils.themes
 from tmt.checks import Check, CheckPlugin, _RawCheck, provides_check
 from tmt.container import container, field
 from tmt.result import CheckResult, ResultOutcome
@@ -158,7 +159,7 @@ def _run_script(
     def _output_logger(
         key: str,
         value: Optional[str] = None,
-        color: Optional[str] = None,
+        color: tmt.utils.themes.Style = None,
         shift: int = 2,
         level: int = 3,
         topic: Optional[tmt.log.Topic] = None,

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -7,6 +7,7 @@ import tmt.log
 import tmt.steps.execute
 import tmt.steps.provision
 import tmt.utils
+import tmt.utils.themes
 from tmt.checks import Check, CheckEvent, CheckPlugin, _RawCheck, provides_check
 from tmt.container import container, field
 from tmt.result import CheckResult, ResultOutcome
@@ -71,7 +72,7 @@ class DmesgCheck(Check):
         def _test_output_logger(
             key: str,
             value: Optional[str] = None,
-            color: Optional[str] = None,
+            color: tmt.utils.themes.Style = None,
             shift: int = 2,
             level: int = 3,
             topic: Optional[tmt.log.Topic] = None,

--- a/tmt/cli/_root.py
+++ b/tmt/cli/_root.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import click
 import fmf
 import fmf.utils
-from click import echo, style
+from click import echo
 
 import tmt
 import tmt.base
@@ -36,6 +36,7 @@ import tmt.utils.rest
 from tmt.cli import CliInvocation, Context, ContextObject, CustomGroup, pass_context
 from tmt.options import Deprecated, create_options_decorator, option
 from tmt.utils import Command, Path, effective_workdir_root
+from tmt.utils.themes import style
 
 if TYPE_CHECKING:
     import tmt.steps.discover

--- a/tmt/config/models/themes.py
+++ b/tmt/config/models/themes.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional, Union
 
-import click
+# TID251: this use of `click.style()` is expected, and on purpose.
+from click import style as _style  # noqa: TID251
 
 import tmt.utils
 from tmt._compat.pydantic import ValidationError
@@ -29,7 +30,7 @@ class Style(MetadataContainer):
         Apply this style to a given string.
         """
 
-        return click.style(text, **self.dict())
+        return _style(text, **self.dict())
 
 
 _DEFAULT_STYLE = Style()

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 from uuid import UUID, uuid4
 
 import fmf.utils
-from click import echo, style
+from click import echo
 
 import tmt.base
 import tmt.export
@@ -21,6 +21,7 @@ import tmt.log
 import tmt.utils
 from tmt.utils import ConvertError, GeneralError, Path, format_value
 from tmt.utils.structured_field import StructuredField
+from tmt.utils.themes import style
 
 log = fmf.utils.Logging('tmt').logger
 

--- a/tmt/export/__init__.py
+++ b/tmt/export/__init__.py
@@ -24,13 +24,14 @@ from typing import (
 
 import fmf
 import fmf.utils
-from click import echo, style
+from click import echo
 
 import tmt
 import tmt.log
 import tmt.utils
 from tmt.plugins import PluginRegistry
 from tmt.utils import Path
+from tmt.utils.themes import style
 
 if TYPE_CHECKING:
     import tmt.base

--- a/tmt/export/nitrate.py
+++ b/tmt/export/nitrate.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 import fmf.context
-from click import echo, style
+from click import echo
 
 import tmt.export
 import tmt.identifier
@@ -23,6 +23,7 @@ import tmt.utils
 import tmt.utils.git
 from tmt.utils import ConvertError, Path
 from tmt.utils.structured_field import StructuredField
+from tmt.utils.themes import style
 
 if TYPE_CHECKING:
     import tmt.base

--- a/tmt/export/polarion.py
+++ b/tmt/export/polarion.py
@@ -4,7 +4,7 @@ import traceback
 from typing import Any, Optional
 
 import fmf.utils
-from click import echo, style
+from click import echo
 
 import tmt.base
 import tmt.convert
@@ -12,6 +12,7 @@ import tmt.export
 import tmt.utils
 from tmt.identifier import ID_KEY, add_uuid_if_not_defined
 from tmt.utils import ConvertError, Path
+from tmt.utils.themes import style
 
 PolarionException: Any = None
 PolarionTestCase: Any = None

--- a/tmt/lint.py
+++ b/tmt/lint.py
@@ -76,11 +76,10 @@ from typing import (
     TypeVar,
 )
 
-from click import style
-
 import tmt
 import tmt.utils
 from tmt.container import container
+from tmt.utils.themes import style
 
 if TYPE_CHECKING:
     import tmt.base

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -41,8 +41,6 @@ from typing import (
     cast,
 )
 
-import click
-
 from tmt._compat.pathlib import Path
 from tmt._compat.warnings import deprecated
 from tmt.container import container, simple_field
@@ -50,6 +48,7 @@ from tmt.container import container, simple_field
 if TYPE_CHECKING:
     import tmt.cli
     import tmt.utils
+    import tmt.utils.themes
 
 # Log in workdir
 LOG_FILENAME = 'log.txt'
@@ -188,10 +187,12 @@ def render_labels(labels: list[str]) -> str:
     if not labels:
         return ''
 
+    from tmt.utils.themes import style
+
     return ''.join(
         # TODO: color here is questionable - it will be removed, but I'd rather not
         # add it at first place, and it should be configurable.
-        click.style(LABEL_FORMAT.format(label=label), fg='cyan')
+        style(LABEL_FORMAT.format(label=label), fg='cyan')
         for label in labels
     )
 
@@ -199,7 +200,7 @@ def render_labels(labels: list[str]) -> str:
 def indent(
     key: str,
     value: Optional[LoggableValue] = None,
-    color: Optional[str] = None,
+    color: 'tmt.utils.themes.Style' = None,
     level: int = 0,
     labels: Optional[list[str]] = None,
     labels_padding: int = 0,
@@ -222,11 +223,12 @@ def indent(
         length.
     """
 
+    from tmt.utils.themes import style
+
     indent = ' ' * INDENT * level
 
     # Colorize
-    if color is not None:
-        key = click.style(key, fg=color)
+    key = style(key, style=color)
 
     # Prepare prefix if labels provided
     prefix = render_labels(labels).ljust(labels_padding) + ' ' if labels else ''
@@ -266,7 +268,7 @@ class LogRecordDetails:
     key: str
     value: Optional[LoggableValue] = None
 
-    color: Optional[str] = None
+    color: 'tmt.utils.themes.Style' = None
     shift: int = 0
 
     logger_labels: list[str] = simple_field(default_factory=list)
@@ -435,7 +437,7 @@ class LoggingFunction(Protocol):
         self,
         key: str,
         value: Optional[str] = None,
-        color: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         level: int = 1,
         topic: Optional[Topic] = None,
@@ -766,7 +768,7 @@ class Logger:
     def print_format(
         self,
         text: str,
-        color: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
     ) -> str:
         """
@@ -787,7 +789,7 @@ class Logger:
     def print(
         self,
         text: str,
-        color: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         file: Optional[TextIO] = None,
     ) -> None:
@@ -799,7 +801,7 @@ class Logger:
         self,
         key: str,
         value: Optional[LoggableValue] = None,
-        color: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
     ) -> None:
         self._log(logging.INFO, LogRecordDetails(key=key, value=value, color=color, shift=shift))
@@ -808,7 +810,7 @@ class Logger:
         self,
         key: str,
         value: Optional[LoggableValue] = None,
-        color: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         level: int = 1,
         topic: Optional[Topic] = None,
@@ -829,7 +831,7 @@ class Logger:
         self,
         key: str,
         value: Optional[LoggableValue] = None,
-        color: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         level: int = 1,
         topic: Optional[Topic] = None,

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -2,7 +2,6 @@ import enum
 import re
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
-import click
 import fmf
 import fmf.utils
 
@@ -13,6 +12,7 @@ import tmt.utils
 from tmt.checks import CheckEvent, CheckResultInterpret
 from tmt.container import SerializableContainer, container, field
 from tmt.utils import GeneralError, Path
+from tmt.utils.themes import style
 
 if TYPE_CHECKING:
     import tmt.base
@@ -211,7 +211,7 @@ class BaseResult(SerializableContainer):
         result = 'errr' if self.result == ResultOutcome.ERROR else self.result.value
 
         components: list[str] = [
-            click.style(result, fg=RESULT_OUTCOME_COLORS[self.result]),
+            style(result, fg=RESULT_OUTCOME_COLORS[self.result]),
             self.name,
         ]
 
@@ -528,26 +528,26 @@ class Result(BaseResult):
         stats = Result.total(results)
         comments = []
         if stats.get(ResultOutcome.PASS):
-            passed = ' ' + click.style('passed', fg='green')
+            passed = ' ' + style('passed', fg='green')
             comments.append(fmf.utils.listed(stats[ResultOutcome.PASS], 'test') + passed)
         if stats.get(ResultOutcome.FAIL):
-            failed = ' ' + click.style('failed', fg='red')
+            failed = ' ' + style('failed', fg='red')
             comments.append(fmf.utils.listed(stats[ResultOutcome.FAIL], 'test') + failed)
         if stats.get(ResultOutcome.SKIP):
-            skipped = ' ' + click.style('skipped', fg='bright_black')
+            skipped = ' ' + style('skipped', fg='bright_black')
             comments.append(fmf.utils.listed(stats[ResultOutcome.SKIP], 'test') + skipped)
         if stats.get(ResultOutcome.INFO):
             count, comment = fmf.utils.listed(stats[ResultOutcome.INFO], 'info').split()
-            comments.append(count + ' ' + click.style(comment, fg='blue'))
+            comments.append(count + ' ' + style(comment, fg='blue'))
         if stats.get(ResultOutcome.WARN):
             count, comment = fmf.utils.listed(stats[ResultOutcome.WARN], 'warn').split()
-            comments.append(count + ' ' + click.style(comment, fg='yellow'))
+            comments.append(count + ' ' + style(comment, fg='yellow'))
         if stats.get(ResultOutcome.ERROR):
             count, comment = fmf.utils.listed(stats[ResultOutcome.ERROR], 'error').split()
-            comments.append(count + ' ' + click.style(comment, fg='magenta'))
+            comments.append(count + ' ' + style(comment, fg='magenta'))
         if stats.get(ResultOutcome.PENDING):
             count, comment = str(stats[ResultOutcome.PENDING]), 'pending'
-            comments.append(count + ' ' + click.style(comment, fg='cyan'))
+            comments.append(count + ' ' + style(comment, fg='cyan'))
         # FIXME: cast() - https://github.com/teemtee/fmf/issues/185
         return cast(str, fmf.utils.listed(comments or ['no results found']))
 
@@ -561,7 +561,7 @@ class Result(BaseResult):
         result = 'errr' if self.result == ResultOutcome.ERROR else self.result.value
 
         components: list[str] = [
-            click.style(result, fg=RESULT_OUTCOME_COLORS[self.result]),
+            style(result, fg=RESULT_OUTCOME_COLORS[self.result]),
             self.name,
         ]
 

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -3,7 +3,6 @@ import subprocess
 import textwrap
 from typing import Any, Optional, cast
 
-import click
 import jinja2
 
 import tmt
@@ -13,6 +12,7 @@ import tmt.options
 import tmt.steps
 import tmt.steps.execute
 import tmt.utils
+import tmt.utils.themes
 from tmt.container import container, field
 from tmt.result import BaseResult, Result, ResultOutcome
 from tmt.steps import safe_filename
@@ -34,6 +34,7 @@ from tmt.utils import (
     format_duration,
     format_timestamp,
 )
+from tmt.utils.themes import style
 
 TEST_PIDFILE_FILENAME = 'tmt-test.pid'
 TEST_PIDFILE_LOCK_FILENAME = f'{TEST_PIDFILE_FILENAME}.lock'
@@ -436,7 +437,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         self,
         key: str,
         value: Optional[str] = None,
-        color: Optional[str] = None,
+        color: tmt.utils.themes.Style = None,
         shift: int = 2,
         level: int = 3,
         topic: Optional[tmt.log.Topic] = None,
@@ -531,7 +532,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         def _test_output_logger(
             key: str,
             value: Optional[str] = None,
-            color: Optional[str] = None,
+            color: tmt.utils.themes.Style = None,
             shift: int = 2,
             level: int = 3,
             topic: Optional[tmt.log.Topic] = None,
@@ -724,7 +725,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                 )
 
                 assert invocation.real_duration is not None  # narrow type
-                duration = click.style(invocation.real_duration, fg='cyan')
+                duration = style(invocation.real_duration, fg='cyan')
                 shift = 1 if self.verbosity_level < 2 else 2
 
                 # Handle test restart. May include guest reboot too.
@@ -772,7 +773,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
 
                 # If test duration information is missing, print 8 spaces to keep indentation
                 def _format_duration(result: BaseResult) -> str:
-                    return click.style(result.duration, fg='cyan') if result.duration else 8 * ' '
+                    return style(result.duration, fg='cyan') if result.duration else 8 * ' '
 
                 for result in invocation.results:
                     logger.verbose(

--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -8,7 +8,6 @@ import textwrap
 from collections.abc import Iterator
 from typing import Any, cast
 
-import click
 import fmf
 import fmf.utils
 
@@ -28,6 +27,7 @@ from tmt import Plan
 from tmt.base import RunData
 from tmt.steps.prepare import PreparePlugin
 from tmt.utils import GeneralError, MetadataError, Path
+from tmt.utils.themes import style
 
 USER_PLAN_NAME = "/user/plan"
 
@@ -87,9 +87,9 @@ class Action(enum.Enum):
 
         index = self.action.index(self.key)
 
-        before = click.style(self.action[0:index], fg="bright_blue")
-        key = click.style(self.key, fg="blue", bold=True, underline=True)
-        after = click.style(self.action[index + 1 :], fg="bright_blue")
+        before = style(self.action[0:index], fg="bright_blue")
+        key = style(self.key, fg="blue", bold=True, underline=True)
+        after = style(self.action[index + 1 :], fg="bright_blue")
 
         longest = max(len(action.name) for action in Action)
         padding = " " * (longest + 3 - len(self.action))
@@ -265,9 +265,9 @@ class Try(tmt.utils.Common):
         parts = ["Let's try"]
 
         # Test names, login, or something
-        test_names = [click.style(test, fg="red") for test in self.tests]
+        test_names = [style(test.name, fg="red") for test in self.tests]
         if self.opt("login"):
-            parts += [click.style("login", fg="red")]
+            parts += [style("login", fg="red")]
         elif test_names and not self.opt("ask"):
             parts += [fmf.utils.listed(test_names, 'test', max=3)]
         else:
@@ -275,13 +275,13 @@ class Try(tmt.utils.Common):
         parts += ["with"]
 
         # Plan names
-        plan_names = [click.style(plan, fg="magenta") for plan in self.plans]
+        plan_names = [style(plan.name, fg="magenta") for plan in self.plans]
         parts += [fmf.utils.listed(plan_names, 'plan', max=3)]
 
         # Image names
         if self.image_and_how:
             parts += ["on"]
-            image_names = [click.style(image, fg="blue") for image in self.image_and_how]
+            image_names = [style(image, fg="blue") for image in self.image_and_how]
             parts += [fmf.utils.listed(image_names)]
 
         self.print(" ".join(parts) + ".")
@@ -336,7 +336,7 @@ class Try(tmt.utils.Common):
                 self.print("")
                 return Action.find(answer)
             except KeyError:
-                self.print(click.style(f"Invalid action '{answer}'.", fg="red"))
+                self.print(style(f"Invalid action '{answer}'.", fg="red"))
 
     def action_start(self, plan: Plan) -> None:
         """
@@ -502,7 +502,7 @@ class Try(tmt.utils.Common):
         """
 
         assert plan.my_run is not None  # Narrow type
-        run_id = click.style(plan.my_run.workdir, fg="magenta")
+        run_id = style(str(plan.my_run.workdir), fg="magenta")
         self.print(f"Run {run_id} kept unfinished. See you soon!")
 
     def action_quit(self, plan: Plan) -> None:
@@ -516,7 +516,7 @@ class Try(tmt.utils.Common):
 
         # Mention the run id and say good bye
         assert plan.my_run is not None  # Narrow type
-        run_id = click.style(plan.my_run.workdir, fg="magenta")
+        run_id = style(str(plan.my_run.workdir), fg="magenta")
         self.print(f"Run {run_id} successfully finished. Bye for now!")
 
     def handle_options(self, plan: Plan) -> None:

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -57,7 +57,7 @@ import urllib3
 import urllib3._collections
 import urllib3.exceptions
 import urllib3.util.retry
-from click import echo, style, wrap_text
+from click import echo, wrap_text
 from ruamel.yaml import YAML, scalarstring
 from ruamel.yaml.comments import CommentedMap
 from ruamel.yaml.parser import ParserError
@@ -68,11 +68,13 @@ import tmt.log
 from tmt._compat.pathlib import Path
 from tmt.container import container
 from tmt.log import LoggableValue
+from tmt.utils.themes import style
 
 if TYPE_CHECKING:
     import tmt.base
     import tmt.cli
     import tmt.steps
+    import tmt.utils.themes
     from tmt._compat.typing import Self, TypeAlias
     from tmt.hardware import Size
 
@@ -1909,7 +1911,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         self,
         key: str,
         value: Optional[str] = None,
-        color: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
     ) -> str:
         """
@@ -1921,7 +1923,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
     def print(
         self,
         text: str,
-        color: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
     ) -> None:
         """
@@ -1941,7 +1943,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         self,
         key: str,
         value: Optional[LoggableValue] = None,
-        color: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
     ) -> None:
         """
@@ -1954,7 +1956,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         self,
         key: str,
         value: Optional[LoggableValue] = None,
-        color: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         level: int = 1,
         topic: Optional[tmt.log.Topic] = None,
@@ -1971,7 +1973,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         self,
         key: str,
         value: Optional[LoggableValue] = None,
-        color: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         level: int = 1,
         topic: Optional[tmt.log.Topic] = None,
@@ -2002,7 +2004,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         self,
         key: str,
         value: Optional[str] = None,
-        color: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
         shift: int = 1,
         level: int = 3,
         topic: Optional[tmt.log.Topic] = None,
@@ -2749,16 +2751,17 @@ def render_exception_stack(
 
     # N806: allow upper-case names to make them look like formatting
     # tags in strings below.
-    R = functools.partial(click.style, fg='red')  # noqa: N806
-    Y = functools.partial(click.style, fg='yellow')  # noqa: N806
-    B = functools.partial(click.style, fg='blue')  # noqa: N806
+    R = functools.partial(style, fg='red')  # noqa: N806
+    Y = functools.partial(style, fg='yellow')  # noqa: N806
+    B = functools.partial(style, fg='blue')  # noqa: N806
 
     yield R('Traceback (most recent call last):')
     yield ''
 
     for frame in exception_traceback.stack:
         yield f'File {Y(frame.filename)}, line {Y(str(frame.lineno))}, in {Y(frame.name)}'
-        yield f'  {B(frame.line)}'
+        if frame.line:
+            yield f'  {B(frame.line)}'
 
         if frame.locals:
             yield ''
@@ -2797,7 +2800,7 @@ def render_exception(
                 for line in item.splitlines():
                     yield f'{INDENT * " "}{line}'
 
-    yield click.style(str(exception), fg='red')
+    yield style(str(exception), fg='red')
 
     if isinstance(exception, RunError):
         yield ''
@@ -3313,7 +3316,7 @@ def assert_window_size(window_size: Optional[int]) -> None:
 def _format_bool(
     value: bool,
     window_size: Optional[int],
-    key_color: Optional[str],
+    key_color: 'tmt.utils.themes.Style',
     list_format: ListFormat,
     wrap: FormatWrap,
 ) -> Iterator[str]:
@@ -3329,7 +3332,7 @@ def _format_bool(
 def _format_list(
     value: list[Any],
     window_size: Optional[int],
-    key_color: Optional[str],
+    key_color: 'tmt.utils.themes.Style',
     list_format: ListFormat,
     wrap: FormatWrap,
 ) -> Iterator[str]:
@@ -3398,7 +3401,7 @@ def _format_list(
 def _format_str(
     value: str,
     window_size: Optional[int],
-    key_color: Optional[str],
+    key_color: 'tmt.utils.themes.Style',
     list_format: ListFormat,
     wrap: FormatWrap,
 ) -> Iterator[str]:
@@ -3448,7 +3451,7 @@ def _format_str(
 def _format_dict(
     value: dict[Any, Any],
     window_size: Optional[int],
-    key_color: Optional[str],
+    key_color: 'tmt.utils.themes.Style',
     list_format: ListFormat,
     wrap: FormatWrap,
 ) -> Iterator[str]:
@@ -3465,7 +3468,7 @@ def _format_dict(
 
     for k, v in value.items():
         # First, render the key.
-        k_formatted = click.style(k, fg=key_color) if key_color else k
+        k_formatted = style(k, style=key_color)
         k_size = len(k) + 2
 
         # Then, render the value. If the window size is known, the value must be
@@ -3576,7 +3579,7 @@ def _format_dict(
 
 #: A type describing a per-type formatting helper.
 ValueFormatter = Callable[
-    [Any, Optional[int], Optional[str], ListFormat, FormatWrap], Iterator[str]
+    [Any, Optional[int], 'tmt.utils.themes.Style', ListFormat, FormatWrap], Iterator[str]
 ]
 
 
@@ -3593,7 +3596,7 @@ _VALUE_FORMATTERS: list[tuple[Any, ValueFormatter]] = [
 def _format_value(
     value: Any,
     window_size: Optional[int] = None,
-    key_color: Optional[str] = None,
+    key_color: 'tmt.utils.themes.Style' = None,
     list_format: ListFormat = ListFormat.LISTED,
     wrap: FormatWrap = 'auto',
 ) -> list[str]:
@@ -3632,7 +3635,7 @@ def _format_value(
 def format_value(
     value: Any,
     window_size: Optional[int] = None,
-    key_color: Optional[str] = None,
+    key_color: 'tmt.utils.themes.Style' = None,
     list_format: ListFormat = ListFormat.LISTED,
     wrap: FormatWrap = 'auto',
 ) -> str:
@@ -3700,8 +3703,8 @@ def format(
     indent: int = 24,
     window_size: int = OUTPUT_WIDTH,
     wrap: FormatWrap = 'auto',
-    key_color: Optional[str] = 'green',
-    value_color: Optional[str] = 'black',
+    key_color: 'tmt.utils.themes.Style' = 'green',
+    value_color: 'tmt.utils.themes.Style' = 'black',
     list_format: ListFormat = ListFormat.LISTED,
 ) -> str:
     """
@@ -3732,9 +3735,7 @@ def format(
     indent_string = (indent + 1) * ' '
 
     # Format the key first
-    output = f"{str(key).rjust(indent, ' ')} "
-    if key_color is not None:
-        output = style(output, fg=key_color)
+    output = style(f"{str(key).rjust(indent, ' ')} ", style=key_color)
 
     # Then the value
     formatted_value = format_value(
@@ -4283,8 +4284,8 @@ class UpdatableMessage(contextlib.AbstractContextManager):  # type: ignore[type-
         key: str,
         enabled: bool = True,
         indent_level: int = 0,
-        key_color: Optional[str] = None,
-        default_value_color: Optional[str] = None,
+        key_color: 'tmt.utils.themes.Style' = None,
+        default_value_color: 'tmt.utils.themes.Style' = None,
         clear_on_exit: bool = False,
     ) -> None:
         """
@@ -4340,7 +4341,7 @@ class UpdatableMessage(contextlib.AbstractContextManager):  # type: ignore[type-
 
         self._update_message_area('')
 
-    def _update_message_area(self, value: str, color: Optional[str] = None) -> None:
+    def _update_message_area(self, value: str, color: 'tmt.utils.themes.Style' = None) -> None:
         """
         Update message area with given value.
 
@@ -4368,7 +4369,7 @@ class UpdatableMessage(contextlib.AbstractContextManager):  # type: ignore[type-
 
         message = tmt.log.indent(
             self.key,
-            value=style(message, fg=color or self.default_value_color),
+            value=style(message, style=color or self.default_value_color),
             color=self.key_color,
             level=self.indent_level,
         )
@@ -4376,7 +4377,7 @@ class UpdatableMessage(contextlib.AbstractContextManager):  # type: ignore[type-
         sys.stdout.write(f"\r{message}")
         sys.stdout.flush()
 
-    def update(self, value: str, color: Optional[str] = None) -> None:
+    def update(self, value: str, color: 'tmt.utils.themes.Style' = None) -> None:
         """
         Update progress message.
 


### PR DESCRIPTION
The goal is to switch from direct use of colors - `style('error!', fg='red') - to semantic styles, `theme.error.apply('error!')`. Such styles can then be controlled through themes.

This step adds custom `style()` function that does what `click.style()` does, but accepts also `tmt.config.models.themes.Style` objects. This will allow for slow transition from colors to themes.

Pull Request Checklist

* [x] implement the feature