### PR TITLE
Base git reference tests on key to prevent flakiness

### DIFF
--- a/tests/discover/references.sh
+++ b/tests/discover/references.sh
@@ -7,8 +7,6 @@ rlJournalStart
         rlRun "tmp=\$(mktemp -d)" 0 "Creating tmp directory for failed run"
         rlRun 'pushd data'
         rlRun 'set -o pipefail'
-        CLONED_HASH=$(git ls-remote https://github.com/teemtee/tmt HEAD | awk '{print $1}' | cut -c1-7)
-        rlLog "Default branch HEAD hash exported as CLONED_HASH=$CLONED_HASH"
     rlPhaseEnd
 
     plan=fmf/nourl/noref/nopath
@@ -62,7 +60,7 @@ rlJournalStart
     rlPhaseStartTest $plan
         rlRun 'tmt run -dddvr discover plan --name $plan finish 2>&1 >/dev/null | tee output'
         rlAssertGrep 'Cloning into' output
-        rlAssertGrep "cloned-commit-hash: $CLONED_HASH" output
+        rlAssertGrep "cloned-commit-hash: " output
         rlAssertGrep 'commit-hash' output
         rlAssertNotGrep 'Checkout ref.*main' output
         rlAssertGrep /tests/core/docs output
@@ -74,7 +72,7 @@ rlJournalStart
     rlPhaseStartTest $plan
         rlRun 'tmt run -dddvr discover plan --name $plan finish 2>&1 >/dev/null | tee output'
         rlAssertGrep 'Cloning into' output
-        rlAssertGrep "cloned-commit-hash: $CLONED_HASH" output
+        rlAssertGrep "cloned-commit-hash: " output
         rlAssertNotGrep 'Checkout ref.*' output
         rlAssertGrep '2 tests selected' output
         rlAssertGrep /tests/full output
@@ -85,7 +83,7 @@ rlJournalStart
     rlPhaseStartTest $plan
         rlRun 'tmt run -dddvr discover plan --name $plan finish 2>&1 >/dev/null | tee output'
         rlAssertGrep 'Cloning into' output
-        rlAssertGrep "cloned-commit-hash: $CLONED_HASH" output
+        rlAssertGrep "cloned-commit-hash: " output
         rlAssertGrep 'Checkout ref.*5407fe5' output
         rlAssertGrep 'ref: 5407fe5' output
         rlAssertGrep '2 tests selected' output
@@ -98,7 +96,7 @@ rlJournalStart
     rlPhaseStartTest $plan
         rlRun 'tmt run -dddvr discover plan --name $plan finish 2>&1 >/dev/null | tee output'
         rlAssertGrep 'Cloning into' output
-        rlAssertGrep "cloned-commit-hash: $CLONED_HASH" output
+        rlAssertGrep "cloned-commit-hash: " output
         rlAssertGrep 'Checkout ref.*eae4d52' output
         rlAssertGrep 'ref: eae4d52' output
         rlAssertGrep '2 tests selected' output


### PR DESCRIPTION
Reference tests were failing intermittently because their assertions depended on a value derived from the main branch's current state. If the main branch was updated while the test suite was running, the expected value would change, causing the test to fail unpredictably. This change modifies the tests to depend on a static key (a stable reference) instead of the dynamic value. This ensures that test assertions remain consistent and deterministic, resolving the flakiness.

Removed-suggestion from code review : https://github.com/teemtee/tmt/pull/3965#pullrequestreview-3154751301
