### PR TITLE
Improve the `ansible-not-available` hint detection

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -64,6 +64,7 @@ from tmt.utils import (
     configure_constant,
     effective_workdir_root,
 )
+from tmt.utils.hints import check_for_message, print_hints
 from tmt.utils.wait import Deadline, Waiting
 
 if TYPE_CHECKING:
@@ -2373,9 +2374,10 @@ class GuestSsh(Guest):
                 log=log,
             )
         except tmt.utils.RunError as exc:
-            if "File 'ansible-playbook' not found." in exc.message:
-                from tmt.utils.hints import print_hints
-
+            if check_for_message(
+                patterns=[re.compile("ansible-playbook.*not found")],
+                outputs=[exc.stderr, exc.stdout, exc.message],
+            ):
                 print_hints('ansible-not-available', logger=self._logger)
             raise exc
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, Optional, Union
 
 import tmt
@@ -8,6 +9,7 @@ import tmt.steps.provision
 import tmt.utils
 from tmt.container import container
 from tmt.utils import Command, OnProcessStartCallback, Path, ShellScript
+from tmt.utils.hints import check_for_message, print_hints
 from tmt.utils.wait import Waiting
 
 
@@ -81,9 +83,10 @@ class GuestLocal(tmt.Guest):
             )
             # fmt: on
         except tmt.utils.RunError as exc:
-            if exc.stderr and 'ansible-playbook: command not found' in exc.stderr:
-                from tmt.utils.hints import print_hints
-
+            if check_for_message(
+                patterns=[re.compile("ansible-playbook.*not found")],
+                outputs=[exc.stderr, exc.stdout, exc.message],
+            ):
                 print_hints('ansible-not-available', logger=self._logger)
             raise exc
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -1,4 +1,5 @@
 import os
+import re
 from shlex import quote
 from typing import Any, Optional, Union, cast
 
@@ -11,6 +12,7 @@ import tmt.utils
 from tmt.container import container, field
 from tmt.steps.provision import GuestCapability
 from tmt.utils import Command, OnProcessStartCallback, Path, ShellScript, retry
+from tmt.utils.hints import check_for_message, print_hints
 from tmt.utils.wait import Deadline, Waiting
 
 # Timeout in seconds of waiting for a connection
@@ -360,9 +362,10 @@ class GuestContainer(tmt.Guest):
                 silent=silent,
             )
         except tmt.utils.RunError as exc:
-            if "File 'ansible-playbook' not found." in exc.message:
-                from tmt.utils.hints import print_hints
-
+            if check_for_message(
+                patterns=[re.compile("ansible-playbook.*not found")],
+                outputs=[exc.stderr, exc.stdout, exc.message],
+            ):
                 print_hints('ansible-not-available', logger=self._logger)
             raise exc
 

--- a/tmt/utils/hints.py
+++ b/tmt/utils/hints.py
@@ -25,8 +25,10 @@ on the first line, followed by more details in the rest of the text.
 # raises, providing more info on command-line and in HTML docs.
 
 import functools
+import re
 import textwrap
 from collections.abc import Iterator
+from typing import Optional
 
 import tmt.container
 import tmt.log
@@ -177,3 +179,24 @@ def print_hints(*ids: str, ignore_missing: bool = False, logger: tmt.log.Logger)
 
     for hint in hints:
         logger.info('hint', hint.render(logger), color='blue')
+
+
+def check_for_message(patterns: list[re.Pattern[str]], outputs: list[Optional[str]]) -> bool:
+    """
+    Check one or more output strings for expected error message
+
+    :param patterns: list of regular expressions to be searched for
+    :param outputs: command output strings to be searched
+
+    :returns: true if if any pattern matches any of the provided outputs
+    """
+
+    for output in outputs:
+        if output is None:
+            continue
+
+        for pattern in patterns:
+            if pattern.search(output):
+                return True
+
+    return False


### PR DESCRIPTION
The error messages about the missing `ansible-playbook` command differ, sometimes they are present in the exception message, sometimes in the standard error output. Let's make the detection more robust.

Pull Request Checklist

* [ ] implement the feature