### PR TITLE
Add 'Local' distgit handler

### DIFF
--- a/tmt/utils/git.py
+++ b/tmt/utils/git.py
@@ -5,6 +5,7 @@ Test Metadata Utilities
 import functools
 import os
 import re
+import shutil
 import subprocess
 import urllib.parse
 from re import Pattern
@@ -640,6 +641,24 @@ class RedHatDistGit(DistGitHandler):
     remote_substring = re.compile(r'redhat/rhel/|pkgs\.devel\.redhat\.com')
 
 
+class LocalDistGit(DistGitHandler):
+    """
+    Local source files
+    """
+
+    usage_name = "local"
+    re_source = re.compile(r"^(\w+) \(([^)]+)\) = ([0-9a-fA-F]+)$")
+    lookaside_server = "file://"
+    uri = "./{filename}"
+
+    def its_me(self, remotes: list[str]) -> bool:
+        """
+        Has to be an explicit request for this type
+        """
+
+        return False
+
+
 def get_distgit_handler(
     remotes: Optional[list[str]] = None,
     usage_name: Optional[str] = None,
@@ -696,11 +715,15 @@ def distgit_download(
 
     for url, source_name in handler.url_and_name(distgit_dir):
         logger.debug(f"Download sources from '{url}'.")
-        with tmt.utils.retry_session() as session:
-            response = session.get(url)
-        response.raise_for_status()
-        target_dir.mkdir(exist_ok=True, parents=True)
-        (target_dir / source_name).write_bytes(response.content)
+        if url.startswith('file://'):
+            target_dir.mkdir(exist_ok=True, parents=True)
+            shutil.copy(url[7:], target_dir / source_name)
+        else:
+            with tmt.utils.retry_session() as session:
+                response = session.get(url)
+            response.raise_for_status()
+            target_dir.mkdir(exist_ok=True, parents=True)
+            (target_dir / source_name).write_bytes(response.content)
 
 
 def git_clone(


### PR DESCRIPTION
When sources are not yet uploaded to lookaside but one wants to run dist-git-source test locally.

I missed this feature, but it might be a niche use case specific to our team workflow.  Feel free to object that one can just push sources to lookaside and be happy.

If makes sense as feature:
- Is `shutil` usage OK or should I use `tmt.utils.filesystem.copy_tree` ?
- Should plugin return absolute path to the source file instead of `./` ? 
- Running `TMT_PLUGIN_DISCOVER_SHELL_DIST_GIT_TYPE=local tmt run` didn't enforce this plugin, I had to write it into plan.fmf. Is that expected limitation (IIRC `how`  was a bit special) or should I look into this as bug?
```
 discover:
  how: shell
  dist-git-source: true
  dist-git-type: local
```
- Do you foresee another usage for "file://" protocol? If so it might be better to add support directly into `retry_session`. 
 

Pull Request Checklist

* [] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
