### PR TITLE
Exclude Stack Overflow links from CI checks (fixes #3711)

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -42,4 +42,4 @@ jobs:
         run: hatch run docs:html -W
 
       - name: Run sphinx linkcheck
-        run: hatch run docs:linkcheck
+        run: hatch run docs:linkcheck -- -D linkcheck_ignore="https://stackoverflow.com/.*"

--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -42,4 +42,4 @@ jobs:
         run: hatch run docs:html -W
 
       - name: Run sphinx linkcheck
-        run: hatch run docs:linkcheck -- -D linkcheck_ignore="https://stackoverflow.com/.*"
+        run: hatch run docs:linkcheck

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -313,6 +313,8 @@ linkcheck_ignore = [
     r'https://github.com/packit/packit/blob/main/packit/utils/logging.py#L10',
     # The site repeatedly refuses to serve pages to github
     r'https://www.cpu-world.com.*',
+    # Stack Overflow uses captcha and these links are not essential
+    r'https://stackoverflow.com.*',
 ]
 
 


### PR DESCRIPTION
## Exclude Stack Overflow links from CI checks (fixes #3711)

### Description
This PR excludes Stack Overflow links from documentation checks because:
- Stack Overflow now requires CAPTCHA validation, causing CI failures (403 errors)
- Linkcheck should skip external sites with access restrictions

Fixes #3711.

### Checklist
- [x] Exclude Stack Overflow links in CI checks
- [x] Verify linkcheck tests pass
 Manual tests confirmed:
- Stack Overflow links (`https://stackoverflow.com/.*`) are now excluded from CI checks.  
- All documentation builds pass with `hatch run docs:html -W`.  
