### PR TITLE
Interrupt current test when tmt is interrupted

### DIFF
--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -18,6 +18,7 @@ import tmt.base
 import tmt.log
 import tmt.steps
 import tmt.utils
+import tmt.utils.signals
 import tmt.utils.wait
 from tmt.checks import CheckEvent
 from tmt.container import container, field, simple_field
@@ -29,6 +30,7 @@ from tmt.steps.discover import Discover, DiscoverPlugin, DiscoverStepData
 from tmt.steps.provision import Guest
 from tmt.utils import (
     Command,
+    CommandOutput,
     Path,
     ShellScript,
     Stopwatch,
@@ -319,6 +321,11 @@ class TestInvocation:
     process: Optional[subprocess.Popen[bytes]] = None
     process_lock: threading.Lock = simple_field(default_factory=threading.Lock)
 
+    #: If set, there is a callback registered through
+    #: :py:func:`tmt.signals.`add_callback` which would be called when
+    #: tmt gets terminated.
+    on_interrupt_callback_token: Optional[int] = None
+
     results: list[Result] = simple_field(default_factory=list)
     check_results: list[CheckResult] = simple_field(default_factory=list)
 
@@ -598,6 +605,107 @@ class TestInvocation:
         self.hard_reboot_requested = False
 
         return True
+
+    def invoke_test(
+        self,
+        command: ShellScript,
+        *,
+        cwd: Path,
+        env: tmt.utils.Environment,
+        log: tmt.log.LoggingFunction,
+        interactive: bool,
+        timeout: Optional[int],
+    ) -> tmt.utils.CommandOutput:
+        """
+        Start the command which represents the test in this invocation.
+
+        :param cwd: if set, command would be executed in the given directory,
+            otherwise the current working directory is used.
+        :param env: environment variables to combine with the current environment
+            before running the command.
+        :param interactive: if set, the command would be executed in an interactive
+            manner, i.e. with stdout and stdout connected to terminal for live
+            interaction with user.
+        :param timeout: if set, command would be interrupted, if still running,
+            after this many seconds.
+        :param log: a logging function to use for logging of command output. By
+            default, ``logger.debug`` is used.
+        :returns: command output.
+        """
+
+        # Write down process and let tmt kill it if tmt gets interrupted.
+        def _save_process(
+            command: Command, process: subprocess.Popen[bytes], logger: tmt.log.Logger
+        ) -> None:
+            """
+            Record process info in the invocation.
+
+            Called by :py:class:`Command` as the ``on_process_start``
+            callback.
+            """
+
+            with self.process_lock:
+                self.process = process
+
+                self.on_interrupt_callback_token = tmt.utils.signals.add_callback(
+                    self.terminate_process, logger=self.logger
+                )
+
+        def _reset_process(
+            command: Command,
+            process: subprocess.Popen[bytes],
+            output: CommandOutput,
+            logger: tmt.log.Logger,
+        ) -> None:
+            """
+            Reset process info in the invocation.
+
+            Called by :py:class:`Command` as the ``on_process_end``
+            callback.
+            """
+
+            with self.process_lock:
+                self.process = None
+
+                if self.on_interrupt_callback_token is not None:
+                    tmt.utils.signals.remove_callback(self.on_interrupt_callback_token)
+
+        with Stopwatch() as timer:
+            self.start_time = format_timestamp(timer.start_time)
+
+            try:
+                output = self.guest.execute(
+                    command,
+                    cwd=cwd,
+                    env=env,
+                    join=True,
+                    interactive=interactive,
+                    tty=self.test.tty,
+                    log=log,
+                    timeout=timeout,
+                    on_process_start=_save_process,
+                    on_process_end=_reset_process,
+                    test_session=True,
+                    friendly_command=str(self.test.test),
+                )
+
+                self.return_code = tmt.utils.ProcessExitCodes.SUCCESS
+
+            except tmt.utils.RunError as error:
+                output = error.output
+
+                self.return_code = error.returncode
+
+                if self.return_code == tmt.utils.ProcessExitCodes.TIMEOUT:
+                    self.logger.debug(f"Test duration '{self.test.duration}' exceeded.")
+
+                elif tmt.utils.ProcessExitCodes.is_pidfile(self.return_code):
+                    self.logger.warning('Test failed to manage its pidfile.')
+
+        self.end_time = format_timestamp(timer.end_time)
+        self.real_duration = format_duration(timer.duration)
+
+        return output
 
     def terminate_process(
         self,

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import textwrap
 from typing import Any, Optional, cast
 
@@ -12,6 +11,7 @@ import tmt.options
 import tmt.steps
 import tmt.steps.execute
 import tmt.utils
+import tmt.utils.signals
 import tmt.utils.themes
 from tmt.container import container, field
 from tmt.result import BaseResult, Result, ResultOutcome
@@ -25,14 +25,10 @@ from tmt.steps.execute import (
 )
 from tmt.steps.provision import Guest
 from tmt.utils import (
-    Command,
     Environment,
     EnvVarValue,
     Path,
     ShellScript,
-    Stopwatch,
-    format_duration,
-    format_timestamp,
 )
 from tmt.utils.themes import style
 
@@ -561,76 +557,43 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                 key=key, value=value, color=color, shift=shift, level=level, topic=topic
             )
 
-        def _save_process(
-            command: Command, process: subprocess.Popen[bytes], logger: tmt.log.Logger
-        ) -> None:
-            with invocation.process_lock:
-                invocation.process = process
-
         # TODO: do we want timestamps? Yes, we do, leaving that for refactoring later,
         # to use some reusable decorator.
         invocation.check_results = self.run_checks_before_test(
             invocation=invocation, environment=environment, logger=logger
         )
 
-        # Execute the test, save the output and return code
-        with Stopwatch() as timer:
-            invocation.start_time = format_timestamp(timer.start_time)
+        # Pick the proper timeout for the test
+        timeout: Optional[int]
 
-            timeout: Optional[int]
+        if self.data.interactive:
+            if test.duration:
+                logger.warning('Ignoring requested duration, not supported in interactive mode.')
 
-            if self.data.interactive:
-                if test.duration:
-                    logger.warning(
-                        'Ignoring requested duration, not supported in interactive mode.'
-                    )
+            timeout = None
 
-                timeout = None
+        elif self.data.ignore_duration:
+            logger.debug("Test duration is not effective due ignore-duration option.")
+            timeout = None
 
-            elif self.data.ignore_duration:
-                logger.debug("Test duration is not effective due ignore-duration option.")
-                timeout = None
+        else:
+            timeout = tmt.utils.duration_to_seconds(
+                test.duration, tmt.base.DEFAULT_TEST_DURATION_L1
+            )
 
-            else:
-                timeout = tmt.utils.duration_to_seconds(
-                    test.duration, tmt.base.DEFAULT_TEST_DURATION_L1
-                )
-
-            try:
-                output = guest.execute(
-                    remote_command,
-                    cwd=workdir,
-                    env=environment,
-                    join=True,
-                    interactive=self.data.interactive,
-                    tty=test.tty,
-                    log=_test_output_logger,
-                    timeout=timeout,
-                    on_process_start=_save_process,
-                    test_session=True,
-                    friendly_command=str(test.test),
-                )
-                invocation.return_code = 0
-                stdout = output.stdout
-            except tmt.utils.RunError as error:
-                stdout = error.stdout
-
-                invocation.return_code = error.returncode
-                if invocation.return_code == tmt.utils.ProcessExitCodes.TIMEOUT:
-                    logger.debug(f"Test duration '{test.duration}' exceeded.")
-
-                elif tmt.utils.ProcessExitCodes.is_pidfile(invocation.return_code):
-                    logger.warning('Test failed to manage its pidfile.')
-
-        with invocation.process_lock:
-            invocation.process = None
-
-        invocation.end_time = format_timestamp(timer.end_time)
-        invocation.real_duration = format_duration(timer.duration)
+        # And invoke the test process.
+        output = invocation.invoke_test(
+            remote_command,
+            cwd=workdir,
+            env=environment,
+            interactive=self.data.interactive,
+            log=_test_output_logger,
+            timeout=timeout,
+        )
 
         # Save the captured output. Do not let the follow-up pulls
         # overwrite it.
-        self.write(invocation.path / TEST_OUTPUT_FILENAME, stdout or '', mode='a', level=3)
+        self.write(invocation.path / TEST_OUTPUT_FILENAME, output.stdout or '', mode='a', level=3)
 
         # Fetch #1: we need logs and everything the test produced so we could
         # collect its results.

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -57,6 +57,7 @@ from tmt.steps import Action, ActionTask, PhaseQueue
 from tmt.utils import (
     Command,
     GeneralError,
+    OnProcessEndCallback,
     OnProcessStartCallback,
     Path,
     ProvisionError,
@@ -1583,6 +1584,7 @@ class Guest(tmt.utils.Common):
         log: Optional[tmt.log.LoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
+        on_process_end: Optional[OnProcessEndCallback] = None,
         **kwargs: Any,
     ) -> tmt.utils.CommandOutput:
         pass
@@ -1600,6 +1602,7 @@ class Guest(tmt.utils.Common):
         log: Optional[tmt.log.LoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
+        on_process_end: Optional[OnProcessEndCallback] = None,
         **kwargs: Any,
     ) -> tmt.utils.CommandOutput:
         pass
@@ -1616,6 +1619,7 @@ class Guest(tmt.utils.Common):
         log: Optional[tmt.log.LoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
+        on_process_end: Optional[OnProcessEndCallback] = None,
         **kwargs: Any,
     ) -> tmt.utils.CommandOutput:
         """
@@ -2345,6 +2349,7 @@ class GuestSsh(Guest):
         log: Optional[tmt.log.LoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
+        on_process_end: Optional[OnProcessEndCallback] = None,
         **kwargs: Any,
     ) -> tmt.utils.CommandOutput:
         """
@@ -2405,6 +2410,7 @@ class GuestSsh(Guest):
             cwd=cwd,
             interactive=interactive,
             on_process_start=on_process_start,
+            on_process_end=on_process_end,
             **kwargs,
         )
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -7,7 +7,7 @@ import tmt.steps
 import tmt.steps.provision
 import tmt.utils
 from tmt.container import container
-from tmt.utils import Command, OnProcessStartCallback, Path, ShellScript
+from tmt.utils import Command, OnProcessEndCallback, OnProcessStartCallback, Path, ShellScript
 from tmt.utils.wait import Waiting
 
 
@@ -99,6 +99,7 @@ class GuestLocal(tmt.Guest):
         log: Optional[tmt.log.LoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
+        on_process_end: Optional[OnProcessEndCallback] = None,
         **kwargs: Any,
     ) -> tmt.utils.CommandOutput:
         """
@@ -126,6 +127,7 @@ class GuestLocal(tmt.Guest):
             cwd=cwd,
             interactive=interactive,
             on_process_start=on_process_start,
+            on_process_end=on_process_end,
             **kwargs,
         )
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -10,7 +10,14 @@ import tmt.steps.provision
 import tmt.utils
 from tmt.container import container, field
 from tmt.steps.provision import GuestCapability
-from tmt.utils import Command, OnProcessStartCallback, Path, ShellScript, retry
+from tmt.utils import (
+    Command,
+    OnProcessEndCallback,
+    OnProcessStartCallback,
+    Path,
+    ShellScript,
+    retry,
+)
 from tmt.utils.wait import Deadline, Waiting
 
 # Timeout in seconds of waiting for a connection
@@ -400,6 +407,7 @@ class GuestContainer(tmt.Guest):
         log: Optional[tmt.log.LoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
+        on_process_end: Optional[OnProcessEndCallback] = None,
         **kwargs: Any,
     ) -> tmt.utils.CommandOutput:
         """
@@ -448,6 +456,7 @@ class GuestContainer(tmt.Guest):
             silent=silent,
             interactive=interactive,
             on_process_start=on_process_start,
+            on_process_end=on_process_end,
             **kwargs,
         )
 

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1013,6 +1013,13 @@ OnProcessStartCallback = Callable[
     None,
 ]
 
