### PR TITLE
Add .zed and .cursor to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,9 +64,6 @@ ENV/
 env.bak/
 venv.bak/
 
-# Jetbrains
-.idea/
-
 # Vim
 
 # Swap
@@ -90,5 +87,8 @@ tags
 # Persistent undo
 [._]*.un~
 
-# Visual Studio Code
+# Editors & IDEs
 .vscode
+.zed/
+.cursor/
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,6 @@ tags
 
 # Editors & IDEs
 .vscode
-.zed/
-.cursor/
+.zed
+.cursor
 .idea


### PR DESCRIPTION
Not sure what else people use. This is just about editors, covering various "AI tools configs" is another story (think `.claude/` and such), as these should probably be in git if they exist?