### PR TITLE
Fix logging of early import errors

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1094,7 +1094,7 @@ def test_import_member(root_logger):
 
 def test_import_member_no_such_module(root_logger):
     with pytest.raises(
-        SystemExit,
+        tmt.utils.GeneralError,
         match=rf"Failed to import the 'tmt\.steps\.nope_does_not_exist'"
         rf" module from '{Path.cwd()}'.",
     ):

--- a/tmt/_bootstrap.py
+++ b/tmt/_bootstrap.py
@@ -1,0 +1,36 @@
+"""
+Loggers for use during tmt startup.
+
+Very special loggers used by tmt plugin discovery and configuration
+loaders. Established logging is needed even by this type of code, and
+loggers must be independent on other packages, therefore they cannot
+be located in ``tmt.cli`` or ``tmt.utils`` - otherwise, we might need
+them for reporting exceptions raised while importing said packages.
+
+By moving these loggers into their own module, both bootstrap and error
+reporting code can use them without deadlocking.
+"""
+
+import tmt.log
+
+#: A logger to use before the proper one can be established.
+#:
+#: .. warning::
+#:
+#:    This logger should be used with utmost care for logging while tmt
+#:    is still starting. Once properly configured logger is spawned,
+#:    honoring relevant options, this logger should not be used anymore.
+_BOOTSTRAP_LOGGER = tmt.log.Logger.get_bootstrap_logger()
+
+#: A logger to use for exception logging.
+#:
+#: .. warning::
+#:
+#:    This logger should be used with utmost care for logging exceptions
+#:    only, no other traffic should be allowed. On top of that, the
+#:    exception logging is handled by a dedicated function,
+#:    :py:func:`tmt.utils.show_exception` - if you find yourself in need
+#:    of logging an exception somewhere in the code, and you think about
+#:    using this logger or calling ``show_exception()`` explicitly,
+#:    it is highly likely you are not on the right track.
+EXCEPTION_LOGGER: tmt.log.Logger = _BOOTSTRAP_LOGGER

--- a/tmt/cli/__init__.py
+++ b/tmt/cli/__init__.py
@@ -13,6 +13,7 @@ import fmf
 import fmf.utils
 
 import tmt
+import tmt._bootstrap
 import tmt.base
 import tmt.log
 import tmt.plugins
@@ -27,31 +28,8 @@ if TYPE_CHECKING:
     R = TypeVar('R')
 
 
-#: A logger to use before the proper one can be established.
-#:
-#: .. warning::
-#:
-#:    This logger should be used with utmost care for logging while tmt
-#:    is still starting. Once properly configured logger is spawned,
-#:    honoring relevant options, this logger should not be used anymore.
-_BOOTSTRAP_LOGGER = tmt.log.Logger.get_bootstrap_logger()
-
-#: A logger to use for exception logging.
-#:
-#: .. warning::
-#:
-#:    This logger should be used with utmost care for logging exceptions
-#:    only, no other traffic should be allowed. On top of that, the
-#:    exception logging is handled by a dedicated function,
-#:    :py:func:`tmt.utils.show_exception` - if you find yourself in need
-#:    of logging an exception somewhere in the code, and you think about
-#:    using this logger or calling ``show_exception()`` explicitly,
-#:    it is highly likely you are not on the right track.
-EXCEPTION_LOGGER: tmt.log.Logger = _BOOTSTRAP_LOGGER
-
-
 # Explore available plugins (need to detect all supported methods first)
-tmt.plugins.explore(_BOOTSTRAP_LOGGER)
+tmt.plugins.explore(tmt._bootstrap._BOOTSTRAP_LOGGER)
 
 
 class TmtExitCode(enum.IntEnum):
