### PR TITLE
Use ParamSpec usage in retry() function for proper args/kwargs annotations

### DIFF
--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -79,7 +79,7 @@ if TYPE_CHECKING:
     import tmt.cli
     import tmt.steps
     import tmt.utils.themes
-    from tmt._compat.typing import Self, TypeAlias
+    from tmt._compat.typing import ParamSpec, Self, TypeAlias
     from tmt.hardware import Size
 
 
@@ -272,8 +272,9 @@ GIT_CLONE_ATTEMPTS: int = configure_constant(DEFAULT_GIT_CLONE_ATTEMPTS, 'TMT_GI
 DEFAULT_GIT_CLONE_INTERVAL: int = 10
 GIT_CLONE_INTERVAL: int = configure_constant(DEFAULT_GIT_CLONE_INTERVAL, 'TMT_GIT_CLONE_INTERVAL')
 
-# A stand-in variable for generic use.
+# A stand-in variables for generic use.
 T = TypeVar('T')
+P = ParamSpec('P')
 
 
 WriteMode = Literal['w', 'a']
@@ -3952,9 +3953,6 @@ def format(
     return output + formatted_value
 
 
-P = ParamSpec('P')
-
-
 # [happz] I was thinking how to slot this under the umbrela of `format()`
 # and `format_value()`, but it's 3 values rather than one, and extending
 # their API did not look sane enough.
@@ -5757,13 +5755,13 @@ def format_duration(duration: datetime.timedelta) -> str:
 
 
 def retry(
-    func: Callable[..., T],
+    func: Callable[P, T],
     attempts: int,
     interval: int,
     label: str,
     logger: tmt.log.Logger,
-    *args: Any,
-    **kwargs: Any,
+    *args: P.args,
+    **kwargs: P.kwargs,
 ) -> T:
     """
     Retry functionality to be used elsewhere in the code.


### PR DESCRIPTION
With `ParamSpec`, mypy and pyright are able to match args and kwargs against
the given callback.

🤖 Polished with [Claude Code](https://claude.ai/code)
