### PR TITLE
Simplify creation of plugin registry and its decorator

### DIFF
--- a/tests/core/about/test.sh
+++ b/tests/core/about/test.sh
@@ -2,12 +2,14 @@
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 EXPECTED_PLUGIN_LIST=\
-"export.plan: dict json template yaml
+"export.fmfid: dict json template yaml
+export.plan: dict json template yaml
 export.story: dict json rst template yaml
 export.test: dict json nitrate polarion template yaml
 package_managers: apk apt bootc dnf dnf5 rpm-ostree yum
 plan_shapers: max-tests repeat
 prepare.feature: crb epel fips profile
+step.cleanup: tmt
 step.discover: fmf shell
 step.execute: tmt upgrade
 step.finish: ansible shell

--- a/tmt/cli/about.py
+++ b/tmt/cli/about.py
@@ -10,7 +10,7 @@ import tmt.utils.rest
 from tmt.cli import Context, CustomGroup, pass_context
 from tmt.cli._root import main
 from tmt.options import option
-from tmt.plugins import PluginRegistry, iter_plugin_registries
+from tmt.plugins import REGISTRIES, PluginRegistry
 from tmt.utils import GeneralError
 from tmt.utils.templates import render_template, render_template_file
 
@@ -53,7 +53,7 @@ def _render_plugins_list_rest() -> str:
 
     return render_template_file(
         TEMPLATES_DIRECTORY / 'plugins-ls.rst.j2',
-        REGISTRIES=iter_plugin_registries(),
+        REGISTRIES=REGISTRIES,
         find_intro=find_intro,
     )
 
@@ -102,10 +102,7 @@ def plugins_ls(context: Context, how: str) -> None:
         _ls(
             context,
             how,
-            {
-                registry.name: list(registry.iter_plugin_ids())
-                for registry in iter_plugin_registries()
-            },
+            {registry.name: list(registry.iter_plugin_ids()) for registry in REGISTRIES},
         )
 
 

--- a/tmt/frameworks/__init__.py
+++ b/tmt/frameworks/__init__.py
@@ -18,24 +18,9 @@ _FRAMEWORK_PLUGIN_REGISTRY: tmt.plugins.PluginRegistry[TestFrameworkClass] = (
     tmt.plugins.PluginRegistry('test.framework')
 )
 
-
-def provides_framework(framework: str) -> Callable[[TestFrameworkClass], TestFrameworkClass]:
-    """
-    A decorator for registering test frameworks.
-
-    Decorate a test framework plugin class to register a test framework.
-    """
-
-    def _provides_framework(framework_cls: TestFrameworkClass) -> TestFrameworkClass:
-        _FRAMEWORK_PLUGIN_REGISTRY.register_plugin(
-            plugin_id=framework,
-            plugin=framework_cls,
-            logger=tmt.log.Logger.get_bootstrap_logger(),
-        )
-
-        return framework_cls
-
-    return _provides_framework
+provides_framework: Callable[[str], Callable[[TestFrameworkClass], TestFrameworkClass]] = (
+    _FRAMEWORK_PLUGIN_REGISTRY.create_decorator()
+)
 
 
 class TestFramework:

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -80,30 +80,12 @@ _PACKAGE_MANAGER_PLUGIN_REGISTRY: tmt.plugins.PluginRegistry[
     'PackageManagerClass[PackageManagerEngine]'
 ] = tmt.plugins.PluginRegistry('package_managers')
 
