### PR TITLE
Introduce `generate_uuid` function to use when importing from Polarion

### DIFF
--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -9,7 +9,7 @@ import shlex
 import subprocess
 from contextlib import suppress
 from typing import TYPE_CHECKING, Any, Optional, Union
-from uuid import UUID, uuid4
+from uuid import UUID
 
 import fmf.utils
 from click import echo
@@ -965,7 +965,7 @@ def read_polarion_case(
             UUID(polarion_case.test_case_id)
             uuid = str(polarion_case.test_case_id)
         except (TypeError, ValueError):
-            uuid = str(uuid4())
+            uuid = tmt.identifier.generate_uuid()
             if not dry_run:
                 polarion_case.tmtid = uuid
                 polarion_case.update()

--- a/tmt/identifier.py
+++ b/tmt/identifier.py
@@ -25,6 +25,13 @@ class IdLeafError(IdError):
     """
 
 
+def generate_uuid() -> str:
+    """
+    Generate and return a new UUID
+    """
+    return str(uuid4())
+
+
 def get_id(node: fmf.Tree, leaf_only: bool = True) -> Optional[str]:
     """
     Get identifier if defined, optionally ensure leaf node
@@ -54,7 +61,7 @@ def add_uuid_if_not_defined(node: fmf.Tree, dry: bool, logger: Logger) -> Option
         return None
 
     # Generate a new one
-    gen_uuid = str(uuid4())
+    gen_uuid = generate_uuid()
     if not dry:
         # ignore[reportUnknownVariableType]: yep, fmf lacks annotations, and
         # pyright can't infer the type. Adding `cast()` seems to be the easiest


### PR DESCRIPTION
While importing tests from polarion, tmt will use the newly added `generate_uuid` function in `tmt.identifier` library to generate the ID.

Resolves #3082 

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
