### PR TITLE
Fix mrack translation for fedora-rawhide to use Server variant

### DIFF
--- a/tmt/steps/provision/mrack/mrack-provisioning-config.yaml
+++ b/tmt/steps/provision/mrack/mrack-provisioning-config.yaml
@@ -103,6 +103,7 @@ beaker:
     Fedora-42%: Server
     Fedora-43%: Server
     Fedora-44%: Server
+    Fedora-Rawhide-%: Server
 
   distro_tags:
     RHEL-9.0%:


### PR DESCRIPTION
This mr fixes the mrack provisioning configuration to properly translate fedora-rawhide images to use the Server variant in Beaker.

fix the following  issue:

if users specify the following in their plan,

```
provision:
    how: beaker
    image: fedora-rawhide
```
 their tmt jobs would failed with:

``<Fault 1: '<class \'bkr.common.bexceptions.BX\'>:No distro tree matches Recipe: <distroRequires><and><distro_name op="like" value="Fedora-Rawhide-%"/><distro_variant op="=" value="BaseOS"/><distro_arch op="=" value="x86_64"/></and></distroRequires>'>``


Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