+#: Type of a callable to be called by :py:meth:`Command.run` after the
+#: child process finishes.
+OnProcessEndCallback = Callable[
+    ['Command', subprocess.Popen[bytes], 'CommandOutput', tmt.log.Logger],
+    None,
+]
+
 
 @container(frozen=True)
 class CommandOutput:
@@ -1145,6 +1152,7 @@ class Command:
         interactive: bool = False,
         timeout: Optional[int] = None,
         on_process_start: Optional[OnProcessStartCallback] = None,
+        on_process_end: Optional[OnProcessEndCallback] = None,
         # Logging
         message: Optional[str] = None,
         friendly_command: Optional[str] = None,
@@ -1170,6 +1178,8 @@ class Command:
             interaction with user.
         :param timeout: if set, command would be interrupted, if still running,
             after this many seconds.
+        :param on_process_end: if set, this callable would be called after the
+            command process finishes.
         :param on_process_start: if set, this callable would be called after the
             command process started.
         :param message: if set, it would be logged for more friendly logging.
@@ -1358,6 +1368,11 @@ class Command:
             level=3,
         )
 
+        output = CommandOutput(stdout, stderr)
+
+        if on_process_end is not None:
+            on_process_end(self, process, output, logger)
+
         # Handle the exit code, return output
         if process.returncode != ProcessExitCodes.SUCCESS:
             if not stream_output:
