### PR TITLE
Update renovate config, format pre-commig config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,30 +15,32 @@
       "matchManagers": ["github-actions"]
     },
     {
+      "description": "Python upgrade is a false-positive. We have to pull in both 3.x and 3.9 for pre-commit.",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": ["python"],
+      "matchFileNames": ["pre-commit.yml"],
+      "enabled": false
+    },
+    {
       "description": "Group all container image updates into a single PR",
       "groupName": "Container Images",
       "matchDatasources": ["docker"]
     },
     {
-      "description": "Group Python and Pre-commit dependencies together",
-      "groupName": "Python & Pre-commit Dependencies",
-      "matchManagers": ["pep621", "pre-commit"]
+      "description": "Group Pre-commit dependencies together",
+      "groupName": "Pre-commit Dependencies",
+      "matchManagers": ["pre-commit"]
     },
     {
-      "description": "Disable updates for main runtime Python dependencies (pyproject.toml [project].dependencies)",
+      "description": "Disable all python dependencies. Specific matchers will be used.",
       "matchManagers": ["pep621"],
-      "matchDepTypes": ["dependencies"],
       "enabled": false
     },
     {
-      "description": "Disable updates for Python interpreter as we use lowest available on supported distros",
-      "matchPackageNames": ["python"],
-      "enabled": false
-    },
-    {
-      "description": "Allow updates for documentation dependencies",
+      "description": "Group documentation dependencies together",
+      "groupName": "Documentation Dependencies",
       "matchManagers": ["pep621"],
-      "matchDepTypes": ["optionalDependencies"],
+      "matchDepTypes": ["project.optional-dependencies"],
       "enabled": true,
       "matchPackageNames": [
         "/renku-sphinx-theme/",
@@ -48,9 +50,10 @@
       ]
     },
     {
-      "description": "Allow updates for development dependencies (pyproject.toml [tool.hatch.envs.dev].dependencies)",
+      "description": "Group hatch dev dependencies together",
+      "groupName": "hatch dev Dependencies",
       "matchManagers": ["pep621"],
-      "matchDepTypes": ["devDependencies"],
+      "matchDepTypes": ["tool.hatch.envs.dev"],
       "enabled": true
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
     ":semanticCommitsDisabled"
   ],
   "separateMajorMinor": false,
