### PR TITLE
Handle `pydantic` compatibility, enable `fedora-rawhide` back

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -24,7 +24,7 @@ actions: &base-actions
     - hatch version
 
 targets: &all-targets
-  - fedora-stable
+  - fedora-all
   - epel-9
 
 # Uncomment below line if OpenScanHub scans are failing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -445,6 +445,7 @@ builtins-ignorelist = ["help", "format", "input", "filter", "copyright", "max"]
 "dataclasses.dataclass".msg = "Use tmt.container.container instead."
 "dataclasses.field".msg = "Use tmt.container.field instead."
 "click.style".msg = "Use tmt.log.style instead."
+"annotationlib".msg = "Use tmt._compat.annotationlib instead"
 
 [tool.ruff.lint.flake8-type-checking]
 runtime-evaluated-base-classes = ["tmt.config.models.BaseConfig"]

--- a/tests/pip/install.fmf
+++ b/tests/pip/install.fmf
@@ -5,6 +5,11 @@ require:
     - python3
     - python3-devel
 tier: null
+adjust+:
+  - when: distro == fedora-rawhide
+    enabled: false
+    because: |
+      Python 3.14 wheels for lxml and pydantic are not available yet
 
 /mini:
     summary: Ensure the minimal pip install works

--- a/tests/precommit/main.fmf
+++ b/tests/precommit/main.fmf
@@ -4,3 +4,9 @@ require:
 - git-core
 - tmt
 tier: 4
+
+adjust+:
+  - when: distro == fedora-rawhide
+    enabled: false
+    because: |
+      Python 3.14 wheels for pydantic are not available yet

--- a/tests/provision/container/toolbox/main.fmf
+++ b/tests/provision/container/toolbox/main.fmf
@@ -21,3 +21,7 @@ adjust+:
     when: distro >= fedora-41
     because: |
         We are not interested in AVCs for this test due to complicated setup.
+  - when: distro == fedora-rawhide
+    enabled: false
+    because: |
+      Python 3.14 wheels for lxml and pydantic are not available yet

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -38,6 +38,10 @@ require+:
             We want to run this locally and it's enough to execute
             on a single distro when run in the CI. We don't need
             to exercise this again and again across all distros.
+      - when: distro == fedora-rawhide
+        enabled: false
+        because: |
+          Python 3.14 wheels for lxml and pydantic are not available yet
 
     /basic:
         summary: Basic unit tests (development packages)
@@ -67,6 +71,10 @@ require+:
         because: Enable in CI only
 
         enabled: true
+      - when: distro == fedora-rawhide
+        enabled: false
+        because: |
+          Python 3.14 wheels for lxml and pydantic are not available yet
 
     /basic:
         summary: Basic unit tests (system packages)

--- a/tmt/_compat/annotationlib.py
+++ b/tmt/_compat/annotationlib.py
@@ -1,0 +1,37 @@
+import sys
+
+if sys.version_info >= (3, 14):
+    from annotationlib import Format, get_annotations
+else:
+    import enum
+    from collections.abc import Mapping
+    from typing import Any, Optional
+
+    class Format(enum.IntEnum):
+        VALUE = 1
+        VALUE_WITH_FAKE_GLOBALS = 2
+        FORWARDREF = 3
+        STRING = 4
+
+    def get_annotations(
+        obj: Any,
+        *,
+        globals: Optional[dict[str, object]] = None,  # noqa: A002
+        locals: Optional[Mapping[str, object]] = None,  # noqa: A002
+        eval_str: bool = False,
+        format: Format = Format.VALUE,
+    ) -> dict[str, str]:
+        if format != Format.STRING:
+            raise NotImplementedError("Format other than Format.STRING is not backported.")
+        if globals or locals or eval_str:
+            raise NotImplementedError("Other input variables are not implemented.")
+        # Technically we should raise if obj does not have annotations,
+        # but if there are any issues with this it would be caught in the CI
+        ann: dict[str, str] = obj.__dict__.get("__annotations__", {})
+        return ann
+
+
+__all__ = [
+    "Format",
+    "get_annotations",
+]

--- a/tmt/_compat/pydantic.py
+++ b/tmt/_compat/pydantic.py
@@ -1,24 +1,13 @@
 # mypy: disable-error-code="assignment"
 from __future__ import annotations
 
