### PR TITLE
Fix regression around rsync usage with directories and ssh connection

### DIFF
--- a/tests/prepare/shell/data/url.fmf
+++ b/tests/prepare/shell/data/url.fmf
@@ -7,7 +7,7 @@ prepare:
     script: cd $TMT_PREPARE_SHELL_URL_REPOSITORY/scripts && ./hello.sh
 execute:
     how: tmt
-    script: tmt --help
+    script: /usr/bin/true
 finish:
     how: shell
     url: https://github.com/teemtee/try

--- a/tests/prepare/shell/main.fmf
+++ b/tests/prepare/shell/main.fmf
@@ -1,3 +1,7 @@
 summary: Test preparing guest using a shell script
 link:
   - verifies: https://github.com/teemtee/tmt/issues/423
+tag+:
+  - provision-container
+  - provision-local
+  - provision-virtual

--- a/tests/prepare/shell/test.sh
+++ b/tests/prepare/shell/test.sh
@@ -3,25 +3,27 @@
 
 rlJournalStart
     rlPhaseStartSetup
+        rlRun "provision_flags='${PROVISION_HOW:+provision --how=$PROVISION_HOW}'"
+
         rlRun "pushd data"
     rlPhaseEnd
 
     rlPhaseStartTest "Custom Script"
-        rlRun "tmt run -rv plan -n custom" 0 "Prepare using a custom script"
+        rlRun "tmt run -arv $provision_flags plan -n custom" 0 "Prepare using a custom script"
     rlPhaseEnd
 
     rlPhaseStartTest "Commandline Script"
-        rlRun "tmt run -arv plan -n custom \
+        rlRun "tmt run -arv $provision_flags plan -n custom \
             prepare -h shell -s './prepare.sh'" 0 "Prepare using a custom script from cmdline"
     rlPhaseEnd
 
     rlPhaseStartTest "Multiple Commandline Scripts"
-        rlRun "tmt run -arv plans -n multiple \
+        rlRun "tmt run -arv $provision_flags plans -n multiple \
             prepare -h shell -s 'touch /tmp/first' -s 'touch /tmp/second'"
     rlPhaseEnd
 
     rlPhaseStartTest "Remote Script"
-        rlRun -s "tmt -vvv run provision prepare finish cleanup plan -n url" 0 "Prepare using a remote script"
+        rlRun -s "tmt -vvv run ${provision_flags:-provision} prepare finish cleanup plan -n url" 0 "Prepare using a remote script"
         rlAssertGrep "Hello world" "$rlRun_LOG" #check for the prepare script
         rlAssertGrep "third" "$rlRun_LOG" # check for the finish script
     rlPhaseEnd

--- a/tests/prepare/shell/test.sh
+++ b/tests/prepare/shell/test.sh
@@ -3,27 +3,26 @@
 
 rlJournalStart
     rlPhaseStartSetup
-        rlRun "provision_flags='${PROVISION_HOW:+provision --how=$PROVISION_HOW}'"
-
+        rlRun "PROVISION_HOW=${PROVISION_HOW:-local}"
         rlRun "pushd data"
     rlPhaseEnd
 
     rlPhaseStartTest "Custom Script"
-        rlRun "tmt run -arv $provision_flags plan -n custom" 0 "Prepare using a custom script"
+        rlRun "tmt run -arv provision --how=$PROVISION_HOW plan -n custom" 0 "Prepare using a custom script"
     rlPhaseEnd
 
     rlPhaseStartTest "Commandline Script"
-        rlRun "tmt run -arv $provision_flags plan -n custom \
+        rlRun "tmt run -arv provision --how=$PROVISION_HOW plan -n custom \
             prepare -h shell -s './prepare.sh'" 0 "Prepare using a custom script from cmdline"
     rlPhaseEnd
 
     rlPhaseStartTest "Multiple Commandline Scripts"
-        rlRun "tmt run -arv $provision_flags plans -n multiple \
+        rlRun "tmt run -arv provision --how=$PROVISION_HOW plans -n multiple \
             prepare -h shell -s 'touch /tmp/first' -s 'touch /tmp/second'"
     rlPhaseEnd
 
     rlPhaseStartTest "Remote Script"
-        rlRun -s "tmt -vvv run ${provision_flags:-provision} prepare finish cleanup plan -n url" 0 "Prepare using a remote script"
+        rlRun -s "tmt -vvv run provision --how=$PROVISION_HOW prepare finish cleanup plan -n url" 0 "Prepare using a remote script"
         rlAssertGrep "Hello world" "$rlRun_LOG" #check for the prepare script
         rlAssertGrep "third" "$rlRun_LOG" # check for the finish script
     rlPhaseEnd

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -153,6 +153,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
                         preserve_perms=True,
                         chmod=0o755,
                         recursive=True,