+  "configMigration": true,
   "packageRules": [
     {
       "description": "Group all GitHub Actions updates into a single PR",
@@ -37,14 +38,14 @@
     {
       "description": "Allow updates for documentation dependencies",
       "matchManagers": ["pep621"],
-      "matchPackagePatterns": [
-        "renku-sphinx-theme",
-        "sphinx",
-        "readthedocs-sphinx-ext",
-        "docutils"
-      ],
       "matchDepTypes": ["optionalDependencies"],
-      "enabled": true
+      "enabled": true,
+      "matchPackageNames": [
+        "/renku-sphinx-theme/",
+        "/sphinx/",
+        "/readthedocs-sphinx-ext/",
+        "/docutils/"
+      ]
     },
     {
       "description": "Allow updates for development dependencies (pyproject.toml [tool.hatch.envs.dev].dependencies)",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,9 +22,10 @@
       "enabled": false
     },
     {
-      "description": "Group all container image updates into a single PR",
+      "description": "Disabled because it breaks folder structure, and need to be more selective.",
       "groupName": "Container Images",
-      "matchDatasources": ["docker"]
+      "matchDatasources": ["docker"],
+      "enabled": false
     },
     {
       "description": "Group Pre-commit dependencies together",
@@ -55,18 +56,6 @@
       "matchManagers": ["pep621"],
       "matchDepTypes": ["tool.hatch.envs.dev"],
       "enabled": true
-    },
-    {
-      "description": "Disable ALL updates for CentOS base images, as we are using major version tags",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["quay.io/centos/centos"],
-      "enabled": false
-    },
-    {
-      "description": "Disable ALL updates for Fedora base images",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["quay.io/fedora/fedora"],
-      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,20 +1,68 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"packageRules": [
-		{
-			"groupName": "CI and devDependencies",
-			"matchManagers": ["github-actions", "pre-commit"]
-		},
-		{
-			"groupName": "Runtime and test",
-			"matchManagers": ["pep621"]
-		}
-	],
-	"separateMajorMinor": false,
-	"extends": [
-		"config:recommended",
-		"schedule:weekly",
-		":enablePreCommit",
-		":semanticCommitTypeAll(chore)"
-	]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "schedule:weekly",
+    ":enablePreCommit",
+    ":semanticCommitsDisabled"
+  ],
+  "separateMajorMinor": false,
+  "packageRules": [
+    {
+      "description": "Group all GitHub Actions updates into a single PR",
+      "groupName": "GitHub Actions",
+      "matchManagers": ["github-actions"]
+    },
+    {
+      "description": "Group all container image updates into a single PR",
+      "groupName": "Container Images",
+      "matchDatasources": ["docker"]
+    },
+    {
+      "description": "Group Python and Pre-commit dependencies together",
+      "groupName": "Python & Pre-commit Dependencies",
+      "matchManagers": ["pep621", "pre-commit"]
+    },
+    {
+      "description": "Disable updates for main runtime Python dependencies (pyproject.toml [project].dependencies)",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["dependencies"],
+      "enabled": false
+    },
+    {
+      "description": "Disable updates for Python interpreter as we use lowest available on supported distros",
+      "matchPackageNames": ["python"],
+      "enabled": false
+    },
+    {
+      "description": "Allow updates for documentation dependencies",
+      "matchManagers": ["pep621"],
+      "matchPackagePatterns": [
+        "renku-sphinx-theme",
+        "sphinx",
+        "readthedocs-sphinx-ext",
+        "docutils"
+      ],
+      "matchDepTypes": ["optionalDependencies"],
+      "enabled": true
+    },
+    {
+      "description": "Allow updates for development dependencies (pyproject.toml [tool.hatch.envs.dev].dependencies)",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["devDependencies"],
+      "enabled": true
+    },
+    {
+      "description": "Disable ALL updates for CentOS base images, as we are using major version tags",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["quay.io/centos/centos"],
+      "enabled": false
+    },
+    {
+      "description": "Disable ALL updates for Fedora base images",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["quay.io/fedora/fedora"],
+      "enabled": false
+    }
+  ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
     rev: "v1.15.0"
     hooks:
       - id: mypy
+        language: python # Required for Renovate additional_dependencies
         language_version: "3.9"
         # TODO: find out how to amend mypy, pyright, pre-commit and package requirements.
         # Apparently, there is no easy way to avoid some level of duplication of
@@ -69,6 +70,7 @@ repos:
     rev: v1.1.399
     hooks:
       - id: pyright
+        language: python # Required for Renovate additional_dependencies
         language_version: "3.9"
         # TODO: find out how to amend mypy, pyright, pre-commit and package requirements.
         # Apparently, there is no easy way to avoid some level of duplication of
@@ -140,6 +142,7 @@ repos:
     rev: v25.2.1
     hooks:
       - id: ansible-lint
+        language: python # Required for Renovate additional_dependencies
         args:
           - ansible/
           - examples/ansible/
@@ -157,38 +160,40 @@ repos:
     hooks:
       - id: ruff
         args:
-          - '--fix'
-          - '--show-fixes'
+          - "--fix"
+          - "--show-fixes"
       - id: ruff-format
 
   - repo: https://github.com/teemtee/tmt.git
     rev: 1.46.0
     hooks:
       - id: tmt-lint
+        language: python # Required for Renovate additional_dependencies
         additional_dependencies:
-          - "docutils>=0.16"         # 0.16 is the current one available for RHEL9
-          - "packaging>=20"          # 20 seems to be available with RHEL8
+          - "docutils>=0.16" # 0.16 is the current one available for RHEL9
+          - "packaging>=20" # 20 seems to be available with RHEL8
           - "pint<0.20"
           - "pydantic>=1.10.14"
-          - "pygments>=2.7.4"        # 2.7.4 is the current one available for RHEL9
+          - "pygments>=2.7.4" # 2.7.4 is the current one available for RHEL9
           # Help installation by reducing the set of inspected botocore release.
           # There is *a lot* of them, and hatch might fetch many of them.
-          - "botocore>=1.25.10"      # 1.25.10 is the current one available for RHEL9
+          - "botocore>=1.25.10" # 1.25.10 is the current one available for RHEL9
           - "typing-extensions>=4.9.0; python_version < '3.13'"
           - "fmf>=1.6.0"
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:
-          - tomli  # Required for python < 3.11
+          - tomli # Required for python < 3.11
 
   - repo: https://github.com/djlint/djLint
     rev: v1.36.4
     hooks:
       - id: djlint
         files: "\\.j2"
-        types_or: ['jinja']
+        types_or: ["jinja"]
 
   - repo: https://github.com/aristanetworks/j2lint.git
     rev: v1.2.0
@@ -205,7 +210,6 @@ repos:
   - repo: https://github.com/AleksaC/hadolint-py
     rev: v2.12.1b3
     hooks:
-
       - id: hadolint
         files: ^containers/.*
 


### PR DESCRIPTION
Followup from https://github.com/teemtee/tmt/pull/3688

To see the changes that this PR has, see the Renovatebot comment https://github.com/teemtee/tmt/pull/3775#issuecomment-2983253299 n this PR.

Grouping the rules to reduce the amount of PRs.

Deferred updating the containers because it would affect the folder structure

Adding `language: python` to at least see if we could use Renovate for bumping the additional dependencies for pre-commit hooks alongside the identical pyproject.toml. Theoretically it should work, but we should probably strive for removing the duplication somehow anyway.

Spent some time fighting Zed IDE autoformatting the yaml on save and I've ultimately caved in an let it correct inconsistencies.  
It uses prettier in the backend for yaml - I've only added `"singleQuote": false` to the default config to reduce the amount of changes