### PR TITLE
Hide the install script command from verbose output

### DIFF
--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -1350,7 +1350,7 @@ class Guest(tmt.utils.Common):
         if not self.facts.is_superuser:
             command = Command("sudo") + command
 
-        self.execute(command)
+        self.execute(command, silent=True)
 
         # Install all scripts on guest
         for script in scripts:


### PR DESCRIPTION
Recently the `mkdir -p /usr/local/bin` command started appearing in the verbose outpu. As this one is not much interesting to the user, let's hide it by making it a silent command.

Pull Request Checklist

* [ ] implement the feature