### PR TITLE
Remove the duplication leftovers from the specs

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -635,7 +635,7 @@ Dynamic ``ref`` Evaluation
 ------------------------------------------------------------------
 
 When using test branching for test maintenance it becomes handy to
-be able to set :ref:`ref</spec/plans/discover/fmf>` dynamically
+be able to set :ref:`ref</plugins/discover/fmf>` dynamically
 depending on the provided :ref:`/spec/context`. This is possible
 using a special file in tmt format stored in a default branch of a
 tests repository. That special file should contain rules assigning

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -39,54 +39,6 @@ description: |
           description: Long test description.
           ...
 
-/shell:
-    summary: Provide a manual list of shell test cases
-    description: |
-        List of test cases to be executed can be defined manually
-        directly in the plan as a list of dictionaries containing
-        test ``name`` and actual ``test`` script. Optionally it is
-        possible to define any other :ref:`/spec/tests` attributes
-        such as ``path`` or ``duration`` here as well. The default
-        :ref:`/spec/tests/duration` for tests defined directly in
-        the discover step is ``1h``.
-
-        It is possible to fetch code from a remote git repository
-        using ``url``. In that case repository is cloned and all
-        paths are relative to the remote git root. Using remote
-        repo and local test code at the same time is not possible
-        within the same discover config, use
-        :ref:`multiple-configs` instead.
-
-        Use the :ref:`/spec/plans/discover/dist-git-source`
-        options to download rpm sources for dist-git repositories.
-
-    example:
-      - |
-        # Define several local tests
-        discover:
-            how: shell
-            tests:
-              - name: /help/main
-                test: tmt --help
-              - name: /help/test
-                test: tmt test --help
-              - name: /help/smoke
-                test: ./smoke.sh
-                path: /tests/shell
-                duration: 1m
-      - |
-        # Fetch tests from a remote repository
-        discover:
-            how: shell
-            url: https://github.com/teemtee/tmt
-            tests:
-              - name: Use tests/full/test.sh from the remote repo
-                path: /tests/full
-                test: ./test.sh
-
-    link:
-      - implemented-by: /tmt/steps/discover/shell.py
-
 /fmf:
     summary: Discover available tests using the fmf format
     description: |

--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -39,52 +39,6 @@ description: |
           description: Long test description.
           ...
 
-/fmf:
-    summary: Discover available tests using the fmf format
-    description: |
-        Use the `Flexible Metadata Format`_ to explore all
-        available tests in given repository.
-
-        See the `fmf identifier`_ and the :ref:`/plugins/discover/fmf`
-        plugin documentation for more details.
-
-        .. _fmf identifier: https://fmf.readthedocs.io/en/latest/concept.html#identifiers
-        .. _Flexible Metadata Format: https://fmf.readthedocs.io/
-
-    example:
-      - |
-        # Discover all fmf tests in the current repository
-        discover:
-            how: fmf
-      - |
-        # Fetch tests from a remote repo, filter by name/tier
-        discover:
-            how: fmf
-            url: https://github.com/teemtee/tmt
-            ref: main
-            path: /metadata/tree/path
-            test: [regexp]
-            filter: tier:1
-      - |
-        # Choose tests verifying given issue
-        discover:
-            how: fmf
-            link: verifies:issues/123$
-      - |
-        # Select only tests which have been modified
-        discover:
-            how: fmf
-            modified-only: true
-            modified-url: https://github.com/teemtee/tmt-official
-            modified-ref: reference/main
-      - |
-        # Extract tests from the distgit sources
-        discover:
-            how: fmf
-            dist-git-source: true
-    link:
-      - implemented-by: /tmt/steps/discover/fmf.py
-
 /dist-git-source:
     summary: Download rpm sources for dist-git repositories
     description: |
@@ -102,7 +56,7 @@ description: |
         order ``60``. All created files and directories by this command
         are directly in ``TMT_SOURCE_DIR``.
 
-        The :ref:`/spec/plans/discover/fmf` plugin supports
+        The :ref:`/plugins/discover/fmf` plugin supports
         additional dist-git options, see its documentation for
         details.
 

--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -22,42 +22,6 @@ description: |
     with results for executed tests. The format of the file is described
     at :ref:`/spec/results`.
 
-/upgrade:
-    summary: Perform system upgrades during testing
-    story:
-        As a tester I want to verify that a configured application
-        or service still correctly works after the system upgrade.
-    example:
-      - |
-        # Main testing plan
-        discover:
-            how: fmf
-        execute:
-            how: upgrade
-            url: https://github.com/teemtee/upgrade
-            upgrade-path: /paths/fedora35to36
-
-      - |
-        # Upgrade path /paths/fedora35to36.fmf in the remote repository
-        discover: # Selects appropriate upgrade tasks (L1 tests)
-            how: fmf
-            filter: "tag:fedora"
-        environment: # This is passed to upgrade tasks
-            SOURCE: 35
-            TARGET: 36
-        execute:
-            how: tmt
-
-      - |
-        # Alternative main testing plan, without upgrade path
-        execute:
-            how: upgrade
-            url: https://github.com/teemtee/upgrade
-            filter: "tag:fedora"
-    link:
-      - implemented-by: /tmt/steps/execute/upgrade.py
-      - verified-by: /tests/execute/upgrade
-
 
 /isolate:
     summary: Run tests in an isolated environment
@@ -85,17 +49,6 @@ description: |
     link:
       - implemented-by: /tmt/steps/execute/internal.py
       - verified-by: /tests/execute/exit-first
-
-/tmt:
-    summary: Internal test executor
-    story: As a user I want to execute tests directly from tmt.
-
-    example: |
-        execute:
-            how: tmt
-    link:
-      - implemented-by: /tmt/steps/execute/internal.py
-      - verified-by: /tests/execute/framework
 
 /script:
     summary: Execute shell scripts

--- a/spec/plans/provision.fmf
+++ b/spec/plans/provision.fmf
@@ -23,15 +23,6 @@ example: |
 link:
     - implemented-by: /tmt/steps/provision
 
-/openstack:
-    summary: Provision a virtual machine in OpenStack
-    description:
-        Create a virtual machine using OpenStack.
-    example: |
-        provision:
-            how: openstack
-            image: f31
-
 /multihost:
     summary: Multihost testing specification
 

--- a/stories/cli/steps.fmf
+++ b/stories/cli/steps.fmf
@@ -96,7 +96,7 @@
             In order to see progress of the testing use the
             ``--verbose`` or ``-v`` switch. Applying the option
             multiple times increases verbosity. This is supported
-            by the :ref:`/spec/plans/execute/tmt` executor only.
+            by the :ref:`/plugins/execute/tmt` executor only.
         example:
           - tmt run -v
           - tmt run -vv
@@ -116,7 +116,7 @@
             directly with the test from the terminal. For example,
             for tests written in shell you can insert a ``bash``
             command in the middle of the script and investigate.
-            Supported by the :ref:`/spec/plans/execute/tmt`
+            Supported by the :ref:`/plugins/execute/tmt`
             executor only.
         example:
           - tmt run --all execute --how tmt --interactive


### PR DESCRIPTION
Removes completely the duplicated information from the following specs:
* discover (shell)
* provision (openstack)
* execute (upgrade & tmt)

Also updates a `tmt` spec mention, so now points to the proper plugin

Pull Request Checklist

* [x] update the specification
