### PR TITLE
Fix the `make coverage` target to actually test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ smoke: tmp  ## Run the smoke-level part of the test suite
 	hatch run test:smoke
 
 coverage: tmp nitrateconf  ## Run the test suite with coverage enabled
-	hatch run test:coverage
+	hatch run test:cov
 
 nitrateconf:
 	test -e ~/.nitrate || echo -en '[nitrate]\nurl = https://nitrate.server/xmlrpc/\n' | tee ~/.nitrate


### PR DESCRIPTION
Seems there was a typo in the `coverage` target definition. It should be running `test:cov` to actually execute some tests.