### PR TITLE
Reconfigure renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
     ":enablePreCommit",
     ":semanticCommitsDisabled"
   ],
+  "schedule": ["* 0-6 * * 1"],
   "separateMajorMinor": false,
   "configMigration": true,
   "packageRules": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,12 +43,7 @@
       "matchManagers": ["pep621"],
       "matchDepTypes": ["project.optional-dependencies"],
       "enabled": true,
-      "matchPackageNames": [
-        "/renku-sphinx-theme/",
-        "/sphinx/",
-        "/readthedocs-sphinx-ext/",
-        "/docutils/"
-      ]
+      "matchJsonata": ["managerData.depGroup = 'docs'"]
     },
     {
       "description": "Group hatch dev dependencies together",


### PR DESCRIPTION
We found out that the default schedule in renovate can be a bit buggy, for more context see:
- https://github.com/teemtee/tmt/pull/3775#issuecomment-3202079568
- https://github.com/renovatebot/renovate/discussions/37720

As a quick drive-by, I also found how to simplify updating individual groups which was postponed until some more work on this is needed: https://github.com/teemtee/tmt/pull/3775#discussion_r2273385867