### PR TITLE
Emit a more specific warning when a hardware constraint is not supported

### DIFF
--- a/tests/unit/test_hardware.py
+++ b/tests/unit/test_hardware.py
@@ -371,12 +371,11 @@ def test_report_support(
     caplog: _pytest.logging.LogCaptureFixture,
 ) -> None:
     # Spec to test against
-    hw_spec = """
+    hw = parse_hw("""
      or:
        - memory: '>= 4 GB'
        - memory: '!= 4 GB'
-    """
-    hw = parse_hw(hw_spec)
+    """)
 
     # For testing purposes we are saying ">=" is the only valid operator.
     def _test_check(constraint: tmt.hardware.Constraint) -> bool:

--- a/tmt/hardware.py
+++ b/tmt/hardware.py
@@ -1789,9 +1789,7 @@ class Hardware(SpecBasedContainer[Spec, Spec]):
                 if name in names or f'{name}.{child_name}' in names or check(constraint):
                     continue
 
-                logger.warning(
-                    f"Hardware requirement '{constraint.printable_name}' is not supported."
-                )
+                logger.warning(f"Hardware requirement '{constraint}' is not supported.")
 
     def format_variants(self) -> Iterator[str]:
         """


### PR DESCRIPTION
Include the full hardware constraint in the warning when it is not supported.

Add a unit test to verify the more detailed warning message.

Fix #3812.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
