### PR TITLE
Support `bootc` installation for `mrack` plugin

### DIFF
--- a/tests/provision/beaker/bootc.sh
+++ b/tests/provision/beaker/bootc.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "pushd data"
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Check bootc works well"
+        rlRun -s "tmt run --dry plan --name plan/bootc$"
+
+        rlAssertGrep 'ostreecontainer --url quay.io/fedora/custom-bootc:latest' $rlRun_LOG
+        rlAssertGrep 'dummysecret' $rlRun_LOG
+        rlAssertGrep '{"auths": {"quay.io": {"auth": "dummysecret"}}}' $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/provision/beaker/bootc.sh
+++ b/tests/provision/beaker/bootc.sh
@@ -16,6 +16,14 @@ rlJournalStart
         rlAssertGrep '{"auths": {"quay.io": {"auth": "dummysecret"}}}' $rlRun_LOG
     rlPhaseEnd
 
+    rlPhaseStartTest "Check bootc works well through command line"
+        rlRun -s "tmt run --dry -a provision -h beaker --bootc --bootc-image-url quay.io/fedora/custom-bootc:latest --bootc-registry-secret dummysecret"
+
+        rlAssertGrep 'ostreecontainer --url quay.io/fedora/custom-bootc:latest' $rlRun_LOG
+        rlAssertGrep 'dummysecret' $rlRun_LOG
+        rlAssertGrep '{"auths": {"quay.io": {"auth": "dummysecret"}}}' $rlRun_LOG
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
     rlPhaseEnd

--- a/tests/provision/beaker/bootc.sh
+++ b/tests/provision/beaker/bootc.sh
@@ -8,26 +8,26 @@ rlJournalStart
         rlRun "set -o pipefail"
     rlPhaseEnd
 
-    rlPhaseStartTest "Check bootc works well"
+    rlPhaseStartTest "Check bootc works well in plan way"
         rlRun -s "tmt run --dry plan --name plan/bootc$"
-
         rlAssertGrep 'ostreecontainer --url quay.io/fedora/custom-bootc:latest' $rlRun_LOG
-        rlAssertGrep 'dummysecret' $rlRun_LOG
         rlAssertGrep '{"auths": {"quay.io": {"auth": "dummysecret"}}}' $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Check bootc works well through command line"
-        rlRun -s "tmt run --dry -a provision -h beaker --bootc --bootc-image-url quay.io/fedora/custom-bootc:latest --bootc-registry-secret dummysecret"
-
-        rlAssertGrep 'ostreecontainer --url quay.io/fedora/custom-bootc:latest' $rlRun_LOG
-        rlAssertGrep 'dummysecret' $rlRun_LOG
-        rlAssertGrep '{"auths": {"quay.io": {"auth": "dummysecret"}}}' $rlRun_LOG
+        rlRun -s "tmt run --dry -a provision -h beaker --bootc --bootc-image-url dummy.repo/fedora/cli-bootc:latest --bootc-registry-secret dumsecret"
+        rlAssertGrep 'ostreecontainer --url dummy.repo/fedora/cli-bootc:latest' $rlRun_LOG
+        rlAssertGrep '{"auths": {"dummy.repo": {"auth": "dumsecret"}}}' $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Check bootc variables are specified while bootc is disabled"
         rlRun -s "tmt run --dry -a provision -h beaker --bootc-registry-secret dummysecret" 2
-
         rlAssertGrep 'Enable bootc with --bootc, or remove variables: bootc_registry_secret' $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Check bootc-image-url is missing"
+        rlRun -s "tmt run --dry -a provision -h beaker --bootc" 2
+        rlAssertGrep 'bootc configuration incomplete. Missing: bootc_image_url' $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/provision/beaker/bootc.sh
+++ b/tests/provision/beaker/bootc.sh
@@ -24,6 +24,12 @@ rlJournalStart
         rlAssertGrep '{"auths": {"quay.io": {"auth": "dummysecret"}}}' $rlRun_LOG
     rlPhaseEnd
 
+    rlPhaseStartTest "Check bootc variables are specified while bootc is disabled"
+        rlRun -s "tmt run --dry -a provision -h beaker --bootc-registry-secret dummysecret" 2
+
+        rlAssertGrep 'Enable bootc with --bootc, or remove variables: bootc_registry_secret' $rlRun_LOG
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
     rlPhaseEnd

--- a/tests/provision/beaker/data/config/hardware.fmf
+++ b/tests/provision/beaker/data/config/hardware.fmf
@@ -1,8 +1,4 @@
 beaker:
   translations:
     - requirement : cpu.model-name
-      template: |
-        cpu:
-          dummyname:
-            _op: "{{ BEAKER_OPERATOR }}"
-            _value: "{{ BEAKER_VALUE }}"
+      template: '{"cpu": {"dummyname": {"_op": "{{ BEAKER_OPERATOR }}", "_value": "{{ BEAKER_VALUE }}"}}}'

