### PR TITLE
Outline the `recipe` specification

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -12,6 +12,11 @@ and quit immediately after, skipping all remaining tests. This is now
 aligned with a test abort or :ref:`exit-first </plugins/execute/tmt>`
 key.
 
+As the first step towards implementing support for executing a
+subset of tests based on reported results, the first draft of the
+:ref:`/spec/recipe` specification was created to gather initial
+feedback on the proposed approach.
+
 
 tmt-1.55.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -82,11 +87,6 @@ explicit configuration of the FIPS crypto-policy.
 
 Custom ``ssh`` options are now provided to the command in the
 correct order so that they have the desired effect.
-
-As the first step towards implementing support for executing a
-subset of tests based on reported results, the first draft of the
-:ref:`/spec/recipe` specification was created to gather initial
-feedback on the proposed approach.
 
 
 tmt-1.53.0

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -83,6 +83,11 @@ explicit configuration of the FIPS crypto-policy.
 Custom ``ssh`` options are now provided to the command in the
 correct order so that they have the desired effect.
 
+As the first step towards implementing support for executing a
+subset of tests based on reported results, the first draft of the
+:ref:`/spec/recipe` specification was created to gather initial
+feedback on the proposed approach.
+
 
 tmt-1.53.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/scripts/generate-stories.py
+++ b/docs/scripts/generate-stories.py
@@ -38,6 +38,7 @@ AREA_TITLES = {
     '/spec/stories': 'Stories',
     '/spec/context': 'Context',
     '/spec/policy': 'Policy',
+    '/spec/recipe': 'Recipe',
     '/spec/hardware': 'Hardware',
     '/spec/results': 'Results',
 }

--- a/docs/spec.rst
+++ b/docs/spec.rst
@@ -54,6 +54,7 @@ Level 3: Stories
     spec/stories
     spec/context
     spec/policy
+    spec/recipe
     spec/hardware
     spec/results
     spec/lint

--- a/spec/recipe.fmf
+++ b/spec/recipe.fmf
@@ -13,8 +13,10 @@ description: |
     to select only a subset of discovered tests to be reexecuted.
 
     .. note::
-        All git repositories specified in the recipe will be fetched again during
-        the recipe execution.
+        All git repositories specified in the recipe will be fetched again during the
+        recipe execution, except for the optional ``run-repository``, which describes
+        the repository where the plans of the previous run were hosted, if any. This key
+        is ignored by tmt when executing the recipe, but can be useful for some users.
 
     .. note::
         When submitting a new run based on a recipe, the ``results`` key of the
@@ -25,8 +27,8 @@ description: |
 
     .. code-block:: yaml
 
-        # Mapping, stores git repository configuration where the plans
-        # for the current run are hosted
+        # Mapping, stores optional git repository configuration where the plans
+        # of the previous run were hosted
         run-repository:
             url: https://github.com/teemtee/tmt
             path: /tests/nested

--- a/spec/recipe.fmf
+++ b/spec/recipe.fmf
@@ -11,94 +11,109 @@ description: |
     Generated recipe can be edited, manually or by using a script, which allows users
     to select only a subset of discovered tests to be reexecuted.
 
+    .. note::
+        All git repositories specified in the recipe will be fetched again during
+        the recipe execution.
+
+    .. note::
+        When submitting a new run based on a recipe, the ``results`` key of the
+        ``execute`` step is ignored. New results will be generated from the actual
+        test execution. Users can use the results listed in the recipe to modify
+        the recipe and filter the tests that should be reexecuted.
+
     .. code-block:: yaml
 
-        # Git repo configuration
-        git:
+        # Mapping, stores git repository configuration where the plans
+        # for the current run are hosted
+        run-repository:
             url: https://github.com/teemtee/tmt
             path: /tests/nested
             ref: c89c4b5
 
-        # Run configuration
+        # Mapping, stores run configuration
         run:
