### PR TITLE
Workaround virt-customize issues in CI

### DIFF
--- a/plans/provision/virtual.fmf
+++ b/plans/provision/virtual.fmf
@@ -29,7 +29,7 @@ prepare+:
     script: |
         tmt run --remove plan --default provision --how virtual finish
         for image in /var/tmp/tmt/testcloud/images/*qcow2; do
-            virt-customize --add $image --run-command 'dnf --refresh install -y beakerlib'
+            virt-customize --add $image --run-command 'echo "nameserver 8.8.8.8" > /etc/resolv.conf; dnf --refresh install -y beakerlib'
         done
 
 context+:


### PR DESCRIPTION
The problem seems to be DNS, let's try to avoid `systemd-resolved` by setting nameserver to google DNS.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
