### PR TITLE
Add example for sharing tests across repositories

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -536,6 +536,49 @@ the :ref:`/spec/plans/discover` step:
         how: fmf
         url: https://src.fedoraproject.org/rpms/tmt/
 
+.. _share-tests-across-repositories:
+
+Share Tests Across Repositories
+------------------------------------------------------------------
+
+It is often beneficial to share tests across different projects or repositories.
+This promotes reusability and reduces duplication of test code. TMT facilitates
+this by allowing you to discover tests from remote Git repositories.
+
+To include tests from another repository, you can add another configuration
+to your ``discover`` step in the plan. This configuration will specify the
+URL of the remote repository and, optionally, a specific revision or branch.
+
+Here's an example of how you might configure your plan to pull tests from an
+external repository:
+
+.. code-block:: yaml
+
+    discover:
+      - name: local-tests
+        how: fmf
+        # Assuming your local tests are in the current repository
+        # and discoverable by fmf.
+      - name: shared-tests
+        how: fmf
+        url: https://github.com/example/shared-tests.git
+        # Optionally, specify a branch, tag, or commit hash
+        ref: main
+        # You can also filter which tests to include from the shared repository
+        filter: "tag:smoke"
+
+In this example:
+
+- The ``local-tests`` configuration discovers tests from the current repository as usual.
+- The ``shared-tests`` configuration fetches tests from the ``https://github.com/example/shared-tests.git``
+  repository.
+  - The ``ref: main`` line ensures that tests are fetched from the ``main`` branch of the shared repository.
+  - The ``filter: "tag:smoke"`` line demonstrates how you can select specific tests (e.g., those tagged with "smoke")
+    from the shared repository.
+
+All discovered tests, both local and shared, will be available for execution in subsequent steps of your plan.
+You can then select them using their FMF names as usual.
+
 
 Extend Steps
 ------------------------------------------------------------------

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -572,9 +572,9 @@ In this example:
 - The ``local-tests`` configuration discovers tests from the current repository as usual.
 - The ``shared-tests`` configuration fetches tests from the ``https://github.com/example/shared-tests.git``
   repository.
-  - The ``ref: main`` line ensures that tests are fetched from the ``main`` branch of the shared repository.
-  - The ``filter: "tag:smoke"`` line demonstrates how you can select specific tests (e.g., those tagged with "smoke")
-    from the shared repository.
+   - The ``ref: main`` line ensures that tests are fetched from the ``main`` branch of the shared repository.
+   - The ``filter: "tag:smoke"`` line demonstrates how you can select specific tests (e.g., those tagged with "smoke")
+     from the shared repository.
 
 All discovered tests, both local and shared, will be available for execution in subsequent steps of your plan.
 You can then select them using their FMF names as usual.


### PR DESCRIPTION
This commit introduces a new section to the examples documentation, specifically detailing how to share tests across different repositories using tmt.

The new section, "Share Tests Across Repositories", is added to `docs/examples.rst` and includes:
- An introduction to the concept of sharing tests.
- An example `discover` step configuration in a tmt plan that demonstrates fetching tests from an external Git repository.
- An explanation of the example, including how to specify repository URL, revision (ref), and test filters.

This addresses the documentation request in issue #1721, focusing on the "sharing tests across repositories" aspect.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
