### PR TITLE
Use proper sdist in `packit srpm`

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,7 +19,7 @@ actions: &base-actions
   create-archive:
     - hatch run docs:man
     - hatch build -t sdist
-    - bash -c "ls dist/tmt-*.tar.gz"
+    - bash -c "echo dist/tmt-$PACKIT_PROJECT_VERSION.tar.gz"
   get-current-version:
     - hatch version
 


### PR DESCRIPTION
If the developer is running `packit srpm` multiple times, only the first sources were being picked up because of the `ls` command. This should make it more robust on that front.