### PR TITLE
Use `self.data` instead of `self.opt()` in `fmf` discover

### DIFF
--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -444,7 +444,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
         Enable standalone mode when listing fmf ids
         """
 
-        if self.opt('fmf_id'):
+        if self.data.fmf_id:
             return True
         return super().is_in_standalone_mode
 
@@ -491,7 +491,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
 
         # Raise an exception if --fmf-id uses w/o url and git root
         # doesn't exist for discovered plan
-        if self.opt('fmf_id'):
+        if self.data.fmf_id:
 
             def assert_git_url(plan_name: Optional[str] = None) -> None:
                 try:
@@ -511,7 +511,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             # It covers only one case, when there is:
             # 1) no --url on CLI
             # 2) plan w/o url exists in test run
-            if not self.opt('url'):
+            if not self.data.url:
                 try:
                     fmf_tree = fmf.Tree(os.getcwd())
                 except fmf.utils.RootError:
@@ -548,15 +548,14 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 logger=self._logger,
             )
             git_root = self.testdir
+
         # Copy git repository root to workdir
         else:
             if path is not None:
                 fmf_root: Optional[Path] = path
             else:
                 fmf_root = Path(self.step.plan.node.root)
-            requires_git = self.opt('sync-repo') or any(
-                self.get(opt) for opt in self._REQUIRES_GIT
-            )
+            requires_git = self.data.sync_repo or any(self.get(opt) for opt in self._REQUIRES_GIT)
             # Path for distgit sources cannot be checked until the
             # they are extracted
             if path and not path.is_dir() and not dist_git_source:


### PR DESCRIPTION
Drop the obsolete usage of `self.opt()` for getting values of the discover plugin keys and directly use `self.data` instead. This also fixes the `sync-repo` key to work not only from the command line but from the `fmf` files as well.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
