### PR TITLE
Explicitly set `LANG` to ensure predictable sorting

### DIFF
--- a/tests/core/about/test.sh
+++ b/tests/core/about/test.sh
@@ -21,6 +21,7 @@ test.framework: beakerlib shell"
 rlJournalStart
     rlPhaseStartSetup
         rlRun "set -o pipefail"
+        rlRun "export LANG=C"
         rlRun "tmpdir=$(mktemp -d)"
 
         rlRun "echo \"$EXPECTED_PLUGIN_LIST\" > $tmpdir/expected-plugin-list.txt"


### PR DESCRIPTION
The test failed locally in an unexpected and confusing way because of a different sort algorithm between Czech and English. Let's use the standard POSIX locale `C` to always get a predictable sorting.

Pull Request Checklist

* [ ] improve the test coverage