### PR TITLE
Change unit test to pytest and move common fixtures to conftest

### DIFF
--- a/tests/unit/test_export_to_nitrate.py
+++ b/tests/unit/test_export_to_nitrate.py
@@ -2,6 +2,7 @@ from collections.abc import Iterator
 
 import pytest
 
+from tests.unit.conftest import create_path_helper
 from tmt.export.nitrate import convert_manual_to_nitrate
 from tmt.utils import Path
 
@@ -10,10 +11,9 @@ TEST_DIR = Path(__file__).parent
 
 
 @pytest.fixture(name="manual_test_path")
-def fixture_manual_test_path(tmppath: Path, make_path_fixture: callable) -> Iterator[Path]:
+def fixture_manual_test_path(tmppath: Path) -> Iterator[Path]:
     """Provides a temporary directory populated with 'manual_test' data."""
-    # We are calling the make_path_fixture from conftest here.
-    yield from make_path_fixture(tmppath, TEST_DIR, "manual_test")
+    yield from create_path_helper(tmppath, TEST_DIR, "manual_test")
 
 
 def test_export_to_nitrate_step(manual_test_path: Path):

--- a/tests/unit/test_export_to_nitrate.py
+++ b/tests/unit/test_export_to_nitrate.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator
+from collections.abc import Iterator
 
 import pytest
 
@@ -10,9 +10,7 @@ TEST_DIR = Path(__file__).parent
 
 
 @pytest.fixture(name="manual_test_path")
-def fixture_manual_test_path(
-    tmppath: Path, make_path_fixture: callable
-) -> Generator[Path, None, None]:
+def fixture_manual_test_path(tmppath: Path, make_path_fixture: callable) -> Iterator[Path]:
     """Provides a temporary directory populated with 'manual_test' data."""
     # We are calling the make_path_fixture from conftest here.
     yield from make_path_fixture(tmppath, TEST_DIR, "manual_test")

--- a/tests/unit/test_export_to_nitrate.py
+++ b/tests/unit/test_export_to_nitrate.py
@@ -6,14 +6,11 @@ from tests.unit.conftest import create_path_helper
 from tmt.export.nitrate import convert_manual_to_nitrate
 from tmt.utils import Path
 
-# The root directory of the tests, used to locate test data
-TEST_DIR = Path(__file__).parent
-
 
 @pytest.fixture(name="manual_test_path")
-def fixture_manual_test_path(tmppath: Path) -> Iterator[Path]:
+def fixture_manual_test_path(tmppath: Path, test_path: Path) -> Iterator[Path]:
     """Provides a temporary directory populated with 'manual_test' data."""
-    yield from create_path_helper(tmppath, TEST_DIR, "manual_test")
+    yield from create_path_helper(tmppath, test_path, "manual_test")
 
 
 def test_export_to_nitrate_step(manual_test_path: Path):

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -1,114 +1,100 @@
-import os
-import shutil
-import tempfile
-from unittest import TestCase
-
 import fmf
+import pytest
 
 import tmt
 import tmt.cli._root
-import tmt.log
 from tests import CliRunner
-from tmt.identifier import ID_KEY
+from tmt.identifier import ID_KEY, add_uuid_if_not_defined
 from tmt.utils import Path
 
+# Common setup for tests in this file
 runner = CliRunner()
