### PR TITLE
Draft: Add `return-on-panic` option to beaker provision plugin

### DIFF
--- a/tests/provision/beaker/data/main.fmf
+++ b/tests/provision/beaker/data/main.fmf
@@ -28,3 +28,8 @@
         bootc-image-url: quay.io/fedora/custom-bootc:latest
         bootc-registry-secret: dummysecret
         image: fedora-42
+
+/plan/watchdog:
+    provision+:
+        return-on-panic: True
+        image: Fedora-42

--- a/tests/provision/beaker/dry.sh
+++ b/tests/provision/beaker/dry.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "pushd data"
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify that beaker-watchdog is set to panic=ignore by default"
+        rlRun -s "tmt run --dry provision --how beaker --image Fedora-42 plan --default"
+        rlAssertGrep 'watchdog panic="ignore"/' $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify that beaker-watchdog is set to return the host to beaker when a kernel panic is detected"
+        rlRun -s "tmt run --dry provision --how beaker --return-on-panic --image Fedora-42 plan --default"
+        rlAssertNotGrep 'watchdog panic="ignore"/' $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "Verify beaker return-on-panic schema optionworks"
+        rlRun -s "tmt run --dry plan --name /plan/watchdog"
+        rlAssertNotGrep 'watchdog panic="ignore"/' $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/provision/beaker/main.fmf
+++ b/tests/provision/beaker/main.fmf
@@ -14,3 +14,7 @@
         Verify translate hardware constraints using custom config
         works well, and override the default translations.
     test: ./hardware.sh
+
+/dry:
+    summary: Verify default beaker configs using dry option
+    test: ./dry.sh

--- a/tmt/schemas/provision/beaker.yaml
+++ b/tmt/schemas/provision/beaker.yaml
@@ -72,5 +72,8 @@ properties:
   bootc-check-system-url:
     type: string
 
+  return-on-panic:
+    type: boolean
+
 required:
   - how

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1161,6 +1161,16 @@ class BeakerGuestData(tmt.steps.provision.GuestSshData):
              """,
     )
 
+    return_on_panic: bool = field(
+        default=False,
+        is_flag=True,
+        option='--return-on-panic',
+        help="""
+             If set, beaker-watchdog will return the host to beaker
+             when a kernel panic is detected.
+             """,
+    )
+
 
 @container
 class ProvisionBeakerData(BeakerGuestData, tmt.steps.provision.ProvisionStepData):
@@ -1204,6 +1214,7 @@ class CreateJobParameters:
     bootc_image_url: Optional[str]
     bootc: bool
     bootc_check_system_url: Optional[str]
+    return_on_panic: bool
 
     def to_mrack(self) -> dict[str, Any]:
         data = dataclasses.asdict(self)
@@ -1225,6 +1236,9 @@ class CreateJobParameters:
                 data['beaker']['ks_append'] = kickstart
         if self.public_key:
             data['beaker']['pubkeys'] = self.public_key
+
+        if not self.return_on_panic:
+            data['beaker']['watchdog'] = {"panic": "ignore"}
 
         return data
 
@@ -1358,6 +1372,9 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
     bootc_check_system_url: Optional[str]
     bootc_registry_secret: Optional[str]
 
+    # beaker-watchdog related attributes
+    return_on_panic: bool
+
     _api: Optional[BeakerAPI] = None
     _api_timestamp: Optional[datetime.datetime] = None
 
@@ -1462,6 +1479,7 @@ class GuestBeaker(tmt.steps.provision.GuestSsh):
             bootc_image_url=self.bootc_image_url,
             bootc=self.bootc,
             bootc_check_system_url=self.bootc_check_system_url,
+            return_on_panic=self.return_on_panic,
         )
 
         if self.is_dry_run:


### PR DESCRIPTION
Add `return-on-panic` option to beaker provision plugin.
When `return-on-panic` is `True` beaker-watchdog will abort the job and return the host to Beaker when kernel panic is detected.

Default value is `False`, setting beaker-watchdog to ignore kernel panics.

**Awaiting completion of subtask: #4004**

Fixes: #3926 

Assisted by: Cursor AI

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