@@ -1378,7 +1393,7 @@ class Command:
                 caller=caller,
             )
 
-        return CommandOutput(stdout, stderr)
+        return output
 
 
 _SANITIZE_NAME_PATTERN: Pattern[str] = re.compile(r'[^\w/-]+')
@@ -2035,6 +2050,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         log: Optional[tmt.log.LoggingFunction] = None,
         timeout: Optional[int] = None,
         on_process_start: Optional[OnProcessStartCallback] = None,
+        on_process_end: Optional[OnProcessEndCallback] = None,
     ) -> CommandOutput:
         """
         Run command, give message, handle errors
@@ -2065,6 +2081,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             env=env,
             interactive=interactive,
             on_process_start=on_process_start,
+            on_process_end=on_process_end,
             join=join,
             log=log,
             timeout=timeout,


### PR DESCRIPTION
If tmt is running a test - or any subprocess - when it's interrupted, it waits for the test to finish before it quits. The patch adds hook for the interrupt-handling code to be able to kill the test invocation process.

There are some gaps though, e.g. it does not work for localhost. With SSH-backed guests, things are easy: there's SSH process, it gets killed, it quits, test quits, everything stops (almost) immediately. It also works with container guests, there's one `podman exec` process running the test, it gets killed, job done. With localhost, tmt runs the test wrapper script, and it seems there needs to be more work done in terms of setting up traps for signals.

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] include a release note
