### PR TITLE
Refactor koji interface to handle multiple identifiers

### DIFF
--- a/tests/core/about/test.sh
+++ b/tests/core/about/test.sh
@@ -8,7 +8,7 @@ export.story: dict json rst template yaml
 export.test: dict json nitrate polarion template yaml
 package_managers: apk apt bootc dnf dnf5 rpm-ostree yum
 plan_shapers: max-tests repeat
-prepare.artifact.providers: brew koji
+prepare.artifact.providers: brew koji koji.build koji.nvr koji.task
 prepare.feature: crb epel fips profile
 step.cleanup: tmt
 step.discover: fmf shell

--- a/tests/unit/artifact/test_koji.py
+++ b/tests/unit/artifact/test_koji.py
@@ -1,47 +1,50 @@
-from unittest.mock import MagicMock, patch
-
 import pytest
 
 from tmt.steps.prepare.artifact.providers.koji import KojiArtifactProvider
 
 
-@pytest.fixture
-def koji_provider(root_logger):
-    """Return a KojiArtifactProvider with a stable build ID for testing."""
-    return KojiArtifactProvider("koji.build:12345", root_logger)
-
-
-# --- Tests ---
-def test_parse_artifact_provider_id_valid(koji_provider):
-    assert koji_provider.id == "12345"
-
-
-@pytest.mark.parametrize("invalid_artifact_provider_id", ["koji.task:111", "koji.build:abc"])
-def test_parse_artifact_provider_id_invalid(root_logger, invalid_artifact_provider_id):
-    with pytest.raises(
-        ValueError, match=f"Invalid Koji identifier: '{invalid_artifact_provider_id}'."
-    ):
-        KojiArtifactProvider(invalid_artifact_provider_id, root_logger)
-
-
-def test_call_api_success(koji_provider):
-    koji_provider._session = MagicMock()
-    koji_provider._session.some_method.return_value = "ok"
-
-    result = koji_provider._call_api("some_method", 1, 2)
-    assert result == "ok"
-
-
-def test_fetch_rpms_populates_list(root_logger):
-    rpm_data = [{"name": "foo", "version": "1.x", "release": "1", "nvr": "foo-1.x-1"}]
-
-    with patch.object(KojiArtifactProvider, "_call_api", return_value=rpm_data) as mock_call:
-        provider = KojiArtifactProvider("koji.build:123", root_logger)
-        assert provider._rpm_list == rpm_data
-        mock_call.assert_called_once_with("listBuildRPMs", 123)
+@pytest.mark.integration
+def test_koji_valid_build(root_logger):
+    provider = KojiArtifactProvider("koji.build:2829512", root_logger)
+    rpms = list(provider.list_artifacts())
+    assert len(rpms) == 13
 
 
 @pytest.mark.integration
-def test_koji_real_build(koji_provider):
-    artifacts = list(koji_provider.list_artifacts())
-    assert len(artifacts) > 0
+def test_koji_valid_nvr(root_logger):
+    provider = KojiArtifactProvider("koji.nvr:tmt-1.58.0-1.fc43", root_logger)
+    rpms = list(provider.list_artifacts())
+    assert len(rpms) == 13
+    assert provider.build_id == 2829512  # Known build ID for this NVR
+
+
+def test_koji_invalid_nvr(root_logger):
+    from tmt.utils import GeneralError
+
+    provider = KojiArtifactProvider("koji.nvr:nonexistent-1.0-1.fc43", root_logger)
+
+    with pytest.raises(GeneralError, match="No build found for NVR 'nonexistent-1.0-1.fc43'."):
+        _ = provider.build_id
+
+
+@pytest.mark.integration
+def test_koji_valid_task_id_actual_build(root_logger):
+    provider = KojiArtifactProvider("koji.task:137451383", root_logger)
+    rpms = list(provider.list_artifacts())
+    assert provider.build_id == 2829512  # Known build ID for this task
+    assert len(rpms) == 13
+
+
+@pytest.mark.integration
+def test_koji_valid_task_id_scratch_build(root_logger):
+    provider = KojiArtifactProvider("koji.task:137705547", root_logger)
+    tasks = provider._get_task_children(137705547)
+    assert len(tasks) == 13
+    assert 137705547 in tasks  # The parent task itself should be included
+    rpms = list(provider.list_artifacts())
+    assert provider.build_id is None
+    assert (
+        rpms[0]._raw_artifact['url']
+        == 'https://kojipkgs.fedoraproject.org/work/tasks/5553/137705553/python-scikit-build-core-0.11.5-5.fc44.src.rpm'
+    )
+    assert len(rpms) == 2

