### PR TITLE
Refactor get_url_content

### DIFF
--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1587,7 +1587,7 @@ class GuestLogBeaker(tmt.steps.provision.GuestLog):
         :returns: content of the log, or ``None`` if the log cannot be retrieved.
         """
         try:
-            return tmt.utils.get_url_content(self.url)
+            return tmt.utils.get_url_content(self.url, verify=False)
         except Exception as error:
             logger.warning(f'Failed to fetch log: {error}')
             return None

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -79,6 +79,7 @@ if TYPE_CHECKING:
     from tmt.hardware import Size
 
 
+
 def sanitize_string(text: str) -> str:
     """Remove invalid Unicode characters from a string"""
     try:
@@ -5527,20 +5528,23 @@ def retry(
     raise RetryError(label, causes=exceptions)
 
 
-def get_url_content(url: str) -> str:
+def get_url_content(url: str, verify: Optional[bool] = True) -> str:
     """
     Get content of a given URL as a string
     """
 
     try:
         with retry_session() as session:
+            if not verify:
+                session.verify = False
+                urllib3.disable_warnings()
             response = session.get(url)
 
             if response.ok:
                 return response.text
 
     except Exception as error:
-        raise GeneralError(f"Could not open url '{url}'.") from error
+        raise GeneralError(f"Could not open url '{url}'.\n{error}") from error
 
     raise GeneralError(f"Could not open url '{url}'.")
 


### PR DESCRIPTION
This improve it in two ways:
 1. Add a verify param so users could download their trusted content, instead of getting the certificate verify failed error.
 2. show the error to users, if the download failed,so they could get a clue how to fix the problem.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
