### PR TITLE
Unify Finish `shell` and Prepare `shell` plugins by sharing logic implementation

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -633,6 +633,10 @@ TMT_PREPARE_SHELL_URL_REPOSITORY
     The value of the repository path in prepare shell step when ``url``
     option is used.
 
+TMT_FINISH_SHELL_URL_REPOSITORY
+    The value of the repository path in finish shell step when ``url``
+    option is used.
+
 .. _test-variables:
 
 Test Variables

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -13,9 +13,10 @@ limit for each test.
 The provision plugins now support setting an ``environment`` key.
 See the documentation of :ref:`/plugins/provision`.
 
-The finish :ref:`/plugins/finish/shell` plugin now supports ``url`` and
-``ref`` options, so finish scripts can be fetched directly from
-remote git repositories.
+The finish :ref:`/plugins/finish/shell` plugin now shares the
+implementation with the prepare :ref:`/plugins/prepare/shell` plugin,
+so does the functionalities. As part of this change ``url`` and ``ref``
+keys, are straightforward included.
 
 
 tmt-1.54.0

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -13,6 +13,10 @@ limit for each test.
 The provision plugins now support setting an ``environment`` key.
 See the documentation of :ref:`/plugins/provision`.
 
+The finish :ref:`/plugins/finish/shell` plugin now supports ``url`` and
+``ref`` options, so finish scripts can be fetched directly from
+remote git repositories.
+
 
 tmt-1.54.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -15,8 +15,8 @@ See the documentation of :ref:`/plugins/provision`.
 
 The finish :ref:`/plugins/finish/shell` plugin now shares the
 implementation with the prepare :ref:`/plugins/prepare/shell` plugin,
-so does the functionalities. As part of this change ``url`` and ``ref``
-keys, are straightforward included.
+so do the functionalities. As part of this change ``url`` and ``ref``
+keys, are now included.
 
 
 tmt-1.54.0

--- a/tests/prepare/shell/data/url.fmf
+++ b/tests/prepare/shell/data/url.fmf
@@ -10,6 +10,6 @@ execute:
     script: tmt --help
 finish:
     how: shell
-    url: https://github.com/teemtee/tests
+    url: https://github.com/teemtee/try
     ref: main
-    script: cd $TMT_FINISH_SHELL_URL_REPOSITORY/scripts && ./hello.sh
+    script: cd $TMT_FINISH_SHELL_URL_REPOSITORY && ls

--- a/tests/prepare/shell/data/url.fmf
+++ b/tests/prepare/shell/data/url.fmf
@@ -8,3 +8,8 @@ prepare:
 execute:
     how: tmt
     script: tmt --help
+finish:
+    how: shell
+    url: https://github.com/teemtee/tests
+    ref: main
+    script: cd $TMT_FINISH_SHELL_URL_REPOSITORY/scripts && ./hello.sh

