### PR TITLE
Fix tests/execute/nonroot for boot based Fedora CoreOS

### DIFF
--- a/tests/execute/nonroot/test.sh
+++ b/tests/execute/nonroot/test.sh
@@ -3,7 +3,8 @@
 
 rlJournalStart
     rlPhaseStartSetup
-        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
+        # bootc images do not persist /tmp on reboot, use /var/tmp instead
+        rlRun "run=\$(mktemp -d -p /var/tmp)" 0 "Create run directory"
         rlRun "pushd data"
     rlPhaseEnd
 

--- a/tests/execute/nonroot/test.sh
+++ b/tests/execute/nonroot/test.sh
@@ -9,7 +9,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        if ! rlRun "TMT_SHOW_TRACEBACK=full tmt run -vvv --id $run"; then
+        if ! rlRun "TMT_SHOW_TRACEBACK=full tmt run -vvvvdddd --id $run"; then
             rlFileSubmit $run/log.txt
         fi
     rlPhaseEnd

--- a/tests/execute/nonroot/test.sh
+++ b/tests/execute/nonroot/test.sh
@@ -3,7 +3,7 @@
 
 rlJournalStart
     rlPhaseStartSetup
-        # bootc images do not persist /tmp on reboot, use /var/tmp instead
+        # use `/var/tmp` to persist the run dir during reboots, because `bootc` package manager used
         rlRun "run=\$(mktemp -d -p /var/tmp)" 0 "Create run directory"
         rlRun "pushd data"
     rlPhaseEnd

--- a/tests/execute/nonroot/test.sh
+++ b/tests/execute/nonroot/test.sh
@@ -9,7 +9,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        if ! rlRun "tmt run -vvv --id $run"; then
+        if ! rlRun "TMT_SHOW_TRACEBACK=full tmt run -vvv --id $run"; then
             rlFileSubmit $run/log.txt
         fi
     rlPhaseEnd

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -270,7 +270,11 @@ rlJournalStart
                 rlAssertGrep "out: no package provides tree-but-spelled-wrong" $rlRun_LOG
 
             elif is_ostree "$image"; then
-                rlAssertGrep "err: error: Packages not found: tree-but-spelled-wrong" $rlRun_LOG
+                if [ "$PROVISION_HOW" = "virtual" ]; then
+                    rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG
+                else
+                    rlAssertGrep "err: error: Packages not found: tree-but-spelled-wrong" $rlRun_LOG
+                fi
 
             elif is_fedora_coreos "$image"; then
                 rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -232,7 +232,11 @@ rlJournalStart
                 rlAssertGrep "out: no package provides tree-but-spelled-wrong" $rlRun_LOG
 
             elif is_ostree "$image"; then
-                rlAssertGrep "err: error: Packages not found: tree-but-spelled-wrong" $rlRun_LOG
+                if [ "$PROVISION_HOW" = "virtual" ]; then
+                    rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG
+                else
+                    rlAssertGrep "err: error: Packages not found: tree-but-spelled-wrong" $rlRun_LOG
+                fi
 
             elif is_fedora_coreos "$image"; then
                 rlAssertGrep "err: No match for argument: tree-but-spelled-wrong" $rlRun_LOG

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -47,7 +47,7 @@ rlJournalStart
         fi
 
         rlRun "package_cache=\$(mktemp -d)" 0 "Create cache directory for downloaded packages"
-        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
+        rlRun "run=\$(mktemp -d -p /var/tmp)" 0 "Create run directory"
         rlRun "pushd data"
 
         rlRun "export TMT_BOOT_TIMEOUT=300"
@@ -96,7 +96,7 @@ rlJournalStart
                 rlRun "distro=fedora-coreos"
 
                 if is_ostree "$image"; then
-                    rlRun "package_manager=rpm-ostree"
+                    rlRun "package_manager=bootc"
 
                 elif [ "$PROVISION_HOW" = "virtual" ]; then
                     rlRun "package_manager=dnf"

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -47,7 +47,7 @@ rlJournalStart
         fi
 
         rlRun "package_cache=\$(mktemp -d)" 0 "Create cache directory for downloaded packages"
-        rlRun "run=\$(mktemp -d -p /var/tmp)" 0 "Create run directory"
+        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
         rlRun "pushd data"
 
         rlRun "export TMT_BOOT_TIMEOUT=300"
@@ -96,7 +96,7 @@ rlJournalStart
                 rlRun "distro=fedora-coreos"
 
                 if is_ostree "$image"; then
