### PR TITLE
Mention the public tmt web service instance

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -816,6 +816,15 @@ user. How to obtain this token is described `here
 manage-api-tokens-for-your-atlassian-account/#Create-an-API-token>`_
 (please note that this can vary if you use custom Jira instance).
 
+Once the link is attached to the respective Jira, clicking on it
+will take you to the tmt web service with test or plan details.
+Here's an example `test`__ and `plan`__. It is also possible to
+reference both `test and plan`__ in a single link.
+
+__ https://tmt.testing-farm.io/?test-url=https%3A%2F%2Fgithub.com%2Fteemtee%2Ftmt.git&test-name=%2Ftests%2Fcore%2Fescaping&test-ref=main
+__ https://tmt.testing-farm.io/?plan-url=https%3A%2F%2Fgithub.com%2Fteemtee%2Ftmt.git&plan-name=%2Fplans%2Ffeatures%2Fcore&plan-ref=main
+__ https://tmt.testing-farm.io/?test-url=https%3A%2F%2Fgithub.com%2Fteemtee%2Ftmt.git&test-name=%2Ftests%2Fcore%2Flink&test-ref=main&plan-url=https%3A%2F%2Fgithub.com%2Fteemtee%2Ftmt.git&plan-name=%2Fplans%2Ffeatures%2Fcore&plan-ref=main
+
 .. versionadded:: 1.37
 
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -5,6 +5,15 @@
 ======================
 
 
+tmt-1.52.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A public instance of the tmt web service has been deployed to
+https://tmt.testing-farm.io/ and can be used together with the
+``tmt link`` command to :ref:`link-issues` with related tests and
+plans.
+
+
 tmt-1.51.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
The public instance of the tmt web service has been deployed. Let's mention it in the release notes and add a couple example links so that users can get a better idea of how it looks like.

Pull Request Checklist

* [ ] write the documentation
* [ ] include a release note