+            # String, path to the fmf root in the repository
             root: "/path/to/fmf/root"
+            # Bool, whether to remove the run directory after the run is finished
             remove: false
+            # Mapping, stores command line environment
             environment: ...
+            # Mapping, stores command line context
             context: ...
 
-        # Plan definitions with all steps
+        # Represents plans with all their steps
         plans:
-            /plan/name:
-                environment: ...
-                context: ...
-                discover:
-                    # Step data
-                    data:
-                      - name: default-0
-                        how: fmf
-                        order: 50
-                        ...
-                    # Discovered tests
-                    tests:
-                      - name: /test/name
-                        summary: Test summary
-                        # Repositories must be fetched again so
-                        # that the test code is actually available.
-                        ...
+          # String, name of the plan
+          - name: /plan/name
+            # Mapping, stores plan environment
+            environment: ...
+            # Mapping, stores plan context
+            context: ...
 
-                provision:
-                    data:
-                      - name: default-0
-                        how: local
-                        order: 50
-                        hardware:
-                            memory: 8 GiB
-                            ...
-                        ...
+            # Represents all steps of this plan
+            discover:
+                # Represents all phases of this step
+                phases:
+                  - name: default-0
+                    how: fmf
+                    order: 50
+                    ...
+                # Represents all discovered tests
+                tests:
+                  - name: /test/name
+                    summary: Test summary
+                    ...
 
-                prepare:
-                    data:
-                      - name: default-0
-                        how: ansible
-                        order: 50
-                        # Playbooks are included directly in the recipe
-                        playbook:
-                          - name: Example playbook
-                            hosts: all
-                            tasks:
-                              - name: Example task
-                                ...
-                        ...
+            provision:
+                phases:
+                  - name: default-0
+                    how: local
+                    order: 50
+                    hardware:
+                        memory: 8 GiB
+                    ...
 
-                execute:
-                    data:
-                      - name: default-0
-                        how: tmt
-                        order: 50
-                        ...
-                    # Test results
-                    results:
-                      # When submitting a new run based on a recipe, the ``results`` key
-                      # is ignored. New results will be generated from the actual test
-                      # execution. Users can use the results listed here to filter
-                      # or select tests which should be reexecuted.
-                      - name: /test/name
-                        result: pass
-                        ...
+            prepare:
+                phases:
+                  - name: default-0
+                    how: ansible
+                    order: 50
+                    # Local path to the playbook, or git reference
+                    playbook: ansible/packages.yml
+                    ...
 
-                report:
-                    data:
-                      - name: default-0
-                        how: display
-                        order: 50
-                        ...
+            execute:
+                phases:
+                  - name: default-0
+                    how: tmt
+                    order: 50
+                    ...
+                # Represents results of all tests
+                results:
+                  - name: /test/name
+                    result: pass
+                    ...
 
-                finish:
-                    data:
-                      - name: default-0
-                        how: shell
-                        order: 50
-                        ...
+            report:
+                phases:
+                  - name: default-0
+                    how: display
+                    order: 50
+                    ...
+
+            finish:
+                phases:
+                  - name: default-0
+                    how: shell
+                    order: 50
+                    ...
+
+            cleanup:
+                phases:
+                  - name: default-0
+                    how: tmt
+                    order: 50
+                    ...
 
 example:
   - |

--- a/spec/recipe.fmf
+++ b/spec/recipe.fmf
@@ -8,16 +8,29 @@ description: |
     information about plans, tests, results, and run configuration. All environment
     variables are evaluated, and git references are replaced with fixed commit hashes.
 
+    Generated recipe can be edited, manually or by using a script, which allows users
+    to select only a subset of discovered tests to be reexecuted.
+
     .. code-block:: yaml
 
-        # Run  configuration
+        # Git repo configuration
+        git:
+            url: https://github.com/teemtee/tmt
+            path: /tests/nested
+            ref: c89c4b5
+
+        # Run configuration
         run:
             root: "/path/to/fmf/root"
             remove: false
