### PR TITLE
Add check for cleanup plugins in Cleanup.go()

### DIFF
--- a/tmt/base.py
+++ b/tmt/base.py
@@ -5079,6 +5079,8 @@ class Clean(tmt.utils.Common):
             if plan.provision.status() == 'done' and plan.cleanup.status() != 'done':
                 # Wake up provision to load the active guests
                 plan.provision.wake()
+                # Wake up cleanup to ensure it's properly initialized
+                plan.cleanup.wake()
                 if not self._matches_how(plan):
                     continue
                 if self.is_dry_run:


### PR DESCRIPTION
Call wake() method when no cleanup plugins are found to ensure proper initialization.

fixes #4185

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
