### PR TITLE
Fix anonymous links, definition lists and link anchors in ReST

### DIFF
--- a/tmt/utils/rest.py
+++ b/tmt/utils/rest.py
@@ -310,6 +310,12 @@ class RestVisitor(docutils.nodes.NodeVisitor):
     visit_reference = _noop_visit
     depart_reference = _noop_departure
 
+    visit_target = _noop_visit
+    depart_target = _noop_departure
+
+    visit_block_quote = _noop_visit
+    depart_block_quote = _noop_visit
+
     def _visit_admonition(self, node: docutils.nodes.Admonition, header: str) -> None:
         self.log_visit(node)
 

--- a/tmt/utils/rest.py
+++ b/tmt/utils/rest.py
@@ -314,7 +314,19 @@ class RestVisitor(docutils.nodes.NodeVisitor):
     depart_target = _noop_departure
 
     visit_block_quote = _noop_visit
-    depart_block_quote = _noop_visit
+    depart_block_quote = _noop_departure
+
+    visit_definition_list = _noop_visit
+    depart_definition_list = _noop_departure
+
+    visit_definition_list_item = _noop_visit
+    depart_definition_list_item = _noop_departure
+
+    visit_term = _noop_visit
+    depart_term = _noop_departure
+
+    visit_definition = _noop_visit
+    depart_definition = _noop_departure
 
     def _visit_admonition(self, node: docutils.nodes.Admonition, header: str) -> None:
         self.log_visit(node)

--- a/tmt/utils/rest.py
+++ b/tmt/utils/rest.py
@@ -333,12 +333,12 @@ class RestVisitor(docutils.nodes.NodeVisitor):
         self.log_visit(node)
 
         self._text_prefix = self._style_stack[-1].apply('    ')
-        self._indent += 2
+        self._indent += 4
 
     def depart_definition(self, node: docutils.nodes.definition) -> None:
         self.log_departure(node)
 
-        self._indent -= 2
+        self._indent -= 4
 
     def _visit_admonition(self, node: docutils.nodes.Admonition, header: str) -> None:
         self.log_visit(node)

--- a/tmt/utils/rest.py
+++ b/tmt/utils/rest.py
@@ -332,7 +332,7 @@ class RestVisitor(docutils.nodes.NodeVisitor):
     def visit_definition(self, node: docutils.nodes.definition) -> None:
         self.log_visit(node)
 
-        self._text_prefix = self._style_stack[-1].apply('  ')
+        self._text_prefix = self._style_stack[-1].apply('    ')
         self._indent += 2
 
     def depart_definition(self, node: docutils.nodes.definition) -> None:


### PR DESCRIPTION
Fixes anonymous links, definition lists and link anchors handling in plugin docstrings. Improves text rendering in `--help` message.

Fixes #3676 and #3696