+            environment: ...
+            context: ...
 
         # Plan definitions with all steps
         plans:
             /plan/name:
+                environment: ...
+                context: ...
                 discover:
                     # Step data
                     data:
@@ -29,6 +42,8 @@ description: |
                     tests:
                       - name: /test/name
                         summary: Test summary
+                        # Repositories must be fetched again so
+                        # that the test code is actually available.
                         ...
 
                 provision:
@@ -63,6 +78,10 @@ description: |
                         ...
                     # Test results
                     results:
+                      # When submitting a new run based on a recipe, the ``results`` key
+                      # is ignored. New results will be generated from the actual test
+                      # execution. Users can use the results listed here to filter
+                      # or select tests which should be reexecuted.
                       - name: /test/name
                         result: pass
                         ...

--- a/spec/recipe.fmf
+++ b/spec/recipe.fmf
@@ -14,9 +14,7 @@ description: |
 
     .. note::
         All git repositories specified in the recipe will be fetched again during the
-        recipe execution, except for the optional ``run-repository``, which describes
-        the repository where the plans of the previous run were hosted, if any. This key
-        is ignored by tmt when executing the recipe, but can be useful for some users.
+        recipe execution.
 
     .. note::
         When submitting a new run based on a recipe, the ``results`` key of the
@@ -26,13 +24,6 @@ description: |
         be reexecuted.
 
     .. code-block:: yaml
-
-        # Mapping, stores optional git repository configuration where the plans
-        # of the previous run were hosted
-        run-repository:
-            url: https://github.com/teemtee/tmt
-            path: /tests/nested
-            ref: main
 
         # Mapping, stores run configuration
         run:

--- a/spec/recipe.fmf
+++ b/spec/recipe.fmf
@@ -5,8 +5,9 @@ story: |
 description: |
     A recipe is a YAML file that captures a complete, static snapshot of a tmt
     run after all dynamic evaluation has been resolved. It includes preprocessed
-    information about plans, tests, results, and run configuration. All environment
-    variables are evaluated.
+    information about plans, tests, and run configuration, as well as links to the
+    ``results.yaml`` files created in previous run. All environment variables included
+    in the recipe are evaluated.
 
     Generated recipe can be edited, manually or by using a script, which allows users
     to select only a subset of discovered tests to be reexecuted.
@@ -18,8 +19,9 @@ description: |
     .. note::
         When submitting a new run based on a recipe, the ``results`` key of the
         ``execute`` step is ignored. New results will be generated from the actual
-        test execution. Users can use the results listed in the recipe to modify
-        the recipe and filter the tests that should be reexecuted.
+        test execution. Users can use this key to access the results created
+        in previous run to modify the recipe and filter the tests that should
+        be reexecuted.
 
     .. code-block:: yaml
 
@@ -88,11 +90,8 @@ description: |
                     how: tmt
                     order: 50
                     ...
-                # Represents results of all tests
-                results:
-                  - name: /test/name
-                    result: pass
-                    ...
+                # String, relative path to the results file from the previous run
+                results: plans/name/execute/results.yaml
 
             report:
                 phases:

--- a/spec/recipe.fmf
+++ b/spec/recipe.fmf
@@ -17,7 +17,7 @@ description: |
         recipe execution.
 
     .. note::
-        When submitting a new run based on a recipe, the ``results`` key of the
+        When submitting a new run based on a recipe, the ``results-path`` key of the
         ``execute`` step is ignored. New results will be generated from the actual
         test execution. Users can use this key to access the results created
         in previous run to modify the recipe and filter the tests that should
@@ -38,7 +38,7 @@ description: |
 
         # Represents plans with all their steps
         plans:
-          # String, name of the plan
+            # String, name of the plan
           - name: /plan/name
             # Mapping, stores plan environment
             environment: ...