+                        mkdir_p=True,
                     ),
                 )
 

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -153,7 +153,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
                         preserve_perms=True,
                         chmod=0o755,
                         recursive=True,
-                        mkdir_p=True,
+                        create_destination=True,
                     ),
                 )
 

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -148,7 +148,12 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
                 guest.push(
                     source=repo_path,
                     destination=repo_path,
-                    options=TransferOptions(protect_args=True, preserve_perms=True, chmod=0o755),
+                    options=TransferOptions(
+                        protect_args=True,
+                        preserve_perms=True,
+                        chmod=0o755,
+                        recursive=True,
+                    ),
                 )
 
         if not self.is_dry_run:

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -354,6 +354,9 @@ class TransferOptions:
     #: Ignore symlinks that point outside the source tree
     safe_links: bool = False
 
+    #: Run a ``mkdir -p`` of the destination before doing transfer
+    mkdir_p: bool = False
+
     def copy(self) -> 'TransferOptions':
         """Create a copy of the options."""
 
@@ -2799,6 +2802,9 @@ class GuestSsh(Guest):
         ]
 
         try:
+            if options.mkdir_p:
+                mkdir_cmd = Command("mkdir", "-p", str(destination.parent))
+                self.execute(mkdir_cmd, silent=True)
             self._run_guest_command(cmd, silent=True)
 
         except tmt.utils.RunError as exc:

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -2787,12 +2787,15 @@ class GuestSsh(Guest):
         if superuser and self.user != 'root':
             cmd += ['--rsync-path', 'sudo rsync']
 
+        # When rsync-ing directories, make sure we do not copy to a subfolder (/foo/bar/bar)
+        path_suffix = "/" if options.recursive else ""
+
         cmd += [
             *options.to_rsync(),
             "-e",
             self._ssh_command.to_element(),
-            source,
-            f"{self._ssh_guest}:{destination}",
+            f"{source}{path_suffix}",
+            f"{self._ssh_guest}:{destination}{path_suffix}",
         ]
 
         try:

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -355,7 +355,7 @@ class TransferOptions:
     safe_links: bool = False
 
     #: Run a ``mkdir -p`` of the destination before doing transfer
-    mkdir_p: bool = False
+    create_destination: bool = False
 
     def copy(self) -> 'TransferOptions':
         """Create a copy of the options."""
@@ -2802,7 +2802,7 @@ class GuestSsh(Guest):
         ]
 
         try:
-            if options.mkdir_p:
+            if options.create_destination:
                 self.execute(Command("mkdir", "-p", destination.parent), silent=True)
             self._run_guest_command(cmd, silent=True)
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -2803,8 +2803,7 @@ class GuestSsh(Guest):
 
         try:
             if options.mkdir_p:
-                mkdir_cmd = Command("mkdir", "-p", str(destination.parent))
-                self.execute(mkdir_cmd, silent=True)
+                self.execute(Command("mkdir", "-p", destination.parent), silent=True)
             self._run_guest_command(cmd, silent=True)
 
         except tmt.utils.RunError as exc:


### PR DESCRIPTION
The original issue is that the rsync command used when trying to `guest.push` on steps like `PrepareShell` do not include flags to copy whole directory and it is missing a `mkdir -p` on the guest to create any missing paths, hence the failure
```
        Cause number 1:

            Command 'rsync --chmod=755 -s -p -e 'ssh -oForwardX11=no -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oConnectionAttempts=5 -oConnectTimeout=60 -oServerAliveInterval=5 -oServerAliveCountMax=60 -oIdentitiesOnly=yes -p10023 -i /var/tmp/tmt/run-002/url/provision/default-0/id_ecdsa -oPasswordAuthentication=no -S/var/tmp/tmt/run-002/ssh-sockets/127.0.0.1-10023-root.socket' /var/tmp/tmt/run-002/url/prepare/default-0/repository root@127.0.0.1:/var/tmp/tmt/run-002/url/prepare/default-0/repository' returned 3.

            # stdout (1/1 lines)
            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            skipping directory repository
            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

            # stderr (2/2 lines)
            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            rsync: [Receiver] change_dir#3 "/var/tmp/tmt/run-002/url/prepare/default-0" failed: No such file or directory (2)
            rsync error: errors selecting input/output files, dirs (code 3) at main.c(829) [Receiver=3.4.1]
            # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fixes #4032 

---

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage