### PR TITLE
Do not run tests against `fedora-rawhide`

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,7 +22,7 @@ actions: &base-actions
     - hatch version
 
 targets: &all-targets
-  - fedora-all
+  - fedora-stable
   - epel-9
 
 # Uncomment below line if OpenScanHub scans are failing


### PR DESCRIPTION
Several times already we've run into issues which are out of our scope, breakages we often cannot influence and they are just slowing us down. Let's skip rawhide builds for now.