### PR TITLE
Discover and load tmt subcommands via entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,15 @@ docs = [
 [project.scripts]
 tmt = "tmt.__main__:run_cli"
 
+[project.entry-points."tmt.subcommand"]
+main = "tmt.cli._root:main"
+about = "tmt.cli.about:about"
+init = "tmt.cli.init:init"
+lint = "tmt.cli.lint:lint"
+run = "tmt.cli.run:run"
+status = "tmt.cli.status:status"
+trying = "tmt.cli.trying:try_command"
+
 [project.urls]
 Homepage = "https://github.com/teemtee/tmt"
 

--- a/tmt/__main__.py
+++ b/tmt/__main__.py
@@ -1,5 +1,4 @@
 import sys
-from importlib.metadata import entry_points
 
 #: An entry point to which subcommands should be attached.
 ENTRY_POINT_NAME = 'tmt.subcommand'
@@ -10,6 +9,16 @@ def import_cli_commands() -> None:
     Import CLI commands from their packages
     """
 
+    # TODO: the whole import compat needs some type annotation polishing,
+    # the amount of waivers needed below is stunning.
+
+    # Cannot import on module-level - early import might trigger various
+    # side-effects, raise exceptions, and that must happen under the
+    # tight control of whoever invoked this function.
+    from tmt._compat.importlib.metadata import (
+        entry_points,  # type: ignore[reportUnknownVariableType,unused-ignore]
+    )
+
     try:
         eps = entry_points()
 
@@ -19,7 +28,7 @@ def import_cli_commands() -> None:
             )
 
         else:
-            entry_point_group = eps[ENTRY_POINT_NAME]
+            entry_point_group = eps[ENTRY_POINT_NAME]  # type: ignore[assignment]
 
         for found in entry_point_group:  # type: ignore[reportUnkownVariable,unused-ignore]
             found.load()

--- a/tmt/__main__.py
+++ b/tmt/__main__.py
@@ -1,4 +1,8 @@
 import sys
+from importlib.metadata import entry_points
+
+#: An entry point to which subcommands should be attached.
+ENTRY_POINT_NAME = 'tmt.subcommand'
 
 
 def import_cli_commands() -> None:
@@ -6,12 +10,22 @@ def import_cli_commands() -> None:
     Import CLI commands from their packages
     """
 
-    # TODO: some kind of `import tmt.cli.*` would be nice
-    import tmt.cli.about  # noqa: F401,I001,RUF100  # type: ignore[reportUnusedImport]
-    import tmt.cli.init  # noqa: F401,I001,RUF100  # type: ignore[reportUnusedImport]
-    import tmt.cli.lint  # noqa: F401,I001,RUF100 # type: ignore[reportUnusedImport]
-    import tmt.cli.status  # noqa: F401,I001,RUF100 # type: ignore[reportUnusedImport]
-    import tmt.cli.trying  # noqa: F401,I001,RUF100 # type: ignore[reportUnusedImport]
+    try:
+        eps = entry_points()
+
+        if hasattr(eps, "select"):
+            entry_point_group = eps.select(  # type: ignore[reportUnknownVariable,unused-ignore]
+                group=ENTRY_POINT_NAME
+            )
+
+        else:
+            entry_point_group = eps[ENTRY_POINT_NAME]
+
+        for found in entry_point_group:  # type: ignore[reportUnkownVariable,unused-ignore]
+            found.load()
+
+    except Exception as exc:
+        raise Exception('Failed to discover and import tmt subcommands.') from exc
 
 
 def run_cli() -> None:


### PR DESCRIPTION
Instead of enumerating submodules in tmt code, switch the subcommand discovery to entrypoint, and expose subcommands there.

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