-test_path = Path(__file__).parent / "id"
-root_logger = tmt.log.Logger.create()
 
 
-class IdEmpty(TestCase):
-    def setUp(self):
-        self.path = Path(tempfile.mkdtemp()) / "empty"
-        shutil.copytree(test_path / "empty", self.path)
-        self.original_directory = Path.cwd()
-        os.chdir(self.path)
-        self.base_tree = fmf.Tree(self.path)
-
-    def tearDown(self):
-        os.chdir(self.original_directory)
-        shutil.rmtree(self.path)
-
-    def test_base(self):
-        node = self.base_tree.find("/some/structure")
-        test = tmt.Test(logger=root_logger, node=node)
-        assert test.id is None
-
-    def test_manually_add_id(self):
-        # TODO: it's really not possible to use fixtures with methods??
-        from tmt.log import Logger
-
-        root_logger = Logger.create(verbose=0, debug=0, quiet=False)
-
-        node = self.base_tree.find("/some/structure")
-        test = tmt.Test(logger=root_logger, node=node)
-        assert test.id is None
-        identifier = tmt.identifier.add_uuid_if_not_defined(node, False, root_logger)
-        assert len(identifier) > 10
-
-        self.base_tree = fmf.Tree(self.path)
-        node = self.base_tree.find("/some/structure")
-        test = tmt.Test(logger=root_logger, node=node)
-        assert test.id == identifier
+@pytest.fixture(name='test_path')
+def fixture_test_path() -> Path:
+    """Provides the path to the test data for 'id' tests"""
+    return Path(__file__).parent / "id"
 
 
-class TestGeneratorDefined(TestCase):
-    def setUp(self):
-        self.path = Path(tempfile.mkdtemp()) / "defined"
-        shutil.copytree(test_path / "defined", self.path)
-        self.original_directory = Path.cwd()
-        os.chdir(self.path)
-
-    def tearDown(self):
-        os.chdir(self.original_directory)
-        shutil.rmtree(self.path)
-
-    def test_test_dry(self):
-        result = runner.invoke(tmt.cli._root.main, ["test", "id", "--dry", "^/no"])
-        assert "added to test '/no" in result.output
-        result = runner.invoke(tmt.cli._root.main, ["test", "id", "--dry", "^/no"])
-        assert "added to test '/no" in result.output
-
-    def test_test_real(self):
-        # Empty before
-        node = fmf.Tree(self.path).find("/no")
-        assert node.get(ID_KEY) is None
-
-        # Generate only when called for the first time
-        result = runner.invoke(tmt.cli._root.main, ["test", "id", "^/no"])
-        assert "added to test '/no" in result.output
-        result = runner.invoke(tmt.cli._root.main, ["test", "id", "^/no"])
-        assert "added to test '/no" not in result.output
-
-        # Defined after
-        node = fmf.Tree(self.path).find("/no")
-        assert len(node.data[ID_KEY]) > 10
+def test_base(empty_path: Path, root_logger: tmt.log.Logger):
+    """The 'id' attribute should be None initially"""
+    base_tree = fmf.Tree(empty_path)
+    node = base_tree.find("/some/structure")
+    test = tmt.Test(logger=root_logger, node=node)
+    assert test.id is None
 
 
-class TestGeneratorEmpty(TestCase):
-    def setUp(self):
-        self.path = Path(tempfile.mkdtemp()) / "empty"
-        shutil.copytree(test_path / "empty", self.path)
-        self.original_directory = Path.cwd()
-        os.chdir(self.path)
+def test_manually_add_id(empty_path: Path, root_logger: tmt.log.Logger):
+    """A new id can be generated and applied manually"""
+    base_tree = fmf.Tree(empty_path)
+    node = base_tree.find("/some/structure")
+    test = tmt.Test(logger=root_logger, node=node)
+    assert test.id is None
 
-    def tearDown(self):
-        os.chdir(self.original_directory)
-        shutil.rmtree(self.path)
+    # Generate and apply a new ID
+    identifier = add_uuid_if_not_defined(node, False, root_logger)
+    assert isinstance(identifier, str)
+    assert len(identifier) > 10
 
-    def test_test_dry(self):
-        result = runner.invoke(tmt.cli._root.main, ["test", "id", "--dry"])
-        assert "added to test '/some/structure'" in result.output
-        result = runner.invoke(tmt.cli._root.main, ["test", "id", "--dry"])
-        assert "added to test '/some/structure'" in result.output
+    # After reloading the fmf tree, the test should have the new ID
+    new_tree = fmf.Tree(empty_path)
+    node = new_tree.find("/some/structure")
+    test = tmt.Test(logger=root_logger, node=node)
+    assert test.id == identifier
 
