### PR TITLE
Apply `sudo` for reboot command when `become` set

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,15 @@
     Releases
 ======================
 
+tmt-1.57.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using the ``become`` option with the ``connect`` provision
+plugin, the reboot command now properly applies ``sudo`` when
+necessary, ensuring correct privilege handling during system
+restarts.
+
+
 tmt-1.56.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/provision/connect/main.fmf
+++ b/tests/provision/connect/main.fmf
@@ -1,0 +1,4 @@
+summary: Test reboot with connect provision and non-root user
+tag+:
+  - provision-only
+  - provision-virtual

--- a/tests/provision/connect/test.sh
+++ b/tests/provision/connect/test.sh
@@ -29,7 +29,7 @@ rlJournalStart
         # Test reboot with non-root user using become (should apply sudo)
         rlRun -s "tmt -vv run --scratch -i $run_connect $provision reboot --step provision"
         rlAssertGrep "Reboot finished" $rlRun_LOG
-        rlAssertGrep "sudo reboot" $rlRun_LOG
+        rlAssertGrep "sudo /bin/bash -c reboot" $rlRun_LOG
 
         # Test reboot without become (should fail for non-root user)
         provision_no_become="provision -h connect --guest localhost --port $guest_port --key $guest_key --user $guest_user"

--- a/tests/provision/connect/test.sh
+++ b/tests/provision/connect/test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "tmp=\$(mktemp -d)" 0 "Create tmp directory"
+        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
+        rlRun "run_connect=\$(mktemp -d)" 0 "Create run directory for connect plugin"
+        rlRun "run_connect_no_become=\$(mktemp -d)" 0 "Create run directory for connect plugin"
+        rlRun "pushd $tmp"
+        rlRun "set -o pipefail"
+        rlRun "tmt init"
+        rlRun "tmt plan create -t mini plan"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Connect with non-root user and reboot"
+        # First provision a host using virtual provisioner with fedora user
+        rlRun "tmt run --scratch -i $run provision -h virtual --user fedora"
+
+        # Extract SSH login details from the provision step
+        rlRun "guest_port=\$(yq -r '.\"default-0\" | .port' $run/plan/provision/guests.yaml)"
+        rlRun "guest_key=\$(yq -r '.\"default-0\" | .key[0]' $run/plan/provision/guests.yaml)"
+        rlRun "guest_user=\$(yq -r '.\"default-0\" | .user' $run/plan/provision/guests.yaml)"
+
+        # Create connect provision command with become=true for reboot
+        provision="provision -h connect --guest localhost --port $guest_port --key $guest_key --user $guest_user --become"
+
+        # Test reboot with non-root user using become (should apply sudo)
+        rlRun -s "tmt -vv run --scratch -i $run_connect $provision reboot --step provision"
+        rlAssertGrep "Reboot finished" $rlRun_LOG
+        rlAssertGrep "sudo /bin/bash -c reboot" $rlRun_LOG
+
+        # Test reboot without become (should fail for non-root user)
+        provision_no_become="provision -h connect --guest localhost --port $guest_port --key $guest_key --user $guest_user"
+        rlRun -s "tmt -vv run --scratch -i $run_connect_no_become $provision_no_become reboot --step provision" 2
+        rlAssertGrep "fail: Command 'reboot' returned 1." $rlRun_LOG
+        rlAssertGrep "Call to Reboot failed: Interactive authentication required." $rlRun_LOG
+
+        rlRun "tmt run -i $run cleanup"
+        rlRun "tmt run -i $run_connect cleanup"
+        rlRun "tmt run -i $run_connect_no_become cleanup"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -r $tmp" 0 "Remove tmp directory"
+        rlRun "rm -r $run $run_connect" 0 "Remove run directories"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/provision/connect/test.sh
+++ b/tests/provision/connect/test.sh
@@ -29,7 +29,7 @@ rlJournalStart
         # Test reboot with non-root user using become (should apply sudo)
         rlRun -s "tmt -vv run --scratch -i $run_connect $provision reboot --step provision"
         rlAssertGrep "Reboot finished" $rlRun_LOG
-        rlAssertGrep "sudo /bin/bash -c reboot" $rlRun_LOG
+        rlAssertGrep "sudo reboot" $rlRun_LOG
 
         # Test reboot without become (should fail for non-root user)
         provision_no_become="provision -h connect --guest localhost --port $guest_port --key $guest_key --user $guest_user"
@@ -45,6 +45,6 @@ rlJournalStart
     rlPhaseStartCleanup
         rlRun "popd"
         rlRun "rm -r $tmp" 0 "Remove tmp directory"
