### PR TITLE
Document explicitly that scripts need to be executable

### DIFF
--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -312,7 +312,7 @@ of the files is up to you. See the :ref:`guide` for more details.
 
 .. note::
 
-    With ``tmt`` files used in the ``script`` or ``test``
+    With ``tmt``, files used in the ``script`` or ``test``
     key are expected to be executable, unlike with STI.
 
 __ https://docs.fedoraproject.org/en-US/ci/standard-test-interface/

--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -312,8 +312,8 @@ of the files is up to you. See the :ref:`guide` for more details.
 
 .. note::
 
-    With ``tmt`` script files used in the ``script`` or ``test``
-    field must be executable, unlike with STI.
+    With ``tmt`` files used in the ``script`` or ``test``
+    key are expected to be executable, unlike with STI.
 
 __ https://docs.fedoraproject.org/en-US/ci/standard-test-interface/
 __ https://docs.fedoraproject.org/en-US/ci/standard-test-roles/

--- a/docs/questions.rst
+++ b/docs/questions.rst
@@ -310,6 +310,11 @@ init`` command in the root of the git repository. Then store the
 new config files with the ``.fmf`` extension. Naming and location
 of the files is up to you. See the :ref:`guide` for more details.
 
+.. note::
+
+    With ``tmt`` script files used in the ``script`` or ``test``
+    field must be executable, unlike with STI.
+
 __ https://docs.fedoraproject.org/en-US/ci/standard-test-interface/
 __ https://docs.fedoraproject.org/en-US/ci/standard-test-roles/
 

--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -66,6 +66,11 @@ description: |
             how: tmt
             script: a-long-test-suite
             duration: 3h
+      - |
+        # Run a script file, note that script files must be executable
+        execute:
+            script: ./run_tests.sh
+
     link:
       - implemented-by: /tmt/steps/execute/internal.py
 

--- a/spec/plans/execute.fmf
+++ b/spec/plans/execute.fmf
@@ -67,7 +67,7 @@ description: |
             script: a-long-test-suite
             duration: 3h
       - |
-        # Run a script file, note that script files must be executable
+        # Run a script file, note that files are expected to be executable
         execute:
             script: ./run_tests.sh
 

--- a/spec/tests/test.fmf
+++ b/spec/tests/test.fmf
@@ -9,6 +9,8 @@ description: |
     Allows to parametrize a single test script and in this way
     create virtual test cases.
 
+    If the test is a script file, it must be executable.
+
     If the test is :ref:`/spec/tests/manual`, it points to the
     document describing the manual test case steps in Markdown
     format with defined structure.

--- a/spec/tests/test.fmf
+++ b/spec/tests/test.fmf
@@ -9,7 +9,7 @@ description: |
     Allows to parametrize a single test script and in this way
     create virtual test cases.
 
-    If the test is a script file, it must be executable.
+    If the test is a file, it is expected to be executable.
 
     If the test is :ref:`/spec/tests/manual`, it points to the
     document describing the manual test case steps in Markdown


### PR DESCRIPTION
Update the Docs to explicitly state that scripts need to be executable when used in the `test` or `script` field.

Fixes: [#3704](https://github.com/teemtee/tmt/issues/3704), [#3703](https://github.com/teemtee/tmt/issues/3703)

Pull Request Checklist

* [ ] write the documentation

