### PR TITLE
Extend timeout for a couple of slow tests

### DIFF
--- a/tests/prepare/freeze/test.sh
+++ b/tests/prepare/freeze/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
     rlPhaseEnd
     rlPhaseStartTest
         # Timeout large enough to boot the VM
-        rlRun "rlWatchdog \"rlRun 'tmt run -vfi $tmp' 2\" 60"
+        rlRun "rlWatchdog \"rlRun 'tmt run -vfi $tmp' 2\" 120"
         # ^ exitcode has to be 2 (prepare failed)
         rlAssertGrep 'status:.*done' "$tmp/plan/provision/step.yaml"
         rlAssertGrep 'status:.*todo' "$tmp/plan/prepare/step.yaml"

--- a/tests/provision/bootc/main.fmf
+++ b/tests/provision/bootc/main.fmf
@@ -4,4 +4,4 @@ tag+:
   - provision-bootc
 require:
   - tmt+provision-virtual
-duration: 60m
+duration: 2h


### PR DESCRIPTION
It already happened several times that the test failed because of the outer beakerlib timeout, still during installing the essential required packages. Let's extend the timeout a bit to give enough time when repositories or network are slow.