### PR TITLE
Add support for skipping tests before and/or after system upgrade

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -12,6 +12,10 @@ plugin, the reboot command now properly applies ``sudo`` when
 necessary, ensuring correct privilege handling during system
 restarts.
 
+New keys, ``skip-tests-before`` and ``skip-tests-after``, were added to
+the :ref:`/plugins/execute/upgrade` plugin, allowing users to skip
+running discovered tests on the old system or new system, respectively.
+
 
 tmt-1.56.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/execute/upgrade/data/plan.fmf
+++ b/tests/execute/upgrade/data/plan.fmf
@@ -16,3 +16,13 @@ execute:
     summary: Basic upgrade test with upgrade path
     execute+:
         upgrade-path: $@{upgrade-path}
+/skip-tests:
+    /before:
+        execute+:
+            upgrade-path: $@{upgrade-path}
+            skip-tests-before: true
+
+    /after:
+        execute+:
+            upgrade-path: $@{upgrade-path}
+            skip-tests-after: true

--- a/tests/execute/upgrade/main.fmf
+++ b/tests/execute/upgrade/main.fmf
@@ -30,3 +30,6 @@ tier: 4
 /skip-tests:
     summary: Skip tests before and/or after upgrade
     test: ./skip-tests.sh
+    tag+:
+      - provision-only
+      - provision-virtual

--- a/tests/execute/upgrade/main.fmf
+++ b/tests/execute/upgrade/main.fmf
@@ -29,4 +29,4 @@ tier: 4
 
 /skip-tests:
     summary: Skip tests before and/or after upgrade
-    test: ./skip-test.sh
+    test: ./skip-tests.sh

--- a/tests/execute/upgrade/main.fmf
+++ b/tests/execute/upgrade/main.fmf
@@ -30,6 +30,7 @@ tier: 4
 /skip-tests:
     summary: Skip tests before and/or after upgrade
     test: ./skip-tests.sh
+    duration: 1h
     tag+:
       - provision-only
       - provision-virtual

--- a/tests/execute/upgrade/main.fmf
+++ b/tests/execute/upgrade/main.fmf
@@ -26,3 +26,7 @@ tier: 4
     summary: Plan and upgrade path in the local repo
     framework: shell
     test: cd local && tmt run -vvv --remove plan --name plan
+
+/skip-tests:
+    summary: Skip tests before and/or after upgrade
+    test: ./skip-test.sh

--- a/tests/execute/upgrade/skip-tests.sh
+++ b/tests/execute/upgrade/skip-tests.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "source fedora-version.sh"
+        rlRun "pushd data"
+        rlRun "run=/var/tmp/tmt/run-upgrade"
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun -s "tmt \
+            --context distro=fedora-${PREVIOUS_VERSION} \
+            --context upgrade-path="${UPGRADE_PATH}" \
+            run --id $run --scratch --rm -vvv --before finish \
+            plan --name /plan/skip-tests/before" 0 "Run the upgrade test"
+
+        # 0 test before + 3 upgrade tasks + 1 test after
+        rlAssertGrep "4 tests passed" $rlRun_LOG
+        rlAssertNotGrep "pass /old/test" $rlRun_LOG
+        rlAssertGrep    "pass /new/test" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest
+        rlRun -s "tmt \
+            --context distro=fedora-${PREVIOUS_VERSION} \
+            --context upgrade-path="${UPGRADE_PATH}" \
+            run --id $run --scratch --rm -vvv --before finish \
+            plan --name /plan/skip-tests/after" 0 "Run the upgrade test"
+
+        # 1 test before + 3 upgrade tasks + 0 test after
+        rlAssertGrep "4 tests passed" $rlRun_LOG
+        rlAssertGrep    "pass /old/test" $rlRun_LOG
+        rlAssertNotGrep "pass /new/test" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "tmt run --id $run finish" 0 "Stop the guest and remove the workdir"
+        rlRun "popd"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/execute/upgrade/skip-tests.sh
+++ b/tests/execute/upgrade/skip-tests.sh
@@ -12,7 +12,7 @@ rlJournalStart
         rlRun -s "tmt \
             --context distro=fedora-${PREVIOUS_VERSION} \
             --context upgrade-path="${UPGRADE_PATH}" \
-            run --id $run --scratch --rm -vvv --before finish \
+            run --id $run --scratch --rm -vvv --before cleanup \
             plan --name /plan/skip-tests/before" 0 "Run the upgrade test"
 
         # 0 test before + 3 upgrade tasks + 1 test after
@@ -25,7 +25,7 @@ rlJournalStart
         rlRun -s "tmt \
             --context distro=fedora-${PREVIOUS_VERSION} \
             --context upgrade-path="${UPGRADE_PATH}" \
-            run --id $run --scratch --rm -vvv --before finish \
+            run --id $run --scratch --rm -vvv --before cleanup \
             plan --name /plan/skip-tests/after" 0 "Run the upgrade test"
 
         # 1 test before + 3 upgrade tasks + 0 test after
@@ -35,7 +35,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartCleanup
-        rlRun "tmt run --id $run finish" 0 "Stop the guest and remove the workdir"
+        rlRun "tmt run --id $run cleanup" 0 "Stop the guest and remove the workdir"
         rlRun "popd"
     rlPhaseEnd
 rlJournalEnd

--- a/tmt/schemas/execute/upgrade.yaml
+++ b/tmt/schemas/execute/upgrade.yaml
@@ -37,6 +37,12 @@ properties:
   script:
     $ref: "/schemas/common#/definitions/one_or_more_strings"
 
+  skip-tests-before:
+    type: boolean
+
+  skip-tests-after:
+    type: boolean
+
   test:
     $ref: "/schemas/common#/definitions/one_or_more_strings"
 


### PR DESCRIPTION
New keys, ``skip-tests-before`` and ``skip-tests-after``, were added to
the `execute/upgrade` plugin, allowing users to skip running discovered
tests on the old system or new system, respectively.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [x] update the specification
* [x] modify the json schema
* [x] include a release note