-    def test_test_real(self):
-        result = runner.invoke(tmt.cli._root.main, ["test", "id"])
-        assert "added to test '/some/structure'" in result.output
 
-        result = runner.invoke(tmt.cli._root.main, ["test", "id"])
-        assert "added to test '/some/structure'" not in result.output
+def test_defined_dry(defined_path: Path):
+    """--dry run should report a new id"""
+    result = runner.invoke(tmt.cli._root.main, ["test", "id", "--dry", "^/no"])
+    assert "added to test '/no" in result.output
+    # A second dry run should report the same
+    result = runner.invoke(tmt.cli._root.main, ["test", "id", "--dry", "^/no"])
+    assert "added to test '/no" in result.output
 
-        base_tree = fmf.Tree(self.path)
-        node = base_tree.find("/some/structure")
-        assert len(node.data[ID_KEY]) > 10
+
+def test_defined_real(defined_path: Path):
+    """A real run should persist the new id"""
+    # Check that there is no id before the run
+    node = fmf.Tree(defined_path).find("/no")
+    assert node.get(ID_KEY) is None
+
+    # The first run should generate and persist the id
+    result = runner.invoke(tmt.cli._root.main, ["test", "id", "^/no"])
+    assert "added to test '/no" in result.output
+
+    # The second run should not add it again
+    result = runner.invoke(tmt.cli._root.main, ["test", "id", "^/no"])
+    assert "added to test '/no" not in result.output
+
+    # Verify that the id has been defined in the file
+    node = fmf.Tree(defined_path).find("/no")
+    assert node.get(ID_KEY) is not None
+    assert isinstance(node.data[ID_KEY], str)
+    assert len(node.data[ID_KEY]) > 10
+
+
+def test_empty_dry(empty_path: Path):
+    """--dry run should report a new id"""
+    result = runner.invoke(tmt.cli._root.main, ["test", "id", "--dry"])
+    assert "added to test '/some/structure'" in result.output
+    # A second dry run should report the same
+    result = runner.invoke(tmt.cli._root.main, ["test", "id", "--dry"])
+    assert "added to test '/some/structure'" in result.output
+
+
+def test_empty_real(empty_path: Path):
+    """A real run should persist the new id"""
+    # The first run should generate and persist the id
+    result = runner.invoke(tmt.cli._root.main, ["test", "id"])
+    assert "added to test '/some/structure'" in result.output
+
+    # The second run should not add it again
+    result = runner.invoke(tmt.cli._root.main, ["test", "id"])
+    assert "added to test '/some/structure'" not in result.output
+
+    # Verify that the id has been defined in the file
+    base_tree = fmf.Tree(empty_path)
+    node = base_tree.find("/some/structure")
+    assert node.get(ID_KEY) is not None
+    assert len(node.data[ID_KEY]) > 10

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -6,7 +6,7 @@ import pytest
 import tmt
 import tmt.cli._root
 from tests import CliRunner
-from tests.unit.conftest import PathFixture
+from tests.unit.conftest import create_path_helper
 from tmt.identifier import ID_KEY, add_uuid_if_not_defined
 from tmt.utils import Path
 
@@ -24,20 +24,18 @@ def fixture_test_path() -> Path:
 def defined_path(
     tmppath: Path,
     test_path: Path,
-    make_path_fixture: PathFixture,
 ) -> Iterator[Path]:
     """Fixture for tests requiring the 'defined' test data."""
-    yield from make_path_fixture(tmppath, test_path, "defined")
+    yield from create_path_helper(tmppath, test_path, "defined")
 
 
 @pytest.fixture
 def empty_path(
     tmppath: Path,
     test_path: Path,
-    make_path_fixture: PathFixture,
 ) -> Iterator[Path]:
     """Fixture for tests requiring the 'empty' test data."""
