### PR TITLE
Refine the description of the `TMT_TREE` variable

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -525,7 +525,7 @@ during ``prepare``, ``execute`` and ``finish`` steps:
 TMT_TREE
     The full path of the working directory where the metadata tree
     is copied. This usually contains the whole git repository where
-    tmt plans are located in. Notice that it might not contain tmt 
+    tmt plans are located in. Notice that it might not contain tmt
     tests if tmt plans and tests are in different git repositories.
 
 TMT_PLAN_DATA

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -524,8 +524,9 @@ during ``prepare``, ``execute`` and ``finish`` steps:
 
 TMT_TREE
     The full path of the working directory where the metadata tree
-    is copied. This usually contains the whole git repository from
-    which tests have been executed.
+    is copied. This usually contains the whole git repository where
+    tmt plans are located in. Notice that it might not contain tmt 
+    tests if tmt plans and tests are in different git repositories.
 
 TMT_PLAN_DATA
     Path to the common directory used for storing logs and other


### PR DESCRIPTION
When tmt plans and tests are in different git repos, the path of TMT_TREE may not contain the files from tests repo. Refine the description to make it more precise.

Pull Request Checklist

* [ ] implement the feature
* [x] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
