### PR TITLE
Allow log selection for `reportportal` plugin

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -8,11 +8,11 @@ tmt-1.52.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :ref:`/plugins/report/reportportal` report plugin now supports
-a new ``upload-log-pattern`` option. This option allows users to select
-which logs should be uploaded by specifying the pattern to search for
-in the log file names. Check result logs are also affected by this
-option but are uploaded only if the check fails or if an error occurs
-during execution.
+a new ``upload-log-pattern`` key. This key allows users to select
+which logs should be uploaded by specifying the pattern to search
+for in the log file names. Check result logs are also affected by
+this key but are uploaded only if the check fails or if an error
+occurs during execution.
 
 
 tmt-1.52.0

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,15 @@
     Releases
 ======================
 
+tmt-1.52.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`/plugins/report/reportportal` report plugin now supports
+a new ``log`` option. This option allows users to select which logs
+should be uploaded by specifying their names. Check result logs are
+also affected by this option but are uploaded only if the check fails
+or if an error occurs during execution.
+
 
 tmt-1.52.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -8,10 +8,11 @@ tmt-1.52.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :ref:`/plugins/report/reportportal` report plugin now supports
-a new ``log`` option. This option allows users to select which logs
-should be uploaded by specifying their names. Check result logs are
-also affected by this option but are uploaded only if the check fails
-or if an error occurs during execution.
+a new ``upload-log-pattern`` option. This option allows users to select
+which logs should be uploaded by specifying the pattern to search for
+in the log file names. Check result logs are also affected by this
+option but are uploaded only if the check fails or if an error occurs
+during execution.
 
 
 tmt-1.52.0

--- a/tmt/schemas/report/reportportal.yaml
+++ b/tmt/schemas/report/reportportal.yaml
@@ -83,7 +83,7 @@ properties:
   link-template:
     type: string
 
-  log:
+  upload-log-pattern:
     $ref: "/schemas/common#/definitions/array_of_strings"
 
   when:

--- a/tmt/schemas/report/reportportal.yaml
+++ b/tmt/schemas/report/reportportal.yaml
@@ -83,6 +83,9 @@ properties:
   link-template:
     type: string
 
+  log:
+    $ref: "/schemas/common#/definitions/array_of_strings"
+
   when:
     $ref: "/schemas/common#/definitions/when"
 

--- a/tmt/schemas/report/reportportal.yaml
+++ b/tmt/schemas/report/reportportal.yaml
@@ -84,7 +84,7 @@ properties:
     type: string
 
   upload-log-pattern:
-    $ref: "/schemas/common#/definitions/array_of_strings"
+    $ref: "/schemas/common#/definitions/one_or_more_strings"
 
   when:
     $ref: "/schemas/common#/definitions/when"

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -628,9 +628,9 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
         Upload all result log files into the ReportPortal instance
         """
 
-        def upload_log(log_path: Path, is_traceback: bool = False) -> None:
+        def upload_log(log_path: Path, is_yaml: bool = False, is_traceback: bool = False) -> None:
             try:
-                if log_path.suffix in ('.yaml', '.yml'):
+                if is_yaml:
                     logs = tmt.utils.yaml_to_list(self.step.plan.execute.read(log_path))
                 else:
                     logs = [self.step.plan.execute.read(log_path)]
@@ -677,7 +677,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
         # Upload failure logs
         if write_out_failures:
             for failure_log in result.failure_logs:
-                upload_log(failure_log, is_traceback=True)
+                upload_log(failure_log, is_yaml=True, is_traceback=True)
 
     def execute_rp_import(self) -> None:
         """

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -648,8 +648,9 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
             )
 
             for log in logs:
-                # Add file name to the log
-                log = f'### `{log_path.name}`\n{log}'
+                # Add file name to the log if it is not a traceback
+                if not is_traceback:
+                    log = f'### `{log_path.name}`\n{log}'
                 # Upload log
                 self.rp_api_post(
                     session=session,

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -649,7 +649,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
 
             for log in logs:
                 # Add file name to the log
-                log = f'# `{log_path.name}`\n{log}'
+                log = f'### `{log_path.name}`\n{log}'
                 # Upload log
                 self.rp_api_post(
                     session=session,

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -648,6 +648,8 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
             )
 
             for log in logs:
+                # Add file name to the log
+                log = f'# `{log_path.name}`\n{log}'
                 # Upload log
                 self.rp_api_post(
                     session=session,

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -70,9 +70,11 @@ def _pattern_list_env_to_default(option: str, default: list[Pattern[str]]) -> li
     env_var = 'TMT_PLUGIN_REPORT_REPORTPORTAL_' + option.upper()
     if env_var not in os.environ or os.getenv(env_var) is None:
         return default
-    return [
-        re.compile(item.strip()) for item in str(os.getenv(env_var)).split(',') if item.strip()
-    ]
+    return tmt.utils.normalize_pattern_list(
+        option,
+        [item.strip() for item in str(os.getenv(env_var)).split(',') if item.strip()],
+        tmt.log.Logger.create(),
+    )
 
 
 def _size_env_to_default(option: str, default: 'Size') -> 'Size':
@@ -321,7 +323,8 @@ class ReportReportPortalData(tmt.steps.report.ReportStepData):
              List of regular expressions to look for in result log names. If any of the
              patterns is found in a log file name, the log will be uploaded to ReportPortal.
              Check result logs will be uploaded only if the check failed or if an error
-             occurred during the execution.
+             occurred during the execution. The search mode is used for pattern matching.
+             See the :ref:`regular-expressions` section for details.
              """,
     )
 

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -73,7 +73,7 @@ def _pattern_list_env_to_default(option: str, default: list[Pattern[str]]) -> li
     return tmt.utils.normalize_pattern_list(
         option,
         [item.strip() for item in str(os.getenv(env_var)).split(',') if item.strip()],
-        tmt.log.Logger.create(),
+        tmt.log.Logger.get_bootstrap_logger(),
     )
 
 


### PR DESCRIPTION
This PR adds a new `upload-log-pattern` key to ReportPortal plugin. This key allows users to select which logs should be uploaded to ReportPortal by specifying the pattern to search for in the log file names. Check result logs are also affected by this key but are uploaded only if the check fails or if an error occurs during execution.

Fixes: #3674 
Fixes: #3820 

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [x] adjust plugin docstring
* [x] modify the json schema
* [ ] mention the version
* [x] include a release note
