### PR TITLE
Drop explicit `dnf5` addition to `coreos` test images

### DIFF
--- a/containers/fedora/coreos/Containerfile
+++ b/containers/fedora/coreos/Containerfile
@@ -5,17 +5,3 @@
 #
 
 FROM quay.io/fedora/fedora-coreos:stable
-
-RUN <<EOF
-set -ex
-
-# Inject `dnf` to make things more complicated for `rpm-ostree` package
-# manager implementation
-rpm-ostree install dnf5
-
-# Populate dnf cache
-dnf5 makecache
-
-# Make sure the image is built with the latest packages
-dnf5 update -y
-EOF

--- a/containers/fedora/coreos/ostree/Containerfile
+++ b/containers/fedora/coreos/ostree/Containerfile
@@ -11,16 +11,6 @@ FROM quay.io/fedora/fedora-coreos:stable
 RUN <<EOF
 set -ex
 
-# Inject `dnf` to make things more complicated for `rpm-ostree` package
-# manager implementation
-rpm-ostree install dnf5
-
-# Populate dnf cache
-dnf5 makecache
-
-# Make sure the image is built with the latest packages
-dnf5 update -y
-
 # Simulate ostree-booted environment
 touch /run/ostree-booted
 EOF


### PR DESCRIPTION
It is no longer needed, coreos has settled down.

Pull Request Checklist

* [x] implement the feature