### PR TITLE
Tweaks of reboot-related logging

### DIFF
--- a/tests/execute/nonroot/test.sh
+++ b/tests/execute/nonroot/test.sh
@@ -9,7 +9,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        if ! rlRun "TMT_SHOW_TRACEBACK=full tmt run -vvvvdddd --id $run"; then
+        if ! rlRun "TMT_SHOW_TRACEBACK=full tmt -vv run --id $run"; then
             rlFileSubmit $run/log.txt
         fi
     rlPhaseEnd

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -2737,6 +2737,8 @@ class GuestSsh(Guest):
 
         current_boot_time = get_boot_time() if fetch_boot_time else 0
 
+        self.debug(f"Triggering reboot with '{action}'.")
+
         try:
             action()
 

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -706,12 +706,9 @@ class GuestArtemis(tmt.GuestSsh):
                 fetch_boot_time=False,
             )
 
-        actual_command = command or tmt.steps.DEFAULT_REBOOT_COMMAND
-        self.debug(f"Reboot using the command '{actual_command}'.")
-
         return super().reboot(
             hard=False,
-            command=actual_command,
+            command=command,
             waiting=waiting,
         )
 

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -1247,6 +1247,8 @@ class GuestTestcloud(tmt.GuestSsh):
                 waiting=waiting,
             )
 
+        self.debug("Soft reboot using the testcloud API.")
+
         if self._instance is None:
             raise tmt.utils.ProvisionError("No instance initialized.")
 


### PR DESCRIPTION
* core code should mention it is now going to trigger a reboot and with what action;
* `artemis` was duplicating output and deciding the reboot command, that is guaranteed by `Guest.reboot()` already;
* `virtual` did not log its soft-reboot code path;
* dropping the increased verbosity in /tests/execute/nonroot that was needed to debug bootc vs VM reboot.

Pull Request Checklist

* [x] implement the feature