### PR TITLE
Add a new `Issues` section to the `Contribute` page

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -9,10 +9,8 @@ Introduction
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Feel free and welcome to contribute to this project. You can start
-with filing issues and ideas for improvement in GitHub tracker__.
-Before creating a new issue you might want to check the existing
-issues to prevent filing a duplicate. Important issues affecting
-many users are marked with the `known issue`__ label.
+with filing :ref:`issues` and ideas for improvement but if you
+feel like contributing some code you are welcome even more!
 
 Our favorite thoughts from The Zen of Python:
 
@@ -61,8 +59,6 @@ couple of recommendations to keep on mind when writing code:
 
   See the "maximum line length" point above for the actual limit.
 
-__ https://github.com/teemtee/tmt/issues
-__ https://github.com/teemtee/tmt/issues?q=label%3A%22known+issue%22
 __ https://www.python.org/dev/peps/pep-0008/
 
 
@@ -567,6 +563,31 @@ __ https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
 
    Changes made directly to documentation in this repository will
    not be reflected in the tldr pages collection.
+
+
+.. _issues:
+
+Issues
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before creating a `new issue`__ you might want to check the
+`existing issues`__ to prevent filing a duplicate. Important
+issues affecting many users are marked with the `known issue`__
+label.
+
+When creating a new issue, do not use any prefixes or file paths
+in the summary, for categorizing issues we are using labels and
+issue types which make it easier to filter relevant areas.
+
+All newly identified bugs have to be filed as github issues and
+marked with the ``Bug`` type. So, before creating a pull request
+which is fixing a bug, make sure there is a corresponding issue
+filed and mention it in the pull request description. This is
+needed because of Functional Safety certification requirements.
+
+__ https://github.com/teemtee/tmt/issues/new
+__ https://github.com/teemtee/tmt/issues
+__ https://github.com/teemtee/tmt/issues?q=label%3A%22known+issue%22
 
 
 Pull Requests

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,14 @@
     Releases
 ======================
 
+tmt-1.58.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A new :ref:`issues` section has been added to the Contribute page.
+It provides a couple of recommendations about filing issues and
+documents that issues have to be filed for newly identified bugs.
+
+
 tmt-1.57.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Document that issues have to be filed for all newly identified bugs. Move all stuff related to issue handling into a separate section. Discourage users from including various prefixes in the summaries as we use labels and types for categorization.

Pull Request Checklist

* [x] write the documentation
* [x] include a release note