--- a/tests/provision/beaker/data/config/hardware.fmf
+++ b/tests/provision/beaker/data/config/hardware.fmf
@@ -1,4 +1,8 @@
 beaker:
   translations:
     - requirement : cpu.model-name
-      template: '{"cpu": {"dummyname": {"_op": "{{ BEAKER_OPERATOR }}", "_value": "{{ BEAKER_VALUE }}"}}}'
+      template: |
+        cpu:
+          dummyname:
+            _op: "{{ BEAKER_OPERATOR }}"
+            _value: "{{ BEAKER_VALUE }}"

--- a/tests/provision/beaker/data/main.fmf
+++ b/tests/provision/beaker/data/main.fmf
@@ -25,5 +25,5 @@
     provision+:
         bootc: True
         bootc_image_url: quay.io/fedora/custom-bootc:latest
-        bootc_secret: dummysecret
+        bootc_registry_secret: dummysecret
         image: fedora-42

--- a/tests/provision/beaker/data/main.fmf
+++ b/tests/provision/beaker/data/main.fmf
@@ -4,6 +4,9 @@
 
     provision:
         how: beaker
+
+/plan/hardware:
+    provision+:
         hardware:
             cpu:
                 model-name: dummy
@@ -17,3 +20,10 @@
                   driver: foo
               - disk:
                   driver: bar
+
+/plan/bootc:
+    provision+:
+        bootc: True
+        image_url: quay.io/fedora/custom-bootc:latest
+        bootc_secret: dummysecret
+        image: fedora-42

--- a/tests/provision/beaker/data/main.fmf
+++ b/tests/provision/beaker/data/main.fmf
@@ -24,6 +24,6 @@
 /plan/bootc:
     provision+:
         bootc: True
-        image_url: quay.io/fedora/custom-bootc:latest
+        bootc_image_url: quay.io/fedora/custom-bootc:latest
         bootc_secret: dummysecret
         image: fedora-42

--- a/tests/provision/beaker/data/main.fmf
+++ b/tests/provision/beaker/data/main.fmf
@@ -24,6 +24,6 @@
 /plan/bootc:
     provision+:
         bootc: True
-        bootc_image_url: quay.io/fedora/custom-bootc:latest
-        bootc_registry_secret: dummysecret
+        bootc-image-url: quay.io/fedora/custom-bootc:latest
+        bootc-registry-secret: dummysecret
         image: fedora-42

--- a/tests/provision/beaker/data/main.fmf
+++ b/tests/provision/beaker/data/main.fmf
@@ -8,18 +8,19 @@
 /plan/hardware:
     provision+:
         hardware:
-            cpu:
-                model-name: dummy
-                processors: 6
-            or:
-              - device:
-                  driver: ahci
-              - device:
-                  driver: uhci
-              - disk:
-                  driver: foo
-              - disk:
-                  driver: bar
+          and:
+            - cpu:
+                 model-name: dummy
+                 processors: 6
+            - or:
+               - device:
+                   driver: ahci
+               - device:
+                   driver: uhci
+               - disk:
+                   driver: foo
+               - disk:
+                   driver: bar
 
 /plan/bootc:
     provision+:

--- a/tests/provision/beaker/hardware.sh
+++ b/tests/provision/beaker/hardware.sh
@@ -9,7 +9,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Check hardware custom config"
-        rlRun -s "BEAKER_CONF='config/client.conf' TMT_CONFIG_DIR='config' tmt run --dry"
+        rlRun -s "TMT_CONFIG_DIR='config' tmt run --dry plan --name plan/hardware"
 
         rlAssertGrep '<dummyname op="==" value="dummy"/>' $rlRun_LOG
         rlAssertGrep '<key_value key="MODULE" op="==" value="ahci"/>' $rlRun_LOG

--- a/tests/provision/beaker/main.fmf
+++ b/tests/provision/beaker/main.fmf
@@ -1,5 +1,5 @@
-# These tests are manual only for now as they need a running
-# Beaker instance
+# The reconnect tests are manual only for now as they need
+# a running Beaker instance
 /reconnect:
     summary: Verify reconnecting to a provisioned guest
     description:

--- a/tests/provision/beaker/main.fmf
+++ b/tests/provision/beaker/main.fmf
@@ -1,6 +1,6 @@
 # These tests are manual only for now as they need a running
 # Beaker instance
-enabled: false
+enabled: true
 
 /reconnect:
     summary: Verify reconnecting to a provisioned guest

--- a/tests/provision/beaker/main.fmf
+++ b/tests/provision/beaker/main.fmf
@@ -8,6 +8,7 @@ enabled: true
         Make sure that it's possible to reconnect to an already
         provisioned guest using an open tmt run.
     test: ./reconnect.sh
+    enabled: false
 
 /hardware:
     summary: Translate hardware by config tests

--- a/tests/provision/beaker/main.fmf
+++ b/tests/provision/beaker/main.fmf
@@ -1,7 +1,5 @@
 # These tests are manual only for now as they need a running
 # Beaker instance
