### PR TITLE
Add a linter for ReST docstrings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -211,3 +211,20 @@ repos:
             tmt/steps/execute/scripts/.*\.sh\.j2|
             tmt/templates/.*
           )$
+
+  - repo: https://github.com/pycqa/flake8
+    rev: "7.2.0"
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-rst-docstrings
+        args:
+          - '--select'
+          - 'RST'
+          # The following are just a subset of what Sphinx defines.
+          # Listing them for flake8-rst-docstrings, in the future we
+          # may need to add more as needed.
+          - '--rst-roles'
+          - 'py:class,py:attr,py:func,py:meth,py:exc,py:mod,py:const,py:data,py:member,ref'
+          - '--rst-directives'
+          - 'versionadded,versionchanged'

--- a/examples/plugins/provision.py
+++ b/examples/plugins/provision.py
@@ -124,7 +124,7 @@ class GuestExample(tmt.Guest):
     """
     Guest provisioned for test execution
 
-    The following keys are expected in the 'data' dictionary::
+    The following keys are expected in the 'data' dictionary:
 
     guest ...... hostname or ip address
     port ....... port to connect to

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -1693,7 +1693,7 @@ def _parse_block(spec: Spec) -> BaseConstraint:
 
     :param spec: raw constraint block specification.
     :returns: block representation as :py:class:`BaseConstraint` or one of its
-    subclasses.
+        subclasses.
     """
 
     if 'and' in spec:

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -71,7 +71,7 @@ class Path(click.ParamType):
         The ``param`` and ``ctx`` arguments may be ``None`` in certain
         situations, such as when converting prompt input.
 
-        If the value cannot be converted, call :meth:`fail` with a
+        If the value cannot be converted, call :py:meth:`fail` with a
         descriptive message.
 
         :param value: The value to convert.

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1535,7 +1535,7 @@ class Guest(tmt.utils.Common):
 
         A rather thin wrapper of :py:meth:`run` whose purpose is to be a single
         point through all commands related to a guest must go through. We expect
-        consistent logging from such commands, be it an ``ansible-playbook`
+        consistent logging from such commands, be it an ``ansible-playbook``
         running on the control host or a test script on the guest.
 
         :param command: a command to execute.

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -571,13 +571,11 @@ class Environment(dict[str, EnvVarValue]):
         ``.env``-like files are supported.
 
         .. code-block:: bash
-           :caption: dotenv file example
 
            A=B
            C=D
 
         .. code-block:: yaml
-           :caption: YAML file example
 
            A: B
            C: D
@@ -656,13 +654,11 @@ class Environment(dict[str, EnvVarValue]):
         Files should be in YAML format (``.yaml`` or ``.yml`` suffixes), or in dotenv format.
 
         .. code-block:: bash
-           :caption: dotenv file example
 
            A=B
            C=D
 
         .. code-block:: yaml
-           :caption: YAML file example
 
            A: B
            C: D

--- a/tmt/utils/hints.py
+++ b/tmt/utils/hints.py
@@ -159,22 +159,22 @@ HINTS: dict[str, Hint] = {
 }
 
 
-def register_hint(id_: str, hint: str) -> None:
+def register_hint(hint_id: str, hint: str) -> None:
     """
     Register a hint for users.
 
-    :param id_: step name for step-specific hints,
+    :param hint_id: step name for step-specific hints,
         ``<step name>/<plugin name>`` for plugin-specific hints,
         or an arbitrary string.
     :param hint: a hint to register.
     """
 
-    if id_ in HINTS:
+    if hint_id in HINTS:
         raise tmt.utils.GeneralError(
-            f"Registering hint '{id_}' collides with an already registered hint."
+            f"Registering hint '{hint_id}' collides with an already registered hint."
         )
 
-    HINTS[id_] = Hint(id_, hint)
+    HINTS[hint_id] = Hint(hint_id, hint)
 
 
 def get_hints(*ids: str, ignore_missing: bool = False) -> list[Hint]:
@@ -214,26 +214,26 @@ def get_hints(*ids: str, ignore_missing: bool = False) -> list[Hint]:
 
 
 @overload
-def get_hint(id_: str, ignore_missing: Literal[True]) -> Optional[Hint]:
+def get_hint(hint_id: str, ignore_missing: Literal[True]) -> Optional[Hint]:
     pass
 
 
 @overload
-def get_hint(id_: str, ignore_missing: Literal[False]) -> Hint:
+def get_hint(hint_id: str, ignore_missing: Literal[False]) -> Hint:
     pass
 
 
-def get_hint(id_: str, ignore_missing: bool = False) -> Optional[Hint]:
+def get_hint(hint_id: str, ignore_missing: bool = False) -> Optional[Hint]:
     """
     Return hint for the provided identifier
 
-    :param id_: Hint identifier.
+    :param hint_id: Hint identifier.
     :param ignore_missing: If not set, non-existent hint will raise an
         exception. Otherwise, non-existent hint will be skipped.
     :returns: Hint if found, None otherwise.
     """
 
-    hints = get_hints(id_, ignore_missing=ignore_missing)
+    hints = get_hints(hint_id, ignore_missing=ignore_missing)
 
     return hints[0] if hints else None
 

--- a/tmt/utils/signals.py
+++ b/tmt/utils/signals.py
@@ -97,7 +97,7 @@ def _quit_tmt(logger: tmt.log.Logger, repeated: bool = False) -> NoReturn:
 
 def _interrupt_handler(signum: int, frame: Optional[FrameType]) -> None:
     """
-    A signal handler for signals that interrupt tmt, ``SIGINT`` and ``SIGTERM`.
+    A signal handler for signals that interrupt tmt, ``SIGINT`` and ``SIGTERM``.
 
     :param signum: delivered signal.
     :param frame: stack frame active when the signal was received.


### PR DESCRIPTION
Powered by flake8-rst-docstrings plugin, it's a flake8 with limited configuration and restricted to just the docstrings. I was unable to find another linter, and ruff does not offer this functionality.

Pull Request Checklist

* [x] implement the feature