### PR TITLE
Remove non-existent checks from the specification

### DIFF
--- a/spec/tests/check.fmf
+++ b/spec/tests/check.fmf
@@ -56,8 +56,8 @@ example:
     # Using `how` key to pick the check.
     check:
       - avc
-      - kernel-panic
-      - how: test-inspector
+      - watchdog
+      - how: dmesg
         enabled: false
 
   - |


### PR DESCRIPTION
Fixes: #3913 

Removed `kernel-panic` from test checks and test results example.
