### PR TITLE
Refactor the `DiscoverFmf.go()` method

### DIFF
--- a/tests/discover/adjust-tests.sh
+++ b/tests/discover/adjust-tests.sh
@@ -11,7 +11,7 @@ rlJournalStart
         rlRun -s "tmt -c trigger=commit run -i $run discover plans --name /fmf/adjust-tests"
         # If we ever change the path...
         tests_yaml="$(find $run -name tests.yaml)"
-        rlAssertExits "$tests_yaml"
+        rlAssertExists "$tests_yaml"
         rlRun -s "yq '.[].require' < $tests_yaml"
         rlAssertGrep "foo" "$rlRun_LOG"
         rlRun -s "yq '.[].duration' < $tests_yaml"

--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -128,7 +128,7 @@ rlJournalStart
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 \
                2>&1 >/dev/null | tee output" 2
         rlAssertGrep "\`tmt run discover --fmf-id\` without \`url\` option \
-in plan \`/plans/example\` can be used only within git repo." output
+in plan \`/plans/example\` or on command line can be used only within git repo." output
 
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id \
                --url https://github.com/teemtee/fmf finish 2>&1 >/dev/null | tee output" 0
@@ -156,25 +156,7 @@ in plan \`/plans/example\` can be used only within git repo." output
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 >/dev/null \
                | tee output" 2
         rlAssertGrep "\`tmt run discover --fmf-id\` without \`url\` option \
-in plan \`/plans/a-non-url\` can be used only within git repo." output
-
-        rlRun "tmt run -rdvvv discover -h fmf --fmf-id \
-               --url https://github.com/teemtee/fmf finish 2>&1 >/dev/null | tee output" 0
-        rlRun "rm -rf $tmp_dir1 $tmp_dir2"
-
-        # 2: w/ url in plan AND w/o url in plan: w/o url in CLI - w/ url in CLI
-        tmp_dir1="$(mktemp -d)"
-        tmp_dir2="$(mktemp -d)"
-        rlRun "cd $tmp_dir1"
-        rlRun "tmt init --template full"
-        rlRun "cd $tmp_dir2"
-        rlRun "tmt init --template base"
-        rlRun "cp plans/example.fmf $tmp_dir1/plans/z-non-url.fmf"
-        rlRun "cd $tmp_dir1"
-        rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 >/dev/null \
-               | tee output" 2
-        rlAssertGrep "\`tmt run discover --fmf-id\` without \`url\` option \
-in plan \`/plans/z-non-url\` can be used only within git repo." output
+in plan \`/plans/a-non-url\` or on command line can be used only within git repo." output
 
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id \
                --url https://github.com/teemtee/fmf finish 2>&1 >/dev/null | tee output" 0

--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -128,7 +128,7 @@ rlJournalStart
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 \
                2>&1 >/dev/null | tee output" 2
         rlAssertGrep "\`tmt run discover --fmf-id\` without \`url\` option \
-in plan \`/plans/example\` or on command line can be used only within git repo." output
+in plan \`/plans/example\` can be used only within git repo." output
 
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id \
                --url https://github.com/teemtee/fmf finish 2>&1 >/dev/null | tee output" 0
@@ -156,7 +156,7 @@ in plan \`/plans/example\` or on command line can be used only within git repo."
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id finish 2>&1 >/dev/null \
                | tee output" 2
         rlAssertGrep "\`tmt run discover --fmf-id\` without \`url\` option \
-in plan \`/plans/a-non-url\` or on command line can be used only within git repo." output
+in plan \`/plans/a-non-url\` can be used only within git repo." output
 
         rlRun "tmt run -rdvvv discover -h fmf --fmf-id \
                --url https://github.com/teemtee/fmf finish 2>&1 >/dev/null | tee output" 0

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -463,11 +463,10 @@ class Discover(tmt.steps.Step):
                 for test_origin in self.tests(enabled=True):
                     fmf_id = test_origin.test.fmf_id
 
-                    if not (fmf_id.url or self.opt('url')):
+                    if not fmf_id.url:
                         raise tmt.utils.DiscoverError(
                             f"`tmt run discover --fmf-id` without `url` option "
-                            f"in plan `{self.plan}` or on command line can be used only "
-                            f"within git repo."
+                            f"in plan `{self.plan}` can be used only within git repo."
                         )
 
                     exported = test_origin.test.fmf_id.to_minimal_spec()

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -476,6 +476,7 @@ class Discover(tmt.steps.Step):
                         exported.pop('ref')
 
                     export_fmf_ids.append(tmt.utils.dict_to_yaml(exported, start=True))
+
                 click.echo(''.join(export_fmf_ids), nl=False)
             return
 

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -463,8 +463,12 @@ class Discover(tmt.steps.Step):
                 for test_origin in self.tests(enabled=True):
                     fmf_id = test_origin.test.fmf_id
 
-                    if not fmf_id.url:
-                        continue
+                    if not (fmf_id.url or self.opt('url')):
+                        raise tmt.utils.DiscoverError(
+                            f"`tmt run discover --fmf-id` without `url` option "
+                            f"in plan `{self.plan}` or on command line can be used only "
+                            f"within git repo."
+                        )
 
                     exported = test_origin.test.fmf_id.to_minimal_spec()
 
@@ -472,7 +476,6 @@ class Discover(tmt.steps.Step):
                         exported.pop('ref')
 
                     export_fmf_ids.append(tmt.utils.dict_to_yaml(exported, start=True))
-
                 click.echo(''.join(export_fmf_ids), nl=False)
             return
 

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -552,7 +552,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             if path is not None:
                 fmf_root: Optional[Path] = path
             else:
-                fmf_root = Path(self.step.plan.node.root) if self.step.plan.node.root else None
+                fmf_root = Path(self.step.plan.fmf_root) if self.step.plan.fmf_root else None
             requires_git = self.opt('sync-repo') or any(
                 self.get(opt) for opt in self._REQUIRES_GIT
             )

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -2,7 +2,6 @@ import contextlib
 import glob
 import re
 import shutil
-from contextlib import suppress
 from typing import Any, Optional, cast
 
 import fmf
@@ -531,11 +530,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 "Cannot manipulate with dist-git without the `--dist-git-merge` option."
             )
 
-        # Raise an exception if --fmf-id is used w/o url and git root
-        # doesn't exist for discovered plan
-        if self.opt('fmf_id'):
-            self.validate_fmf_id_requirements(url)
-
         self.log_import_plan_details()
 
         # Clone provided git repository (if url given) with disabled
@@ -643,45 +637,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
         if self.step.plan.my_run is not None:
             for policy in self.step.plan.my_run.policies:
                 policy.apply_to_tests(tests=self._tests, logger=self._logger)
-        
-    def validate_fmf_id_requirements(self, url: Optional[str] = None) -> None:
-        """
-        Validate environment requirements for the --fmf-id option.
-        """
-
-        # It covers only one case, when there is:
-        # 1) no --url on CLI
-        # 2) plan w/o url exists in test run
-        if not self.opt('url'):
-            try:
-                fmf_tree = fmf.Tree(Path.cwd())
-            except fmf.utils.RootError:
-                raise tmt.utils.DiscoverError(
-                    "No metadata found in the current directory. Use 'tmt init' to get started."
-                )
-            for attr in fmf_tree.climb():
-                with suppress(AttributeError):
-                    plan_url = attr.data.get('discover').get('url')
-                    plan_name = attr.name
-                    assert plan_name is not None
-                    if not plan_url:
-                        try:
-                            self.get_git_root(directory=Path.cwd())
-                        except tmt.utils.RunError:
-                            raise tmt.utils.DiscoverError(
-                                f"`tmt run discover --fmf-id` without `url` option "
-                                f"in plan `{plan_name}` can be used only within git repo."
-                            )
-
-        # All other cases are covered by this condition
-        if not url:
-            try:
-                self.get_git_root(directory=Path.cwd())
-            except tmt.utils.RunError:
-                raise tmt.utils.DiscoverError(
-                    f"`tmt run discover --fmf-id` without `url` option "
-                    f"in plan `{self.step.plan.name}` can be used only within git repo."
-                )
 
     def process_distgit_source(self, distgit_dir: Path, sourcedir: Path) -> None:
         """
@@ -716,8 +671,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
         # merge or not, detect later
         self.step.plan.discover.extract_tests_later = True
         self.info("Tests will be discovered after dist-git patching in prepare.")
-
-
 
     def do_the_discovery(self, path: Optional[Path] = None) -> None:
         """

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -552,7 +552,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             if path is not None:
                 fmf_root: Optional[Path] = path
             else:
-                fmf_root = Path(self.step.plan.node.root)
+                fmf_root = Path(self.step.plan.node.root) if self.step.plan.node.root else None
             requires_git = self.opt('sync-repo') or any(
                 self.get(opt) for opt in self._REQUIRES_GIT
             )


### PR DESCRIPTION
Pull Request Checklist

Would it be also worth it to refactor the part between these two helper methods?  

* [x] implement the feature

Checking for `URL`  in the `tmt/steps/discover/fmf.py` was dropped completely and information about missing git repo has been moved into `tmt/steps/discover/__init__.py` instead. When `--fmf-id` is used in a directory without git root and there is no `URL` fed to `tmt run discover --how fmf` then the user gets notified about this.

During testing I've found out that two tests are identical in the `tests/discover/filtering.sh`, specifically the 
` # 2: w/o url in plan AND w/ url in plan: w/o url in CLI - w/ url in CLI` and `# 2: w/ url in plan AND w/o url in plan: w/o url in CLI - w/ url in CLI` scenarios.
They both use two plans, one with and one without `URL`, then calling `tmt run discover --how fmf --fmf-id` either with or without `--url` on a command line. 
The difference is that in first scenario the non-url-plan is called `a-non-url.fmf` and in the second scenario it it called `z-non-url.fmf`. The result is the same, so one of the test was dropped. (I think the original idea was about an order in which they were supposed to be discovered, first with url followed with non-url, and in the the other scenario vice-versa).

Changed `self.step.plan.node.root` into `fmf_root` and added the `if else` statement into  
`fmf_root = Path(self.step.plan.fmf_root) if self.step.plan.fmf_root else None` in `tmt/steps/discover/fmf.py`.
The reason is because `node.root` is not well annotated and `fmf_root` will give the same results. Adding the existence check is due to the fact that `fmf_root` can be None and tmt would fail with ugly exception message `argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'NoneType'.`

Fixes #2448 