-                    rlRun "package_manager=bootc"
+                    rlRun "package_manager=rpm-ostree"
 
                 elif [ "$PROVISION_HOW" = "virtual" ]; then
                     rlRun "package_manager=dnf"

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -47,7 +47,7 @@ rlJournalStart
         fi
 
         rlRun "package_cache=\$(mktemp -d)" 0 "Create cache directory for downloaded packages"
-        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
+        rlRun "run=\$(mktemp -d -p /var/tmp)" 0 "Create run directory"
         rlRun "pushd data"
 
         rlRun "export TMT_BOOT_TIMEOUT=300"
@@ -96,7 +96,14 @@ rlJournalStart
                 rlRun "distro=fedora-coreos"
 
                 if is_ostree "$image"; then
-                    rlRun "package_manager=rpm-ostree"
+
+                    if [ "$PROVISION_HOW" = "virtual" ]; then
+                      rlRun "package_manager=bootc"
+
+                    else
+                      rlRun "package_manager=rpm-ostree"
+
+                    fi
 
                 elif [ "$PROVISION_HOW" = "virtual" ]; then
                     rlRun "package_manager=dnf"

--- a/tests/provision/bootc/main.fmf
+++ b/tests/provision/bootc/main.fmf
@@ -5,9 +5,3 @@ tag+:
 require:
   - tmt+provision-virtual
 duration: 60m
-
-# As for now there is an expected AVC failure:
-# https://github.com/osbuild/bootc-image-builder/issues/645
-check:
-  - how: avc
-    result: xfail

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -215,6 +215,10 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
     _engine_class: type[PackageManagerEngineT]
     engine: PackageManagerEngineT
 
