### PR TITLE
Enable back the `avc` test check

### DIFF
--- a/tests/main.fmf
+++ b/tests/main.fmf
@@ -3,9 +3,7 @@ framework: beakerlib
 contact: Petr Šplíchal <psplicha@redhat.com>
 tier: 2
 require: [tmt]
-# Disabled because of irrelevant AVC denial cause by crun
-# https://github.com/containers/container-selinux/issues/389
-#check: [avc]
+check: [avc]
 duration: 10m
 environment:
     TMT_FEELING_SAFE: 1


### PR DESCRIPTION
Let's not forget to enable the check once the issue is fixed. https://github.com/containers/container-selinux/issues/389