### PR TITLE
Raise duration for execute/{basic,duration}

### DIFF
--- a/tests/execute/basic/main.fmf
+++ b/tests/execute/basic/main.fmf
@@ -1,4 +1,5 @@
 summary: Check that test status is correctly reported
+duration: 20m
 tag+:
   - beakerlib
   - provision-connect

--- a/tests/execute/duration/main.fmf
+++ b/tests/execute/duration/main.fmf
@@ -1,5 +1,5 @@
 summary: Verify that the test duration is correctly handled
-duration: 20m
+duration: 30m
 tag+:
   - provision-container
   - provision-virtual


### PR DESCRIPTION
Hitting in CI timeouts in both tests. Try to raise the timeout to see if reproducible also with longer duration.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
