### PR TITLE
Building and testing `tmt` on `aarch64` macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ srpm: tarball ver2spec  ## Build SRPM
 	rpmbuild --define '_topdir $(TMP)' -bs tmt.spec
 
 _deps:  # Minimal dependencies (common for 'deps' and 'develop' targets)
-	sudo dnf install -y hatch python3-devel python3-hatch-vcs rpm-build
+	sudo dnf install -y hatch python3-devel python3-hatch-vcs rpm-build clang beakerlib
 
 build-deps: _deps tarball ver2spec  ## Install build dependencies
 	rpmbuild --define '_topdir $(TMP)' -br tmt.spec || sudo dnf builddep -y $(TMP)/SRPMS/tmt-*buildreqs.nosrc.rpm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Utilities",
     "Topic :: Software Development :: Testing",
@@ -186,7 +185,7 @@ template = "dev"
 description = "Run scripts with multiple Python versions"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.12", "3.13"]
+python = ["3.9", "3.13"]
 
 [tool.hatch.envs.docs]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,7 @@ dev-mode = false
 
 [tool.hatch.envs.test]
 template = "dev"
-description = "Run scripts with system python"
+description = "Test environment"
 
 [tool.hatch.envs.docs]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Utilities",
     "Topic :: Software Development :: Testing",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,10 +183,7 @@ dev-mode = false
 
 [tool.hatch.envs.test]
 template = "dev"
-description = "Run scripts with multiple Python versions"
-
-[[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.13"]
+description = "Run scripts with system python"
 
 [tool.hatch.envs.docs]
 dependencies = [


### PR DESCRIPTION
Fix #3880. Coverage fails due to missing libraries in python3.12. This change enables building on macos - aarch64.
Fedora42 over UTM. This commit removes the test matrix so we only test only for system python while building. 
Tests for different python version now occur during CI Test.