--- a/tests/unit/artifact/test_koji.py
+++ b/tests/unit/artifact/test_koji.py
@@ -1,5 +1,3 @@
-import re
-
 import pytest
 
 from tmt.steps.prepare.artifact.providers.koji import KojiArtifactProvider
@@ -25,9 +23,7 @@ def test_koji_invalid_nvr(root_logger):
 
     provider = KojiArtifactProvider("koji.nvr:nonexistent-1.0-1.fc43", root_logger)
 
-    with pytest.raises(
-        GeneralError, match=re.escape("No build found for NVR 'nonexistent-1.0-1.fc43'.")
-    ):
+    with pytest.raises(GeneralError, match=r"No build found for NVR 'nonexistent-1\.0-1\.fc43'\."):
         _ = provider.build_id
 
 

--- a/tests/unit/artifact/test_koji.py
+++ b/tests/unit/artifact/test_koji.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from tmt.steps.prepare.artifact.providers.koji import KojiArtifactProvider
@@ -23,7 +25,9 @@ def test_koji_invalid_nvr(root_logger):
 
     provider = KojiArtifactProvider("koji.nvr:nonexistent-1.0-1.fc43", root_logger)
 
-    with pytest.raises(GeneralError, match="No build found for NVR 'nonexistent-1.0-1.fc43'."):
+    with pytest.raises(
+        GeneralError, match=re.escape("No build found for NVR 'nonexistent-1.0-1.fc43'.")
+    ):
         _ = provider.build_id
 
 

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -2,9 +2,9 @@
 Koji Artifact Provider
 """
 
-import os
 import types
 from collections.abc import Iterator
+from functools import cached_property
 from shlex import quote
 from typing import Any, Optional
 
@@ -47,10 +47,6 @@ class RpmArtifactInfo(ArtifactInfo):
     Represents a single RPM package.
     """
 
-    # TODO: Make RPM_BASE_URL configurable via FMF/CLI, not just env var
-    BASE_URL = os.getenv("RPM_BASE_URL", "https://kojipkgs.fedoraproject.org/packages").rstrip(
-        "/"
-    )  # For actual package downloads
     _raw_artifact: dict[str, str]
 
     @property
@@ -60,14 +56,25 @@ class RpmArtifactInfo(ArtifactInfo):
 
     @property
     def location(self) -> str:
-        """Get the download URL for the given RPM metadata."""
-        return (
-            f"{self.BASE_URL}/{self._raw_artifact['name']}/"
-            f"{self._raw_artifact['version']}/"
-            f"{self._raw_artifact['release']}/"
-            f"{self._raw_artifact['arch']}/"
-            f"{self.id}"
-        )
+        return self._raw_artifact['url']
+
+    @property
+    def is_draft(self) -> bool:
+        """
+        Whether this RPM is a draft/scratch artifact.
+        """
+        return bool(self._raw_artifact.get('draft', False))
+
+
+@container
+class KojiScratchRpmArtifactInfo(RpmArtifactInfo):
+    """
+    Represents a single RPM url from Koji scratch builds.
+    """
+
+    @property
+    def id(self) -> str:
+        return f"{self._raw_artifact['filename']}"
 
 
 # ignore[type-arg]: TypeVar in provider registry annotations is