-        rlRun "rm -r $run $run_connect" 0 "Remove run directories"
+        rlRun "rm -r $run $run_connect $run_connect_no_become" 0 "Remove run directories"
     rlPhaseEnd
 rlJournalEnd

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -2151,7 +2151,7 @@ class Reboot(Action):
             default=None,
             help=f"""
             A command to run on the guest to trigger the reboot.
-            Default is '{DEFAULT_REBOOT_COMMAND}'.
+            Default is ``{DEFAULT_REBOOT_COMMAND}``.
             """,
         )
         def reboot(context: 'tmt.cli.Context', **kwargs: Any) -> None:

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -2147,7 +2147,7 @@ class Reboot(Action):
         )
         @option(
             '--command',
-            type=Optional[str],
+            type=str,
             default=None,
             help=f"""
             A command to run on the guest to trigger the reboot.

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -2147,9 +2147,12 @@ class Reboot(Action):
         )
         @option(
             '--command',
-            type=str,
-            default=str(DEFAULT_REBOOT_COMMAND),
-            help='A command to run on the guest to trigger the reboot.',
+            type=Optional[str],
+            default=None,
+            help=f"""
+            A command to run on the guest to trigger the reboot.
+            Default is '{DEFAULT_REBOOT_COMMAND}'.
+            """,
         )
         def reboot(context: 'tmt.cli.Context', **kwargs: Any) -> None:
             """
@@ -2184,7 +2187,12 @@ class Reboot(Action):
         assert hasattr(self.parent, 'plan')
         assert self.parent.plan is not None
         for guest in self.parent.plan.provision.ready_guests:
-            guest.reboot(hard=self.opt('hard'), command=tmt.utils.ShellScript(self.opt('command')))
+            guest.reboot(
+                hard=self.opt('hard'),
+                command=tmt.utils.ShellScript(self.opt('command'))
+                if self.opt('command')
+                else None,
+            )
         self.info('reboot', 'Reboot finished', color='yellow')
 
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -2936,7 +2936,14 @@ class GuestSsh(Guest):
                 f"Guest '{self.multihost_name}' does not support hard reboot."
             )
 
-        command = command or tmt.steps.DEFAULT_REBOOT_COMMAND
+        default_reboot_command = tmt.steps.DEFAULT_REBOOT_COMMAND
+
+        if self.become:
+            default_reboot_command = ShellScript(
+                f'sudo {default_reboot_command.to_shell_command()}'
+            )
+
+        command = command or default_reboot_command
         waiting = waiting or default_reboot_waiting()
 
         self.debug(f"Soft reboot using command '{command}'.")

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -132,14 +132,9 @@ class GuestConnect(tmt.steps.provision.GuestSsh):
             )
 
         if command is not None:
-            reboot_command = command
-
-            if str(command) == str(tmt.steps.DEFAULT_REBOOT_COMMAND) and self.become:
-                reboot_command = ShellScript(f'sudo {reboot_command}')
-
             return super().reboot(
                 hard=False,
-                command=reboot_command,
+                command=command,
                 waiting=waiting,
             )
 

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -139,6 +139,8 @@ class GuestConnect(tmt.steps.provision.GuestSsh):
             )
 
         if self.soft_reboot is not None:
+            self.debug(f"Soft reboot using the soft reboot command '{self.soft_reboot}'.")
+
             # ignore[union-attr]: mypy still considers `self.soft_reboot` as possibly
             # being `None`, missing the explicit check above.
             return self.perform_reboot(

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -144,18 +144,10 @@ class GuestConnect(tmt.steps.provision.GuestSsh):
             )
 
         if self.soft_reboot is not None:
-            reboot_command = self.soft_reboot
-
-            # Handle default reboot command with becom
-            if command == tmt.steps.DEFAULT_REBOOT_COMMAND and self.become:
-                reboot_command = ShellScript(f'sudo {reboot_command.to_shell_command()}')
-
-            self.debug(f"Soft reboot using the soft reboot command '{reboot_command}'.")
-
             # ignore[union-attr]: mypy still considers `self.soft_reboot` as possibly
             # being `None`, missing the explicit check above.
             return self.perform_reboot(
-                lambda: self._run_guest_command(reboot_command.to_shell_command()),
+                lambda: self._run_guest_command(self.soft_reboot.to_shell_command()),  # type: ignore[union-attr]
                 waiting,
             )
 


### PR DESCRIPTION
While working on #3791 I was connecting to host via the `connect` provisioner and I found out that the `reboot` fails because `sudo` is missing when running it.

Add tests to cover the fix.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [x] include a release note
