### PR TITLE
Fix typos in `kickstart` metadata in the provisioning guide

### DIFF
--- a/spec/plans/provision/kickstart.fmf
+++ b/spec/plans/provision/kickstart.fmf
@@ -70,8 +70,7 @@ example:
                 %post
                 systemctl disable firewalld
                 %end
-            metadata: |
-                "no-autopart harness=restraint"
+            metadata: "no_autopart harness=restraint"
             kernel-options: "ksdevice=eth1"
             kernel-options-post: "quiet"
 


### PR DESCRIPTION

The previous example code included spurious quotes and a typo in the `no_autopart` kickstart metadata specification.  This commit fixes the example by moving the metadata specification to a single line and correcting said typo.

Pull Request Checklist

* [ ] implement the feature
* [x] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
