### PR TITLE
Allow a single `link` in the `fmf` discover plugin

### DIFF
--- a/tmt/schemas/discover/fmf.yaml
+++ b/tmt/schemas/discover/fmf.yaml
@@ -41,7 +41,7 @@ properties:
     $ref: "/schemas/common#/definitions/one_or_more_strings"
 
   link:
-    $ref: "/schemas/common#/definitions/array_of_strings"
+    $ref: "/schemas/common#/definitions/one_or_more_strings"
 
   filter:
     $ref: "/schemas/common#/definitions/one_or_more_strings"

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -112,6 +112,7 @@ class DiscoverFmfStepData(tmt.steps.discover.DiscoverStepData):
             and target. Relation part can be omitted to match all
             relations.
              """,
+        normalize=tmt.utils.normalize_string_list,
     )
 
     filter: list[str] = field(


### PR DESCRIPTION
In order to keep consistency with other `fmf` discover keys, let's support both single string and a list of strings when selecting tests by the `link` key.

Fix #1374.

Pull Request Checklist

* [ ] implement the feature
* [ ] extend the test coverage
* [ ] modify the json schema
* [ ] include a release note