### PR TITLE
Temporarily disable the `avc` test check

### DIFF
--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -3,7 +3,9 @@ framework: beakerlib
 contact: Petr Šplíchal <psplicha@redhat.com>
 tier: 2
 require: [tmt]
-check: [avc]
+# Disabled because of irrelevant AVC denial cause by crun
+# https://github.com/containers/container-selinux/issues/389
+#check: [avc]
 duration: 10m
 environment:
     TMT_FEELING_SAFE: 1


### PR DESCRIPTION
In order to unblock merging, let's disable the check until https://github.com/containers/container-selinux/issues/389 is fixed.