### PR TITLE
Move man generation inside the CI

### DIFF
--- a/.github/workflows/gen-files.yml
+++ b/.github/workflows/gen-files.yml
@@ -1,0 +1,24 @@
+name: gen-files
+run-name: Generate files
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  HATCH_ENV_TYPE_VIRTUAL_PATH: ${{ github.workspace }}/.hatch_envs
+
+jobs:
+  man:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-docs-env
+      - name: Generate man file and check if it changed anything
+        run: |
+          hatch run docs:man
+          git diff --exit-code

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-tmt.1
 
 # Testing
 .mypy_cache

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,7 +17,6 @@ srpm_build_deps:
 
 actions: &base-actions
   create-archive:
-    - hatch run docs:man
     - hatch build -t sdist
     - bash -c "ls dist/tmt-*.tar.gz"
   get-current-version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ man = [
     "tail -n+8 docs/overview.rst >> {root}/man.rst",
     # TODO rst2man cannot process this directive, removed for now
     "sed '/versionadded::/d' -i {root}/man.rst",
-    "rst2man.py {root}/man.rst > {root}/tmt.1",
+    "rst2man.py {root}/man.rst > {root}/docs/tmt.1",
     "rm -f {root}/man.rst",
     ]
 
@@ -462,7 +462,7 @@ markers = [
 [tool.codespell]
 ignore-words = "docs/codespell.dic"
 exclude-file = "docs/codespell.ignore"
-skip = "tests/execute/weird/data/weird.txt,tests/lint/plan/data/invalid_attr.fmf,tests/lint/plan/test.sh"
+skip = "tests/execute/weird/data/weird.txt,tests/lint/plan/data/invalid_attr.fmf,tests/lint/plan/test.sh,docs/tmt.1"
 
 [tool.djlint]
 use_gitignore=true

--- a/tmt.spec
+++ b/tmt.spec
@@ -145,7 +145,7 @@ export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
 %pyproject_save_files tmt
 
 mkdir -p %{buildroot}%{_mandir}/man1
-install -pm 644 tmt.1 %{buildroot}%{_mandir}/man1
+install -pm 644 docs/tmt.1 %{buildroot}%{_mandir}/man1
 mkdir -p %{buildroot}%{_datadir}/bash-completion/completions
 install -pm 644 completions/bash/%{name} %{buildroot}%{_datadir}/bash-completion/completions/%{name}
 mkdir -p %{buildroot}/etc/%{name}/


### PR DESCRIPTION
This simplifies the sdist generation. The file is synced via the CI, checking if any changes to the man file was needed, in which case the developer should run
```
$ hatch run docs:man
```

---

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
