### PR TITLE
Use the `fedora-bootc:latest` image in the `bootc` test

### DIFF
--- a/tests/provision/bootc/data/includes-deps.containerfile
+++ b/tests/provision/bootc/data/includes-deps.containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-bootc:42
+FROM quay.io/fedora/fedora-bootc:latest
 
 RUN dnf -y install cloud-init rsync vim && \
     ln -s ../cloud-init.target /usr/lib/systemd/system/default.target.wants && \

--- a/tests/provision/bootc/data/includes-deps.containerfile
+++ b/tests/provision/bootc/data/includes-deps.containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-bootc:41
+FROM quay.io/fedora/fedora-bootc:42
 
 RUN dnf -y install cloud-init rsync vim && \
     ln -s ../cloud-init.target /usr/lib/systemd/system/default.target.wants && \


### PR DESCRIPTION
The fix for a recent issue has been released in `fedora-bootc:42`. Let's use `fedora-bootc:latest` instead, so that we don't have to update the versions every half a year.

Related: https://github.com/bootc-dev/bootc/issues/1308