### PR TITLE
Fix how plan/guest `ansible` key is displayed

### DIFF
--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -26,7 +26,7 @@ rlJournalStart
             rlRun -s "$tmt login -c true -s $step"
 
             if [ "$step" = "provision" ]; then
-                rlRun "grep '^    $step$' -A15 '$rlRun_LOG' | grep -i interactive"
+                rlRun "grep '^    $step$' -A16 '$rlRun_LOG' | grep -i interactive"
             elif [ "$step" = "prepare" ]; then
                 rlRun "grep '^    $step$' -A18 '$rlRun_LOG' | grep -i interactive"
             elif [ "$step" = "execute" ]; then

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -946,6 +946,8 @@ class Plan(
             echo(tmt.utils.format('tier', self.tier, key_color='cyan'))
         if self.link is not None:
             self.link.show()
+        if self.ansible:
+            echo(tmt.utils.format('ansible', self.ansible.to_spec(), key_color='cyan'))
         if self.verbosity_level:
             self._show_additional_keys()
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1465,11 +1465,8 @@ class GuestData(
             elif isinstance(value, dict):
                 printable_value = tmt.utils.format_value(value)
 
-            elif isinstance(value, tmt.hardware.Hardware):
+            elif isinstance(value, (tmt.hardware.Hardware, tmt.ansible.GuestAnsible)):
                 printable_value = tmt.utils.to_yaml(value.to_spec())
-
-            elif isinstance(value, tmt.ansible.GuestAnsible):
-                printable_value = tmt.utils.dict_to_yaml(cast(dict[str, Any], value.to_spec()))
 
             else:
                 printable_value = str(value)

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -32,6 +32,7 @@ from typing import (
 import fmf.utils
 
 import tmt
+import tmt.ansible
 import tmt.hardware
 import tmt.hardware.constraints
 import tmt.log
@@ -1466,6 +1467,9 @@ class GuestData(
 
             elif isinstance(value, tmt.hardware.Hardware):
                 printable_value = tmt.utils.to_yaml(value.to_spec())
+
+            elif isinstance(value, tmt.ansible.GuestAnsible):
+                printable_value = tmt.utils.dict_to_yaml(cast(dict[str, Any], value.to_spec()))
 
             else:
                 printable_value = str(value)

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -13,6 +13,7 @@ import fmf.utils
 from click import echo
 
 import tmt
+import tmt.ansible
 import tmt.guest
 import tmt.hardware
 import tmt.log
@@ -39,6 +40,15 @@ if TYPE_CHECKING:
 class ProvisionStepData(tmt.steps.StepData):
     # guest role in the multihost scenario
     role: Optional[str] = None
+
+    ansible: Optional[tmt.ansible.GuestAnsible] = field(
+        default=cast(Optional[tmt.ansible.GuestAnsible], None),
+        normalize=tmt.ansible.normalize_guest_ansible,
+        serialize=lambda ansible: ansible.to_serialized() if ansible else None,
+        unserialize=lambda serialized: (
+            tmt.ansible.GuestAnsible.from_serialized(serialized) if serialized else None
+        ),
+    )
 
     hardware: Optional[tmt.hardware.Hardware] = field(
         default=cast(Optional[tmt.hardware.Hardware], None),
@@ -198,9 +208,13 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin[ProvisionStepDataT, None]):
         keys = keys or list(set(self.data.keys()))
 
         show_hardware = 'hardware' in keys
+        show_ansible = 'ansible' in keys
 
         if show_hardware:
             keys.remove('hardware')
+
+        if show_ansible:
+            keys.remove('ansible')
 
         super().show(keys=keys)
 
@@ -209,6 +223,9 @@ class ProvisionPlugin(tmt.steps.GuestlessPlugin[ProvisionStepDataT, None]):
 
             if hardware:
                 echo(tmt.utils.format('hardware', tmt.utils.to_yaml(hardware.to_spec())))
+
+        if show_ansible and self.data.ansible:
+            echo(tmt.utils.format('ansible', tmt.utils.to_yaml(self.data.ansible.to_spec())))
 
 
 class ProvisionTask(tmt.queue.GuestlessTask[None]):


### PR DESCRIPTION
Showing the object itself is not correct, we need its spec if nothing more.

Pull Request Checklist

* [x] implement the feature