-    yield from make_path_fixture(tmppath, test_path, "empty")
+    yield from create_path_helper(tmppath, test_path, "empty")
 
 
 def test_base(empty_path: Path, root_logger: tmt.log.Logger):

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -1,9 +1,12 @@
+from collections.abc import Iterator
+
 import fmf
 import pytest
 
 import tmt
 import tmt.cli._root
 from tests import CliRunner
+from tests.unit.conftest import PathFixture
 from tmt.identifier import ID_KEY, add_uuid_if_not_defined
 from tmt.utils import Path
 
@@ -15,6 +18,26 @@ runner = CliRunner()
 def fixture_test_path() -> Path:
     """Provides the path to the test data for 'id' tests"""
     return Path(__file__).parent / "id"
+
+
+@pytest.fixture
+def defined_path(
+    tmppath: Path,
+    test_path: Path,
+    make_path_fixture: PathFixture,
+) -> Iterator[Path]:
+    """Fixture for tests requiring the 'defined' test data."""
+    yield from make_path_fixture(tmppath, test_path, "defined")
+
+
+@pytest.fixture
+def empty_path(
+    tmppath: Path,
+    test_path: Path,
+    make_path_fixture: PathFixture,
+) -> Iterator[Path]:
+    """Fixture for tests requiring the 'empty' test data."""
+    yield from make_path_fixture(tmppath, test_path, "empty")
 
 
 def test_base(empty_path: Path, root_logger: tmt.log.Logger):

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -15,9 +15,9 @@ runner = CliRunner()
 
 
 @pytest.fixture(name='test_path')
-def fixture_test_path() -> Path:
+def fixture_test_path(test_path) -> Path:
     """Provides the path to the test data for 'id' tests"""
-    return Path(__file__).parent / "id"
+    return test_path / "id"
 
 
 @pytest.fixture

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -91,6 +91,18 @@ def nested_file(tmppath: Path) -> tuple[Path, Path, Path]:
     return top_dir, sub_dir, file
 
 
+# Present two trees we have for identifier unit tests as fixtures, to make them
+# usable in other tests as well.
+@pytest.fixture(name='id_tree_defined')
+def fixture_id_tree_defined() -> fmf.Tree:
+    return fmf.Tree(Path(__file__).parent / 'id' / 'defined')
+
+
+@pytest.fixture(name='id_tree_empty')
+def fixture_id_tree_empty() -> fmf.Tree:
+    return fmf.Tree(Path(__file__).parent / 'id' / 'empty')
+
+
 _test_public_git_url_input = [
     ('git@github.com:teemtee/tmt.git', 'https://github.com/teemtee/tmt.git'),
     (


### PR DESCRIPTION
Fix #3769
```/home/vaibhav/.local/share/hatch/env/virtual/tmt/ovVD67rI/dev/bin/python /var/lib/snapd/snap/pycharm-community/503/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py --path /home/vaibhav/office/tmt/tests/unit/test_id.py 
Testing started at 14:44 ...
Launching pytest with arguments /home/vaibhav/office/tmt/tests/unit/test_id.py --no-header --no-summary -q in /home/vaibhav/office/tmt/tests/unit

============================= test session starts ==============================
collecting ... collected 6 items

test_id.py::test_base 
test_id.py::test_manually_add_id 
test_id.py::test_defined_dry 
test_id.py::test_defined_real 
test_id.py::test_empty_dry 
test_id.py::test_empty_real 

======================= 6 passed, 1572 warnings in 0.42s =======================
PASSED                                             [ 16%]PASSED                                  [ 33%]PASSED                                      [ 50%]PASSED                                     [ 66%]PASSED                                        [ 83%]PASSED                                       [100%]
Process finished with exit code 0
```