### PR TITLE
Fix plugin key rendering for sequences

### DIFF
--- a/docs/templates/plugins.rst.j2
+++ b/docs/templates/plugins.rst.j2
@@ -60,8 +60,7 @@
             {% if not actual_default %}
     Default: *not set*
             {% else %}
-    Default: {% for default_item in actual_default %}``{{ default_item.pattern | default(default_item) }}``{% if not loop.last %}, {% endif %}{% endfor %}
-
+    Default: {% for default_item in actual_default %}``{{ default_item.pattern | default(default_item) }}``{% if not loop.last %}, {% endif %}{% endfor +%}
             {% endif %}
         {% elif is_enum(actual_default) %}
     Default: ``{{ actual_default.value }}``

--- a/docs/templates/plugins.rst.j2
+++ b/docs/templates/plugins.rst.j2
@@ -59,8 +59,9 @@
         {% elif actual_default is sequence %}
             {% if not actual_default %}
     Default: *not set*
-        {% else %}
+            {% else %}
     Default: {% for default_item in actual_default %}``{{ default_item.pattern | default(default_item) }}``{% if not loop.last %}, {% endif %}{% endfor %}
+
             {% endif %}
         {% elif is_enum(actual_default) %}
     Default: ``{{ actual_default.value }}``


### PR DESCRIPTION
When a sequence is rendered, a new line is missing after the generated list which results in the environment variable to be concatenated with the default.

Pull Request Checklist

* [x] implement the feature