@@ -84,7 +84,7 @@ description: |
                     order: 50
                     ...
                 # String, relative path to the results file from the previous run
-                results: plans/name/execute/results.yaml
+                results-path: plans/name/execute/results.yaml
 
             report:
                 phases:

--- a/spec/recipe.fmf
+++ b/spec/recipe.fmf
@@ -1,0 +1,87 @@
+story: |
+    As a user, I want tmt to generate a recipe file that can be reused to reproduce
+    a run with the exact same configuration, without requiring additional input.
+
+description: |
+    A recipe is a YAML file that captures a complete, static snapshot of a tmt
+    run after all dynamic evaluation has been resolved. It includes preprocessed
+    information about plans, tests, results, and run configuration. All environment
+    variables are evaluated, and git references are replaced with fixed commit hashes.
+
+    .. code-block:: yaml
+
+        # Run  configuration
+        run:
+            root: "/path/to/fmf/root"
+            remove: false
+
+        # Plan definitions with all steps
+        plans:
+            /plan/name:
+                discover:
+                    # Step data
+                    data:
+                      - name: default-0
+                        how: fmf
+                        order: 50
+                        ...
+                    # Discovered tests
+                    tests:
+                      - name: /test/name
+                        summary: Test summary
+                        ...
+
+                provision:
+                    data:
+                      - name: default-0
+                        how: local
+                        order: 50
+                        hardware:
+                            memory: 8 GiB
+                            ...
+                        ...
+
+                prepare:
+                    data:
+                      - name: default-0
+                        how: ansible
+                        order: 50
+                        # Playbooks are included directly in the recipe
+                        playbook:
+                          - name: Example playbook
+                            hosts: all
+                            tasks:
+                              - name: Example task
+                                ...
+                        ...
+
+                execute:
+                    data:
+                      - name: default-0
+                        how: tmt
+                        order: 50
+                        ...
+                    # Test results
+                    results:
+                      - name: /test/name
+                        result: pass
+                        ...
+
+                report:
+                    data:
+                      - name: default-0
+                        how: display
+                        order: 50
+                        ...
+
+                finish:
+                    data:
+                      - name: default-0
+                        how: shell
+                        order: 50
+                        ...
+
+example:
+  - |
+    # Reproduce a run using a recipe file
+    tmt run --recipe /path/to/recipe.yaml

--- a/spec/recipe.fmf
+++ b/spec/recipe.fmf
@@ -6,7 +6,7 @@ description: |
     A recipe is a YAML file that captures a complete, static snapshot of a tmt
     run after all dynamic evaluation has been resolved. It includes preprocessed
     information about plans, tests, results, and run configuration. All environment
-    variables are evaluated, and git references are replaced with fixed commit hashes.
+    variables are evaluated.
 
     Generated recipe can be edited, manually or by using a script, which allows users
     to select only a subset of discovered tests to be reexecuted.
@@ -28,7 +28,7 @@ description: |
         run-repository:
             url: https://github.com/teemtee/tmt
             path: /tests/nested
-            ref: c89c4b5
+            ref: main
 
         # Mapping, stores run configuration
         run:

--- a/spec/recipe.fmf
+++ b/spec/recipe.fmf
@@ -104,3 +104,6 @@ example:
   - |
     # Reproduce a run using a recipe file
     tmt run --recipe /path/to/recipe.yaml
+
+link:
+  - relates: https://github.com/teemtee/tmt/issues/2332


### PR DESCRIPTION
Introduce draft of tmt recipe specification as the first step towards implementing support for executing a subset of tests based on reported results.

The recipe captures a complete, static snapshot of a tmt run and can be reused to reproduce the run with the exact same configuration, without requiring additional input. It contains preprocessed information about plans, tests, and run configuration, eliminating the need for dynamic evaluation.


Resolves: #3854
Related: [TT-273](https://issues.redhat.com/browse/TT-273)

Pull Request Checklist

* [x] update the specification
* [x] include a release note