### PR TITLE
Extract abort-related properties from test invocation

### DIFF
--- a/tmt/checks/internal/abort.py
+++ b/tmt/checks/internal/abort.py
@@ -38,7 +38,7 @@ class Abort(CheckPlugin[AbortCheck]):
         environment: Optional[tmt.utils.Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
-        if invocation.abort_requested and invocation.return_code != ProcessExitCodes.SUCCESS:
+        if invocation.abort.requested and invocation.return_code != ProcessExitCodes.SUCCESS:
             return [CheckResult(name=CHECK_NAME, result=ResultOutcome.FAIL, note=['Test aborted'])]
 
         return []

--- a/tmt/steps/abort.py
+++ b/tmt/steps/abort.py
@@ -1,0 +1,44 @@
+import functools
+
+import tmt.log
+import tmt.steps.scripts
+import tmt.utils
+from tmt.container import container
+from tmt.utils import (
+    Path,
+)
+
+
+class AbortStep(tmt.utils.GeneralError):
+    """
+    Raised by a plugin phases when the entire step should abort.
+    """
+
+
+@container
+class AbortContext:
+    """
+    Provides API for handling a phase-requested abort of a step.
+    """
+
+    #: Path in which the abort request file should be stored.
+    path: Path
+
+    #: Used for logging.
+    logger: tmt.log.Logger
+
+    @functools.cached_property
+    def request_path(self) -> Path:
+        """
+        A path to the abort request file.
+        """
+
+        return self.path / tmt.steps.scripts.TMT_ABORT_SCRIPT.created_file
+
+    @property
+    def requested(self) -> bool:
+        """
+        Whether a testing abort was requested
+        """
+
+        return self.request_path.exists()

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -26,6 +26,7 @@ from tmt.options import option
 from tmt.plugins import PluginRegistry
 from tmt.result import CheckResult, Result, ResultGuestData, ResultInterpret, ResultOutcome
 from tmt.steps import Action, ActionTask, PhaseQueue, PluginTask, Step
+from tmt.steps.abort import AbortContext, AbortStep
 from tmt.steps.discover import Discover, DiscoverPlugin, DiscoverStepData
 from tmt.steps.provision import Guest
 from tmt.utils import (
@@ -96,14 +97,6 @@ class ExecuteStepData(tmt.steps.WhereableStepData, tmt.steps.StepData):
 
 
 ExecuteStepDataT = TypeVar('ExecuteStepDataT', bound=ExecuteStepData)
-
-
-class AbortExecute(tmt.utils.GeneralError):
-    """
-    Raised by ``execute`` phases when the entire step should abort.
-    """
-
-    pass
 
 
 @container
@@ -214,14 +207,6 @@ class TestInvocation:
 
         return self.test_data_path / tmt.steps.scripts.TMT_REBOOT_SCRIPT.created_file
 
-    @functools.cached_property
-    def abort_request_path(self) -> Path:
-        """
-        A path to the abort request file
-        """
-
-        return self.test_data_path / tmt.steps.scripts.TMT_ABORT_SCRIPT.created_file
-
     @property
     def soft_reboot_requested(self) -> bool:
         """
@@ -251,14 +236,6 @@ class TestInvocation:
         return self.return_code in self.test.restart_on_exit_code
 
     @property
-    def abort_requested(self) -> bool:
-        """
-        Whether a testing abort was requested
-        """
-
-        return self.abort_request_path.exists()
-
-    @property
     def is_guest_healthy(self) -> bool:
         """
         Whether the guest is deemed to be healthy and responsive.
@@ -277,6 +254,14 @@ class TestInvocation:
             return False
 
         return True
+
+    @functools.cached_property
+    def abort(self) -> AbortContext:
+        """
+        Abort context for this invocation.
+        """
+
+        return AbortContext(path=self.test_data_path, logger=self.logger)
 
     def handle_restart(self) -> bool:
         """
@@ -1289,7 +1274,7 @@ class Execute(tmt.steps.Step):
                 # Special exception serving as a signal to not run any more phases.
                 # Not necessarily a failed task calling for the final exception
                 # to be raised, crashing the whole run.
-                if isinstance(outcome.exc, AbortExecute):
+                if isinstance(outcome.exc, AbortStep):
                     break
 
                 failed_tasks.append(outcome)

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -18,9 +18,9 @@ from tmt.checks import CheckPlugin
 from tmt.container import container, field
 from tmt.result import Result, ResultOutcome
 from tmt.steps import safe_filename
+from tmt.steps.abort import AbortStep
 from tmt.steps.execute import (
     TEST_OUTPUT_FILENAME,
-    AbortExecute,
     TestInvocation,
 )
 from tmt.steps.provision import Guest
@@ -696,7 +696,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         # via `self.results`, to signal abort we need a bigger gun. Once
         # we get back to refactoring the plugin, this would turn into a
         # better way of transporting "plugin outcome" back to the step.
-        abort_execute_exception: Optional[AbortExecute] = None
+        abort_execute_exception: Optional[AbortStep] = None
 
         with UpdatableMessage(self) as progress_bar:
             while index < len(test_invocations):
@@ -750,7 +750,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                             result.result = ResultOutcome.ERROR
                             result.note.append('reboot timeout')
 
-                if invocation.abort_requested:
+                if invocation.abort.requested:
                     for result in invocation.results:
                         # In case of aborted all results in list will be aborted
                         result.note.append('aborted')
@@ -766,7 +766,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                     variables={'PROGRESS': f'[{progress}]'},
                 ).print_results(invocation.results)
 
-                abort_execute = invocation.abort_requested or (
+                abort_execute = invocation.abort.requested or (
                     self.data.exit_first
                     and any(
                         result.result in (ResultOutcome.FAIL, ResultOutcome.ERROR)
@@ -775,13 +775,13 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                 )
 
                 if abort_execute:
-                    if invocation.abort_requested:
+                    if invocation.abort.requested:
                         abort_message = f'Test {test.name} aborted, stopping execution.'
 
                     else:
                         abort_message = f'Test {test.name} failed, stopping execution.'
 
-                    abort_execute_exception = AbortExecute(abort_message)
+                    abort_execute_exception = AbortStep(abort_message)
 
                     progress_bar.clear()
 


### PR DESCRIPTION
A standalone class grouping abort-related properties is born instead, and the test invocation class contains its instance.

Eventually, new class should be more involved in handling of `tmt-abort` calls on tmt side, and should be composable with other tmt code that runs user-provided code - `shell` and `ansible` plugins of `prepare` and `finish` steps.

Part of #902 - an experiment of sorts, because "reboot context" needs to be extracted from test invocation, so its code could be used in `prepare` and `finish` as well. The issue does not consider abort as interesting as reboots, but it's a similar concept, so starting with smaller class first, to see how it goes.

Pull Request Checklist

* [x] implement the feature