### PR TITLE
Introduce a new label `ci | skip` for disabling tests

### DIFF
--- a/.github/workflows/doc-tests.yml
+++ b/.github/workflows/doc-tests.yml
@@ -16,6 +16,7 @@ jobs:
   doc-test:
     name: Sphinx Documentation Tests
     runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.labels.*.name, 'ci | skip')"
 
     steps:
       - uses: actions/checkout@v4

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -76,6 +76,13 @@ _:
               tags:
                 BusinessUnit: tmt
 
+  # Core test requires
+  - &require-core-tests
+    require:
+      label:
+        absent:
+          - ci | skip
+
   # Full test requires
   - &require-full-tests
     require:
@@ -84,6 +91,7 @@ _:
           - ci | full test
         absent:
           - status | discuss
+          - ci | skip
 
 
 jobs:
@@ -105,6 +113,7 @@ jobs:
 
   # Test core
   - <<: *test-base
+    <<: *require-core-tests
     targets: *latest-targets
     identifier: core
     tmt_plan: '/plans/features/(core|basic)'

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -526,7 +526,9 @@ Pull Requests
 When submitting a new pull request which is not completely ready
 for merging but you would like to get an early feedback on the
 concept, use the GitHub feature to mark it as a ``Draft`` rather
-than using the ``WIP`` prefix in the summary.
+than using the ``WIP`` prefix in the summary. You might also want
+to assign the ``ci | skip`` label if there's no point in running
+tests yet.
 
 During the pull request review it is recommended to add new
 commits with your changes on the top of the branch instead of


### PR DESCRIPTION
For very early drafts it might not make any sense to run test coverage. Adding the `ci | skip` label to the pull request will turn off any testing until the pull request draft is ready.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation