### PR TITLE
Add `awk` as an essential requirement of tmt `execute` plugin

### DIFF
--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -24,6 +24,7 @@ from tmt.utils import (
 ReducedPackages = list[Union[Package, PackagePath]]
 
 PACKAGE_PATH: dict[FileSystemPath, str] = {
+    FileSystemPath('/usr/bin/awk'): 'gawk',
     FileSystemPath('/usr/bin/arch'): 'busybox',
     FileSystemPath('/usr/bin/flock'): 'flock',
     FileSystemPath('/usr/bin/python3'): 'python3',

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -877,4 +877,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         :returns: a list of requirements.
         """
 
-        return [tmt.base.DependencySimple('/usr/bin/flock')]
+        return [
+            tmt.base.DependencySimple('/usr/bin/awk'),
+            tmt.base.DependencySimple('/usr/bin/flock'),
+        ]


### PR DESCRIPTION
`awk` is used several times in scripts the plugin installs and offers to users, namely `tmt-reboot`. It seems that `awk` is no longer available by default in Fedora 42 containers, so we need to be explicit about its necessity.

Pull Request Checklist

* [x] implement the feature