### PR TITLE
Add submitted files as logs

### DIFF
--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -1185,6 +1185,23 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
         # (e.g. saves them as a tmt subresults).
         return invocation.test.test_framework.extract_results(invocation, results, logger)
 
+    def collect_submitted_files(self, invocation: TestInvocation) -> list[Path]:
+        """
+        Collect paths of all files submitted during test
+        """
+
+        submitted_files = []
+        test_data_dir = invocation.test_data_path
+        submission_log = test_data_dir / "submitted-files.log"
+
+        if submission_log.exists():
+            for line in submission_log.read_text().splitlines():
+                file_path = Path(line)
+                relative_path = invocation.relative_test_data_path / file_path.name
+                submitted_files.append(relative_path)
+
+        return submitted_files
+
     def timeout_hint(self, invocation: TestInvocation) -> None:
         """
         Append a duration increase hint to the test output

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -648,7 +648,12 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         # and it's hard to pick the main one, who knows what custom results might
         # cover, so let's make sure every single result can lead to check results
         # related to its lifetime.
+
+        submitted_files = self.collect_submitted_files(invocation)
+
         for result in invocation.results:
+            if result.name == invocation.test.name:
+                result.log.extend(submitted_files)
             result.check = invocation.check_results
 
         return invocation.results

--- a/tmt/steps/execute/scripts/tmt-file-submit
+++ b/tmt/steps/execute/scripts/tmt-file-submit
@@ -31,3 +31,13 @@ fi
 [ -d "$TMT_TEST_DATA" ] || mkdir -p "$TMT_TEST_DATA"
 cp -f "$FILENAME" "$TMT_TEST_DATA"
 echo "File '$FILENAME' stored to '$TMT_TEST_DATA'."
+
+# Silent skip for journal.xml so it doesn't get saved
+# into submitted-files.log and displayed twice at report
+basename_file=$(basename "$FILENAME")
+if [[ "$basename_file" == "journal.xml" ]]; then
+    exit 0
+fi
+
+# Collecting paths of submitted files into a single log
+echo "$FILENAME" >> "$TMT_TEST_DATA/submitted-files.log"


### PR DESCRIPTION
Fixes https://github.com/teemtee/tmt/issues/2398 

Pull Request Checklist

* [x] implement the feature
* [ ] extend the test coverage
* [ ] adjust plugin docstring
* [ ] include a release note

Should this be covered by tests? Mentioned in the release notes?

Also - while playing with the submitting of files and displaying them, I've found out that journal.xml is copied to $TMT_TEST_DATA from the folder sitting above it. I had to specifically filter this out in the tmt-file-submit script so it wouldn't get displayed at report step twice. Is this behavior intended? 

If not, then moving
```
# Silent skip for journal.xml so it doesn't get saved
# into submitted-files.log and displayed twice at report
basename_file=$(basename "$FILENAME")
if [[ "$basename_file" == "journal.xml" ]]; then
    exit 0
fi
```
above the
```
[ -d "$TMT_TEST_DATA" ] || mkdir -p "$TMT_TEST_DATA"
cp -f "$FILENAME" "$TMT_TEST_DATA"
echo "File '$FILENAME' stored to '$TMT_TEST_DATA'."
```
would fix it.