### PR TITLE
Use the old syntax in `Containerfile.{mini|full}`

### DIFF
--- a/containers/Containerfile.full
+++ b/containers/Containerfile.full
@@ -1,22 +1,17 @@
 FROM quay.io/fedora/fedora:latest
 
-RUN <<EOF
-set -ex
-
-# Adjust system defaults
-sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf
-echo "Set disable_coredump false" >> /etc/sudo.conf
-
-# Install necessary packages
-dnf install -y dnf-plugins-core
-dnf copr enable -y @teemtee/stable
-dnf install -y tmt+all beakerlib
-dnf autoremove -y
-dnf clean all
-
-# Prepare a directory for experimenting
-mkdir /tmt
-EOF
+RUN set -ex && \
+    # Adjust system defaults
+    sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf && \
+    echo "Set disable_coredump false" >> /etc/sudo.conf && \
+    # Install necessary packages
+    dnf install -y dnf-plugins-core && \
+    dnf copr enable -y @teemtee/stable && \
+    dnf install -y tmt+all beakerlib && \
+    dnf autoremove -y && \
+    dnf clean all && \
+    # Prepare a directory for experimenting
+    mkdir /tmt
 
 # Prepare files for experimenting
 COPY .fmf /tmt/.fmf

--- a/containers/Containerfile.mini
+++ b/containers/Containerfile.mini
@@ -1,22 +1,17 @@
 FROM quay.io/fedora/fedora:latest
 
-RUN <<EOF
-set -ex
-
-# Adjust system defaults
-sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf
-echo "Set disable_coredump false" >> /etc/sudo.conf
-
-# Install necessary packages
-dnf install -y dnf-plugins-core
-dnf copr enable -y @teemtee/stable
-dnf install -y tmt
-dnf autoremove -y
-dnf clean all
-
-# Prepare a directory for experimenting
-mkdir /tmt
-EOF
+RUN set -ex && \
+    # Adjust system defaults
+    sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf && \
+    echo "Set disable_coredump false" >> /etc/sudo.conf && \
+    # Install necessary packages
+    dnf install -y dnf-plugins-core && \
+    dnf copr enable -y @teemtee/stable && \
+    dnf install -y tmt && \
+    dnf autoremove -y && \
+    dnf clean all && \
+    # Prepare a directory for experimenting
+    mkdir /tmt
 
 # Prepare files for experimenting
 COPY .fmf /tmt/.fmf


### PR DESCRIPTION
This should fix problem with building and publishing tmt container images after the release as buildah does not support the new heredoc syntax.