@@ -103,29 +110,63 @@ class KojiArtifactProvider(ArtifactProvider[RpmArtifactInfo]):
         artifacts = provider.download_artifacts(guest, Path("/tmp"), [])
     """
 
-    # TODO: Make RPM_BASE_URL configurable via FMF/CLI, not just env var
-    API_URL = os.getenv("KOJI_API_URL", "https://koji.fedoraproject.org/kojihub")  # For metadata
+    SUPPORTED_PREFIXES = ("koji.build:", "koji.task:", "koji.nvr:")
+
+    def __new__(cls, raw_provider_id: str, logger: tmt.log.Logger) -> 'KojiArtifactProvider':
+        """
+        Factory method to return the appropriate subclass based on the prefix
+        of the raw_provider_id.
+
+        :raises ValueError: If the prefix is not supported
+        """
+        if raw_provider_id.startswith("koji.build:"):
+            return super().__new__(KojiBuild)
+        if raw_provider_id.startswith("koji.task:"):
+            return super().__new__(KojiTask)
+        if raw_provider_id.startswith("koji.nvr:"):
+            return super().__new__(KojiNvr)
+        # If we get here, the prefix is not supported
+        raise ValueError(
+            f"Unsupported artifact ID format: '{raw_provider_id}'. "
+            f"Supported formats are: 'koji.build:', 'koji.task:', 'koji.nvr:'"
+        )
 
     def __init__(self, raw_provider_id: str, logger: tmt.log.Logger):
         super().__init__(raw_provider_id, logger)
         self._session = self._initialize_session()
-        self._rpm_list = self._fetch_rpms()
+        self._build_provider: Optional[KojiBuild] = None
 
-    def _fetch_rpms(self) -> list[dict[str, Any]]:
+    @cached_property
+    def build_id(self) -> Optional[int]:
         """
-        Fetch and cache the list of RPMs for the given artifact ID.
+        Resolve and return the build ID.
+
+        - If provided directly, return it.
+        - If provided via NVR, resolve using getBuild.
+        - If provided via task_id, resolve using listBuilds.
+
+        :return: The resolved build ID, or None if not found for task_id
+        :raises GeneralError: If the build cannot be found
         """
-        return self._call_api('listBuildRPMs', int(self.id)) or []
+        raise NotImplementedError
+
+    @cached_property
+    def rpm_list(self) -> list[RpmArtifactInfo]:
+        """Return all RPM artifacts for the given identifier."""
+        raise NotImplementedError
 
     def _initialize_session(self) -> 'ClientSession':
         """
         A koji session initialized via the koji.ClientSession function.
