### PR TITLE
Spec file cleanup

### DIFF
--- a/packaging/rpm/tmt.spec
+++ b/packaging/rpm/tmt.spec
@@ -42,10 +42,6 @@ metadata specification (L1 and L2) and allows easy test execution.
 Summary:        Dependencies required for tmt test import and export
 Requires:       tmt == %{version}-%{release}
 Requires:       make
-Requires:       python3-bugzilla
-Requires:       python3-nitrate
-Requires:       python3-html2text
-Requires:       python3-markdown
 
 %description -n tmt+test-convert %_metapackage_description
 
@@ -60,7 +56,6 @@ Requires:       ansible-collection-containers-podman
 %package -n     tmt+provision-virtual
 Summary:        Dependencies required for tmt virtual machine provisioner
 Requires:       tmt == %{version}-%{release}
-Requires:       python3-testcloud >= 0.11.7
 Requires:       libvirt-daemon-config-network
 Requires:       openssh-clients
 # Recommend qemu system emulators for supported arches

--- a/packaging/rpm/tmt.spec
+++ b/packaging/rpm/tmt.spec
@@ -14,19 +14,6 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-docutils
 
 Requires:       git-core rsync sshpass
-
-%if 0%{?fedora} < 40
-Obsoletes:      python3-tmt < %{version}-%{release}
-Provides:       tmt-report-html == %{version}-%{release}
-Obsoletes:      tmt-report-html < %{version}-%{release}
-Provides:       tmt-report-junit == %{version}-%{release}
-Obsoletes:      tmt-report-junit < %{version}-%{release}
-Provides:       tmt-report-polarion == %{version}-%{release}
-Obsoletes:      tmt-report-polarion < %{version}-%{release}
-Provides:       tmt-report-reportportal == %{version}-%{release}
-Obsoletes:      tmt-report-reportportal < %{version}-%{release}
-%endif
-
 Recommends:     bash-completion
 Recommends:     ansible-core
 
@@ -53,10 +40,6 @@ metadata specification (L1 and L2) and allows easy test execution.
 
 %package -n     tmt+test-convert
 Summary:        Dependencies required for tmt test import and export
-Provides:       tmt-test-convert == %{version}-%{release}
-%if 0%{?fedora} < 40
-Obsoletes:      tmt-test-convert < %{version}-%{release}
-%endif
 Requires:       tmt == %{version}-%{release}
 Requires:       make
 Requires:       python3-bugzilla
@@ -68,10 +51,6 @@ Requires:       python3-markdown
 
 %package -n     tmt+provision-container
 Summary:        Dependencies required for tmt container provisioner
-Provides:       tmt-provision-container == %{version}-%{release}
-%if 0%{?fedora} < 40
-Obsoletes:      tmt-provision-container < %{version}-%{release}
-%endif
 Requires:       tmt == %{version}-%{release}
 Requires:       podman
 Requires:       ansible-collection-containers-podman
@@ -80,10 +59,6 @@ Requires:       ansible-collection-containers-podman
 
 %package -n     tmt+provision-virtual
 Summary:        Dependencies required for tmt virtual machine provisioner
-Provides:       tmt-provision-virtual == %{version}-%{release}
-%if 0%{?fedora} < 40
-Obsoletes:      tmt-provision-virtual < %{version}-%{release}
-%endif
 Requires:       tmt == %{version}-%{release}
 Requires:       python3-testcloud >= 0.11.7
 Requires:       libvirt-daemon-config-network
@@ -101,7 +76,6 @@ Recommends:     qemu-system-x86-core
 
 %package -n     tmt+provision-bootc
 Summary:        Dependencies required for tmt bootc machine provisioner
-Provides:       tmt-provision-bootc == %{version}-%{release}
 Requires:       tmt == %{version}-%{release}
 Requires:       tmt+provision-virtual == %{version}-%{release}
 Requires:       podman
@@ -118,10 +92,6 @@ Requires:       (podman-machine if (filesystem(x86-64) or filesystem(aarch-64)))
 
 %package -n     tmt+provision-beaker
 Summary:        Dependencies required for tmt beaker provisioner
-Provides:       tmt-provision-beaker == %{version}-%{release}
-%if 0%{?fedora} < 40
-Obsoletes:      tmt-provision-beaker < %{version}-%{release}
-%endif
 Requires:       tmt == %{version}-%{release}
 Requires:       python3-mrack-beaker
 
@@ -138,10 +108,6 @@ Requires:       mock
 # Replace with pyproject_extras_subpkg at some point
 %package -n     tmt+all
 Summary:        Extra dependencies for the Test Management Tool
-Provides:       tmt-all == %{version}-%{release}
-%if 0%{?fedora} < 40
-Obsoletes:      tmt-all < %{version}-%{release}
-%endif
 Requires:       tmt+export-polarion == %{version}-%{release}
 Requires:       tmt+link-jira == %{version}-%{release}
 Requires:       tmt+prepare-artifact == %{version}-%{release}

--- a/packaging/rpm/tmt.spec
+++ b/packaging/rpm/tmt.spec
@@ -131,7 +131,6 @@ package to have all available plugins ready for testing.
 %pyproject_buildrequires
 
 %build
-export SETUPTOOLS_SCM_PRETEND_VERSION=%{version}
 %pyproject_wheel
 
 # Build the man files


### PR DESCRIPTION
Some spec file cleanups. Unfortunately we still do not have a workaround for adding `Requires:` into `%pyproject_extras_subpkg` and seems like it will never be, but there are still a few cleanups we can do
- Remove the `Provides`/`Obsoletes`. The only remaining affected place is epel9, but there have been so many releases and rhel minor releases in between that we can drop it
- `tmt+all` can be a simple `%pyproject_extras_subpkg`. Trying to retain the old description by re-defining it
- Removed the `Python3-*` dependencies. Those should already be covered by python dependencies magic
- Removed `SETUPTOOLS_SCM_PRETEND_VERSION` workaround. We are not actually using it, otherwise it would have failed in `%pyproject_buildrequires` step