### PR TITLE
Detect and report an unreachable guest

### DIFF
--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -632,6 +632,8 @@ class GuestArtemis(tmt.GuestSsh):
         self.verbose('primary address', self.primary_address, 'green')
         self.verbose('topology address', self.topology_address, 'green')
 
+        self.assert_reachable()
+
     def remove(self) -> None:
         """
         Remove the guest

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -160,6 +160,8 @@ class GuestConnect(tmt.steps.provision.GuestSsh):
         self.verbose('primary address', self.primary_address, 'green')
         self.verbose('topology address', self.topology_address, 'green')
 
+        self.assert_reachable()
+
 
 @tmt.steps.provides_method('connect')
 class ProvisionConnect(tmt.steps.provision.ProvisionPlugin[ProvisionConnectData]):
@@ -278,4 +280,5 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin[ProvisionConnectData]
         self._guest = GuestConnect(
             logger=self._logger, data=data, name=self.name, parent=self.step
         )
+        self._guest.start()
         self._guest.setup()

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -148,6 +148,8 @@ class GuestLocal(tmt.Guest):
         self.verbose('primary address', self.primary_address, 'green')
         self.verbose('topology address', self.topology_address, 'green')
 
+        self.assert_reachable()
+
     def stop(self) -> None:
         """
         Stop the guest
@@ -267,4 +269,5 @@ class ProvisionLocal(tmt.steps.provision.ProvisionPlugin[ProvisionLocalData]):
             self.warn("The 'local' provision plugin does not support hardware requirements.")
 
         self._guest = GuestLocal(logger=self._logger, data=data, name=self.name, parent=self.step)
+        self._guest.start()
         self._guest.setup()

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1431,6 +1431,8 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
         self.verbose('primary address', self.primary_address, 'green')
         self.verbose('topology address', self.topology_address, 'green')
 
+        self.assert_reachable()
+
     def remove(self) -> None:
         """
         Remove the guest

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -251,6 +251,8 @@ class GuestContainer(tmt.Guest):
             )
         )
 
+        self.assert_reachable()
+
     def reboot(
         self,
         hard: bool = False,


### PR DESCRIPTION
This PR adds a check to ensure that every guest is reachable after it has been provisioned. It also fixes the issue where tmt tries to sync guest facts when the guest is unreachable.

Fixes #1121 

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
