### PR TITLE
Throw error when context keys are missing values

### DIFF
--- a/tests/discover/parametrize.sh
+++ b/tests/discover/parametrize.sh
@@ -75,6 +75,12 @@ rlJournalStart
         rlAssertGrep 'url: https://github.com/teemtee/foobar' 'output'
     rlPhaseEnd
 
+    rlPhaseStartTest 'Empty context value should fail gracefully'
+        rlRun "tmt -c foo= run -r $plan_noctx $steps 2>&1 | tee output" 2
+        rlAssertGrep "Context dimension 'foo' has an empty value" 'output'
+        rlAssertGrep "Use 'KEY=VALUE' format or remove the dimension entirely" 'output'
+    rlPhaseEnd
+
     rlPhaseStartTest 'Using context and variable to select tests'
         rlRun -s "tmt -c PICK_FMF='^/tests/(unit|basic/ls)$' \
             run -e PICK_TMT='^/tests/core/ls$' \

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -318,19 +318,16 @@ class FmfContext(dict[str, list[str]]):
             -c distro=fedora-33 -> {'distro': ['fedora']}
             -c arch=x86_64,ppc64 -> {'arch': ['x86_64', 'ppc64']}
         """
-        for spec_item in spec:
-            if '=' in spec_item and spec_item.endswith('='):
-                key = spec_item.split('=')[0]
+
+        raw_fmf_context: dict[str, list[str]] = {}
+        for key, value in Environment.from_sequence(spec, logger).items():
+            if not value.strip():
                 raise GeneralError(
                     f"Context dimension '{key}' has an empty value. "
                     f"Use 'KEY=VALUE' format or remove the dimension entirely."
                 )
-        return FmfContext(
-            {
-                key: value.split(',')
-                for key, value in Environment.from_sequence(spec, logger).items()
-            }
-        )
+            raw_fmf_context[key] = value.split(',')
+        return FmfContext(raw_fmf_context)
 
     @classmethod
     def _normalize_fmf(

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -318,7 +318,13 @@ class FmfContext(dict[str, list[str]]):
             -c distro=fedora-33 -> {'distro': ['fedora']}
             -c arch=x86_64,ppc64 -> {'arch': ['x86_64', 'ppc64']}
         """
