### PR TITLE
Include `key`, `order`, and `public-key` in beaker provision schema

### DIFF
--- a/tests/provision/beaker/data/main.fmf
+++ b/tests/provision/beaker/data/main.fmf
@@ -14,13 +14,13 @@
                  processors: 6
             - or:
                - device:
-                   driver: ahci
+                   - driver: ahci
                - device:
-                   driver: uhci
+                   - driver: uhci
                - disk:
-                   driver: foo
+                   - driver: foo
                - disk:
-                   driver: bar
+                   - driver: bar
 
 /plan/bootc:
     provision+:
@@ -28,3 +28,29 @@
         bootc-image-url: quay.io/fedora/custom-bootc:latest
         bootc-registry-secret: dummysecret
         image: fedora-42
+
+/plan/schema1:
+    provision+:
+      - name: server1
+        image: $@{distro}
+        key: ~/.ssh/key
+        public-key: ~/.ssh/key.pub
+        role: server
+        hardware:
+            hostname: my_host2
+        order: 1
+
+/plan/schema2:
+    provision+:
+      - name: server2
+        image: $@{distro}
+        key:
+            - ~/.ssh/key1
+            - ~/.ssh/key2
+        public-key:
+            - ~/.ssh/key1.pub
+            - ~/.ssh/key2.pub
+        role: server
+        hardware:
+            hostname: my_host2
+        order: 2

--- a/tests/provision/beaker/data/main.fmf
+++ b/tests/provision/beaker/data/main.fmf
@@ -14,13 +14,13 @@
                  processors: 6
             - or:
                - device:
-                   - driver: ahci
+                   driver: ahci
                - device:
-                   - driver: uhci
+                   driver: uhci
                - disk:
-                   - driver: foo
+                   driver: foo
                - disk:
-                   - driver: bar
+                   driver: bar
 
 /plan/bootc:
     provision+:

--- a/tests/provision/beaker/main.fmf
+++ b/tests/provision/beaker/main.fmf
@@ -14,3 +14,10 @@
         Verify translate hardware constraints using custom config
         works well, and override the default translations.
     test: ./hardware.sh
+
+/schema:
+    summary: Verify beaker provision schema
+    description:
+        Verify that the beaker plugin schema contains the
+        appropriate keys.
+    test: ./schema.sh

--- a/tests/provision/beaker/schema.sh
+++ b/tests/provision/beaker/schema.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "pushd data"
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Check that beaker schema contains correct keys"
+        rlRun -s "tmt lint"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/provision/beaker/schema.sh
+++ b/tests/provision/beaker/schema.sh
@@ -9,7 +9,8 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Check that beaker schema contains correct keys"
-        rlRun -s "tmt lint"
+        rlRun -s "tmt lint /plan/schema"
+        rlAssertNotGrep "is not valid under any of the given schemas" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/schemas/provision/beaker.yaml
+++ b/tmt/schemas/provision/beaker.yaml
@@ -52,13 +52,17 @@ properties:
   beaker-job-owner:
     type: string
 
+  key:
+    $ref: "/schemas/common#/definitions/one_or_more_strings"
+
   public-key:
-    type: array
-    items:
-      type: string
+    $ref: "/schemas/common#/definitions/one_or_more_strings"
 
   beaker-job-group:
     type: string
+
+  order:
+    $ref: "/schemas/core#/definitions/order"
 
   bootc-registry-secret:
     type: string


### PR DESCRIPTION
- Add `key` and `order`.
- Update `public-key` to allow a single string.
- Add `tmt lint` test for beaker provision schema. 

Fixes: #4033 

Pull Request Checklist

* [x] extend the test coverage
* [x] modify the json schema
