### PR TITLE
Improve setting FIPS mode by explicitly setting crypto-policy

### DIFF
--- a/tmt/steps/prepare/feature/fips-enable.yaml
+++ b/tmt/steps/prepare/feature/fips-enable.yaml
@@ -65,6 +65,12 @@
           changed_when: output.rc == 0
           when: ansible_architecture == "s390x"
 
+    - name: Enable FIPS Policy
+      ansible.builtin.command: update-crypto-policies --set FIPS
+      register: output
+      changed_when: "'is not sufficient for' in output.stderr"
+      when: ansible_distribution_major_version | int == 10
+
     - name: Enable FIPS mode
       ansible.builtin.command: fips-mode-setup --enable
       environment:
@@ -90,8 +96,6 @@
       changed_when: false
       when: ansible_distribution_major_version | int < 10
 
-    # On RHEL-10, FIPS policy is set by "auto-policy" feature without touching
-    # /etc/crypto-policies/state/current and hence we cannot inspect that file.
     - name: Check that FIPS policy is enabled
       ansible.builtin.shell: test "$(update-crypto-policies --show)" == "FIPS"
       changed_when: false


### PR DESCRIPTION
Enhances the robustness of FIPS mode implementation by moving from a reliance on the systemd/dracut-configured auto-policy to an explicit configuration of the FIPS crypto-policy.

While the existing approach correctly enables FIPS mode, it depends on the system's automatic policy selection safeguard mechanism that's there to prevent accidental misconfiguration. This change makes the resulting FIPS configuration more resilient to potential changes or inconsistencies in the auto-policy safeguard behavior.

By directly setting the FIPS crypto-policy, we ensure a more predictable and secure state.

Pull Request Checklist

* [x] implement the feature