### PR TITLE
Teach `GuestContainer` how to handle `recursive` flag

### DIFF
--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -490,7 +490,7 @@ class GuestContainer(tmt.Guest):
                 silent=True,
             )
 
-        # When rsync-ing directories, make sure we do not copy to a subfolder (/foo/bar/bar)
+        # Make sure we do not copy to a subfolder (/foo/bar/bar), see `man podman-cp`
         path_suffix = "/." if options.recursive else ""
 
         # In case explicit destination is given, use `podman cp` to copy data


### PR DESCRIPTION
Caught this issue in https://github.com/teemtee/tmt/pull/4120 (and it is blocking it).

Basically if the `destination` is a path and already exists and `source` is also a directory it copies the directory under `destination` similar to the `rsync foo bar` vs `rsync foo/ bar/` issue. The relevant documentation of `podman-cp` here is:
```
       src_path specifies a file:
         - dest_path does not exist
           - the file is saved to a file created at dest_path (note that parent directory must exist).
         - dest_path exists and is a file
           - the destination is overwritten with the source file's contents.
         - dest_path exists and is a directory
           - the file is copied into this directory using the base name from src_path.

       src_path specifies a directory:
         - dest_path does not exist
           - dest_path is created as a directory and the contents of the source directory are copied into this directory.
         - dest_path exists and is a file
           - Error condition: cannot copy a directory to a file.
         - dest_path exists and is a directory
           - src_path ends with /
             - the source directory is copied into this directory.
           - src_path ends with /. (i.e., slash followed by dot)
             - the content of the source directory is copied into this directory.
```

---

Pull Request Checklist

* [x] implement the feature
