### PR TITLE
Link to `Testing Farm` section instead of using `TF` acronym

### DIFF
--- a/spec/plans/provision/artemis.fmf
+++ b/spec/plans/provision/artemis.fmf
@@ -17,9 +17,10 @@ description: |
 
     .. note::
 
-        When used together with TF infrastructure
-        some of the options from the first example below
-        will be filled for you by the TF service.
+        When used together with :ref:`Testing Farm<testing-farm>`
+        infrastructure some of the options from the first example below
+        will be filled for you by the :ref:`Testing Farm<testing-farm>`
+        service.
 
 example:
   - |


### PR DESCRIPTION
While working on another issue found a place where we could
rather link to the `Testing Farm` docs section instead of
the unclear `TF` acronym.

Signed-off-by: Miroslav Vadkerti <mvadkert@redhat.com>

Pull Request Checklist

* [x] write the documentation
