### PR TITLE
Add workdir-root to tmt clean test

### DIFF
--- a/tests/clean/runs/test.sh
+++ b/tests/clean/runs/test.sh
@@ -34,7 +34,7 @@ rlJournalStart
         rlAssertNotGrep "(done\s+){1}(todo\s+){6}$run1\s+/plan1" "$rlRun_LOG" -E
         rlAssertGrep "(done\s+){1}(todo\s+){6}$run2\s+/plan1" "$rlRun_LOG" -E
 
-        rlRun -s "tmt clean runs -v -l"
+        rlRun -s "tmt clean runs -v -l --workdir-root $tmprun"
         rlAssertGrep "Removing workdir '$run2'" "$rlRun_LOG"
         rlRun -s "tmt status --workdir-root $tmprun -vv"
         rlAssertNotGrep "(done\s+){1}(todo\s+){6}$run2\s+/plan1" "$rlRun_LOG" -E


### PR DESCRIPTION
Encountered the issue in https://github.com/teemtee/tmt/pull/3869:
```
:: [ 08:04:58 ] :: [  BEGIN   ] :: Running 'tmt clean runs -v -l'
clean
runs
workdir root: /var/tmp/tmt
    Removing workdir '/var/tmp/tmt/clean-004'.
```
Could not reproduce it locally though, and I've triggered a retest (seems to be persistent there though)

---

Closes #3955 
