### PR TITLE
Extend `html` report schema to include `file` key

### DIFF
--- a/tests/report/html/data/main.fmf
+++ b/tests/report/html/data/main.fmf
@@ -54,3 +54,15 @@
     adjust:
       - when: report_multihost == yes
         enabled: true
+
+/report-file-plan:
+    summary: Verify html report with custom file option
+    discover:
+        how: fmf
+    provision:
+        how: local
+    execute:
+        how: tmt
+    report:
+        - how: html
+          file: foo.html

--- a/tests/report/html/test.sh
+++ b/tests/report/html/test.sh
@@ -137,6 +137,11 @@ rlJournalStart
         rlAssertGrep 'class="result skip">skip</td>' $tmp/$test_name_suffix -F
     rlPhaseEnd
 
+    rlPhaseStartTest "Lint warnings for html report file should be gone"
+        rlRun -s "tmt lint /report-file-plan"
+        rlAssertNotGrep "is not valid under any of the given schemas" $rlRun_LOG
+    rlPhaseEnd
+
     rlPhaseStartCleanup
         rlRun "rm output"
         rlRun "popd"

--- a/tests/report/html/test.sh
+++ b/tests/report/html/test.sh
@@ -18,7 +18,7 @@ rlJournalStart
 
             # Path of the generated file should be shown and the page should exist
             rlAssertGrep "output: .*/index.html" $rlRun_LOG
-            HTML=$(grep "output:" $rlRun_LOG | sed 's/.*output: //')
+            HTML=$(grep "output:.*/plan/report/default-0/index.html" $rlRun_LOG | sed 's/.*output: //')
             rlAssertExists "$HTML" || rlDie "Report file '$HTML' not found, nothing to check."
 
             test_name_suffix=error

--- a/tmt/schemas/report/html.yaml
+++ b/tmt/schemas/report/html.yaml
@@ -22,6 +22,9 @@ properties:
   name:
     type: string
 
+  file:
+    type: string
+
   open:
     type: boolean
 


### PR DESCRIPTION
Fixes #4027 

* [X] implement the feature
* [ ] write the documentation
* [X] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [X] modify the json schema
* [ ] mention the version
* [ ] include a release note
