### PR TITLE
Rename `--keep` param of tmt.clean_guest to `--preserve`

### DIFF
--- a/tests/clean/guests/test.sh
+++ b/tests/clean/guests/test.sh
@@ -65,7 +65,7 @@ rlJournalStart
         rlRun "tmpkeep=\$(mktemp -d)" 0 "Create a temporary directory for keep test"
         rlRun -s "tmt run -i $tmpkeep/run1 --until provision provision -h local"
         rlRun -s "tmt run -i $tmpkeep/run2 --until provision provision -h local"
-        rlRun "tmt clean guests --workdir-root $tmpkeep --keep 1"
+        rlRun "tmt clean guests --workdir-root $tmpkeep --preserve 1"
         rlRun -s "tmt status --workdir-root $tmpkeep -vv"
         rlAssertGrep "(done\s+){2}(todo\s+){4}done\s+$tmpkeep/run1" "$rlRun_LOG" -E
         rlAssertGrep "(done\s+){2}(todo\s+){5}$tmpkeep/run2" "$rlRun_LOG" -E

--- a/tmt/cli/_root.py
+++ b/tmt/cli/_root.py
@@ -1849,11 +1849,11 @@ def clean_runs(
     help='Run id(name or directory path) to stop the guest of. Can be specified multiple times.',
 )
 @option(
-    '-k',
-    '--keep',
+    '-p',
+    '--preserve',
     type=int,
     default=None,
-    help='The number of latest guests to keep, clean the rest.',
+    help='The number of latest guests to preserve, clean the rest.',
 )
 @option(
     '-h',
@@ -1868,7 +1868,7 @@ def clean_guests(
     workdir_root: Optional[Path],
     last: bool,
     id_: tuple[str, ...],
-    keep: Optional[int],
+    preserve: Optional[int],
     **kwargs: Any,
 ) -> None:
     """
@@ -1894,7 +1894,7 @@ def clean_guests(
     context.obj.clean_partials["guests"].append(
         lambda: clean_obj.guests(
             (context.parent and context.parent.params.get('id_', [])) or id_,
-            (context.parent and context.parent.params.get('keep', [])) or keep,
+            (context.parent and context.parent.params.get('preserve', [])) or preserve,
         )
     )
 


### PR DESCRIPTION
there are --keep option both in [run ](https://github.com/teemtee/tmt/blob/main/tmt/cli/_root.py#L278)and [clean guest](https://github.com/teemtee/tmt/blob/main/tmt/cli/_root.py#L1849), we need rename one to avoid collision which would be a problem when user run `tmt clean guest --keep`

Fixes: #4193

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
