### PR TITLE
Move the alternative `where` key definition to deferred stories

### DIFF
--- a/spec/plans/discover.fmf
+++ b/spec/plans/discover.fmf
@@ -107,6 +107,7 @@ description: |
 
 /where:
     summary: Execute tests on selected guests
+
     description: |
         In the :ref:`/spec/plans/provision/multihost` scenarios it
         is often necessary to execute test code on selected guests
@@ -114,31 +115,27 @@ description: |
         The ``where`` key allows to select guests where the tests
         should be executed by providing their ``name`` or the
         ``role`` they play in the scenario. Use a list to specify
-        multiple names or roles. By default, when the ``where`` key
-        is not defined, tests are executed on all provisioned
+        multiple names or roles. By default, when the ``where``
+        key is not defined, tests are executed on all provisioned
         guests.
-
-        There is also an alternative to the syntax using a ``where``
-        dictionary encapsulating the ``discover`` config under keys
-        corresponding to guest names or roles. This can result in
-        much more concise config especially when defining several
-        shell scripts for each guest or role.
 
     example:
       - |
-        # Run different script for each guest or role
+        # Run a different script for each guest or role
         discover:
-            how: shell
+          - how: shell
+            where: client
             tests:
               - name: run-the-client-code
                 test: client.py
-                where: client
+          - how: shell
+            where: server
+            tests:
               - name: run-the-server-code
                 test: server.py
-                where: server
 
       - |
-        # Filter different set of tests for each guest or role
+        # Filter different sets of tests for each guest or role
         discover:
           - how: fmf
             filter: tag:client-tests
@@ -147,35 +144,6 @@ description: |
             filter: tag:server-tests
             where: server
 
-      - |
-        # Alternative syntax using the 'where' dictionary
-        # encapsulating for tests defined by fmf
-        discover:
-            where:
-                client:
-                  - how: fmf
-                    filter: tag:client-tests
-                server:
-                  - how: fmf
-                    filter: tag:server-tests
-
-      - |
-        # Alternative syntax using the 'where' dictionary
-        # encapsulating for shell script tests
-        discover:
-            where:
-                server:
-                    how: shell
-                    tests:
-                      - test: first server script
-                      - test: second server script
-                      - test: third server script
-                client:
-                    how: shell
-                    tests:
-                      - test: first client script
-                      - test: second client script
-                      - test: third client script
     link:
       - implemented-by: /tmt/steps
       - verified-by: /tests/multihost/complete

--- a/stories/deferred/where.fmf
+++ b/stories/deferred/where.fmf
@@ -1,0 +1,41 @@
+summary: An alternative syntax for the ``where`` key
+
+story:
+    As a user I want a bit more concise way to define which tests
+    should run on which guest.
+
+description:
+    This is an alternative syntax proposed for the ``where`` key
+    which uses a dictionary encapsulating the ``discover`` config
+    under keys corresponding to guest names or roles. This can
+    result in much more concise config especially when defining
+    several shell scripts for each guest or role.
+
+example:
+  - |
+    # Filter discovered fmf tests by tag
+    discover:
+        where:
+            client:
+              - how: fmf
+                filter: tag:client-tests
+            server:
+              - how: fmf
+                filter: tag:server-tests
+
+  - |
+    # Directly define tests as shell scripts
+    discover:
+        where:
+            server:
+                how: shell
+                tests:
+                  - test: server-script-one.sh
+                  - test: server-script-two.sh
+                  - test: server-script-three.sh
+            client:
+                how: shell
+                tests:
+                  - test: client-script-one.sh
+                  - test: client-script-two.sh
+                  - test: client-script-three.sh


### PR DESCRIPTION
The original draft of the `where` key specification in #1606 contained and alternative syntax which was never implemented and thus is confusing to the users. Let's move it to the deferred stories for now. We can return to the idea later if there is enough interest for that approach.

Pull Request Checklist

* [x] update the specification