### PR TITLE
Mock provision: make detection of finished processes more deterministic

### DIFF
--- a/tests/provision/mock/main.fmf
+++ b/tests/provision/mock/main.fmf
@@ -1,3 +1,5 @@
+require+:
+  - tmt+provision-mock
 tag+:
   - provision-only
   - provision-mock

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -102,7 +102,7 @@ class _MockPackageManager(PackageManager[MockEngine]):
     """
 
     probe_command = Command('/usr/bin/false')
-    probe_priority = 140
+    probe_priority = 130
     _engine_class = MockEngine
 
     def check_presence(self, *installables: Installable) -> dict[Installable, bool]:

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -102,7 +102,7 @@ class _MockPackageManager(PackageManager[MockEngine]):
     """
 
     probe_command = Command('/usr/bin/false')
-    probe_priority = 130
+    probe_priority = 140
     _engine_class = MockEngine
 
     def check_presence(self, *installables: Installable) -> dict[Installable, bool]:

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -447,6 +447,10 @@ class MockShell:
                 # guaranteed.
                 if len(events) == 1 and events[0][0] == returncode_fd:
                     content = os.read(returncode_fd, 16)
+                    if not content:
+                        # EPOLLHUP with no data: the writer (echo $?>) has not
+                        # yet opened the FIFO. Keep waiting until it does.
+                        continue
                     try:
                         returncode = int(content.decode('ascii').strip())
                     except ValueError:

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -186,8 +186,6 @@ class MockShell:
         Invoke commands in the mock shell without checking for errors.
         This is done by writing the commands to the shell, ending each with
         a newline.
-        Each command invocation causes the shell to print a newline when the
-        command has finished.
         """
 
         assert self.epoll is not None
@@ -195,24 +193,29 @@ class MockShell:
         assert self.mock_shell.stdin is not None
         assert self.mock_shell.stdout is not None
         assert self.mock_shell.stderr is not None
+        finished_keyword = 'TMT_FINISHED_EXEC'
 
-        self.mock_shell.stdin.write(''.join(command + '\n' for command in commands))
-        # Issue a command writing a binary zero on the standard output after all
+        self.mock_shell.stdin.write('\n'.join(commands))
+        # Issue a command writing a terminator on the standard output after all
         # the previous commands are finished.
-        self.mock_shell.stdin.write('echo -e \\\\x00\n')
+        self.mock_shell.stdin.write(f'\necho {finished_keyword}\n')
         self.mock_shell.stdin.flush()
 
         # Wait until we read the binary zero from stdout.
-        loop = True
-        while loop and self.mock_shell.poll() is None:
+        while True:
+            mock_shell_result = self.mock_shell.poll()
+            if mock_shell_result is not None:
+                raise tmt.utils.ProvisionError(f'Mock shell abruptly exited: {mock_shell_result}.')
             events = self.epoll.poll()
             for fileno, _ in events:
                 if (
                     fileno == self.mock_shell_stdout_fd
-                    and self.mock_shell.stdout.read() == '\x00\n'
+                    and self.mock_shell.stdout.read() == f'{finished_keyword}\n'
                 ):
-                    loop = False
                     break
+            else:
+                continue
+            break
         for line in self.mock_shell.stderr.readlines():
             self.parent.debug('mock', line.rstrip(), color='blue', level=2)
 
@@ -440,8 +443,7 @@ class MockShell:
                     break
                 for fileno, _ in events:
                     if fileno == self.mock_shell_stdout_fd:
-                        # Various environments may print variable number of
-                        # times here.
+                        # Mock prints newlines on stdout.
                         self.mock_shell.stdout.read()
                     elif fileno == self.mock_shell_stderr_fd:
                         # Whatever we sent on mock shell's input it prints on

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -424,6 +424,15 @@ class MockShell:
             yield  # type: ignore[misc]
 
             while self.mock_shell.poll() is None:
+                # The `epoll.poll` call returns a list of pairs of all the
+                # events, that are currently ready. The pair consists of the
+                # file descriptor and the event type (we only registered
+                # select.EPOLLIN - ready for reading).
+                #
+                # `epoll.poll` is level-based: each time it is invoked, it
+                # returns a list of descriptors which are ready and it will
+                # contain those descriptors until we actually read from the
+                # descriptor.
                 events = self.epoll.poll(timeout=timeout)
 
                 if len(events) == 0:
@@ -433,8 +442,9 @@ class MockShell:
 
                 # The command is finished when the returncode is written to its
                 # file.
-                # We want to break loop after we handled all the other epoll
-                # events because the event ordering is not guaranteed.
+                # We want to break loop after we handled all the epoll events
+                # other than `returncode` because the event ordering is not
+                # guaranteed.
                 if len(events) == 1 and events[0][0] == returncode_fd:
                     content = os.read(returncode_fd, 16)
                     returncode = int(content.decode('utf-8').strip())

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -201,16 +201,15 @@ class MockShell:
         self.mock_shell.stdin.write(f'\necho {finished_keyword}\n')
         self.mock_shell.stdin.flush()
 
-        # Wait until we read the binary zero from stdout.
+        # Wait until we read the `finished_keyword`.
         while True:
             mock_shell_result = self.mock_shell.poll()
             if mock_shell_result is not None:
                 raise tmt.utils.ProvisionError(f'Mock shell abruptly exited: {mock_shell_result}.')
             events = self.epoll.poll()
             for fileno, _ in events:
-                if (
-                    fileno == self.mock_shell_stdout_fd
-                    and self.mock_shell.stdout.read() == f'{finished_keyword}\n'
+                if fileno == self.mock_shell_stdout_fd and self.mock_shell.stdout.read().endswith(
+                    f'{finished_keyword}\n'
                 ):
                     break
             else:

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -447,8 +447,13 @@ class MockShell:
                 # guaranteed.
                 if len(events) == 1 and events[0][0] == returncode_fd:
                     content = os.read(returncode_fd, 16)
-                    returncode = int(content.decode('utf-8').strip())
-                    returncode_io.try_unregister()
+                    try:
+                        returncode = int(content.decode('ascii').strip())
+                    except ValueError:
+                        # Missing `returncode` is handled outside of the loop.
+                        break
+                    finally:
+                        returncode_io.try_unregister()
                     break
                 for fileno, _ in events:
                     if fileno == self.mock_shell_stdout_fd:

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -197,16 +197,21 @@ class MockShell:
         assert self.mock_shell.stderr is not None
 
         self.mock_shell.stdin.write(''.join(command + '\n' for command in commands))
+        # Issue a command writing a binary zero on the standard output after all
+        # the previous commands are finished.
+        self.mock_shell.stdin.write('echo -e \\\\x00\n')
         self.mock_shell.stdin.flush()
 
-        # Wait until the previous commands finished.
-        loop = len(commands)
-        while loop != 0 and self.mock_shell.poll() is None:
+        # Wait until we read the binary zero from stdout.
+        loop = True
+        while loop and self.mock_shell.poll() is None:
             events = self.epoll.poll()
             for fileno, _ in events:
-                if fileno == self.mock_shell_stdout_fd:
-                    loop -= 1
-                    self.mock_shell.stdout.read()
+                if (
+                    fileno == self.mock_shell_stdout_fd
+                    and self.mock_shell.stdout.read() == '\x00\n'
+                ):
+                    loop = False
                     break
         for line in self.mock_shell.stderr.readlines():
             self.parent.debug('mock', line.rstrip(), color='blue', level=2)
@@ -424,16 +429,23 @@ class MockShell:
                     # kill the process spawned inside the mock shell
                     pass
 
-                # The command is finished when mock shell prints a newline on its
-                # stdout. We want to break loop after we handled all the other
-                # epoll events because the event ordering is not guaranteed.
-                if len(events) == 1 and events[0][0] == self.mock_shell_stdout_fd:
-                    self.mock_shell.stdout.read()
+                # The command is finished when the returncode is written to its
+                # file.
+                # We want to break loop after we handled all the other epoll
+                # events because the event ordering is not guaranteed.
+                if len(events) == 1 and events[0][0] == returncode_fd:
+                    content = os.read(returncode_fd, 16)
+                    returncode = int(content.decode('utf-8').strip())
+                    returncode_io.try_unregister()
                     break
                 for fileno, _ in events:
-                    # Whatever we sent on mock shell's input it prints on the stderr
-                    # so just discard it.
-                    if fileno == self.mock_shell_stderr_fd:
+                    if fileno == self.mock_shell_stdout_fd:
+                        # Various environments may print variable number of
+                        # times here.
+                        self.mock_shell.stdout.read()
+                    elif fileno == self.mock_shell_stderr_fd:
+                        # Whatever we sent on mock shell's input it prints on
+                        # the stderr so just discard it.
                         self.mock_shell.stderr.read()
                     elif fileno == stdout_fd:
                         content = os.read(stdout_fd, 128)
@@ -445,12 +457,6 @@ class MockShell:
                         stream_err += content
                         if not content:
                             stderr_io.try_unregister()
-                    elif fileno == returncode_fd:
-                        content = os.read(returncode_fd, 16)
-                        if not content:
-                            returncode_io.try_unregister()
-                        else:
-                            returncode = int(content.decode('utf-8').strip())
 
             stdout = stream_out.string
             stderr = stream_err.string

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -446,6 +446,7 @@ class MockShell:
                 # other than `returncode` because the event ordering is not
                 # guaranteed.
                 if len(events) == 1 and events[0][0] == returncode_fd:
+                    # Read the return code number string into a large enough buffer.
                     content = os.read(returncode_fd, 16)
                     if not content:
                         # EPOLLHUP with no data: the writer (echo $?>) has not

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -709,6 +709,8 @@ class GuestMock(tmt.Guest):
         source = source or self.plan_workdir
         destination = destination or source
 
+        if options.delete:
+            self.mock_shell.execute(Command('rm', '-rf', str(destination)), logger=self._logger)
         if source.is_dir():
             self.mock_shell.execute(Command('mkdir', '-p', str(destination)), logger=self._logger)
             p = self.mock_shell._spawn_command(

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -446,8 +446,13 @@ class MockShell:
                 # other than `returncode` because the event ordering is not
                 # guaranteed.
                 if len(events) == 1 and events[0][0] == returncode_fd:
-                    # Read the return code number string into a large enough buffer.
-                    content = os.read(returncode_fd, 16)
+                    try:
+                        # Read the return code number string into a large enough buffer.
+                        content = os.read(returncode_fd, 16)
+                    except BlockingIOError:
+                        # EAGAIN: the writer opened the FIFO but has not written data yet.
+                        # Keep waiting.
+                        continue
                     if not content:
                         # EPOLLHUP with no data: the writer (echo $?>) has not
                         # yet opened the FIFO. Keep waiting until it does.


### PR DESCRIPTION
Based on: #4173 
I found out that various environments (`fedora-rawhide-x86_64`) print different number of empty strings on their stdout as the commands spawned in the chroots finish. This causes some environments to hang.
This PR makes the detection more deterministic.

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