--- a/tests/prepare/shell/test.sh
+++ b/tests/prepare/shell/test.sh
@@ -21,8 +21,9 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Remote Script"
-        rlRun -s "tmt -vvv run provision prepare cleanup plan -n url" 0 "Prepare using a remote script"
-        rlAssertGrep "Hello world" "$rlRun_LOG"
+        rlRun -s "tmt -vvv run provision prepare finish cleanup plan -n url" 0 "Prepare using a remote script"
+        rlAssertGrep "Hello world" "$rlRun_LOG" #check for the prepare script
+        rlAssertGrep "third" "$rlRun_LOG" # check for the finish script
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -27,17 +27,16 @@ class FinishShell(tmt.steps.finish.FinishPlugin[tmt.steps.finish.FinishStepData]
     Scripts can also be fetched from a remote git repository.
     Specify the ``url`` for the repository and optionally ``ref``
     to checkout a specific branch, tag or commit.
-    The ``script`` paths will then be treated as relative to the
-    repository root.
+    ``TMT_PREPARE_SHELL_URL_REPOSITORY`` will hold the value of the
+    repository path.
 
     .. code-block:: yaml
 
         finish:
             how: shell
             url: https://github.com/teemtee/tmt.git
-            ref: my_branch
-            script:
-              - tmt/steps/finish/script.sh
+            ref: main
+            script: cd $TMT_PREPARE_SHELL_URL_REPOSITORY && make docs
 
     Use the :ref:`/spec/core/order` attribute to select in which order
     finishing tasks should happen if there are multiple configs. Default

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -57,6 +57,21 @@ class FinishShell(tmt.steps.finish.FinishPlugin[FinishShellData]):
               - upload-logs.sh || true
               - rm -rf /tmp/temporary-files
 
+    Scripts can also be fetched from a remote git repository.
+    Specify the ``url`` for the repository and optionally ``ref``
+    to checkout a specific branch, tag or commit.
+    The ``script`` paths will then be treated as relative to the
+    repository root.
+
+    .. code-block:: yaml
+
+        finish:
+            how: shell
+            url: https://github.com/teemtee/tmt.git
+            ref: my_branch
+            script:
+              - tmt/steps/finish/script.sh
+
     Use the :ref:`/spec/core/order` attribute to select in which order
     finishing tasks should happen if there are multiple configs. Default
     order is ``50``.

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -5,9 +5,7 @@ from tmt.steps.prepare.shell import PrepareShell
 
 
 @tmt.steps.provides_method('shell')
-class FinishShell(
-    tmt.steps.finish.FinishPlugin[tmt.steps.finish.FinishStepData], PrepareShell
-):
+class FinishShell(tmt.steps.finish.FinishPlugin[tmt.steps.finish.FinishStepData], PrepareShell):
     """
     Perform finishing tasks using shell (bash) scripts.
 

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -27,7 +27,7 @@ class FinishShell(tmt.steps.finish.FinishPlugin[tmt.steps.finish.FinishStepData]
     Scripts can also be fetched from a remote git repository.
     Specify the ``url`` for the repository and optionally ``ref``
     to checkout a specific branch, tag or commit.
-    ``TMT_PREPARE_SHELL_URL_REPOSITORY`` will hold the value of the
+    ``TMT_FINISH_SHELL_URL_REPOSITORY`` will hold the value of the
     repository path.
 
     .. code-block:: yaml
@@ -36,12 +36,14 @@ class FinishShell(tmt.steps.finish.FinishPlugin[tmt.steps.finish.FinishStepData]
             how: shell
             url: https://github.com/teemtee/tmt.git
             ref: main
-            script: cd $TMT_PREPARE_SHELL_URL_REPOSITORY && make docs
+            script: cd $TMT_FINISH_SHELL_URL_REPOSITORY && make docs
 
     Use the :ref:`/spec/core/order` attribute to select in which order
     finishing tasks should happen if there are multiple configs. Default
     order is ``50``.
     """
+
+    _cloned_repo_path_envvar_name = "TMT_FINISH_SHELL_URL_REPOSITORY"
 
     # We are reusing "prepare" step for "finish",
     # and they both have different expectations

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -120,11 +120,13 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
         overview = fmf.utils.listed(self.data.script, 'script')
         logger.info('overview', f'{overview} found', 'green')
 
-        workdir = self.step.plan.worktree
-        assert workdir is not None  # narrow type
+        worktree = self.step.plan.worktree
+        assert worktree is not None  # narrow type
 
         if self.data.url:
-            repo_path = workdir / "repository"
+            assert self.workdir is not None  # narrow type
+
+            repo_path = self.workdir / "repository"
 
             environment[self._cloned_repo_path_envvar_name] = EnvVarValue(repo_path.resolve())
 
@@ -158,7 +160,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
 
             environment.update(
                 topology.push(
-                    dirpath=workdir,
+                    dirpath=worktree,
                     guest=guest,
                     logger=logger,
                     filename_base=safe_filename(
@@ -168,7 +170,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             )
 
         prepare_wrapper_filename = safe_filename(PREPARE_WRAPPER_FILENAME, self, guest)
-        prepare_wrapper_path = workdir / prepare_wrapper_filename
+        prepare_wrapper_path = worktree / prepare_wrapper_filename
 
         logger.debug('prepare wrapper', prepare_wrapper_path, level=3)
 
@@ -189,6 +191,6 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
                 command = tmt.utils.ShellScript(f'sudo -E {prepare_wrapper_path}')
             else:
                 command = tmt.utils.ShellScript(f'{prepare_wrapper_path}')
-            guest.execute(command=command, cwd=workdir, env=environment)
+            guest.execute(command=command, cwd=worktree, env=environment)
 
         return outcome

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -37,9 +37,8 @@ class PrepareShellData(tmt.steps.prepare.PrepareStepData):
         metavar='REPOSITORY',
         help="""
             URL of a repository to clone. It will be pushed to guests before
-            running any scripts,
-            and environment variable ``TMT_PREPARE_SHELL_URL_REPOSITORY`` will
-            hold its path on the guest.
+            running any scripts, the path on the guest will be stored in
+            a step variable.
             """,
     )
 


### PR DESCRIPTION
Related: #3640.

The finish `shell` plugin is going to reuse the implementation of prepare `shell` developed in https://github.com/teemtee/tmt/pull/3862, this way all the functionalities are now unified, for example the new `url` and `ref ` implementations.

Pull Request Checklist

* [x] implement the feature
* [x] adjust plugin docstring
* [x] include a release note
