### PR TITLE
Add `name` key to the `upgrade` execute schema

### DIFF
--- a/tests/lint/plan/test.sh
+++ b/tests/lint/plan/test.sh
@@ -42,7 +42,6 @@ rlJournalStart
         rlAssertGrep "warn C000 value of \"how\" is not \"shell\"" $rlRun_LOG
         rlAssertGrep "warn C000 value of \"how\" is not \"fmf\"" $rlRun_LOG
         rlAssertGrep "warn C000 value of \"how\" is not \"tmt\"" $rlRun_LOG
-        rlAssertGrep "warn C000 key \"name\" not recognized by schema /schemas/execute/upgrade" $rlRun_LOG
         rlAssertGrep "warn C000 value of \"how\" is not \"upgrade\"" $rlRun_LOG
         rlAssertGrep "fail C000 fmf node failed schema validation" $rlRun_LOG
         rlAssertGrep "fail P003 unknown execute method \"somehow\" in \"default-0\"" $rlRun_LOG

--- a/tmt/schemas/execute/upgrade.yaml
+++ b/tmt/schemas/execute/upgrade.yaml
@@ -25,6 +25,9 @@ properties:
   exit-first:
     type: boolean
 
+  name:
+    type: string
+
   filter:
     $ref: "/schemas/common#/definitions/one_or_more_strings"
 


### PR DESCRIPTION
Since tmt-1.55 keys unrecognized by a schema are considered a fail and not a warn.

TMT defaults to insert the `name` in the execute phase before the schema validation, resulting in a 'name': 'default-x'.
Example:
```
warn: /upgrade:execute - {'how': 'upgrade', 'url': 'https://gitlab.cee.redhat.com/oamg/rhel-major-upgrade', 'upgrade-path': '9to10.cut', 'name': 'default-0'} is not valid under any of the given schemas
```

Added `name` key in the upgrade schema.
Removed the expectation of a `name` key not being recognized by a schema from test.

Pull Request Checklist

* [x] implement the feature
* [x] modify the json schema
* [x] extend the test coverage

Fixes https://github.com/teemtee/tmt/issues/3974 