+    #: If set, this package manager can be used for building derived
+    #: images under the hood of the ``bootc`` package manager.
+    bootc_builder: bool = False
+
     #: A command to run to check whether the package manager is available on
     #: a guest.
     probe_command: Command

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -198,12 +198,10 @@ class Bootc(PackageManager[BootcEngine]):
                 # https://github.com/bootc-dev/bootc/issues/1259 for more information.
                 self.guest.execute(
                     ShellScript(
-                        f"""
-                        {sudo} ( \
-                            ( podman pull {base_image} || podman pull containers-storage:{base_image} ) \
-                            || bootc image copy-to-storage --target {base_image} \
-                        )
-                        """  # noqa: E501
+                        f'{sudo} {tmt.utils.DEFAULT_SHELL} -c "('
+                        f'  ( podman pull {base_image} || podman pull containers-storage:{base_image} )'  # noqa: E501
+                        f'  || bootc image copy-to-storage --target {base_image}'
+                        ')"'
                     )
                 )
                 self.guest.execute(
@@ -214,11 +212,7 @@ class Bootc(PackageManager[BootcEngine]):
                 # Build the container image
                 self.info("package", "building container image with dependencies", "green")
                 self.guest.execute(
-                    ShellScript(
-                        f"""
-                        {sudo} podman build -t {image_tag} -f {containerfile_path} .
-                        """
-                    )
+                    ShellScript(f'{sudo} podman build -t {image_tag} -f {containerfile_path} .')
                 )
 
                 # Switch to the new image for next boot

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -10,7 +10,6 @@ from tmt.package_managers import (
     Options,
     PackageManager,
     PackageManagerEngine,
-    dnf,
     provides_package_manager,
 )
 from tmt.utils import Command, CommandOutput, GeneralError, Path, RunError, ShellScript
@@ -21,7 +20,7 @@ class BootcEngine(PackageManagerEngine):
         """Initialize bootc engine for package management"""
         super().__init__(*args, **kwargs)
 
-        self.aux_engine = dnf.DnfEngine(*args, **kwargs)
+        self.aux_engine = self.guest.bootc_builder._engine_class(*args, **kwargs)
 
         self.initialize_containerfile_directives()
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -173,6 +173,8 @@ class Dnf(PackageManager[DnfEngine]):
 
     _engine_class = DnfEngine
 
+    bootc_builder = True
+
     probe_command = ShellScript(
         """
         type dnf && ((dnf --version | grep -E 'dnf5 version') && exit 1 || exit 0)
@@ -295,6 +297,8 @@ class Yum(Dnf):
     NAME = 'yum'
 
     _engine_class = YumEngine
+
+    bootc_builder = False
 
     probe_command = ShellScript(
         """

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -200,6 +200,8 @@ class InstallBase(tmt.utils.Common):
             # Wrapping them with try/except gives us a chance to attach the original exception
             # to whatever the code may raise, and therefore preserve the information attached
             # to the original exception.
+            self.warn('Installation failed, trying again after metadata refresh.')
+
             try:
                 # Refresh cache in case of recent but not updated change do repodata
                 self.guest.package_manager.refresh_metadata()

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -2698,6 +2698,8 @@ class GuestSsh(Guest):
 
         current_boot_time = get_boot_time() if fetch_boot_time else 0
 
+        self.debug(f"Triggering reboot action '{action}' with boot time {current_boot_time}.")
+
         try:
             action()
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -2698,8 +2698,6 @@ class GuestSsh(Guest):
 
         current_boot_time = get_boot_time() if fetch_boot_time else 0
 
-        self.debug(f"Triggering reboot action '{action}' with boot time {current_boot_time}.")
-
         try:
             action()
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -376,6 +376,11 @@ class GuestFacts(SerializableContainer):
         # and reports `package_manager` parameter to be `object`.
         default=cast(Optional['tmt.package_managers.GuestPackageManager'], None)
     )
+    bootc_builder: Optional['tmt.package_managers.GuestPackageManager'] = field(
+        # cast: since the default is None, mypy cannot infere the full type,
+        # and reports `bootc_builder` parameter to be `object`.
+        default=cast(Optional['tmt.package_managers.GuestPackageManager'], None)
+    )
 
     has_selinux: Optional[bool] = None
     has_systemd: Optional[bool] = None
@@ -602,6 +607,41 @@ class GuestFacts(SerializableContainer):
 
         return None
 
+    def _query_bootc_builder(
+        self, guest: 'Guest'
+    ) -> Optional['tmt.package_managers.GuestPackageManager']:
+        # Discover as many package managers as possible: sometimes, the
+        # first discovered package manager is not the only or the best
+        # one available. Collect them, and sort them by their priorities
+        # to find the most suitable one.
+
+        discovered_package_managers: list[
+            PackageManagerClass[tmt.package_managers.PackageManagerEngine]
+        ] = []
+
+        for (
+            _,
+            package_manager_class,
+        ) in tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.items():
+            if not package_manager_class.bootc_builder:
+                continue
+
+            if self._execute(guest, package_manager_class.probe_command):
+                discovered_package_managers.append(package_manager_class)
+
+        discovered_package_managers.sort(key=lambda pm: pm.probe_priority, reverse=True)
+
+        if discovered_package_managers:
+            guest.debug(
+                'Discovered bootc builders',
+                fmf.utils.listed([pm.NAME for pm in discovered_package_managers]),
+                level=4,
+            )
+
+            return discovered_package_managers[0].NAME
+
+        return None
+
     def _query_has_selinux(self, guest: 'Guest') -> Optional[bool]:
         """
         Detect whether guest uses SELinux.
@@ -728,6 +768,7 @@ class GuestFacts(SerializableContainer):
         self.distro = self._query_distro(guest)
         self.kernel_release = self._query_kernel_release(guest)
         self.package_manager = self._query_package_manager(guest)
+        self.bootc_builder = self._query_bootc_builder(guest)
         self.has_selinux = self._query_has_selinux(guest)
         self.has_systemd = self._query_has_systemd(guest)
         self.is_superuser = self._query_is_superuser(guest)
@@ -754,6 +795,11 @@ class GuestFacts(SerializableContainer):
             'package_manager',
             'package manager',
             self.package_manager if self.package_manager else 'unknown',
+        )
+        yield (
+            'bootc builder',
+            'bootc builder',
+            self.bootc_builder if self.bootc_builder else 'unknown',
         )
         yield 'has_selinux', 'selinux', 'yes' if self.has_selinux else 'no'
         yield 'has_systemd', 'systemd', 'yes' if self.has_systemd else 'no'
@@ -1195,6 +1241,17 @@ class Guest(tmt.utils.Common):
             )
 
         return tmt.package_managers.find_package_manager(self.facts.package_manager)(
+            guest=self, logger=self._logger
+        )
+
+    @functools.cached_property
+    def bootc_builder(
+        self,
+    ) -> 'tmt.package_managers.PackageManager[tmt.package_managers.PackageManagerEngine]':
+        if not self.facts.bootc_builder:
+            raise tmt.utils.GeneralError(f"Bootc builder was not detected on guest '{self.name}'.")
+
+        return tmt.package_managers.find_package_manager(self.facts.bootc_builder)(
             guest=self, logger=self._logger
         )
 


### PR DESCRIPTION
The Fedora CoreOS has moved to `bootc` and that revealed some genuine issues:

1. the container images need to be prepared under `root` user, so they are visible to the `bootc switch` command, which must be run under `root`.

2. the `/tmp` directory used by the test does not persist between reboots, use `/var/tmp` instead.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage