### PR TITLE
Support fetching logs in Artemis provision plugin

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -41,6 +41,10 @@ directory located within the tmt run's workdir. If
 triggered, and the default scripts path under the run's workdir
 will be used.
 
+:ref:`/plugins/provision/artemis` provision plugin now supports
+fetching logs. The plugin will attempt to fetch only the logs
+specified by the ``log_type`` key.
+
 
 tmt-1.57.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -41,9 +41,9 @@ directory located within the tmt run's workdir. If
 triggered, and the default scripts path under the run's workdir
 will be used.
 
-:ref:`/plugins/provision/artemis` provision plugin now supports
-fetching logs. The plugin will attempt to fetch only the logs
-specified by the ``log-type`` key.
+The :ref:`/plugins/provision/artemis` provision plugin now
+supports fetching logs. The plugin will attempt to fetch only the
+logs specified by the ``log-type`` key.
 
 
 tmt-1.57.0

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -43,7 +43,7 @@ will be used.
 
 :ref:`/plugins/provision/artemis` provision plugin now supports
 fetching logs. The plugin will attempt to fetch only the logs
-specified by the ``log_type`` key.
+specified by the ``log-type`` key.
 
 
 tmt-1.57.0

--- a/tmt/schemas/provision/artemis.yaml
+++ b/tmt/schemas/provision/artemis.yaml
@@ -101,6 +101,15 @@ properties:
           - "console:dump/url"
           - "console:interactive/url"
           - "sys.log:dump/url"
+          - "flasher-debug:dump/url"
+          - "flasher-debug:dump/blob"
+          - "flasher-event:dump/url"
+          - "flasher-event:dump/blob"
+          - "anaconda.log:dump/blob"
+          - "storage.log:dump/blob"
+          - "program.log:dump/blob"
+          - "packaging.log:dump/blob"
+          - "ks.cfg:dump/blob"
       - type: array
         items:
           type: string
@@ -109,6 +118,15 @@ properties:
             - "console:dump/url"
             - "console:interactive/url"
             - "sys.log:dump/url"
+            - "flasher-debug:dump/url"
+            - "flasher-debug:dump/blob"
+            - "flasher-event:dump/url"
+            - "flasher-event:dump/blob"
+            - "anaconda.log:dump/blob"
+            - "storage.log:dump/blob"
+            - "program.log:dump/blob"
+            - "packaging.log:dump/blob"
+            - "ks.cfg:dump/blob"
 
 required:
   - how

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -848,7 +848,7 @@ class GuestLogArtemis(tmt.steps.provision.GuestLog):
         :returns: content of the log, or ``None`` if the log cannot be retrieved.
         """
         if self.guest.guestname is None:
-            logger.warning("Failed to fetch log - guest does not exist")
+            logger.warning("Failed to fetch log - guest does not exist.")
             return None
 
         response = self.guest.api.inspect(f'/guests/{self.guest.guestname}/logs/{self.log_type}')


### PR DESCRIPTION
Artemis provision plugin now supports fetching logs. The plugin will attempt to fetch only the logs specified by the `log-type` key.

Resolves #3975 

Pull Request Checklist

* [x] implement the feature
* [x] modify the json schema
* [x] include a release note