-import pydantic
-
-if pydantic.__version__.startswith('1.'):
-    from pydantic import (
-        BaseModel,
-        Extra,
-        Field,
-        HttpUrl,
-        ValidationError,
-    )
-else:
-    from pydantic.v1 import (  # type: ignore[no-redef]
-        BaseModel,
-        Extra,
-        Field,
-        HttpUrl,
-        ValidationError,
-    )
+from pydantic import (
+    BaseModel,
+    Extra,
+    Field,
+    HttpUrl,
+    ValidationError,
+)
 
 __all__ = [
     "BaseModel",

--- a/tmt/_compat/pydantic.py
+++ b/tmt/_compat/pydantic.py
@@ -1,17 +1,55 @@
 # mypy: disable-error-code="assignment"
 from __future__ import annotations
 
+import importlib.metadata
+
 from pydantic import (
-    BaseModel,
-    Extra,
+    ConfigDict,
     Field,
     HttpUrl,
     ValidationError,
 )
 
+PYDANTIC_VERSION = importlib.metadata.version('pydantic')
+
+PYDANTIC_V1 = PYDANTIC_VERSION.startswith("1.")
+
+if PYDANTIC_V1:
+    from typing import Any
+
+    from pydantic import BaseModel as _BaseModel
+
+    from tmt._compat.typing import Self
+
+    class BaseModel(_BaseModel):
+        @classmethod
+        def model_validate(cls, obj: Any, **kwargs: Any) -> Self:
+            if kwargs:
+                raise NotImplementedError(
+                    "Backport of model_validate to parse_obj does not include kwargs."
+                )
+            return cls.parse_obj(obj)
+
+        def model_dump(self, **kwargs: Any) -> dict[str, Any]:
+            return self.dict(**kwargs)
+
+        @property
+        def model_fields_set(self) -> set[str]:
+            return set(self.__dict__.keys())
+
+        # The names of the model_fields and __fields__ value types are different,
+        # but it shouldn't matter for our implementation so far
+        @property
+        def model_fields(self) -> dict[str, Any]:  # type: ignore[override]
+            return self.__fields__
+
+else:
+    from pydantic import BaseModel
+
 __all__ = [
+    "PYDANTIC_V1",
     "BaseModel",
-    "Extra",
+    "ConfigDict",
     "Field",
     "HttpUrl",
     "ValidationError",

--- a/tmt/config/__init__.py
+++ b/tmt/config/__init__.py
@@ -112,7 +112,7 @@ class Config:
             return None
 
         try:
-            return model.parse_obj(subtree.data)
+            return model.model_validate(subtree.data)
 
         except ValidationError as error:
             raise tmt.utils.SpecificationError(

--- a/tmt/config/models/themes.py
+++ b/tmt/config/models/themes.py
@@ -49,7 +49,7 @@ class _Theme(MetadataContainer):
                 f"No such theme field '{self.__class__.__name__.lower()}.{field}'."
             )
 
-        # Using model_fields is deprecated and will be removed in pyright v3
+        # Using model_fields is deprecated and will be removed in pydantic v3
         # If we can convert this to class method then we can avoid this issue.
         if self.model_fields[field].annotation is not Style:  # pyright: ignore[reportDeprecated]
             raise tmt.utils.GeneralError(

--- a/tmt/config/models/themes.py
+++ b/tmt/config/models/themes.py
@@ -30,7 +30,7 @@ class Style(MetadataContainer):
         Apply this style to a given string.
         """
 
-        return _style(text, **self.dict())
+        return _style(text, **self.model_dump())
 
 
 _DEFAULT_STYLE = Style()
@@ -44,14 +44,14 @@ class _Theme(MetadataContainer):
         A safer, type-annotated variant of ``getattr(theme, field)``.
         """
 
-        if field not in self.__fields__:
+        if field not in self.model_fields_set:
             raise tmt.utils.GeneralError(
                 f"No such theme field '{self.__class__.__name__.lower()}.{field}'."
             )
 
-        # attr-defined: `type_` seems to be invisible to mypy. It might
-        # be causes by Pydantic v1/v2 difference.
-        if self.__fields__[field].type_ is not Style:  # type: ignore[attr-defined]
+        # Using model_fields is deprecated and will be removed in pyright v3
+        # If we can convert this to class method then we can avoid this issue.
+        if self.model_fields[field].annotation is not Style:  # pyright: ignore[reportDeprecated]
             raise tmt.utils.GeneralError(
                 f"Theme field '{self.__class__.__name__.lower()}.{field}' is not a style."
             )
@@ -108,7 +108,7 @@ class Theme(_Theme):
     @classmethod
     def from_spec(cls: type['Theme'], data: Any) -> 'Theme':
         try:
-            return Theme.parse_obj(data)
+            return Theme.model_validate(data)
 
         except ValidationError as error:
             raise tmt.utils.SpecificationError("Invalid theme configuration.") from error

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -68,6 +68,7 @@ from ruamel.yaml.representer import Representer
 from urllib3.response import HTTPResponse
 
 import tmt.log
+from tmt._compat.annotationlib import Format, get_annotations
 from tmt._compat.pathlib import Path
 from tmt._compat.typing import ParamSpec
 from tmt.container import container
@@ -5463,7 +5464,7 @@ class NormalizeKeysMixin(_CommonBase):
             if klass is Common:
                 return
 
-            for name, value in klass.__dict__.get('__annotations__', {}).items():
+            for name, value in get_annotations(klass, format=Format.STRING).items():
                 # Skip special fields that are not keys.
                 if name in (
                     '_KEYS_SHOW_ORDER',


### PR DESCRIPTION
Introduce a compatibility layer for `pydantic` so that we can use both `v1` and `v2`. Thanks to this we can enable `fedora-rawhide` jobs again as `v2` will be used there which is working nicely with Python 3.14.

Related bugs:

 * pydantic: https://bugzilla.redhat.com/show_bug.cgi?id=2372054
 * tmt fails to install: https://bugzilla.redhat.com/show_bug.cgi?id=2372233

Reverts: #3816
Fixes: #3918