### PR TITLE
Rename --max option to --max-tests-per-plan with deprecation

### DIFF
--- a/tests/run/max/main.fmf
+++ b/tests/run/max/main.fmf
@@ -1,1 +1,1 @@
-summary: Verify --max option splits plans into smaller plans
+summary: Verify --max-tests-per-plan option splits plans into smaller plans

--- a/tests/run/max/test.sh
+++ b/tests/run/max/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun -s "tmt run -vv --id $run --max 3"
+        rlRun -s "tmt run -vv --id $run --max-tests-per-plan 3"
         rlAssertGrep "Splitting plan to batches of 3 tests." $rlRun_LOG
         rlAssertGrep "3 tests selected" $rlRun_LOG
         rlAssertGrep "summary: 3 tests passed" $rlRun_LOG

--- a/tmt/plugins/plan_shapers/max_tests.py
+++ b/tmt/plugins/plan_shapers/max_tests.py
@@ -38,7 +38,7 @@ class MaxTestsPlanShaper(PlanShaper):
                 help='Split every plan to include N tests at maximum.',
                 type=int,
                 default=-1,
-                deprecated=Deprecated('1.57', hint='use ``--max-tests-per-plan`` instead'),
+                deprecated=Deprecated('1.55', hint='use ``--max-tests-per-plan`` instead'),
             ),
         ]
 

--- a/tmt/plugins/plan_shapers/max_tests.py
+++ b/tmt/plugins/plan_shapers/max_tests.py
@@ -21,16 +21,25 @@ class MaxTestsPlanShaper(PlanShaper):
 
     @classmethod
     def run_options(cls) -> list['ClickOptionDecoratorType']:
-        from tmt.options import option
+        from tmt.options import Deprecated, option
 
         return [
             option(
-                '--max',
+                '--max-tests-per-plan',
                 metavar='N',
-                help='Split plans to include N tests at max.',
+                envvar='TMT_RUN_MAX_TESTS_PER_PLAN',
+                help='Split every plan to include N tests at maximum.',
                 type=int,
                 default=-1,
-            )
+            ),
+            option(
+                '--max',
+                metavar='N',
+                help='Split every plan to include N tests at maximum.',
+                type=int,
+                default=-1,
+                deprecated=Deprecated('1.57', hint='use ``--max-tests-per-plan`` instead'),
+            ),
         ]
 
     @classmethod
@@ -38,7 +47,10 @@ class MaxTestsPlanShaper(PlanShaper):
         if not plan.my_run:
             return False
 
-        max_test_count = plan.my_run.opt('max')
+        # Check new option first, fall back to deprecated option
+        max_test_count = plan.my_run.opt('max-tests-per-plan')
+        if max_test_count <= 0:
+            max_test_count = plan.my_run.opt('max')
 
         if max_test_count <= 0:
             return False
@@ -55,7 +67,10 @@ class MaxTestsPlanShaper(PlanShaper):
 
         assert plan.my_run is not None
 
-        max_test_per_batch = plan.my_run.opt('max')
+        # Check new option first, fall back to deprecated option
+        max_test_per_batch = plan.my_run.opt('max-tests-per-plan')
+        if max_test_per_batch <= 0:
+            max_test_per_batch = plan.my_run.opt('max')
 
         plan.info(f'Splitting plan to batches of {max_test_per_batch} tests.')
 


### PR DESCRIPTION
The --max option is now deprecated in favor of --max-tests-per-plan for better clarity. The old option still works but shows a deprecation warning.

🤖 Polished by [Claude Code](https://claude.ai/code)

Pull Request Checklist

* [x] implement the feature

---

Reviewed-by: [Claude Code](https://claude.ai/code)