### PR TITLE
Introduce `add_step` and `add_phase` helpers to add dynamic phases to steps

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -3339,6 +3339,30 @@ class Plan(
 
         return False
 
+    # TODO: Make the str type-hint more narrow
+    def add_phase(self, step: Union[str, tmt.steps.Step], phase: tmt.steps.Phase) -> None:
+        """
+        Add a phase dynamically to the current plan.
+
+        :param step: The (future) step in which to add the phase.
+        :param phase: The phase to add to the step.
+        """
+        if isinstance(step, str):
+            for s in self.steps():
+                if s.step_name == step:
+                    step = s
+                    break
+            else:
+                raise GeneralError(f"Tried to add to an unknown step: {step}")
+        assert isinstance(step, tmt.steps.Step)
+        if step.plan != self:
+            raise GeneralError(
+                f"Tried to add to a step belonging to a different plan: {step.plan}"
+            )
+        # FIXME: Check that the current step/phase will be in the future
+        # FIXME: Do we only add if the current step is enabled?
+        step.add_phase(phase)
+
 
 class StoryPriority(enum.Enum):
     MUST_HAVE = 'must have'

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -1257,6 +1257,17 @@ class Step(tmt.utils.MultiInvokableCommon, tmt.export.Exportable['Step']):
             key=lambda phase: phase.order,
         )
 
+    def add_phase(self, phase: Phase) -> None:
+        """
+        Add a phase dynamically to the current step.
+
+        :param phase: The phase to add.
+        """
+        # FIXME: Check that the where are consistent
+        if not isinstance(phase, self._plugin_base_class):
+            raise GeneralError(f"The phase {phase} is not part of {self}")
+        self._phases.append(phase)
+
     def actions(self) -> None:
         """
         Run all loaded Login or Reboot action instances of the step

--- a/tmt/steps/prepare/distgit.py
+++ b/tmt/steps/prepare/distgit.py
@@ -73,7 +73,6 @@ def insert_to_prepare_step(
     future_requires: PreparePlugin[Any] = cast(
         PreparePlugin[Any], PreparePlugin.delegate(prepare_step, data=data_require)
     )
-    prepare_step._phases.append(future_requires)
 
     # Future install recommend
     data_recommend = PrepareInstallData(
@@ -88,27 +87,28 @@ def insert_to_prepare_step(
     future_recommends: PreparePlugin[Any] = cast(
         PreparePlugin[Any], PreparePlugin.delegate(prepare_step, data=data_recommend)
     )
-    prepare_step._phases.append(future_recommends)
 
-    prepare_step._phases.append(
-        PrepareDistGit(
-            step=prepare_step,
-            data=DistGitData(
-                where=where,
-                source_dir=sourcedir,
-                phase_name=discover_plugin.name,
-                install_builddeps=discover_plugin.get('dist-git-install-builddeps'),
-                require=discover_plugin.get('dist-git-require'),
-                how='distgit',
-                name="Prepare dist-git sources (buildrequires, patches, discovery...)",
-            ),
-            workdir=None,
-            discover=discover_plugin,
-            future_requires=future_requires,
-            future_recommends=future_recommends,
-            logger=discover_plugin._logger.descend(logger_name="extract-distgit", extra_shift=0),
-        )
+    prepare_dist_git = PrepareDistGit(
+        step=prepare_step,
+        data=DistGitData(
+            where=where,
+            source_dir=sourcedir,
+            phase_name=discover_plugin.name,
+            install_builddeps=discover_plugin.get('dist-git-install-builddeps'),
+            require=discover_plugin.get('dist-git-require'),
+            how='distgit',
+            name="Prepare dist-git sources (buildrequires, patches, discovery...)",
+        ),
+        workdir=None,
+        discover=discover_plugin,
+        future_requires=future_requires,
+        future_recommends=future_recommends,
+        logger=discover_plugin._logger.descend(logger_name="extract-distgit", extra_shift=0),
     )
+
+    prepare_step.add_phase(future_requires)
+    prepare_step.add_phase(future_recommends)
+    prepare_step.add_phase(prepare_dist_git)
 
 
 @container


### PR DESCRIPTION
This primarily offers some interface to dynamically extend phases, which would be useful for external plugin creators.

Wanted to port the PrepareDistGit to use the add_step, but don't think it's doable right now, would require a bit more refactoring.

Note on my distinction between `TODO` and `FIXME`. `FIXME`s I want to be discussed and resolved within the PR, while `TODO`s could be deferred for more investigation. Would probably be nice to make this a contributor guideline?

---

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [ ] extend the test coverage
* [ ] mention the version
* [ ] include a release note
      (worth considering, do we add release notes for something that is meant more for developers?)
