### PR TITLE
Disable the `virt-customize` speed-up due to DNS issues

### DIFF
--- a/plans/provision/virtual.fmf
+++ b/plans/provision/virtual.fmf
@@ -24,13 +24,15 @@ prepare+:
         sudo systemctl start libvirtd
         sudo systemctl status libvirtd
 
-  - name: prepare-image
-    summary: Fetch the image, refresh dnf cache, install beakerlib
-    script: |
-        tmt run --remove plan --default provision --how virtual finish
-        for image in /var/tmp/tmt/testcloud/images/*qcow2; do
-            virt-customize --add $image --run-command 'dnf --refresh install -y beakerlib'
-        done
+
+# TODO hotfix disable the image preparation because of weird dns issues
+#  - name: prepare-image
+#    summary: Fetch the image, refresh dnf cache, install beakerlib
+#    script: |
+#        tmt run --remove plan --default provision --how virtual finish
+#        for image in /var/tmp/tmt/testcloud/images/*qcow2; do
+#            virt-customize --add $image --run-command 'dnf --refresh install -y beakerlib'
+#        done
 
 context+:
   provision_how: virtual

--- a/tests/execute/upgrade/data/plan.fmf
+++ b/tests/execute/upgrade/data/plan.fmf
@@ -6,6 +6,9 @@ provision:
 execute:
     how: upgrade
     url: https://github.com/teemtee/upgrade
+    # TODO: revert once merged, workaround for 1.47 release
+    # https://github.com/teemtee/upgrade/pull/15
+    ref: dnf5
 
 /no-path:
     summary: Basic upgrade test with no upgrade path

--- a/tests/libraries/apache/data/main.fmf
+++ b/tests/libraries/apache/data/main.fmf
@@ -8,5 +8,6 @@
 
 /test:
     test: ./test.sh
+    framework: beakerlib
     require:
       - library(httpd/http)


### PR DESCRIPTION
As a hotfix, let's use `fedora-41` instead of `fedora-42` to work around the weird dns issues and unblock the release.

For reference the error was:

```
>>> Curl error (6): Could not resolve hostname for https://mirrors.fedoraproject
>>> Librepo error: Cannot prepare internal mirrorlist: Curl error (6): Could notFailed to download metadata (metalink: "https://mirrors.fedoraproject.org/metalink?repo=updates-released-f41&arch=x86_64") for repository "updates"
Librepo error: Cannot prepare internal mirrorlist: Curl error (6): Could not resolve hostname for https://mirrors.fedoraproject.org/metalink?repo=updates-released-f41&arch=x86_64 [Could not resolve host: mirrors.fedoraproject.org]
virt-customize: error: dnf --refresh install -y beakerlib: command exited with an error
```