### PR TITLE
Refactoring task queue, part 1

### DIFF
--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -248,9 +248,7 @@ class Finish(tmt.steps.Step):
                 sync_with_guests(
                     self,
                     'pull',
-                    PullTask(
-                        logger=self._logger, guests=guest_copies, source=self.plan.data_directory
-                    ),
+                    PullTask(guest_copies, self.plan.data_directory, self._logger),
                     self._logger,
                 )
 

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -406,9 +406,7 @@ class Prepare(tmt.steps.Step):
             guest_copies.append(guest_copy)
 
         if guest_copies:
-            sync_with_guests(
-                self, 'push', PushTask(logger=self._logger, guests=guest_copies), self._logger
-            )
+            sync_with_guests(self, 'push', PushTask(guest_copies, self._logger), self._logger)
 
             # To separate "push" from "prepare" queue visually
             self.info('')
@@ -497,9 +495,7 @@ class Prepare(tmt.steps.Step):
             sync_with_guests(
                 self,
                 'pull',
-                PullTask(
-                    logger=self._logger, guests=guest_copies, source=self.plan.data_directory
-                ),
+                PullTask(guest_copies, self.plan.data_directory, self._logger),
                 self._logger,
             )
 


### PR DESCRIPTION
This is a part of longer series or changes aiming at cleaner implementation, allowing for better visibility for type checkers and developers, and reuse of code by future parallelization code.

* task classes are no longer `@container`s - it not necessary, and makes some code simpler (no need to override `__init__`, for example).
* extracted two common tasks into helpers: extracting outcome of a task, and running task for a set of "units" (guests, phases).
* propagate return values of tasks.
* more docstrings.

Pull Request Checklist

* [x] implement the feature