-enabled: true
-
 /reconnect:
     summary: Verify reconnecting to a provisioned guest
     description:

--- a/tmt/schemas/provision/beaker.yaml
+++ b/tmt/schemas/provision/beaker.yaml
@@ -63,14 +63,11 @@ properties:
   bootc_secret:
     type: string
 
-  image_url:
+  bootc_image_url:
     type: string
 
   bootc:
     type: boolean
-
-  distro_name:
-    type: string
 
 required:
   - how

--- a/tmt/schemas/provision/beaker.yaml
+++ b/tmt/schemas/provision/beaker.yaml
@@ -60,13 +60,16 @@ properties:
   beaker-job-group:
     type: string
 
-  bootc_secret:
+  bootc-secret:
     type: string
 
-  bootc_image_url:
+  bootc-image-url:
     type: string
 
   bootc:
+    type: boolean
+
+  bootc-check-system-url:
     type: boolean
 
 required:

--- a/tmt/schemas/provision/beaker.yaml
+++ b/tmt/schemas/provision/beaker.yaml
@@ -60,7 +60,7 @@ properties:
   beaker-job-group:
     type: string
 
-  bootc-secret:
+  bootc-registry-secret:
     type: string
 
   bootc-image-url:
@@ -70,7 +70,7 @@ properties:
     type: boolean
 
   bootc-check-system-url:
-    type: boolean
+    type: string
 
 required:
   - how

--- a/tmt/schemas/provision/beaker.yaml
+++ b/tmt/schemas/provision/beaker.yaml
@@ -60,5 +60,17 @@ properties:
   beaker-job-group:
     type: string
 
+  bootc_secret:
+    type: string
+
+  image_url:
+    type: string
+
+  bootc:
+    type: boolean
+
+  distro_name:
+    type: string
+
 required:
   - how

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1426,9 +1426,8 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
     @property
     def _bootc_registry_credentials(self) -> dict[str, Any]:
         """Create authentication dictionary with proper credential handling"""
-        if not self.data.bootc_registry_secret:
+        if not self.data.registry_secret or not self.data.bootc_image_url:
             return {}
-        assert self.data.bootc_image_url
         base_repo = _get_registry_from_url(self.data.bootc_image_url)
         # Support multiple registries
         return {"auths": {base_repo: {"auth": self.data.bootc_registry_secret}}}

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1356,20 +1356,17 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
     bootc: bool
     bootc_image_url: Optional[str]
     bootc_check_system_url: Optional[str]
-    registry_secret: Optional[str]
+    bootc_registry_secret: Optional[str]
 
     _api: Optional[BeakerAPI] = None
     _api_timestamp: Optional[datetime.datetime] = None
 
-    def __init__(
-        self,
-        *,
-        data: BeakerGuestData,
-        name: Optional[str] = None,
-        parent: Optional[tmt.utils.Common] = None,
-        logger: tmt.log.Logger,
-    ) -> None:
-        super().__init__(data=data, parent=parent, name=name, logger=logger)
+    def __init__(self, *args: Any, **kwargs: Any):
+        """
+        Make sure that the mrack module is available and imported
+        """
+
+        super().__init__(*args, **kwargs)
 
         assert isinstance(self.parent, tmt.steps.provision.Provision)
         self.mrack_log = f"{self.parent.workdir}/{self.parent.name}-mrack.log"
@@ -1431,11 +1428,11 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
     @property
     def _bootc_registry_credentials(self) -> dict[str, Any]:
         """Create authentication dictionary with proper credential handling"""
-        if not self.registry_secret or not self.bootc_image_url:
+        if not self.bootc_registry_secret or not self.bootc_image_url:
             return {}
         base_repo = _get_registry_from_url(self.bootc_image_url)
         # Support multiple registries
-        return {"auths": {base_repo: {"auth": self.registry_secret}}}
+        return {"auths": {base_repo: {"auth": self.bootc_registry_secret}}}
 
     def start(self) -> None:
         """

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1444,9 +1444,7 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
 
         if self.job_id and self.primary_address:
             return
-        """
-        Create beaker job xml request and submit it to Beaker hub
-        """
+
         tmt_name = self._tmt_name()
         data = CreateJobParameters(
             tmt_name=tmt_name,


### PR DESCRIPTION
Support using users' ready to use image (harness repo added, and required packages installed) to perform bootc installation on beaker.

`bootc_secret`, `distro_name` and `image_url` are needed in all scenarios, `boot_secret` is used for fetching from the  registry, while `distro_name` will be used in beaker installation. This mr also enabled tests/provision/beaker test, as the problem why we disabled it has already been solved with a mrack mr, which was merged and landed a long time ago.

This mr move content of `_create()` into `start()`, so we would leave `start()` after printing the job XML in dry run mode, never reaching the job submission or printing primary address of nonexistent guest.

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note