### PR TITLE
Add `pending` result outcome to `reportportal` plugin

### DIFF
--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -414,6 +414,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
         ResultOutcome.WARN: "FAILED",
         ResultOutcome.ERROR: "FAILED",
         ResultOutcome.SKIP: "SKIPPED",
+        ResultOutcome.PENDING: "SKIPPED",
     }
 
     def handle_response(self, response: requests.Response) -> None:


### PR DESCRIPTION
This PR adds the missing `pending` result outcome to the reportportal plugin.

Fixes: #3773 

Pull Request Checklist

* [x] implement the feature