@@ -251,7 +229,8 @@ class HelpFormatter(click.HelpFormatter):
         col_spacing: int = 2,
     ) -> None:
         rows = [
-            (option, tmt.utils.rest.render_rst(help, _BOOTSTRAP_LOGGER)) for option, help in rows
+            (option, tmt.utils.rest.render_rst(help, tmt._bootstrap._BOOTSTRAP_LOGGER))
+            for option, help in rows
         ]
 
         super().write_dl(rows, col_max=col_max, col_spacing=col_spacing)

--- a/tmt/cli/_root.py
+++ b/tmt/cli/_root.py
@@ -17,6 +17,7 @@ import fmf.utils
 from click import echo
 
 import tmt
+import tmt._bootstrap
 import tmt.base
 import tmt.cli
 import tmt.config
@@ -160,7 +161,7 @@ def main(
     #
     # ignore[unused-ignore]: mypy does not report this issue, and the
     # ignore fools mypy into reporting the waiver as unused.
-    tmt.cli.EXCEPTION_LOGGER = logger  # type: ignore[reportConstantRedefinition,unused-ignore]
+    tmt._bootstrap.EXCEPTION_LOGGER = logger  # type: ignore[reportConstantRedefinition,unused-ignore]
 
     # Save click context and fmf context for future use
     tmt.utils.Common.store_cli_invocation(click_contex)

--- a/tmt/cli/_root.py
+++ b/tmt/cli/_root.py
@@ -19,7 +19,6 @@ from click import echo
 import tmt
 import tmt._bootstrap
 import tmt.base
-import tmt.cli
 import tmt.config
 import tmt.convert
 import tmt.identifier

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -14,7 +14,7 @@ from typing import Any, Generic, Optional, TypeVar, cast
 import tmt
 import tmt.utils
 from tmt.log import Logger
-from tmt.utils import Path
+from tmt.utils import GeneralError, Path
 
 ModuleT = TypeVar('ModuleT', bound=ModuleType)
 
@@ -305,7 +305,7 @@ def import_module(
 
     return _import_or_raise(
         module=module,
-        exc_class=SystemExit,
+        exc_class=GeneralError,
         exc_message=f"Failed to import the '{module}' module from '{path}'.",
         logger=logger,
     )

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -2817,7 +2817,7 @@ def show_exception(
         logfiles as well as to standard error output.
     """
 
-    from tmt.cli import EXCEPTION_LOGGER
+    from tmt._bootstrap import EXCEPTION_LOGGER
 
     traceback_verbosity = traceback_verbosity or TracebackVerbosity.from_env()
 


### PR DESCRIPTION
In some conditions, exceptions raised while importing plugins could have been reported as just the exception message, without any traceback. This was caused by the necessary loggers being defined in `tmt.cli` package, which must be imported correctly first for the loggers to be available. But, `tmt.cli` runs plugin discovery, and if for whatever reason import of a plugin fails, subsequent call to `show_exception()` would also raise an exception, because it would try to import unavailable `tmt.cli.EXCEPTION_LOGGER`, resulting in the most simple error logging implemented.

By moving bootstrap and exception loggers into their own module, both plugin discovery spawned from `tmt.cli` and the error reporting code can reach loggers they need, as their existence no longer depends on `tmt.cli` and plugins being imported successfully.

Make a small typo in `tmt/config/themes/default.yaml`, e.g. change `restructuredtext-literal` to `restructuredtext-literal-`. `tmt lint` will crash with a single line or output:

```
Failed to import the 'tmt.steps.discover.fmf' module from '/home/happz/git/tmt'.
```

With this patch, one gets full chain of errors:

```
$ tmt lint

Failed to import the 'tmt.steps.discover.fmf' module from '/home/happz/git/tmt'.

The exception was caused by 1 earlier exceptions

Cause number 1:

    Invalid theme configuration.

    The exception was caused by 1 earlier exceptions

    Cause number 1:

        1 validation error for Theme
        restructuredtext-admonition-warning-
          extra fields not permitted (type=value_error.extra)
```

Pull Request Checklist

* [x] implement the feature