-        api_url being the base URL for the koji instance
+        Also sets self._topurl and self._api_url being the base URL for the koji instance
         """
         import_koji(self.logger)
 
         try:
-            return ClientSession(self.API_URL)
+            config = koji.read_config("koji")  # type: ignore[union-attr]
+            self._api_url = config.get("server")
+            self._topurl = config.get("topurl")
+            return ClientSession(self._api_url)
         except Exception as error:
             raise tmt.utils.GeneralError("Failed to initialize API session.") from error
 
@@ -145,24 +186,29 @@ class KojiArtifactProvider(ArtifactProvider[RpmArtifactInfo]):
         except Exception as error:
             raise tmt.utils.GeneralError(f"API call '{method}' failed.") from error
 
+    def _get_build_provider(self, build_id: int) -> 'KojiBuild':
+        """
+        Cache a KojiBuild instance to avoid redundant API calls
+        """
+        if not self._build_provider:
+            self._build_provider = KojiBuild(f"koji.build:{build_id}", self.logger)
+        return self._build_provider
+
     @classmethod
     def _extract_provider_id(cls, raw_provider_id: str) -> ArtifactProviderId:
-        # Eg: 'koji.build:123456'
-        prefix = "koji.build:"
-        if not raw_provider_id.startswith(prefix):
-            raise ValueError(f"Invalid Koji identifier: '{raw_provider_id}'.")
-
-        parsed = raw_provider_id[len(prefix) :]
-        if not parsed.isdigit():
-            raise ValueError(f"Invalid Koji identifier: '{raw_provider_id}'.")
-        return parsed
+        for prefix in cls.SUPPORTED_PREFIXES:
+            if raw_provider_id.startswith(prefix):
+                value = raw_provider_id[len(prefix) :]
+                if not value:
+                    raise ValueError(f"Missing value in '{raw_provider_id}'.")
+                return value
+        raise ValueError(f"Unsupported artifact ID format: '{raw_provider_id}'.")
 
     def list_artifacts(self) -> Iterator[RpmArtifactInfo]:
         """
         List all RPM artifacts for the given build.
         """
-        for rpm in self._rpm_list:
-            yield RpmArtifactInfo(_raw_artifact=rpm)
+        yield from self.rpm_list
 
     def _download_artifact(
         self, artifact: RpmArtifactInfo, guest: Guest, destination: tmt.utils.Path
@@ -184,3 +230,133 @@ class KojiArtifactProvider(ArtifactProvider[RpmArtifactInfo]):
             )
         except Exception as error:
             raise DownloadError(f"Failed to download '{artifact}'.") from error
+
+    def make_rpm_artifact(self, rpm_meta: dict[str, str]) -> RpmArtifactInfo:
+        """
+        Create a normal build RPM artifact from metadata returned by listBuildRPMs.
+        """
+        name = rpm_meta["name"]
+        version = rpm_meta["version"]
+        release = rpm_meta["release"]
+        arch = rpm_meta["arch"]
+
+        # Construct the full URL for this RPM
+        url = (
+            f"{self._topurl}/packages/{name}/"
+            f"{version}/{release}/{arch}/"
+            f"{name}-{version}-{release}.{arch}.rpm"
+        )
+
+        return RpmArtifactInfo(_raw_artifact={**rpm_meta, "url": url})
+
+    def make_scratch_artifact(self, task_id: int, filename: str) -> KojiScratchRpmArtifactInfo:
+        """
+        Create a scratch RPM artifact from a task output filename.
+        """
+        pathinfo = koji.PathInfo(  # type: ignore[union-attr]
+            topdir=self._topurl
+        )
+        work_path = pathinfo.work("DEFAULT")
+        task_path = pathinfo.taskrelpath(task_id)
+        url = f"{work_path}/{task_path}/{filename}"
+
+        raw_artifact = {
+            "filename": filename,
+            "url": url,
+        }
+        return KojiScratchRpmArtifactInfo(_raw_artifact=raw_artifact)
+
+
+@provides_artifact_provider("koji.task")  # type: ignore[arg-type]
+class KojiTask(KojiArtifactProvider):
+    @cached_property
+    def build_id(self) -> Optional[int]:
+        task_id = int(self.id)
+        builds = self._call_api("listBuilds", taskID=task_id)
+        if builds:
+            build_id = builds[0]["build_id"]  # Assume the task produced a single build
+            assert isinstance(build_id, int)
+            return build_id
+        return None
+
+    def _get_task_children(self, task_id: int) -> list[int]:
+        """
+        Recursively fetch all child tasks of the given task ID.
+
+        :param task_id: The parent task ID
+        :return: List of all child task IDs
+        """
+        child_tasks: list[int] = [task_id]  # Include the parent task itself
+        direct_children = self._call_api("getTaskChildren", task_id)
+        for child in direct_children:
+            child_id = child["id"]
+            assert isinstance(child_id, int)
+            child_tasks.append(child_id)
+            # Recursively fetch grandchildren
+            child_tasks.extend(self._get_task_children(child_id))
+        return child_tasks
+
+    @cached_property
+    def rpm_list(self) -> list[RpmArtifactInfo]:
+        self.logger.debug(f"Fetching RPMs for task '{self.id}'.")
+        # If task produced a build, reuse build path
+        if self.build_id is not None:
+            self.logger.debug(
+                f"Task '{self.id}' produced build '{self.build_id}', fetching RPMs from the build."
+            )
+            return self._get_build_provider(self.build_id).rpm_list
+
+        # Otherwise, list the task output files for scratch builds
+        self.logger.debug(f"Task '{self.id}' did not produce a build, fetching scratch RPMs.")
+        rpms: list[RpmArtifactInfo] = []
+        seen_ids = set()  # Multiple tasks may produce the same RPM
+        for child_task in self._get_task_children(int(self.id)):
+            for filename in self._call_api("listTaskOutput", child_task):
+                if not filename.endswith(".rpm"):
+                    self.logger.warning(f"Skipping '{filename}': not an RPM")
+                    continue
+                rpm = self.make_scratch_artifact(child_task, filename)
+                if rpm.id not in seen_ids:
+                    rpms.append(rpm)
+                    seen_ids.add(rpm.id)
+                else:
+                    self.logger.debug(
+                        f"Skipping redundant RPM '{rpm.id}' from task '{child_task}'"
+                    )
+        return rpms
+
+
+@provides_artifact_provider('koji.build')  # type: ignore[arg-type]
+class KojiBuild(KojiArtifactProvider):
+    @cached_property
+    def build_id(self) -> int:
+        return int(self.id)
+
+    @cached_property
+    def rpm_list(self) -> list[RpmArtifactInfo]:
+        """
+        Resolve and return the list of RPMs for the given build ID or NVR.
+
+        :return: List of RpmArtifactInfo objects
+        """
+        self.logger.debug(f"Fetching RPMs for build '{self.build_id}'.")
+        rpm_dicts = self._call_api("listBuildRPMs", self.build_id)
+        return [self.make_rpm_artifact(rpm) for rpm in rpm_dicts]
+
+
+@provides_artifact_provider("koji.nvr")  # type: ignore[arg-type]
+class KojiNvr(KojiArtifactProvider):
+    @cached_property
+    def build_id(self) -> int:
+        nvr = self.id
+        build = self._call_api("getBuild", nvr)
+        if not build:
+            raise tmt.utils.GeneralError(f"No build found for NVR '{nvr}'.")
+        build_id = build["id"]
+        assert isinstance(build_id, int)
+        return build_id
+
+    @cached_property
+    def rpm_list(self) -> list[RpmArtifactInfo]:
+        self.logger.debug(f"Fetching RPMs for NVR '{self.id}'.")
+        return self._get_build_provider(self.build_id).rpm_list

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -276,8 +276,11 @@ class KojiTask(KojiArtifactProvider):
     @cached_property
     def build_id(self) -> Optional[int]:
         task_id = int(self.id)
-        builds = self._call_api("listBuilds", taskID=task_id)
-        if builds:
+        if builds := self._call_api("listBuilds", taskID=task_id):
+            if len(builds) > 1:
+                self.logger.warning(
+                    f"Task '{task_id}' produced {len(builds)} builds, using the first one."
+                )
             build_id = builds[0]["build_id"]  # Assume the task produced a single build
             assert isinstance(build_id, int)
             return build_id

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -114,8 +114,12 @@ class KojiArtifactProvider(ArtifactProvider[RpmArtifactInfo]):
 
     def __new__(cls, raw_provider_id: str, logger: tmt.log.Logger) -> 'KojiArtifactProvider':
         """
