### PR TITLE
Add the `DeepWiki` badge and link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
                     tmt - Test Management Tool
 ==================================================================
 
-|docs| |matrix| |fedora-pkg| |copr-build| |pypi-version| |license|
+|docs| |deepwiki| |matrix| |fedora-pkg| |copr-build| |pypi-version| |license|
 
 The ``tmt`` tool provides a user-friendly way to work with tests.
 You can comfortably create new tests, safely and easily run tests
@@ -42,6 +42,10 @@ Use the ``tldr tmt`` command to quickly get started.
 .. |docs| image:: https://img.shields.io/badge/Read%20the%20Docs-8CA1AF?logo=readthedocs&logoColor=fff
     :target: https://tmt.readthedocs.io/
     :alt: Documentation
+
+.. |deepwiki| image:: https://deepwiki.com/badge.svg
+    :target: https://deepwiki.com/teemtee/tmt
+    :alt: Ask DeepWiki
 
 .. |matrix| image:: https://img.shields.io/badge/Matrix-000?logo=matrix&logoColor=fff
     :target: https://matrix.to/#/#tmt:fedoraproject.org

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -829,6 +829,9 @@ https://github.com/teemtee/tmt
 Docs:
 https://tmt.readthedocs.io/
 
+Ask DeepWiki:
+https://deepwiki.com/teemtee/tmt
+
 Stories:
 https://tmt.readthedocs.io/en/stable/stories.html
 


### PR DESCRIPTION
Let's make deepwiki easily discoverable, it can help public contributors to get more insight into the codebase and ask questions and investigate and AI generated documentation directly.

Also according to some notes on the internet, this should cause an automatic weekly update of the docs, but I am not able to confirm this on an official site, found a note about this functionlity in this article:

https://dev.to/rishabh-hub/harnessing-deepwiki-a-developers-guide-to-smarter-code-exploration-30dd

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [ ] include a release note
