### PR TITLE
Exclude inactive test cases from Polarion Test Case search

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -15,6 +15,10 @@ The Guide has been extended with a new :ref:`guest-preparation`
 section which covers :ref:`minimal-requirements` for guests and
 describes :ref:`helper-scripts` used for special test actions.
 
+Searching a Test Case in Polarion during test export/import or
+test run export will no longer find test cases that are set as
+inactive.
+
 
 tmt-1.57.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We don't want to search among inactive test cases especially for Test Runs. If the test cases are moved between projects this can sometimes lead to having duplicate test cases and common practice is disabling the ones in the old project. Until now tmt was preferring returning any Test Case matching so excluding old cases meant removing a lot of data from those old ones.

Pull Request Checklist

* [x] implement the feature