-
+        for spec_item in spec:
+            if '=' in spec_item and spec_item.endswith('='):
+                key = spec_item.split('=')[0]
+                raise GeneralError(
+                    f"Context dimension '{key}' has an empty value. "
+                    f"Use 'KEY=VALUE' format or remove the dimension entirely."
+                )
         return FmfContext(
             {
                 key: value.split(',')


### PR DESCRIPTION
Fix #3921. Thow meaningful error when incorrect
context parameters are passed while running tmt
from command line

Now we get an explicit error when sending incomplete context parameters.
```
(dev) ➜  tmt git:(github-issue-3921) TMT_SHOW_TRACEBACK=2 tmt -c foo= run discover plan -n '/plans/features/advanced'

Context dimension 'foo' has an empty value. Use 'KEY=VALUE' format or remove the dimension entirely.

    Traceback (most recent call last):

    File /home/vaibhav/office/tmt/tmt/__main__.py, line 40, in run_cli
      tmt.cli._root.main()

      tmt = <module 'tmt' from '/home/vaibhav/office/tmt/tmt/__init__.py'>
      error = GeneralError("Context dimension 'foo' has an empty value. Use 'KEY=VALUE' format or remove the dimension entirely.")

    File /home/vaibhav/.local/share/hatch/env/virtual/tmt/ovVD67rI/dev/lib/python3.13/site-packages/click/core.py, line 1442, in __call__
      return self.main(*args, **kwargs)

      self = <CustomGroup main>
      args = ()
      kwargs = {}

    File /home/vaibhav/.local/share/hatch/env/virtual/tmt/ovVD67rI/dev/lib/python3.13/site-packages/click/core.py, line 1363, in main
      rv = self.invoke(ctx)

      self = <CustomGroup main>
      args = ['run', 'discover', 'plan', '-n', '/plans/features/advanced']
      prog_name = 'tmt'
      complete_var = None
      standalone_mode = True
      windows_expand_args = True
      extra = {}
      ctx = <click.core.Context object at 0x7f1de9caa510>

    File /home/vaibhav/.local/share/hatch/env/virtual/tmt/ovVD67rI/dev/lib/python3.13/site-packages/click/core.py, line 1827, in invoke
      super().invoke(ctx)

      self = <CustomGroup main>
      ctx = <click.core.Context object at 0x7f1de9caa510>
      _process_result = <function Group.invoke.<locals>._process_result at 0x7f1de9b4bf60>
      args = ['discover', 'plan', '-n', '/plans/features/advanced']
      cmd_name = 'run'
      cmd = <CustomGroup run>
      __class__ = <class 'click.core.Group'>

    File /home/vaibhav/.local/share/hatch/env/virtual/tmt/ovVD67rI/dev/lib/python3.13/site-packages/click/core.py, line 1226, in invoke
      return ctx.invoke(self.callback, **ctx.params)

      self = <CustomGroup main>
      ctx = <click.core.Context object at 0x7f1de9caa510>

    File /home/vaibhav/.local/share/hatch/env/virtual/tmt/ovVD67rI/dev/lib/python3.13/site-packages/click/core.py, line 794, in invoke
      return callback(*args, **kwargs)

      self = <click.core.Context object at 0x7f1de9caa510>
      callback = <function main at 0x7f1de9b58680>
      args = ()
      kwargs = {'context': ('foo=',), 'root': '.', 'verbose': 0, 'debug': 0, 'quiet': None, 'log_topic': (), 'feeling_safe': False, 'show_time': None, 'version': None, 'no_color': False, 'force_color': False, 'pre_check': False}
      ctx = <click.core.Context object at 0x7f1de9caa510>

    File /home/vaibhav/.local/share/hatch/env/virtual/tmt/ovVD67rI/dev/lib/python3.13/site-packages/click/decorators.py, line 34, in new_func
      return f(get_current_context(), *args, **kwargs)

      args = ()
      kwargs = {'context': ('foo=',), 'root': '.', 'verbose': 0, 'debug': 0, 'quiet': None, 'log_topic': (), 'feeling_safe': False, 'show_time': None, 'version': None, 'no_color': False, 'force_color': False, 'pre_check': False}
      f = <function main at 0x7f1de9b58ae0>

    File /home/vaibhav/office/tmt/tmt/cli/_root.py, line 236, in main
      fmf_context=tmt.utils.FmfContext.from_spec('cli', context, logger),

      click_contex = <click.core.Context object at 0x7f1de9caa510>
      root = '.'
      context = ('foo=',)
      no_color = False
      force_color = False
      show_time = None
      pre_check = False
      kwargs = {'verbose': 0, 'debug': 0, 'quiet': None, 'log_topic': (), 'feeling_safe': False, 'version': None}
      apply_colors_output = True
      apply_colors_logging = True
      logger = <Logger: name=tmt verbosity=0 debug=0 quiet=False topics=set() apply_colors_output=True apply_colors_logging=True>
      tree = <tmt.base.Tree object at 0x7f1de9caa900>

    File /home/vaibhav/office/tmt/tmt/utils/__init__.py, line 373, in from_spec
      return cls._normalize_command_line(list(spec), logger)

      cls = <class 'tmt.utils.FmfContext'>
      key_address = 'cli'
      spec = ('foo=',)
      logger = <Logger: name=tmt verbosity=0 debug=0 quiet=False topics=set() apply_colors_output=True apply_colors_logging=True>

    File /home/vaibhav/office/tmt/tmt/utils/__init__.py, line 324, in _normalize_command_line
      raise GeneralError(

      cls = <class 'tmt.utils.FmfContext'>
      spec = ['foo=']
      logger = <Logger: name=tmt verbosity=0 debug=0 quiet=False topics=set() apply_colors_output=True apply_colors_logging=True>
      spec_item = 'foo='
      key = 'foo'

```
