### PR TITLE
Import `mrack` when the `GuestBeaker` instance is created

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -20,6 +20,10 @@ new tmt command would then spawn its own and conflict with the forgotten
 one. tmt no longer leaves the SSH master process running, preventing the
 issue.
 
+An issue in the :ref:`/plugins/provision/beaker` provision plugin
+prevented reconnecting to running guests. This has been fixed so
+now it's possible to fully work with existing tmt runs as well.
+
 
 tmt-1.48.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/provision/beaker/main.fmf
+++ b/tests/provision/beaker/main.fmf
@@ -1,6 +1,17 @@
-summary: translate hardware by config tests
-description:
-    Verify translate hardware constraints using custom config works well,
-    and override the default translations.
-test: ./hardware.sh
+# These tests are manual only for now as they need a running
+# Beaker instance
 enabled: false
+
+/reconnect:
+    summary: Verify reconnecting to a provisioned guest
+    description:
+        Make sure that it's possible to reconnect to an already
+        provisioned guest using an open tmt run.
+    test: ./reconnect.sh
+
+/hardware:
+    summary: Translate hardware by config tests
+    description:
+        Verify translate hardware constraints using custom config
+        works well, and override the default translations.
+    test: ./hardware.sh

--- a/tests/provision/beaker/reconnect.sh
+++ b/tests/provision/beaker/reconnect.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "run=\$(mktemp -d)" 0 "Create a run directory"
+        rlRun "tmp=\$(mktemp -d)" 0 "Create a tmp directory"
+        rlRun "pushd $tmp"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun "tmt run --id $run provision --how beaker"
+        rlRun "tmt run --id $run login --command 'echo ok'"
+        rlRun "tmt run --id $run finish"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlGetTestState || rlFileSubmit "$run/log.txt"
+        rlRun "rm -r $run $tmp" 0 "Remove testing directories"
+    rlPhaseEnd
+rlJournalEnd

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1207,6 +1207,16 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
     _api: Optional[BeakerAPI] = None
     _api_timestamp: Optional[datetime.datetime] = None
 
+    def __init__(self, *args: Any, **kwargs: Any):
+        """
+        Make sure that the mrack module is available and imported
+        """
+
+        super().__init__(*args, **kwargs)
+
+        assert isinstance(self.parent, tmt.steps.provision.Provision)
+        import_and_load_mrack_deps(self.parent.workdir, self.parent.name, self._logger)
+
     @property
     def api(self) -> BeakerAPI:
         """
@@ -1214,10 +1224,6 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
         """
 
         def _construct_api() -> tuple[BeakerAPI, datetime.datetime]:
-            assert self.parent is not None
-
-            import_and_load_mrack_deps(self.parent.workdir, self.parent.name, self._logger)
-
             return BeakerAPI(self), datetime.datetime.now(datetime.timezone.utc)
 
         if self._api is None:


### PR DESCRIPTION
Let's perform the conditional `mrack` import when a new `GuestBeaker` instance is being created. In this way we ensure that the functionality will be available for all its methods. Included a simple manual test for now.

Fix #3716.
Fix #3659.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [x] include a release note