-        Factory method to return the appropriate subclass based on the prefix
-        of the raw_provider_id.
+        Create a specific Koji provider based on the ``raw_provider_id`` prefix.
+
+        The supported provides are:
+        :py:class:`KojiBuild`,
+        :py:class:`KojiTask`,
+        :py:class:`KojiNvr`.
 
         :raises ValueError: If the prefix is not supported
         """


### PR DESCRIPTION
## Summary of classes in this PR:

### `RpmArtifactInfo`
- Represents a single RPM package.
- Knows its **ID** and **download location (URL)**.
- Can be a “draft” RPM (i.e., from a scratch build).

### `KojiScratchRpmArtifactInfo`
- Subclass of `RpmArtifactInfo`.
- Specifically represents an RPM from a **scratch build**.
- The ID is just the filename.
- The URL points directly to the task output.

### `KojiArtifactProvider`
- Base provider class that interacts with Koji.
- Factory method (`__new__`) chooses the appropriate subclass:
  - `KojiBuild` → for a build ID
  - `KojiTask` → for a task ID
  - `KojiNvr` → for a NVR
- Key methods:
  - `make_rpm_artifact`, `make_scratch_artifact` → create artifact objects
  - `list_artifacts` / `rpm_list` → list RPM artifacts
  - `_download_artifact` → download rpms to a guest

### `KojiTask`
- Handles rpms produced by **tasks**.
- Recursively gathers child tasks.
- Differentiates between:
  - Tasks that produced a **build**
  - **Scratch builds**
- Constructs URLs for scratch rpms.

### `KojiBuild`
- Handles RPMs from a **build ID**.
- Fetches the list of rpms.

### `KojiNvr`
- Handles RPMs referenced by **NVR**.
- Resolves NVR to a build ID.
- Delegates to `KojiBuild` for fetching rpms.


Pull Request Checklist

* [X] implement the feature
* [ ] write the documentation
* [X] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
