### PR TITLE
Run dmesg and coredump commands with `silent=True`

### DIFF
--- a/tests/test/check/test-coredump.sh
+++ b/tests/test/check/test-coredump.sh
@@ -63,8 +63,9 @@ rlJournalStart
             assert_check_result "coredump as an after-test should fail" "fail" "after-test" "/coredump/segfault"
 
             # Verify coredump was captured
-            rlRun find $run/plan/execute/data/guest/default-0/coredump/segfault-1/checks/ -maxdepth 1 \  # grep needed as find returns 0 even without match
-            \( -name 'dump._usr_bin_bash_SIGSEGV_*.core' -o -name 'dump._usr_bin_sleep_SIGSEGV_*.core' \) -print | grep -q .
+            rlRun "find $run/plan/execute/data/guest/default-0/coredump/segfault-1/checks/ -maxdepth 1 \
+                    # grep needed as find returns 0 even without match \
+            \\\( -name 'dump._usr_bin_bash_SIGSEGV_*.core' -o -name 'dump._usr_bin_sleep_SIGSEGV_*.core' \\\) -print | grep -q ."
             rlLogInfo "$(ls -l $run/plan/execute/data/guest/default-0/coredump/segfault-1/checks/)"
         fi
     rlPhaseEnd

--- a/tmt/checks/coredump.py
+++ b/tmt/checks/coredump.py
@@ -78,8 +78,9 @@ class CoredumpCheck(Check):
             guest.execute(
                 ShellScript("mkdir -p /etc/systemd/coredump.conf.d")
                 & ShellScript(
-                    f"echo '{COREDUMP_CONFIG}' > /etc/systemd/coredump.conf.d/50-tmt.conf"
-                )
+                    f"echo '{COREDUMP_CONFIG}' > /etc/systemd/coredump.conf.d/50-tmt.conf",
+                ),
+                silent=True,
             )
             return
         except tmt.utils.RunError:
@@ -93,7 +94,8 @@ class CoredumpCheck(Check):
                     & ShellScript(
                         f"echo '{COREDUMP_CONFIG}' | sudo tee "
                         "/etc/systemd/coredump.conf.d/50-tmt.conf > /dev/null"
-                    )
+                    ),
+                    silent=True,
                 )
                 logger.debug("Configured coredump with sudo")
                 return
@@ -309,7 +311,7 @@ class CoredumpCheck(Check):
                 cmd = f"{sudo_prefix}coredumpctl list --all --no-legend --no-pager"
                 logger.debug("No prior coredumps found, checking all available coredumps")
 
-            output = guest.execute(ShellScript(cmd)).stdout
+            output = guest.execute(ShellScript(cmd), silent=True).stdout
 
             if not output:
                 return []

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -96,7 +96,7 @@ class DmesgCheck(Check):
         if not guest.facts.is_superuser:
             script = tmt.utils.ShellScript(f'sudo {script.to_shell_command()}')
 
-        return guest.execute(script, log=_test_output_logger)
+        return guest.execute(script, log=_test_output_logger, silent=True)
 
     def _save_dmesg(
         self, invocation: 'TestInvocation', event: CheckEvent, logger: tmt.log.Logger


### PR DESCRIPTION
This is to keep it consistent with avc test check and have less noisy output for users by default, especially from coredump, which prints `err: No match found.` when, it passes by not finding any new coredumps.

Was not able to verify or modify tests as even on main branch, running `PROVISION_HOW=virtual ./test-coredump` is completely broken failed shell stuff. (at least for me)

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] mention the version
* [ ] include a release note
