### PR TITLE
Limit EFI handling to Beaker systems only

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -15,6 +15,11 @@ The Guide has been extended with a new :ref:`guest-preparation`
 section which covers :ref:`minimal-requirements` for guests and
 describes :ref:`helper-scripts` used for special test actions.
 
+The ``tmt-reboot`` command was changed to handle special EFI
+handling for Beaker systems only. The ``-e`` option can be used
+to force this behaviour. See the :ref:`/stories/features/reboot`
+section for updated usage details.
+
 
 tmt-1.57.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/stories/features/reboot.fmf
+++ b/stories/features/reboot.fmf
@@ -24,10 +24,12 @@ description: |
     option of the reboot script, e.g. ``tmt-reboot -t 3600`` to
     wait for up to an hour for the guest to come back up.
 
-    On machines booted in UEFI mode, by default, the *BootNext*
-    property shall be set to the value of *BootCurrent*. The
-    ``-e`` option of the reboot script can be used to prevent
-    this from being set, e.g. ``tmt-reboot -e``.
+    On Beaker machines booted in UEFI mode, by default, the
+    ``BootNext`` property shall be set to the value of ``BootCurrent``.
+    If ``BootCurrent`` cannot be found, use the value of file
+    ``/root/EFI_BOOT_ENTRY.TXT`` for ``BootNext``. The ``-e``
+    option of the reboot script can be used to force this behaviour,
+    e.g. ``tmt-reboot -e``.
 
     For backward-compatibility with the `restraint`__ framework
     the ``rstrnt-reboot`` and ``rhts-reboot`` commands are provided

--- a/tmt/steps/scripts/tmt-reboot
+++ b/tmt/steps/scripts/tmt-reboot
@@ -17,20 +17,21 @@ PATH=/sbin:/usr/sbin:$PATH
 
 command=""
 timeout=""
-efi=True
+efi=False
 while getopts "c:t:e" flag; do
     case "${flag}" in
         c) command="${OPTARG}";;
         t) timeout="${OPTARG}";;
-        e) efi=False;;
+        e) efi=True;;
         *) exit 1;;
     esac
 done
 
-if [ $efi = True ]; then
+# Handle EFI for Beaker
+if [[ $efi = True || -f /root/EFI_BOOT_ENTRY.TXT ]]; then
     if efibootmgr &>/dev/null ; then
         os_boot_entry=$(efibootmgr | awk '/BootCurrent/ { print $2 }')
-        # fall back to /root/EFI_BOOT_ENTRY.TXT if it exists and BootCurrent is not available
+        # fall back to /root/EFI_BOOT_ENTRY.TXT if BootCurrent is not available
         if [[ -z "$os_boot_entry" && -f /root/EFI_BOOT_ENTRY.TXT ]] ; then
             os_boot_entry=$(</root/EFI_BOOT_ENTRY.TXT)
         fi
@@ -38,8 +39,10 @@ if [ $efi = True ]; then
             logger -s "efibootmgr -n $os_boot_entry"
             efibootmgr -n "$os_boot_entry"
         else
-            logger -s "Could not determine value for BootNext!"
+            logger -s "Could not determine the value for BootNext, no changes were made!"
         fi
+    else
+        logger -s "No efibootmgr command found, skipping handling of EFI for Beaker!"
     fi
 fi
 


### PR DESCRIPTION
The ``tmt-reboot`` command was changed to handle special EFI handling for Beaker systems only. The ``-e`` option can be used to force this behaviour. According to the information I gathered about the issue, seems this is really needed by default on Beaker UEFI systems and can cause issues otherwise.

Resolves #4007

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [ ] extend the test coverage
* [x] include a release note
