### PR TITLE
Custom `ssh` options should have precedence

### DIFF
--- a/tests/provision/ssh-options/test.sh
+++ b/tests/provision/ssh-options/test.sh
@@ -22,7 +22,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Test global SSH options occur first in ssh parameters $PROVISION_HOW"
-      rlRun "TMT_SSH_SERVER_ALIVE_INTERVAL=7 TMT_SSH_SERVER_ALIVE_COUNT_MAX=9 tmt  run --scratch -vvi $run -a provision -h $PROVISION_HOW"
+      rlRun "TMT_SSH_SERVER_ALIVE_INTERVAL=7 TMT_SSH_SERVER_ALIVE_COUNT_MAX=9 tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW"
       # check that default and custom_ssh_options are present
       rlAssertGrep "Run command: ssh .*-oServerAliveInterval=7" "$run/log.txt"
       rlAssertGrep "Run command: ssh .*-oServerAliveInterval=5" "$run/log.txt"

--- a/tests/provision/ssh-options/test.sh
+++ b/tests/provision/ssh-options/test.sh
@@ -21,6 +21,18 @@ rlJournalStart
         rlAssertGrep "Run command: ssh .*-oServeralivecountmax=123456789" "$run/log.txt"
     rlPhaseEnd
 
+    rlPhaseStartTest "Test global SSH options occur first in ssh parameters $PROVISION_HOW"
+      rlRun "TMT_SSH_SERVER_ALIVE_INTERVAL=7 TMT_SSH_SERVER_ALIVE_COUNT_MAX=9 tmt  run --scratch -vvi $run -a provision -h $PROVISION_HOW"
+      # check that default and custom_ssh_options are present
+      rlAssertGrep "Run command: ssh .*-oServerAliveInterval=7" "$run/log.txt"
+      rlAssertGrep "Run command: ssh .*-oServerAliveInterval=5" "$run/log.txt"
+      rlAssertGrep "Run command: ssh .*-oServerAliveCountMax=60" "$run/log.txt"
+      rlAssertGrep "Run command: ssh .*-oServerAliveCountMax=9" "$run/log.txt"
+      # check that custom_ssh_options occur before default ssh options
+      rlAssertGrep "Run command: ssh .*-oServerAliveInterval=7.*-oServerAliveInterval=5" "$run/log.txt"
+      rlAssertGrep "Run command: ssh .*-oServerAliveCountMax=9.*-oServerAliveCountMax=60" "$run/log.txt"
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $run" 0 "Remove run directory"

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -156,7 +156,8 @@ DEFAULT_SSH_OPTIONS: tmt.utils.RawCommand = [
 #: This is the base set of SSH options tmt would use for all SSH
 #: connections. It is a combination of the default SSH options and those
 #: provided by environment variables.
-BASE_SSH_OPTIONS: tmt.utils.RawCommand = DEFAULT_SSH_OPTIONS + configure_ssh_options()
+#: Note on precedence of SSH options: https://github.com/teemtee/tmt/issues/3872#issuecomment-3101540471
+BASE_SSH_OPTIONS: tmt.utils.RawCommand = configure_ssh_options() + DEFAULT_SSH_OPTIONS
 
 #: SSH master socket path is limited to this many characters.
 #:

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -160,7 +160,7 @@ DEFAULT_SSH_OPTIONS: tmt.utils.RawCommand = [
 #: variables take precedence over default values. For options that set
 #: a specific value (e.g., ``ServerAliveInterval``), the first occurrence
 #: takes precedence. For simple on/off flags (e.g., ``-v``/``-q``), the last one wins.
-#: Identity files (-i) are all considered in order.
+#: Identity files (``-i``) are all considered in order.
 BASE_SSH_OPTIONS: tmt.utils.RawCommand = configure_ssh_options() + DEFAULT_SSH_OPTIONS
 
 #: SSH master socket path is limited to this many characters.

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -159,7 +159,7 @@ DEFAULT_SSH_OPTIONS: tmt.utils.RawCommand = [
 #: SSH options are processed in order. Options provided via environment
 #: variables take precedence over default values. For options that set
 #: a specific value (e.g., ``ServerAliveInterval``), the first occurrence
-#: takes precedence. For simple on/off flags (e.g., -v/-q), the last one wins.
+#: takes precedence. For simple on/off flags (e.g., ``-v``/``-q``), the last one wins.
 #: Identity files (-i) are all considered in order.
 BASE_SSH_OPTIONS: tmt.utils.RawCommand = configure_ssh_options() + DEFAULT_SSH_OPTIONS
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -158,7 +158,7 @@ DEFAULT_SSH_OPTIONS: tmt.utils.RawCommand = [
 #: provided by environment variables.
 #: SSH options are processed in order. Options provided via environment
 #: variables take precedence over default values. For options that set
-#: a specific value (e.g., ServerAliveInterval), the first occurrence
+#: a specific value (e.g., ``ServerAliveInterval``), the first occurrence
 #: takes precedence. For simple on/off flags (e.g., -v/-q), the last one wins.
 #: Identity files (-i) are all considered in order.
 BASE_SSH_OPTIONS: tmt.utils.RawCommand = configure_ssh_options() + DEFAULT_SSH_OPTIONS

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -156,7 +156,11 @@ DEFAULT_SSH_OPTIONS: tmt.utils.RawCommand = [
 #: This is the base set of SSH options tmt would use for all SSH
 #: connections. It is a combination of the default SSH options and those
 #: provided by environment variables.
-#: Note on precedence of SSH options: https://github.com/teemtee/tmt/issues/3872#issuecomment-3101540471
+#: SSH options are processed in order. Options provided via environment
+#: variables take precedence over default values. For options that set
+#: a specific value (e.g., ServerAliveInterval), the first occurrence
+#: takes precedence. For simple on/off flags (e.g., -v/-q), the last one wins.
+#: Identity files (-i) are all considered in order.
 BASE_SSH_OPTIONS: tmt.utils.RawCommand = configure_ssh_options() + DEFAULT_SSH_OPTIONS
 
 #: SSH master socket path is limited to this many characters.


### PR DESCRIPTION
Fix #3872. This commit makes sure custom ssh options are given priority over default ssh options. 
Notes about testing and Precedence included in the issue.
Observations : https://github.com/teemtee/tmt/issues/3872#issuecomment-3096228161
Notes on precedence : https://github.com/teemtee/tmt/issues/3872#issuecomment-3101540471


