### PR TITLE
Update `CODEOWNERS`, remove default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,14 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence
-*                                   @psss @lukaszachy @happz @thrix @janhavlin @martinhoyer
-
 # Provision plugins
 /tmt/steps/provision/artemis.py     @happz
+/tmt/steps/provision/mrack*         @dav-pascual
 /tmt/steps/provision/testcloud.py   @frantisekz
 
 # Report plugins
 /tmt/steps/report/polarion.py       @KwisatzHaderach
+/tmt/steps/report/reportportal.py   @4N0body5
 
 # Export plugins
 /tmt/export/polarion.py             @KwisatzHaderach
+
+# Specific areas
+/tmt/trying.py                      @falconizmi

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Provision plugins
 /tmt/steps/provision/artemis.py     @happz
 /tmt/steps/provision/mrack*         @dav-pascual
-/tmt/steps/provision/testcloud.py   @frantisekz
+/tmt/steps/provision/testcloud.py   @lbrabec
 
 # Report plugins
 /tmt/steps/report/polarion.py       @KwisatzHaderach


### PR DESCRIPTION
As agreed on the hacking session, let's remove the default review assignments as they are just causing noise and are mostly ignored. Keep and update a couple specific ones which still make sense.