### PR TITLE
Add support for custom retries when attempting to stop testcloud VM

### DIFF
--- a/tmt/schemas/provision/virtual.yaml
+++ b/tmt/schemas/provision/virtual.yaml
@@ -55,5 +55,11 @@ properties:
   role:
     $ref: "/schemas/common#/definitions/role"
 
+  stop-retries:
+    type: number
+
+  stop-retry-delay:
+    type: number
+
 required:
   - how


### PR DESCRIPTION
The default number of retries seem to be too low in some conditions, namely when bootc package manager builds new derived images & attempts to reboot the guest for changes to take effect.

Pull Request Checklist

* [x] implement the feature