### PR TITLE
Support `--dry` option in the `bootc` provision plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,8 @@ TMT_TEST_CONTAINER_IMAGES := $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/alpine:late
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/40/unprivileged:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/ubi/8/upstream:latest \
                              $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/ubuntu/22.04/upstream:latest \
-                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/debian/12.7/upstream:latest
+                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/debian/12.7/upstream:latest \
+                             $(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/latest/bootc:latest
 
 # The list of targets building individual tmt test images.
 TMT_TEST_IMAGES_TARGETS := $(foreach image,$(TMT_TEST_CONTAINER_IMAGES),images/test/$(subst :,\:,$(image)))
@@ -255,6 +256,8 @@ $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/ubuntu/2
 $(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/debian/12.7/upstream\:latest:
 	$(call build-test-container-image,$@,debian/12.7/Containerfile.upstream)
 
+$(TMT_TEST_IMAGE_TARGET_PREFIX)/$(TMT_TEST_CONTAINER_IMAGE_NAME_PREFIX)/fedora/latest/bootc\:latest:
+	$(call build-test-container-image,$@,fedora/latest/bootc/Containerfile)
 ##
 ## Development
 ##

--- a/containers/fedora/latest/bootc/Containerfile
+++ b/containers/fedora/latest/bootc/Containerfile
@@ -1,0 +1,7 @@
+#
+# A Fedora bootc image tailored for tmt test suite
+#
+# tmt/container/test/fedora/latest/bootc:latest
+#
+
+FROM quay.io/fedora/fedora-bootc:latest

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -13,6 +13,8 @@ what YAML allows. These keys are always ignored by ``tmt lint``.
 See the :ref:`/spec/core/extra` key specification for details and
 examples.
 
+Added ``--dry`` option for the :ref:`/plugins/provision/bootc` plugin.
+
 
 tmt-1.49.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/images.sh
+++ b/tests/images.sh
@@ -148,7 +148,7 @@ function test_phase_prefix () {
 
 # Building of container images
 function build_container_image () {
-    if [ "$PROVISION_HOW" != "container" ]; then
+    if [ "$PROVISION_HOW" != "container" -a "$PROVISION_HOW" != "bootc" ]; then
         rlLogInfo "Skipping the build of $1 container image because of PROVISION_HOW=$PROVISION_HOW"
         return
     fi

--- a/tests/provision/bootc/test.sh
+++ b/tests/provision/bootc/test.sh
@@ -12,7 +12,7 @@ rlJournalStart
         rlRun "mkdir -p /var/tmp/tmt"
         rlRun "run=\$(mktemp -d --tmpdir=/var/tmp/tmt)" 0 "Create run directory"
         rlRun "dry_run=\$(mktemp -d --tmpdir=/var/tmp/tmt)" 0 "Create dry run directory"
-        rlRun "dry_run_image='quay.io/fedora/fedora-bootc:41'" 0 "Create dry run directory"
+        rlRun "dry_run_image='quay.io/fedora/fedora-bootc:41'" 0 "Set dry run container image"
         rlRun "pushd data"
         rlRun "df -h" 0 "Check available disk space"
     rlPhaseEnd

--- a/tests/provision/bootc/test.sh
+++ b/tests/provision/bootc/test.sh
@@ -11,8 +11,16 @@ rlJournalStart
         # in the podman machine mount
         rlRun "mkdir -p /var/tmp/tmt"
         rlRun "run=\$(mktemp -d --tmpdir=/var/tmp/tmt)" 0 "Create run directory"
+        rlRun "dry_run=\$(mktemp -d --tmpdir=/var/tmp/tmt)" 0 "Create dry run directory"
         rlRun "pushd data"
         rlRun "df -h" 0 "Check available disk space"
+    rlPhaseEnd
+    # This test must be ran first, or podman machine and container image will exist.
+    rlPhaseStartTest "Test dry run for bootc works as expected"
+        rlRun -s "tmt -vvv run --dry --scratch -i $dry_run plan --name /plans/containerfile/includes-deps"
+	rlRun "ls $dry_run/plans/containerfile/includes-deps/provision/default-0/ | grep qcow2" "1"
+	rlRun "podman machine ls  | grep podman-machine-tmt" "1"
+	rlRun "podman inspect fedora-bootc:41" "125"
     rlPhaseEnd
 
     rlPhaseStartTest "Image that needs dependencies"

--- a/tests/provision/bootc/test.sh
+++ b/tests/provision/bootc/test.sh
@@ -12,15 +12,17 @@ rlJournalStart
         rlRun "mkdir -p /var/tmp/tmt"
         rlRun "run=\$(mktemp -d --tmpdir=/var/tmp/tmt)" 0 "Create run directory"
         rlRun "dry_run=\$(mktemp -d --tmpdir=/var/tmp/tmt)" 0 "Create dry run directory"
+        rlRun "dry_run_image='quay.io/fedora/fedora-bootc:41'" 0 "Create dry run directory"
         rlRun "pushd data"
         rlRun "df -h" 0 "Check available disk space"
     rlPhaseEnd
+
     # This test must be ran first, or podman machine and container image will exist.
     rlPhaseStartTest "Test dry run for bootc works as expected"
-        rlRun -s "tmt -vvv run --dry --scratch -i $dry_run plan --name /plans/containerfile/includes-deps"
-	rlRun "ls $dry_run/plans/containerfile/includes-deps/provision/default-0/ | grep qcow2" "1"
-	rlRun "podman machine ls  | grep podman-machine-tmt" "1"
-	rlRun "podman inspect fedora-bootc:41" "125"
+        rlRun -s "tmt -vvv run --dry --scratch -i $dry_run provision -h bootc --container-image $dry_run_image"
+        rlRun "ls $dry_run/plans/containerfile/includes-deps/provision/default-0/ | grep qcow2" "1"
+        rlRun "podman machine ls  | grep podman-machine-tmt" "1"
+        rlRun "podman inspect fedora-bootc:41" "125"
     rlPhaseEnd
 
     rlPhaseStartTest "Image that needs dependencies"
@@ -69,6 +71,7 @@ rlJournalStart
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $run" 0 "Remove run directory"
+        rlRun "rm -r $dry_run" 0 "Remove dry run directory"
         rlRun "podman rmi $IMAGE_INCLUDES_DEPS" 0,1
         rlRun "podman rmi $IMAGE_NEEDS_DEPS" 0,1
     rlPhaseEnd

--- a/tests/provision/bootc/test.sh
+++ b/tests/provision/bootc/test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 . /usr/share/beakerlib/beakerlib.sh || exit 1
+. ../../images.sh || exit 1
 
 IMAGE_NEEDS_DEPS="localhost/tmt-bootc-needs-deps"
 IMAGE_INCLUDES_DEPS="localhost/tmt-bootc-includes-deps"
@@ -12,17 +13,17 @@ rlJournalStart
         rlRun "mkdir -p /var/tmp/tmt"
         rlRun "run=\$(mktemp -d --tmpdir=/var/tmp/tmt)" 0 "Create run directory"
         rlRun "dry_run=\$(mktemp -d --tmpdir=/var/tmp/tmt)" 0 "Create dry run directory"
-        rlRun "dry_run_image='quay.io/fedora/fedora-bootc:41'" 0 "Set dry run container image"
         rlRun "pushd data"
         rlRun "df -h" 0 "Check available disk space"
+        build_container_image "fedora/latest/bootc\:latest"
     rlPhaseEnd
 
     # This test must be ran first, or podman machine and container image will exist.
     rlPhaseStartTest "Test dry run for bootc works as expected"
-        rlRun -s "tmt -vvv run --dry --scratch -i $dry_run provision -h bootc --container-image $dry_run_image"
+        rlRun -s "tmt -vvv run --dry --scratch -i $dry_run provision -h bootc --container-image $TEST_IMAGE_PREFIX/fedora/latest/bootc:latest"
         rlRun "ls $dry_run/plans/containerfile/includes-deps/provision/default-0/ | grep qcow2" "1"
         rlRun "podman machine ls  | grep podman-machine-tmt" "1"
-        rlRun "podman inspect fedora-bootc:41" "125"
+        rlRun "podman images | grep localhost/tmtmodified" "1"
     rlPhaseEnd
 
     rlPhaseStartTest "Image that needs dependencies"

--- a/tmt/steps/provision/bootc.py
+++ b/tmt/steps/provision/bootc.py
@@ -71,23 +71,24 @@ class GuestBootc(GuestTestcloud):
         self._rootless = rootless
 
     def remove(self) -> None:
-        if self._instance:
-            tmt.utils.Command("podman", "rmi", self.containerimage).run(
-                cwd=self.workdir,
-                stream_output=True,
-                logger=self._logger,
-                env=PODMAN_ENV if self._rootless else None,
+        if not self._instance:
+            return
+        tmt.utils.Command("podman", "rmi", self.containerimage).run(
+            cwd=self.workdir,
+            stream_output=True,
+            logger=self._logger,
+            env=PODMAN_ENV if self._rootless else None,
+        )
+        try:
+            tmt.utils.Command("podman", "machine", "rm", "-f", PODMAN_MACHINE_NAME).run(
+                cwd=self.workdir, stream_output=True, logger=self._logger
             )
-            try:
-                tmt.utils.Command("podman", "machine", "rm", "-f", PODMAN_MACHINE_NAME).run(
-                    cwd=self.workdir, stream_output=True, logger=self._logger
-                )
-            except BaseException:
-                self._logger.debug(
-                    "Unable to remove podman machine '{PODMAN_MACHINE_NAME}', it might not exist."
-                )
+        except BaseException:
+            self._logger.debug(
+                "Unable to remove podman machine '{PODMAN_MACHINE_NAME}', it might not exist."
+            )
 
-            super().remove()
+        super().remove()
 
 
 @container


### PR DESCRIPTION
Diffrent from virtual plugin, bootc plugin do many work, _build_bootc_disk for instance, before self._guest.start(), we need to check is_dry_run on all places where it takes real action and prevent it to do so.

Fixes #3750.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