-
-def provides_package_manager(
-    package_manager: str,
-) -> Callable[
-    ['PackageManagerClass[PackageManagerEngineT]'], 'PackageManagerClass[PackageManagerEngineT]'
-]:
-    """
-    A decorator for registering package managers.
-
-    Decorate a package manager plugin class to register a package manager.
-    """
-
-    def _provides_package_manager(
-        package_manager_cls: 'PackageManagerClass[PackageManagerEngineT]',
-    ) -> 'PackageManagerClass[PackageManagerEngineT]':
-        _PACKAGE_MANAGER_PLUGIN_REGISTRY.register_plugin(
-            plugin_id=package_manager,
-            plugin=package_manager_cls,  # type: ignore[arg-type]
-            logger=tmt.log.Logger.get_bootstrap_logger(),
-        )
-
-        return package_manager_cls
-
-    return _provides_package_manager
+provides_package_manager: Callable[
+    [str],
+    Callable[
+        ['PackageManagerClass[PackageManagerEngine]'], 'PackageManagerClass[PackageManagerEngine]'
+    ],
+] = _PACKAGE_MANAGER_PLUGIN_REGISTRY.create_decorator()
 
 
 def find_package_manager(

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -155,7 +155,9 @@ class ApkEngine(PackageManagerEngine):
         raise tmt.utils.GeneralError("There is no support for debuginfo packages in apk.")
 
 
-@provides_package_manager('apk')
+# ignore[type-arg]: TypeVar in package manager registry annotations is
+# puzzling for type checkers. And not a good idea in general, probably.
+@provides_package_manager('apk')  # type: ignore[arg-type]
 class Apk(PackageManager[ApkEngine]):
     NAME = 'apk'
 

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -239,7 +239,9 @@ class AptEngine(PackageManagerEngine):
         raise tmt.utils.GeneralError("There is no support for debuginfo packages in apt.")
 
 
-@provides_package_manager('apt')
+# ignore[type-arg]: TypeVar in package manager registry annotations is
+# puzzling for type checkers. And not a good idea in general, probably.
+@provides_package_manager('apt')  # type: ignore[arg-type]
 class Apt(PackageManager[AptEngine]):
     NAME = 'apt'
 

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -142,7 +142,9 @@ class BootcEngine(PackageManagerEngine):
         return script
 
 
-@provides_package_manager('bootc')
+# ignore[type-arg]: TypeVar in package manager registry annotations is
+# puzzling for type checkers. And not a good idea in general, probably.
+@provides_package_manager('bootc')  # type: ignore[arg-type]
 class Bootc(PackageManager[BootcEngine]):
     NAME = 'bootc'
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -167,7 +167,9 @@ class DnfEngine(PackageManagerEngine):
         return script
 
 
-@provides_package_manager('dnf')
+# ignore[type-arg]: TypeVar in package manager registry annotations is
+# puzzling for type checkers. And not a good idea in general, probably.
+@provides_package_manager('dnf')  # type: ignore[arg-type]
 class Dnf(PackageManager[DnfEngine]):
     NAME = 'dnf'
 
@@ -230,7 +232,9 @@ class Dnf5Engine(DnfEngine):
     skip_missing_packages_option = '--skip-unavailable'
 
 
-@provides_package_manager('dnf5')
+# ignore[type-arg]: TypeVar in package manager registry annotations is
+# puzzling for type checkers. And not a good idea in general, probably.
+@provides_package_manager('dnf5')  # type: ignore[arg-type]
 class Dnf5(Dnf):
     NAME = 'dnf5'
 
@@ -303,7 +307,9 @@ class YumEngine(DnfEngine):
         return ShellScript(f'{self.command.to_script()} makecache')
 
 
-@provides_package_manager('yum')
+# ignore[type-arg]: TypeVar in package manager registry annotations is
+# puzzling for type checkers. And not a good idea in general, probably.
+@provides_package_manager('yum')  # type: ignore[arg-type]
 class Yum(Dnf):
     NAME = 'yum'
 

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -113,7 +113,9 @@ class RpmOstreeEngine(PackageManagerEngine):
         raise GeneralError("rpm-ostree does not support debuginfo packages.")
 
 
-@provides_package_manager('rpm-ostree')
+# ignore[type-arg]: TypeVar in package manager registry annotations is
+# puzzling for type checkers. And not a good idea in general, probably.
+@provides_package_manager('rpm-ostree')  # type: ignore[arg-type]
 class RpmOstree(PackageManager[RpmOstreeEngine]):
     NAME = 'rpm-ostree'
 

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -472,7 +472,7 @@ class PluginRegistry(Generic[RegisterableT]):
         """
 
         def _registerable_decorator(
-            plugin_id: str, *args: P.args, **kwargs: P.kwargs
+            plugin_id: str, /, *args: P.args, **kwargs: P.kwargs
         ) -> Callable[[RegisterableT], RegisterableT]:
             def __registerable_decorator(cls: RegisterableT) -> RegisterableT:
                 self.register_plugin(
@@ -493,7 +493,7 @@ class PluginRegistry(Generic[RegisterableT]):
         # the correct type, but having a name, it leads to `Arg(str, 'plugin_id')`
         # rather than `str` when mypy processes the annotations. And that's
         # not the same thing.
-        return _registerable_decorator  # type: ignore[return-value]
+        return _registerable_decorator
 
 
 class ModuleImporter(Generic[ModuleT]):

--- a/tmt/plugins/__init__.py
+++ b/tmt/plugins/__init__.py
@@ -9,13 +9,15 @@ import sys
 from collections.abc import Iterator
 from importlib.metadata import entry_points
 from types import ModuleType
-from typing import Any, Generic, Optional, TypeVar, cast
+from typing import Any, Callable, Generic, Optional, TypeVar, cast
 
 import tmt
 import tmt.utils
+from tmt._compat.typing import Concatenate, ParamSpec
 from tmt.log import Logger
 from tmt.utils import GeneralError, Path
 
+P = ParamSpec('P')
 ModuleT = TypeVar('ModuleT', bound=ModuleType)
 
 
@@ -333,13 +335,46 @@ def import_member(
 
 RegisterableT = TypeVar('RegisterableT')
 
+#: A collection of known registries.
+REGISTRIES: list['PluginRegistry[Any]'] = []
+
 
 class PluginRegistry(Generic[RegisterableT]):
     """
     A container for plugins of shared purpose.
 
     A fancy wrapper for a dictionary at its core, but allows for nicer
-    annotations and more visible semantics.
+    annotations and more visible semantics when working with plugins.
+
+    For the basic use cases, the following should provide overview of
+    the usage:
+
+    .. code-block:: python
+
+        # Create a new registry called `my plugins`, collecting plugins
+        # of `MyPlugin` class:
+        my_registry: PluginRegistry[type[MyPlugin]] = PluginRegistry('my plugins')
+
+        # Create a decorator to mark classes as plugins belonging to the
+        # new registry:
+        my_plugin = my_registry.create_decorator()
+
+        # Register a couple of plugins:
+        @my_plugin('foo')
+        class Foo(MyPlugin):
+            ...
+
+        @my_plugin('bar')
+        class Bar(MyPlugin):
+            ...
+
+        # Work with plugins:
+        my_registry.get_plugin('foo')  # Foo
+        my_registry.get_plugin('baz')  # None
+
+        my_registry.iter_plugin_ids()  # 'foo', 'bar', ...
+        my_registry.iter_plugins()     # Foo, Bar, ...
+        my_registry.items()            # ('foo', Foo), ('bar', Bar), ...
     """
 
     _plugins: dict[str, RegisterableT]
@@ -348,6 +383,9 @@ class PluginRegistry(Generic[RegisterableT]):
         self.name = name
 
         self._plugins = {}
+
+        global REGISTRIES
+        REGISTRIES.append(self)
 
     def register_plugin(
         self,
@@ -417,6 +455,46 @@ class PluginRegistry(Generic[RegisterableT]):
     def __bool__(self) -> bool:
         return bool(self._plugins)
 
+    def create_decorator(
+        self, on_register: Optional[Callable[Concatenate[str, RegisterableT, P], None]] = None
+    ) -> Callable[Concatenate[str, P], Callable[[RegisterableT], RegisterableT]]:
+        """
+        Create a decorator that, applied to classes, registers them as plugins.
+
+        :param on_register: if specified, it is called for every plugin
+            being registered. It must accept plugin ID and plugin class,
+            any additional positional and keyword arguments are made part
+            of the decorator signature.
+        :returns: a decorator registering the decorated class with the
+            registry. The decorator must accept a single argument, the
+            plugin ID, plus any additional positional and keyword arguments
+            accepted by the ``on_register`` callback.
+        """
+
+        def _registerable_decorator(
+            plugin_id: str, *args: P.args, **kwargs: P.kwargs
+        ) -> Callable[[RegisterableT], RegisterableT]:
+            def __registerable_decorator(cls: RegisterableT) -> RegisterableT:
+                self.register_plugin(
+                    plugin_id=plugin_id,
+                    plugin=cls,
+                    logger=Logger.get_bootstrap_logger(),
+                )
+
+                if on_register:
+                    on_register(plugin_id, cls, *args, **kwargs)
+
+                return cls
+
+            return __registerable_decorator
+
+        # ignore[return-value]: on paper, return value is not compatible
+        # with the declaration, as `plugin_id` is a named argument. It is
+        # the correct type, but having a name, it leads to `Arg(str, 'plugin_id')`
+        # rather than `str` when mypy processes the annotations. And that's
+        # not the same thing.
+        return _registerable_decorator  # type: ignore[return-value]
+
 
 class ModuleImporter(Generic[ModuleT]):
     """
@@ -446,42 +524,3 @@ class ModuleImporter(Generic[ModuleT]):
 
         assert self._module  # narrow type
         return self._module
-
-
-def iter_plugin_registries() -> Iterator[PluginRegistry[Any]]:
-    # TODO: maybe there is a better way, but as of now, registries do
-    # not report their existence, there is no method to iterate over
-    # them. Using a static list for now.
-    from tmt.base import Plan, Story, Test
-    from tmt.checks import _CHECK_PLUGIN_REGISTRY
-    from tmt.frameworks import _FRAMEWORK_PLUGIN_REGISTRY
-    from tmt.package_managers import _PACKAGE_MANAGER_PLUGIN_REGISTRY
-    from tmt.plugins.plan_shapers import _PLAN_SHAPER_PLUGIN_REGISTRY
-    from tmt.steps.discover import DiscoverPlugin
-    from tmt.steps.execute import ExecutePlugin
-    from tmt.steps.finish import FinishPlugin
-    from tmt.steps.prepare import PreparePlugin
-    from tmt.steps.prepare.feature import _FEATURE_PLUGIN_REGISTRY
-    from tmt.steps.provision import ProvisionPlugin
-    from tmt.steps.report import ReportPlugin
-
-    yield Story._export_plugin_registry
-    yield Plan._export_plugin_registry
-    yield Test._export_plugin_registry
-    yield _CHECK_PLUGIN_REGISTRY
-    yield _FRAMEWORK_PLUGIN_REGISTRY
-    yield _PLAN_SHAPER_PLUGIN_REGISTRY
-    yield _PACKAGE_MANAGER_PLUGIN_REGISTRY
-    yield _FEATURE_PLUGIN_REGISTRY
-    yield DiscoverPlugin._supported_methods
-    yield ProvisionPlugin._supported_methods
-    yield PreparePlugin._supported_methods
-    yield ExecutePlugin._supported_methods
-    yield FinishPlugin._supported_methods
-    yield ReportPlugin._supported_methods
-
-
-def iter_plugins() -> Iterator[tuple[PluginRegistry[RegisterableT], str, RegisterableT]]:
-    for registry in iter_plugin_registries():
-        for plugin_id, plugin_class in registry.items():
-            yield registry, plugin_id, plugin_class

--- a/tmt/plugins/plan_shapers/__init__.py
+++ b/tmt/plugins/plan_shapers/__init__.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any, Callable
 
-import tmt.log
 import tmt.utils
 from tmt.plugins import PluginRegistry
 
@@ -9,29 +8,6 @@ if TYPE_CHECKING:
     from tmt.base import Plan
     from tmt.options import ClickOptionDecoratorType
     from tmt.steps.discover import TestOrigin
-
-
-PlanShaperClass = type['PlanShaper']
-
-
-_PLAN_SHAPER_PLUGIN_REGISTRY: PluginRegistry[PlanShaperClass] = PluginRegistry('plan_shapers')
-
-
-def provides_plan_shaper(shaper: str) -> Callable[[PlanShaperClass], PlanShaperClass]:
-    """
-    A decorator for registering plan shaper plugins.
-
-    Decorate a plan shaper plugin class to register a plan shaper.
-    """
-
-    def _provides_plan_shaper(plan_shaper_cls: PlanShaperClass) -> PlanShaperClass:
-        _PLAN_SHAPER_PLUGIN_REGISTRY.register_plugin(
-            plugin_id=shaper, plugin=plan_shaper_cls, logger=tmt.log.Logger.get_bootstrap_logger()
-        )
-
-        return plan_shaper_cls
-
-    return _provides_plan_shaper
 
 
 class PlanShaper(tmt.utils.Common):
@@ -69,3 +45,11 @@ class PlanShaper(tmt.utils.Common):
         """
 
         raise NotImplementedError
+
+
+_PLAN_SHAPER_PLUGIN_REGISTRY: PluginRegistry[type[PlanShaper]] = PluginRegistry('plan_shapers')
+
+provides_plan_shaper: Callable[
+    [str],
+    Callable[[type[PlanShaper]], type[PlanShaper]],
+] = _PLAN_SHAPER_PLUGIN_REGISTRY.create_decorator()


### PR DESCRIPTION
Adds a helper and some annotations for easier creation of plugin registries and corresponding decorators for marking plugins.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation