### PR TITLE
Guest fact discovery via a single script

### DIFF
--- a/tests/prepare/shell/test.sh
+++ b/tests/prepare/shell/test.sh
@@ -28,12 +28,12 @@ rlJournalStart
         }
 
         rlPhaseStartTest "Custom Script"
-            rlRun -s "tmt run -arv provision --how=$PROVISION_HOW $image_opt plan -n custom" 0 "Prepare using a custom script"
+            rlRun -s "tmt -vvvddd run -ar provision --how=$PROVISION_HOW $image_opt plan -n custom" 0 "Prepare using a custom script"
             assert_image_mode
         rlPhaseEnd
 
         rlPhaseStartTest "Commandline Script"
-            rlRun "tmt run -arv provision --how=$PROVISION_HOW $image_opt plan -n custom \
+            rlRun "tmt -vvvddd run -ar provision --how=$PROVISION_HOW $image_opt plan -n custom \
                 prepare -h shell -s './prepare.sh'" 0 "Prepare using a custom script from cmdline"
             assert_image_mode
         rlPhaseEnd
@@ -42,7 +42,7 @@ rlJournalStart
             # NOTE: These paths need to persist from the image and survive a reboot
             # See https://developers.redhat.com/articles/2025/08/25/what-image-mode-3-way-merge
             rlRun "FIRST=/usr/share/first SECOND=/usr/share/second"
-            rlRun -s "tmt run -arv -e FIRST=$FIRST -e SECOND=$SECOND provision --how=$PROVISION_HOW $image_opt plans -n multiple \
+            rlRun -s "tmt -vvvddd run -ar -e FIRST=$FIRST -e SECOND=$SECOND provision --how=$PROVISION_HOW $image_opt plans -n multiple \
                 prepare -h shell -s 'touch $FIRST' -s 'touch $SECOND'"
             assert_image_mode
         rlPhaseEnd

--- a/tests/provision/facts/test-guest.sh
+++ b/tests/provision/facts/test-guest.sh
@@ -75,7 +75,7 @@ rlJournalStart
 
         rlAssertGrep "arch: $arch" $rlRun_LOG
         rlAssertGrep "distro: $distro" $rlRun_LOG
-        rlAssertGrep "kernel: $kernel" $rlRun_LOG
+        rlAssertGrep "kernel release: $kernel" $rlRun_LOG
         rlAssertGrep "package manager: $package_manager" $rlRun_LOG
         rlAssertGrep "selinux: $selinux" $rlRun_LOG
         rlAssertGrep "is superuser: $is_superuser" $rlRun_LOG
@@ -86,7 +86,7 @@ rlJournalStart
 
             rlAssertGrep "arch: $arch" $rlRun_LOG
             rlAssertGrep "distro: $distro" $rlRun_LOG
-            rlAssertGrep "kernel: $kernel" $rlRun_LOG
+            rlAssertGrep "kernel release: $kernel" $rlRun_LOG
             rlAssertGrep "package manager: $package_manager" $rlRun_LOG
             rlAssertGrep "selinux: $selinux" $rlRun_LOG
             rlAssertGrep "is superuser: $bfu_is_superuser" $rlRun_LOG

--- a/tests/provision/facts/test-guest.sh
+++ b/tests/provision/facts/test-guest.sh
@@ -74,7 +74,7 @@ rlJournalStart
 
         rlAssertGrep "arch: $arch" $rlRun_LOG
         rlAssertGrep "distro: $distro" $rlRun_LOG
-        rlAssertGrep "kernel: $kernel" $rlRun_LOG
+        rlAssertGrep "kernel release: $kernel" $rlRun_LOG
         rlAssertGrep "package manager: $package_manager" $rlRun_LOG
         rlAssertGrep "selinux: $selinux" $rlRun_LOG
         rlAssertGrep "is superuser: $is_superuser" $rlRun_LOG
@@ -85,7 +85,7 @@ rlJournalStart
 
             rlAssertGrep "arch: $arch" $rlRun_LOG
             rlAssertGrep "distro: $distro" $rlRun_LOG
-            rlAssertGrep "kernel: $kernel" $rlRun_LOG
+            rlAssertGrep "kernel release: $kernel" $rlRun_LOG
             rlAssertGrep "package manager: $package_manager" $rlRun_LOG
             rlAssertGrep "selinux: $selinux" $rlRun_LOG
             rlAssertGrep "is superuser: $bfu_is_superuser" $rlRun_LOG

--- a/tests/provision/facts/test-runner.sh
+++ b/tests/provision/facts/test-runner.sh
@@ -38,7 +38,7 @@ rlJournalStart
 
         rlAssertNotGrep "arch: $arch" $rlRun_LOG
         rlAssertNotGrep "distro: $distro" $rlRun_LOG
-        rlAssertNotGrep "kernel: $kernel" $rlRun_LOG
+        rlAssertNotGrep "kernel release: $kernel" $rlRun_LOG
         rlAssertNotGrep "package manager: $package_manager" $rlRun_LOG
         rlAssertNotGrep "selinux: $selinux" $rlRun_LOG
         rlAssertNotGrep "is superuser: $is_superuser" $rlRun_LOG
@@ -47,7 +47,7 @@ rlJournalStart
 
         rlAssertGrep "arch: $arch" $rlRun_LOG
         rlAssertGrep "distro: $distro" $rlRun_LOG
-        rlAssertGrep "kernel: $kernel" $rlRun_LOG
+        rlAssertGrep "kernel release: $kernel" $rlRun_LOG
         rlAssertGrep "package manager: $package_manager" $rlRun_LOG
         rlAssertGrep "selinux: $selinux" $rlRun_LOG
         rlAssertGrep "is superuser: $is_superuser" $rlRun_LOG

--- a/tests/provision/facts/test-runner.sh
+++ b/tests/provision/facts/test-runner.sh
@@ -37,7 +37,7 @@ rlJournalStart
 
         rlAssertNotGrep "arch: $arch" $rlRun_LOG
         rlAssertNotGrep "distro: $distro" $rlRun_LOG
-        rlAssertNotGrep "kernel: $kernel" $rlRun_LOG
+        rlAssertNotGrep "kernel release: $kernel" $rlRun_LOG
         rlAssertNotGrep "package manager: $package_manager" $rlRun_LOG
         rlAssertNotGrep "selinux: $selinux" $rlRun_LOG
         rlAssertNotGrep "is superuser: $is_superuser" $rlRun_LOG
@@ -46,7 +46,7 @@ rlJournalStart
 
         rlAssertGrep "arch: $arch" $rlRun_LOG
         rlAssertGrep "distro: $distro" $rlRun_LOG
-        rlAssertGrep "kernel: $kernel" $rlRun_LOG
+        rlAssertGrep "kernel release: $kernel" $rlRun_LOG
         rlAssertGrep "package manager: $package_manager" $rlRun_LOG
         rlAssertGrep "selinux: $selinux" $rlRun_LOG
         rlAssertGrep "is superuser: $is_superuser" $rlRun_LOG

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -233,8 +233,6 @@ def test_discovery(
 
         assert guest.facts.package_manager == expected
 
-        assert_log(caplog, message=MATCH(rf"^Discovered package manager: {expected_discovery}$"))
-
     # Images in which `dnf5`` would be the best possible choice, do not
     # come with `dnf5`` pre-installed. Therefore run the discovery first,
     # but expect to find *dnf* instead of `dnf5`. Then install `dnf5`,

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -236,8 +236,6 @@ def test_discovery(
 
         assert guest.facts.package_manager == expected
 
-        assert_log(caplog, message=MATCH(rf"^Discovered package manager: {expected_discovery}$"))
-
     # Images in which `dnf5`` would be the best possible choice, do not
     # come with `dnf5`` pre-installed. Therefore run the discovery first,
     # but expect to find *dnf* instead of `dnf5`. Then install `dnf5`,

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -3369,7 +3369,7 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
 
         log = functools.partial(logger.debug, color='green', level=3)
 
-        log('tmt runner')
+        log('tmt runner facts')
 
         for _, key_formatted, value_formatted in self.runner.facts.format():
             log(key_formatted, value_formatted, shift=1)

--- a/tmt/base/run.py
+++ b/tmt/base/run.py
@@ -607,7 +607,7 @@ class Run(HasRunWorkdir, HasUserAnchorPath, HasEnvironment, tmt.utils.Common):
 
         log = functools.partial(logger.debug, color='green', level=3)
 
-        log('tmt runner')
+        log('tmt runner facts')
 
         for _, key_formatted, value_formatted in self.runner.facts.format():
             log(key_formatted, value_formatted, shift=1)

--- a/tmt/base/run.py
+++ b/tmt/base/run.py
@@ -640,7 +640,7 @@ class Run(HasRunWorkdir, HasUserAnchorPath, HasEnvironment, tmt.utils.Common):
 
         log = functools.partial(logger.debug, color='green', level=3)
 
-        log('tmt runner')
+        log('tmt runner facts')
 
         for _, key_formatted, value_formatted in self.runner.facts.format():
             log(key_formatted, value_formatted, shift=1)

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -16,7 +16,7 @@ import string
 import subprocess
 import textwrap
 import threading
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterator, Sequence
 from shlex import quote
 from typing import (
     TYPE_CHECKING,

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -5,6 +5,7 @@ import dataclasses
 import enum
 import functools
 import hashlib
+import inspect
 import os
 import re
 import secrets
@@ -13,6 +14,7 @@ import shutil
 import signal as _signal
 import string
 import subprocess
+import textwrap
 import threading
 from collections.abc import Iterable, Iterator, Sequence
 from shlex import quote
@@ -20,6 +22,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Generic,
     Literal,
     NewType,
     Optional,
@@ -576,6 +579,200 @@ class GuestCapability(enum.Enum):
     SYSLOG_ACTION_READ_CLEAR = 'syslog-action-read-clear'
 
 
+class guest_fact(Generic[T]):  # noqa: N801
+    """
+    A descriptor that associates a shell snippet with a guest fact attribute.
+
+    This descriptor allows facts to be collected efficiently by registering
+    shell snippets that can be combined into a single script execution.
+    """
+
+    #: A shell snippet responsible for discovering a fact. Its standard
+    #: output is passed to :py:attr:`extract`, standard error output is
+    #: ignored.
+    snippet: str
+
+    #: If set, it is used instead of :py:attr:`snippet`. The callable
+    #: is invoked during the construction of the discover script, and
+    #: its return value must comply with the rules for :py:attr:`snippet`.
+    snippet_creator: Callable[[], str]
+
+    #: A callable that receives the standard output of the shell snippet,
+    #: and returns the actual value of the fact, to be assigned to the
+    #: corresponding :py:class:`GuestFacts` attribute.
+    extract: Callable[[str], T]
+
+    #: Name of the attribute which owns this descriptor. Needed to support
+    #: the descriptor API.
+    name: Optional[str]
+
+    def __init__(
+        self,
+        probe: Union[str, Callable[[], str]],
+        extract: Callable[[str], T],
+    ) -> None:
+        """
+        Initialize a fact collector.
+
+        :param snippet: a shell snippet responsible for discovering the
+            fact. Its standard output is passed to :py:attr:`extract`,
+            standard error output is ignored. If a callable is used,
+            its return value is supposed to be the snippet, and must
+            comply with the rules above.
+        :param extract: a callable that receives the standard output of
+            the shell snippet, and returns the actual value of the fact,
+            to be assigned to the corresponding :py:class:`GuestFacts`
+            attribute.
+        """
+
+        if isinstance(probe, str):
+            self.snippet = textwrap.dedent(probe).strip()
+
+        else:
+            self.snippet_creator = probe
+
+        self.extract = extract
+
+        self.name = None
+
+    def __set_name__(self, owner: type, name: str) -> None:
+        """
+        Called when the descriptor is assigned to a class attribute.
+        """
+
+        self.name = name
+
+    @overload
+    def __get__(self, obj: None, objtype: Optional[type] = None) -> 'guest_fact[T]':
+        pass
+
+    @overload
+    def __get__(self, obj: 'GuestFacts', objtype: Optional[type] = None) -> T:
+        pass
+
+    def __get__(
+        self, obj: Optional['GuestFacts'], objtype: Optional[type] = None
+    ) -> Union['guest_fact[T]', T]:
+        """
+        Get the fact value from the instance.
+        """
+
+        if obj is None:
+            return self
+
+        assert self.name
+
+        return cast(T, obj._raw_facts.get(self.name))
+
+    def __set__(self, obj: 'GuestFacts', value: T) -> None:
+        """
+        Set the fact value on the instance.
+        """
+
+        assert self.name
+
+        obj._raw_facts[self.name] = value
+
+
+class string_guest_fact(guest_fact[Optional[str]]):  # noqa: N801
+    """
+    A guest fact whose value is a simple string.
+    """
+
+    def __init__(self, probe: str) -> None:
+        super().__init__(
+            probe, lambda output: output.strip() if output.strip() != 'unknown' else None
+        )
+
+
+class flag_guest_fact(guest_fact[Optional[bool]]):  # noqa: N801
+    """
+    A guest fact whose value is a booleab flag.
+    """
+
+    def __init__(self, probe: str) -> None:
+        super().__init__(
+            probe, lambda output: output.strip() == 'true' if output.strip() != 'unknown' else None
+        )
+
+
+class keyval_guest_fact(guest_fact[dict[str, str]]):  # noqa: N801
+    """
+    A guest fact whose value is a key/value mapping.
+    """
+
+    @staticmethod
+    def _parse(content: str) -> dict[str, str]:
+        """
+        Parse key=value content (like os-release or lsb-release).
+
+        :param content: File content with key=value pairs.
+        :returns: Dictionary of parsed key/value pairs.
+        """
+
+        result: dict[str, str] = {}
+
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+
+            if '=' not in line:
+                continue
+
+            key, value = line.split('=', 1)
+
+            # Remove quotes if present
+            if value and value[0] in '"\'':
+                # If ast.literal_eval fails, keep the original value
+                with contextlib.suppress(ValueError, SyntaxError):
+                    value = ast.literal_eval(value)
+
+            result[key] = value
+
+        return result
+
+    def __init__(self, path: Path) -> None:
+        super().__init__(f"cat {shlex.quote(str(path))}", keyval_guest_fact._parse)
+
+
+class package_manager_guest_fact(guest_fact[Optional['tmt.package_managers.GuestPackageManager']]):  # noqa: N801
+    """
+    A guest fact whose value is a package manager name.
+    """
+
+    def __init__(
+        self,
+        predicate: Optional[
+            Callable[[type['tmt.package_managers.PackageManager[Any]']], bool]
+        ] = None,
+    ) -> None:
+        def _snippet_creator() -> str:
+            probes: list[str] = []
+
+            for package_manager_class in sorted(
+                tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.iter_plugins(),
+                key=lambda pm: pm.probe_priority,
+                reverse=True,
+            ):
+                if predicate and not predicate(package_manager_class):
+                    continue
+
+                probes.append(
+                    f"({package_manager_class.probe_command.to_element()}) 1>&2 && echo '{package_manager_class.NAME}'"  # noqa: E501
+                )
+
+            return '\n'.join(probes)
+
+        def _extract(output: str) -> Optional['tmt.package_managers.GuestPackageManager']:
+            if not output:
+                return None
+
+            return output.splitlines()[0]
+
+        super().__init__(_snippet_creator, _extract)
+
+
 @container
 class GuestFacts(SerializableContainer):
     """
@@ -584,433 +781,129 @@ class GuestFacts(SerializableContainer):
     Inspired by Ansible or Puppet facts, interesting guest facts tmt
     discovers while managing the guest are stored in this container,
     plus the code performing the discovery of these facts.
+
+    Each fact is represented as an attribute with the proper type
+    annotation, assigned an instance of :py:class:`guest_fact` class, or
+    one of its subclasses.
+
+    * ``guest_fact`` classes implement the Python descriptor API, see
+      https://docs.python.org/3/howto/descriptor.html, which allows us
+      to attach interesting information to each fact.
+    * the information we attach is 1. a shell script snippet, "probe",
+      to be executed on the guest, whose responsibility is to print
+      something to its standard output, and 2. a callable, "extractor",
+      that is given this standard output, and is expected to produce the
+      actual value of the corresponding fact.
+
+    For example, a probe for the :py:attr:`arch` fact is simple, it calls
+    the ``arch`` command. The corresponding extractor is also trivial,
+    and takes the output produced by the probe - a raw output of
+    ``arch`` - and returns it as the value of the ``arch`` fact.
+
+    Probes of flag-like facts, :py:attr:`has_selinux` for example, usually
+    test some system property, and echo ``true`` or ``false``. The
+    corresponding extractor turns it into a proper ``bool`` value.
+
+    When discovering facts, i.e. when :py:meth:`sync` is called, relevant
+    probes are collected and joined into a single shell script that is
+    then executed on the guest. :py:meth:`_extract_facts` then extracts
+    the actual values, and updates :py:attr:`_raw_facts` mapping.
+    Descriptors then return values from this mapping instead of running
+    any additional code on the guest.
     """
+
+    #: Store the actual values of facts. This mapping serves as a
+    #: storage for descriptors, see :py:meth:`guest_fact.__get__`.
+    #: It is this mapping that is refreshed by :py:meth:`sync`.
+    _raw_facts: dict[str, Any] = field(default_factory=dict)
 
     #: Set to ``True`` by the first call to :py:meth:`sync`.
     in_sync: bool = False
 
-    arch: Optional[str] = None
-    distro: Optional[str] = None
-    kernel_release: Optional[str] = None
-    package_manager: Optional['tmt.package_managers.GuestPackageManager'] = field(
-        # cast: since the default is None, mypy cannot infere the full type,
-        # and reports `package_manager` parameter to be `object`.
-        default=cast(Optional['tmt.package_managers.GuestPackageManager'], None)
-    )
-    bootc_builder: Optional['tmt.package_managers.GuestPackageManager'] = field(
-        # cast: since the default is None, mypy cannot infere the full type,
-        # and reports `bootc_builder` parameter to be `object`.
-        default=cast(Optional['tmt.package_managers.GuestPackageManager'], None)
-    )
-
-    has_selinux: Optional[bool] = None
-    has_systemd: Optional[bool] = None
-    has_rsync: Optional[bool] = None
-    is_superuser: Optional[bool] = None
-    can_sudo: Optional[bool] = None
-    sudo_prefix: Optional[str] = None
-    is_ostree: Optional[bool] = None
-    is_image_mode: Optional[bool] = None
-    is_toolbox: Optional[bool] = None
-    toolbox_container_name: Optional[str] = None
-    is_container: Optional[bool] = None
-    systemd_soft_reboot: Optional[bool] = None
-
-    #: Various Linux capabilities and whether they are permitted to
-    #: commands executed on this guest.
-    capabilities: dict[GuestCapability, bool] = field(
-        default_factory=cast(Callable[[], dict[GuestCapability, bool]], dict),
-        serialize=lambda capabilities: (
-            {capability.value: enabled for capability, enabled in capabilities.items()}
-            if capabilities
-            else {}
-        ),
-        unserialize=lambda raw_value: {
-            GuestCapability(raw_capability): enabled
-            for raw_capability, enabled in raw_value.items()
-        },
-    )
-
-    os_release_content: dict[str, str] = field(default_factory=dict)
-    lsb_release_content: dict[str, str] = field(default_factory=dict)
-
-    def has_capability(self, cap: GuestCapability) -> bool:
-        if not self.capabilities:
-            return False
-
-        return self.capabilities.get(cap, False)
-
-    def _execute(self, guest: 'Guest', command: Command) -> Optional[tmt.utils.CommandOutput]:
+    @classmethod
+    def _facts(cls) -> dict[str, guest_fact[Any]]:
         """
-        Run a command on the given guest, ignoring :py:class:`tmt.utils.RunError`.
+        Find all defined facts and their descriptors.
 
-        On image mode systems execute the commands immediately.
-
-        :returns: command output if the command quit with a zero exit code,
-            ``None`` otherwise.
+        :returns: a mapping with fact names as keys, and fact descriptors
+            as values.
         """
 
-        try:
-            return guest.execute(command, silent=True)
+        return {
+            name: value for name, value in inspect.getmembers(cls) if isinstance(value, guest_fact)
+        }
 
-        except tmt.utils.RunError:
-            pass
-
-        return None
-
-    def _fetch_keyval_file(self, guest: 'Guest', filepath: Path) -> dict[str, str]:
+    @functools.cached_property
+    def _fact_snippets(self) -> dict[str, str]:
         """
-        Load key/value pairs from a file on the given guest.
+        Collect all fact collection snippets from the facts.
 
-        Converts file with ``key=value`` pairs into a mapping. Some values might
-        be wrapped with quotes.
-
-        .. code:: shell
-
-           $ cat /etc/os-release
-           NAME="Ubuntu"
-           VERSION="20.04.5 LTS (Focal Fossa)"
-           ID=ubuntu
-           ID_LIKE=debian
-           ...
-
-        See https://www.freedesktop.org/software/systemd/man/os-release.html for
-        more details on syntax of these files.
-
-        :returns: mapping with key/value pairs loaded from ``filepath``, or an
-            empty mapping if it was impossible to load the content.
+        :returns: a mapping with fact names as keys, and shell snippets
+            as values.
         """
 
-        content: dict[str, str] = {}
+        return {
+            name: (value.snippet if hasattr(value, 'snippet') else value.snippet_creator())
+            for name, value in self._facts().items()
+        }
 
-        output = self._execute(guest, Command('cat', filepath))
+    def _create_collection_script(self, *facts: str) -> ShellScript:
+        """
+        Generate a comprehensive shell script to collect all facts.
 
-        if not output or not output.stdout:
-            return content
+        :returns: a shell script that invokes all probes, and "wraps"
+            them with markers for the future parsing.
+        """
 
-        def _iter_pairs() -> Iterator[tuple[str, str]]:
-            assert output  # narrow type in a closure
-            assert output.stdout  # narrow type in a closure
+        scripts: list[str] = []
 
-            line_pattern = re.compile(r'([A-Z][A-Z_0-9]+)=(.*)')
+        for fact, snippet in self._fact_snippets.items():
+            if fact not in facts:
+                continue
 
-            for line_number, line in enumerate(output.stdout.splitlines(keepends=False), start=1):
-                line = line.rstrip()
+            # The extra `echo` is there to enforce at least one empty line
+            # in the output.
+            scripts.append(f'echo ">>> {fact}"\n{snippet}\necho\necho "<<<"\n')
 
-                if not line or line.startswith('#'):
-                    continue
+        return ShellScript('\n\n'.join(scripts))
 
-                match = line_pattern.match(line)
+    def _extract_facts(self, output: str) -> dict[str, str]:
+        """
+        Parse the output of the fact collection script.
 
-                if not match:
-                    raise tmt.utils.ProvisionError(
-                        f"Cannot parse line {line_number} in '{filepath}' on guest '{guest.name}':"
-                        f" {line}"
+        :param output: raw output from the fact collection script.
+        :returns: a mapping between fact names and their values, as
+            extracted from the output.
+        """
+
+        facts = {}
+
+        current_fact: Optional[str] = None
+        current_fact_content: list[str] = []
+
+        for line in output.splitlines():
+            line = line.strip()
+
+            if line.startswith('>>> '):
+                current_fact = line[4:]
+
+            elif line.startswith('<<<'):
+                if current_fact is None:
+                    raise GeneralError(
+                        "Malformed fact probe output: closing marker '<<<' without opening marker"
                     )
 
-                key, value = match.groups()
-
-                if value and value[0] in '"\'':
-                    value = ast.literal_eval(value)
-
-                yield key, value
-
-        return dict(_iter_pairs())
-
-    def _probe(self, guest: 'Guest', probes: list[tuple[Command, T]]) -> Optional[T]:
-        """
-        Find a first successful command.
-
-        :param guest: the guest to run commands on.
-        :param probes: list of command/mark pairs.
-        :returns: "mark" corresponding to the first command to quit with
-            a zero exit code.
-        :raises tmt.utils.GeneralError: when no command succeeded.
-        """
-
-        for command, outcome in probes:
-            if self._execute(guest, command):
-                return outcome
-
-        return None
-
-    def _query(self, guest: 'Guest', probes: list[tuple[Command, str]]) -> Optional[str]:
-        """
-        Find a first successful command, and extract info from its output.
-
-        :param guest: the guest to run commands on.
-        :param probes: list of command/pattenr pairs.
-        :returns: substring extracted by the first matching pattern.
-        :raises tmt.utils.GeneralError: when no command succeeded, or when no
-            pattern matched.
-        """
-
-        for command, pattern in probes:
-            output = self._execute(guest, command)
-
-            if not output or not output.stdout:
-                guest.debug('query', f"Command '{command!s}' produced no usable output.")
-                continue
-
-            match = re.search(pattern, output.stdout)
-
-            if not match:
-                guest.debug('query', f"Command '{command!s}' produced no usable output.")
-                continue
-
-            return match.group(1)
-
-        return None
-
-    def _query_arch(self, guest: 'Guest') -> Optional[str]:
-        return self._query(guest, [(Command('arch'), r'(.+)')])
-
-    def _query_distro(self, guest: 'Guest') -> Optional[str]:
-        # Try some low-hanging fruits first. We already might have the answer,
-        # provided by some standardized locations.
-        if 'PRETTY_NAME' in self.os_release_content:
-            return self.os_release_content['PRETTY_NAME']
-
-        if 'DISTRIB_DESCRIPTION' in self.lsb_release_content:
-            return self.lsb_release_content['DISTRIB_DESCRIPTION']
-
-        # Nope, inspect more files.
-        return self._query(
-            guest,
-            [
-                (Command('cat', '/etc/redhat-release'), r'(.*)'),
-                (Command('cat', '/etc/fedora-release'), r'(.*)'),
-            ],
-        )
-
-    def _query_kernel_release(self, guest: 'Guest') -> Optional[str]:
-        return self._query(guest, [(Command('uname', '-r'), r'(.+)')])
-
-    def _discover_package_manager(
-        self,
-        guest: 'Guest',
-        plugin_classes: Iterable[
-            type[tmt.package_managers.PackageManager[tmt.package_managers.PackageManagerEngine]]
-        ],
-        *,
-        debug_label: str,
-    ) -> Optional['tmt.package_managers.GuestPackageManager']:
-        # Sort available package managers by priority and probe them one by one,
-        # break after the first one is detected.
-
-        for package_manager_class in sorted(
-            plugin_classes, key=lambda pm: pm.probe_priority, reverse=True
-        ):
-            if self._execute(guest, package_manager_class.probe_command):
-                guest.debug(
-                    f'Discovered {debug_label}',
-                    package_manager_class.NAME,
-                    level=4,
+                facts[current_fact] = self._facts()[current_fact].extract(
+                    '\n'.join(current_fact_content)
                 )
-                return package_manager_class.NAME
 
-        return None
+                current_fact = None
+                current_fact_content = []
 
-    def _query_package_manager(
-        self, guest: 'Guest'
-    ) -> Optional['tmt.package_managers.GuestPackageManager']:
-        return self._discover_package_manager(
-            guest,
-            plugin_classes=(
-                package_manager_class
-                for package_manager_class in (
-                    tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.iter_plugins()
-                )
-            ),
-            debug_label='package manager',
-        )
+            else:
+                current_fact_content.append(line)
 
-    def _query_bootc_builder(
-        self, guest: 'Guest'
-    ) -> Optional['tmt.package_managers.GuestPackageManager']:
-        return self._discover_package_manager(
-            guest,
-            plugin_classes=(
-                pm
-                for pm in tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.iter_plugins()
-                if pm.bootc_builder
-            ),
-            debug_label='bootc builder',
-        )
-
-    def _query_has_selinux(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether guest has SELinux and it is enabled.
-
-        For detection ``/sys/fs/selinux/enforce`` is used. This file exists
-        only when SELinux is actually available and mounted (regardless of
-        enforcing/permissive mode).
-        """
-        try:
-            guest.execute(Command('test', '-e', '/sys/fs/selinux/enforce'), silent=True)
-            return True
-        except tmt.utils.RunError:
-            return False
-
-    def _query_has_systemd(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether guest uses systemd.
-        For detection we check if systemctl exists and is executable.
-        """
-        try:
-            guest.execute(Command('systemctl', '--version'), silent=True)
-            return True
-        except tmt.utils.RunError:
-            return False
-
-    def _query_systemd_soft_reboot(self, guest: 'Guest') -> Optional[bool]:
-        output = self._execute(
-            guest,
-            (
-                ShellScript('systemctl --help | grep -q "soft-reboot"')
-                & ShellScript('cat /proc/sys/kernel/random/boot_id')
-            ).to_shell_command(),
-        )
-
-        return output is not None and output.stdout is not None
-
-    def _query_has_rsync(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether ``rsync`` is available.
-        """
-
-        try:
-            guest.execute(Command('rsync', '--version'), silent=True)
-
-            return True
-
-        except tmt.utils.RunError:
-            return False
-
-    def _query_is_superuser(self, guest: 'Guest') -> Optional[bool]:
-        output = self._execute(guest, Command('whoami'))
-
-        if output is None or output.stdout is None:
-            return None
-
-        return output.stdout.strip() == 'root'
-
-    def _query_can_sudo(self, guest: 'Guest') -> Optional[bool]:
-        try:
-            guest.execute(Command("sudo", "-n", "true"), silent=True)
-        except tmt.utils.RunError:
-            # Failed non-interactive sudo, so we can't sudo
-            return False
-        # Otherwise we may use sudo
-        return True
-
-    def _query_sudo_prefix(self, guest: 'Guest') -> str:
-        # Note: we cannot reuse `is_superuser` or `can_sudo` fact so we just recall the query
-        # functions for now
-        if self._query_is_superuser(guest):
-            # Root user does not need sudo
-            return ""
-        if self._query_can_sudo(guest):
-            return "sudo"
-        return ""
-
-    def _query_is_ostree(self, guest: 'Guest') -> Optional[bool]:
-        # https://github.com/vrothberg/chkconfig/commit/538dc7edf0da387169d83599fe0774ea080b4a37#diff-562b9b19cb1cd12a7343ce5c739745ebc8f363a195276ca58e926f22927238a5R1334
-        output = self._execute(
-            guest,
-            ShellScript(
-                """
-                ( [ -e /run/ostree-booted ] || [ -L /ostree ] ) && echo yes || echo no
-                """
-            ).to_shell_command(),
-        )
-
-        if output is None or output.stdout is None:
-            return None
-
-        return output.stdout.strip() == 'yes'
-
-    def _query_is_image_mode(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether guest is an image mode based system.
-
-        An image mode based system has the image set to a image reference.
-        In case ``bootc`` is installed on a non image mode system, it
-        reports ``null``.
-        """
-
-        # Note: we cannot reuse `sudo_prefix` fact so we just recall the query
-        # function for now
-        sudo_prefix = self._query_sudo_prefix(guest)
-
-        command = Command("bootc", "status", "--format", "yaml")
-        if sudo_prefix:
-            command = Command(sudo_prefix) + command
-
-        image = self._query(guest, [(command, r'image: (.+)')])
-
-        # if bootc reports status and the image is not `image: null`, we are in image mode
-        if image and image != "null":
-            return True
-
-        return False
-
-    def _query_is_toolbox(self, guest: 'Guest') -> Optional[bool]:
-        # https://www.reddit.com/r/Fedora/comments/g6flgd/toolbox_specific_environment_variables/
-        output = self._execute(
-            guest,
-            ShellScript('[ -e /run/.toolboxenv ] && echo yes || echo no').to_shell_command(),
-        )
-
-        if output is None or output.stdout is None:
-            return None
-
-        return output.stdout.strip() == 'yes'
-
-    def _query_toolbox_container_name(self, guest: 'Guest') -> Optional[str]:
-        output = self._execute(
-            guest,
-            ShellScript('[ -e /run/.containerenv ] && echo yes || echo no').to_shell_command(),
-        )
-
-        if output is None or output.stdout is None:
-            return None
-
-        if output.stdout.strip() == 'no':
-            return None
-
-        output = self._execute(guest, Command('cat', '/run/.containerenv'))
-
-        if output is None or output.stdout is None:
-            return None
-
-        for line in output.stdout.splitlines():
-            if line.startswith('name="'):
-                return line[6:-1]
-
-        return None
-
-    def _query_is_container(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether guest is a container (running systemd)
-
-        In containers running systemd pid 1 has environment variable ``container`` set
-        (e.g. container=podman). See https://systemd.io/CONTAINER_INTERFACE/ for more details.
-        """
-        output = self._execute(guest, ShellScript('echo -n "$container"').to_shell_command())
-
-        if output is None or output.stdout is None:
-            return None
-
-        return len(output.stdout) > 0
-
-    def _query_capabilities(self, guest: 'Guest') -> dict[GuestCapability, bool]:
-        # TODO: there must be a canonical way of getting permitted capabilities.
-        # For now, we're interested in whether we can access kernel message buffer.
-        return {
-            GuestCapability.SYSLOG_ACTION_READ_ALL: True,
-            GuestCapability.SYSLOG_ACTION_READ_CLEAR: True,
-        }
+        return facts
 
     def sync(self, guest: 'Guest', *facts: str) -> None:
         """
@@ -1022,42 +915,15 @@ class GuestFacts(SerializableContainer):
             ``is_container`` - will be synced.
         """
 
-        if facts:
-            for fact in facts:
-                if not hasattr(self, fact):
-                    raise GeneralError(f"Cannot sync unknown guest fact '{fact}'.")
+        output = guest.execute(
+            self._create_collection_script(*(facts or self._facts().keys())).to_shell_command(),
+            silent=True,
+        )
 
-                method_name = f'_query_{fact}'
+        if not output.stdout:
+            return
 
-                if not hasattr(self, method_name):
-                    raise GeneralError(
-                        f"Cannot sync guest fact '{fact}', query method '{method_name}' not found."
-                    )
-
-                setattr(self, fact, getattr(self, method_name)(guest))
-
-        else:
-            self.os_release_content = self._fetch_keyval_file(guest, Path('/etc/os-release'))
-            self.lsb_release_content = self._fetch_keyval_file(guest, Path('/etc/lsb-release'))
-
-            self.arch = self._query_arch(guest)
-            self.distro = self._query_distro(guest)
-            self.kernel_release = self._query_kernel_release(guest)
-            self.package_manager = self._query_package_manager(guest)
-            self.bootc_builder = self._query_bootc_builder(guest)
-            self.has_selinux = self._query_has_selinux(guest)
-            self.has_systemd = self._query_has_systemd(guest)
-            self.systemd_soft_reboot = self._query_systemd_soft_reboot(guest)
-            self.has_rsync = self._query_has_rsync(guest)
-            self.is_superuser = self._query_is_superuser(guest)
-            self.can_sudo = self._query_can_sudo(guest)
-            self.sudo_prefix = self._query_sudo_prefix(guest)
-            self.is_ostree = self._query_is_ostree(guest)
-            self.is_image_mode = self._query_is_image_mode(guest)
-            self.is_toolbox = self._query_is_toolbox(guest)
-            self.toolbox_container_name = self._query_toolbox_container_name(guest)
-            self.is_container = self._query_is_container(guest)
-            self.capabilities = self._query_capabilities(guest)
+        self._raw_facts.update(self._extract_facts(output.stdout))
 
         self.in_sync = True
 
@@ -1065,44 +931,194 @@ class GuestFacts(SerializableContainer):
         """
         Format facts for pretty printing.
 
-        :yields: three-item tuples: the field name, its pretty label, and formatted representation
-            of its value.
+        :yields: three-item tuples: the field name, its pretty label,
+            and formatted representation of its value.
         """
 
-        def _value(field: str, label: str) -> tuple[str, str, str]:
-            v = getattr(self, field)
+        for fact in self._facts():
+            label = fact.replace('_', ' ')
+            value = getattr(self, fact)
 
-            return field, label, v or 'unknown'
+            if value is None:
+                yield fact, label, 'unknown'
 
-        def _flag(field: str, label: str) -> tuple[str, str, str]:
-            v = getattr(self, field)
+            elif isinstance(value, bool):
+                yield fact, label, 'yes' if value else 'no'
 
-            return field, label, 'yes' if v else 'no'
+            elif isinstance(value, str):
+                yield fact, label, value
 
-        yield _value('arch', 'arch')
-        yield _value('distro', 'distro')
-        yield _value('kernel_release', 'kernel')
-        yield _value('package_manager', 'package manager')
-        yield _value('bootc_builder', 'bootc builder')
-        yield _flag('is_container', 'is container')
-        yield _flag('is_ostree', 'is ostree')
-        yield _flag('is_image_mode', 'is image mode')
-        yield _flag('is_toolbox', 'is toolbox')
-        yield _flag('has_selinux', 'selinux')
-        yield _flag('has_systemd', 'systemd')
-        yield _flag('systemd_soft_reboot', 'systemd soft-reboot')
-        yield _flag('has_rsync', 'rsync')
-        yield _flag('is_superuser', 'is superuser')
-        yield _flag('can_sudo', 'can sudo')
+            elif isinstance(value, dict):
+                pass
+
+            else:
+                raise GeneralError(f"Undefined formatting of guest fact '{fact}'.")
+
+    def has_capability(self, cap: GuestCapability) -> bool:
+        """Check if the guest has a specific capability."""
+        if not self.capabilities:
+            return False
+        return self.capabilities.get(cap, False)
+
+    #: Content of the ``/etc/os-release`` file. If the file does not
+    #: exist, the mapping will be empty.
+    os_release_content = keyval_guest_fact(Path('/etc/os-release'))
+
+    #: Content of the ``/etc/lsb-release`` file. If the file does not
+    #: exist, the mapping will be empty.
+    lsb_release_content = keyval_guest_fact(Path('/etc/lsb-release'))
+
+    #: Architecture of the guest, as reported by the ``arch`` command.
+    arch = string_guest_fact("arch || echo 'unknown'")
+
+    #: Name of the distribution on the guest.
+    distro = string_guest_fact(
+        """
+        if [ -f /etc/os-release ] && grep -q 'PRETTY_NAME=' /etc/os-release; then
+            grep '^PRETTY_NAME=' /etc/os-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/'
+
+        elif [ -f /etc/lsb-release ] && grep -q 'DISTRIB_DESCRIPTION=' /etc/lsb-release; then
+            grep '^DISTRIB_DESCRIPTION=' /etc/lsb-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/'
+
+        elif [ -f /etc/redhat-release ]; then
+            cat /etc/redhat-release
+
+        elif [ -f /etc/fedora-release ]; then
+            cat /etc/fedora-release
+
+        else
+            echo 'unknown'
+        fi
+        """  # noqa: E501
+    )
+
+    #: Release of the running kernel, as reported by the ``uname -r``
+    #: command.
+    kernel_release = string_guest_fact("uname -r || echo 'unknown'")
+
+    #: Whether SELinux is present and enabled.
+    has_selinux = flag_guest_fact(
+        "if [ -e /sys/fs/selinux/enforce ]; then echo 'true'; else echo 'false'; fi",
+    )
+
+    #: Whether systemd is available.
+    has_systemd = flag_guest_fact(
+        "if systemctl --version 1>&2; then echo 'true'; else echo 'false'; fi",
+    )
+
+    #: Whether systemd soft-reboot is supported.
+    systemd_soft_reboot = flag_guest_fact(
+        """
+        if systemctl --help | grep -q 'soft-reboot' && [ -f /proc/sys/kernel/random/boot_id ]; then
+            echo 'true'
+        else
+            echo 'false'
+        fi
+        """
+    )
+
+    #: Whether rsync is available.
+    has_rsync = flag_guest_fact("if rsync --version 1>&2; then echo 'true'; else echo 'false'; fi")
+
+    #: Whether the current user is superuser.
+    is_superuser = flag_guest_fact(
+        'if [ "$(whoami)" = "root" ]; then echo \'true\'; else echo \'false\'; fi'
+    )
+
+    #: Whether the current user can use ``sudo``.
+    can_sudo = flag_guest_fact("if sudo -n true 1>&2; then echo 'true'; else echo 'false'; fi")
+
+    #: A prefix to use when invoking commands with ``sudo``.
+    sudo_prefix = string_guest_fact(
+        """
+        if [ "$(whoami)" = "root" ]; then
+            echo ''
+        elif sudo -n true 1>&2; then
+            echo 'sudo'
+        else
+            echo ''
+        fi
+        """
+    )
+
+    #: Whether the guest is an OSTree-based system.
+    is_ostree = flag_guest_fact(
+        "if [ -e /run/ostree-booted ] || [ -L /ostree ]; then echo 'true'; else echo 'false'; fi",
+    )
+
+    #: Whether the guest is an image-mode system.
+    #:
+    #: An image mode based system has the image set to a image reference.
+    #: In case ``bootc`` is installed on a non image mode system, it
+    #: reports ``null``.
+    is_image_mode = flag_guest_fact(
+        """
+        if type bootc &> /dev/null; then
+            image="$(sudo bootc status --format yaml | grep -Po 'image: \\K(.*)')"
+
+            if [ -n "$image" ]; then
+                if [ "$image" = "null" ]; then echo 'false'; else echo 'true'; fi
+            else
+                echo 'unknown'
+            fi
+        else
+            echo 'false'
+        fi
+        """
+    )
+
+    #: Whether the guest is a toolbox container
+    is_toolbox = flag_guest_fact(
+        "if [ -e /run/.toolboxenv ]; then echo 'true'; else echo 'false'; fi"
+    )
+
+    #: Name of the toolbox container (if applicable).
+    toolbox_container_name = string_guest_fact(
+        """
+        if [ -e /run/.containerenv ]; then
+            if grep -q '^name=' /run/.containerenv; then
+                grep '^name=' /run/.containerenv | sed 's/^name=\\"\\(.*\\)\\"$/\\1/'
+            else
+                echo 'unknown'
+            fi
+        else
+            echo 'unknown'
+        fi
+        """
+    )
+
+    #: Whether the guest is a container.
+    is_container = flag_guest_fact(
+        'if [ -n "${container:-}" ]; then echo \'true\'; else echo \'false\'; fi'
+    )
+
+    #: Name of the package manager available on the guest.
+    package_manager = package_manager_guest_fact()
+
+    #: name of the bootc builder available on the guest.
+    bootc_builder = package_manager_guest_fact(lambda pm: pm.bootc_builder)
+
+    #: Various Linux capabilities and whether they are permitted.
+    capabilities: dict[GuestCapability, bool] = field(
+        default_factory=lambda: {
+            GuestCapability.SYSLOG_ACTION_READ_ALL: True,
+            GuestCapability.SYSLOG_ACTION_READ_CLEAR: True,
+        },
+        serialize=lambda capabilities: (
+            {capability.value: enabled for capability, enabled in capabilities.items()}
+            if capabilities
+            else {}
+        ),
+        unserialize=lambda raw_value: {
+            GuestCapability(raw_capability): enabled
+            for raw_capability, enabled in raw_value.items()
+        },
+    )
 
 
 GUEST_FACTS_INFO_FIELDS: list[str] = ['arch', 'distro']
 GUEST_FACTS_VERBOSE_FIELDS: list[str] = [
-    # SIM118: Use `{key} in {dict}` instead of `{key} in {dict}.keys()`
-    # "NormalizeKeysMixin" has no attribute "__iter__" (not iterable)
-    key
-    for key in GuestFacts.keys()  # noqa: SIM118
-    if key not in GUEST_FACTS_INFO_FIELDS
+    key for key in GuestFacts._facts() if key not in GUEST_FACTS_INFO_FIELDS
 ]
 
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -984,7 +984,7 @@ class GuestFacts(SerializableContainer):
             elif line.startswith('<<<'):
                 if current_fact is None:
                     raise GeneralError(
-                        "Malformed fact probe output: closing marker '<<<' without opening marker"
+                        "Malformed fact probe output: closing marker '<<<' without opening marker."
                     )
 
                 facts[current_fact] = self._facts()[current_fact].extract(
@@ -996,6 +996,11 @@ class GuestFacts(SerializableContainer):
 
             else:
                 current_fact_content.append(line)
+
+        if current_fact is not None:
+            raise GeneralError(
+                f"Malformed fact probe output: fact '{current_fact}' was opened but never closed."
+            )
 
         return facts
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -606,10 +606,14 @@ class guest_fact(Generic[T]):  # noqa: N801
     #: the descriptor API.
     name: Optional[str]
 
+    #: If set, the listed guest facts must be discovered before this one.
+    requires: tuple[str, ...]
+
     def __init__(
         self,
         probe: Union[str, Callable[[], str]],
         extract: Callable[[str], T],
+        *requires: str,
     ) -> None:
         """
         Initialize a fact collector.
@@ -623,6 +627,9 @@ class guest_fact(Generic[T]):  # noqa: N801
             the shell snippet, and returns the actual value of the fact,
             to be assigned to the corresponding :py:class:`GuestFacts`
             attribute.
+        :param requires: if set, the listed guest facts must be
+            discovered before this one. Fact discovery will reorder
+            snippets to honor the given requirements.
         """
 
         if isinstance(probe, str):
@@ -634,6 +641,8 @@ class guest_fact(Generic[T]):  # noqa: N801
         self.extract = extract
 
         self.name = None
+
+        self.requires = requires
 
     def __set_name__(self, owner: type, name: str) -> None:
         """
@@ -690,9 +699,11 @@ class flag_guest_fact(guest_fact[Optional[bool]]):  # noqa: N801
     A guest fact whose value is a booleab flag.
     """
 
-    def __init__(self, probe: str) -> None:
+    def __init__(self, probe: str, *requires: str) -> None:
         super().__init__(
-            probe, lambda output: output.strip() == 'true' if output.strip() != 'unknown' else None
+            probe,
+            lambda output: output.strip() == 'true' if output.strip() != 'unknown' else None,
+            *requires,
         )
 
 
@@ -732,8 +743,8 @@ class keyval_guest_fact(guest_fact[dict[str, str]]):  # noqa: N801
 
         return result
 
-    def __init__(self, path: Path) -> None:
-        super().__init__(f"cat {shlex.quote(str(path))}", keyval_guest_fact._parse)
+    def __init__(self, path: Path, *requires: str) -> None:
+        super().__init__(f"cat {shlex.quote(str(path))}", keyval_guest_fact._parse, *requires)
 
 
 class package_manager_guest_fact(guest_fact[Optional['tmt.package_managers.GuestPackageManager']]):  # noqa: N801
@@ -743,6 +754,7 @@ class package_manager_guest_fact(guest_fact[Optional['tmt.package_managers.Guest
 
     def __init__(
         self,
+        *requires: str,
         predicate: Optional[
             Callable[[type['tmt.package_managers.PackageManager[Any]']], bool]
         ] = None,
@@ -770,7 +782,7 @@ class package_manager_guest_fact(guest_fact[Optional['tmt.package_managers.Guest
 
             return output.splitlines()[0]
 
-        super().__init__(_snippet_creator, _extract)
+        super().__init__(_snippet_creator, _extract, *requires)
 
 
 @container
@@ -797,8 +809,8 @@ class GuestFacts(SerializableContainer):
 
     For example, a probe for the :py:attr:`arch` fact is simple, it calls
     the ``arch`` command. The corresponding extractor is also trivial,
-    and takes the output produced by the probe - a raw output of
-    ``arch`` - and returns it as the value of the ``arch`` fact.
+    and takes the output produced by the probe - a raw output of the
+    ``arch`` command - and returns it as the value of the ``arch`` fact.
 
     Probes of flag-like facts, :py:attr:`has_selinux` for example, usually
     test some system property, and echo ``true`` or ``false``. The
@@ -810,6 +822,15 @@ class GuestFacts(SerializableContainer):
     the actual values, and updates :py:attr:`_raw_facts` mapping.
     Descriptors then return values from this mapping instead of running
     any additional code on the guest.
+
+    In the collection shell script, every probe output is is assigned to
+    a variable of the same name as the fact (``arch`` shell variable
+    holds the output of the ``arch``  probe snippet, and so on). Probes
+    invoked later in the sequence can use previously probed facts in
+    their own probes; to make sure the required variables have been set,
+    the fact must enumerate required facts in its
+    :py:attr:`guest_fact.requires` attribute - the collectionshell script
+    will then run probes in the necessary order.
     """
 
     #: Store the actual values of facts. This mapping serves as a
@@ -834,7 +855,7 @@ class GuestFacts(SerializableContainer):
         }
 
     @functools.cached_property
-    def _fact_snippets(self) -> dict[str, str]:
+    def _fact_snippets(self) -> list[tuple[str, guest_fact[Any], str]]:
         """
         Collect all fact collection snippets from the facts.
 
@@ -842,10 +863,14 @@ class GuestFacts(SerializableContainer):
             as values.
         """
 
-        return {
-            name: (value.snippet if hasattr(value, 'snippet') else value.snippet_creator())
+        return [
+            (
+                name,
+                value,
+                (value.snippet if hasattr(value, 'snippet') else value.snippet_creator()),
+            )
             for name, value in self._facts().items()
-        }
+        ]
 
     def _create_collection_script(self, *facts: str) -> ShellScript:
         """
@@ -855,15 +880,84 @@ class GuestFacts(SerializableContainer):
             them with markers for the future parsing.
         """
 
-        scripts: list[str] = []
+        # Since facts may have requirements, we need some basic ordering.
+        # It is really trivial: facts are processed in a queue-like
+        # fashion; if a fact requires facts that have not been yet emitted
+        # into the collection script, the fact is put at the end of the
+        # queue, and we try to continue with the next fact in the queue.
+        # Hopefully, we would then emit the required facts first, then
+        # reaching those that were blocked.
 
-        for fact, snippet in self._fact_snippets.items():
-            if fact not in facts:
-                continue
+        # Facts that remain to be emitted into the collection script.
+        pending_facts = [
+            (name, fact, snippet)
+            for name, fact, snippet in self._fact_snippets[:]
+            if name in facts
+        ]
+        # Facts that were already emitted into the collection script.
+        # If a pending fact requires these, it can be emitted as well
+        # since its requirements are already ready.
+        emitted_facts: set[str] = set()
+        # Facts that cannot be emitted into the collection script because
+        # one or more of their requirements are still pending.
+        blocked_facts: set[str] = set()
 
+        scripts: list[str] = [f'unset {name}' for name, _, _ in pending_facts if name in facts]
+
+        def _emit_fact_probe(name: str, fact: guest_fact[Any], snippet: str) -> None:
             # The extra `echo` is there to enforce at least one empty line
             # in the output.
-            scripts.append(f'echo ">>> {fact}"\n{snippet}\necho\necho "<<<"\n')
+            scripts.append(
+                '\n'.join(
+                    [
+                        f'{name}=$({snippet})',
+                        f'echo ">>> {name}"',
+                        f'echo "${name}"',
+                        'echo "<<<"',
+                    ]
+                )
+            )
+
+            # Let others know this fact is done, ...
+            emitted_facts.add(name)
+
+            # ... and if it was blocked, clear the flag.
+            blocked_facts.discard(name)
+
+        while pending_facts:
+            name, fact, snippet = pending_facts.pop(0)
+
+            # No requirements? Cool, emit the snippet.
+            if not fact.requires:
+                _emit_fact_probe(name, fact, snippet)
+                continue
+
+            # Let's see which requirements are still pending.
+            pending_requires = {
+                required_fact
+                for required_fact in fact.requires
+                if required_fact not in emitted_facts
+            }
+
+            # No pending requirements? Also nice, emit the snippet.
+            if not pending_requires:
+                _emit_fact_probe(name, fact, snippet)
+                continue
+
+            # If we already saw this fact, and we already mark it as
+            # blocked, landing here means we processed all requirements
+            # positioned in the queue before it, and yet we are still
+            # left with one or more pending requirements. Moving it at
+            # the end of the queue and trying again will not help.
+            if name in blocked_facts:
+                raise GeneralError(
+                    f"Guest fact '{name}' remains blocked by required facts {pending_facts}."
+                )
+
+            # Ok, first time resolving requirements of this fact: mark
+            # it as blocked, and move it to the end of the queue.
+            blocked_facts.add(name)
+            pending_facts.append((name, fact, snippet))
 
         return ShellScript('\n\n'.join(scripts))
 
@@ -1054,7 +1148,7 @@ class GuestFacts(SerializableContainer):
     is_image_mode = flag_guest_fact(
         """
         if type bootc &> /dev/null; then
-            image="$(sudo bootc status --format yaml | grep -Po 'image: \\K(.*)')"
+            image="$($sudo_prefix bootc status --format yaml | grep -Po 'image: \\K(.*)')"
 
             if [ -n "$image" ]; then
                 if [ "$image" = "null" ]; then echo 'false'; else echo 'true'; fi
@@ -1064,7 +1158,8 @@ class GuestFacts(SerializableContainer):
         else
             echo 'false'
         fi
-        """
+        """,
+        'sudo_prefix',
     )
 
     #: Whether the guest is a toolbox container
@@ -1096,7 +1191,7 @@ class GuestFacts(SerializableContainer):
     package_manager = package_manager_guest_fact()
 
     #: name of the bootc builder available on the guest.
-    bootc_builder = package_manager_guest_fact(lambda pm: pm.bootc_builder)
+    bootc_builder = package_manager_guest_fact(predicate=lambda pm: pm.bootc_builder)
 
     #: Various Linux capabilities and whether they are permitted.
     capabilities: dict[GuestCapability, bool] = field(

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -951,7 +951,7 @@ class GuestFacts(SerializableContainer):
             # the end of the queue and trying again will not help.
             if name in blocked_facts:
                 raise GeneralError(
-                    f"Guest fact '{name}' remains blocked by required facts {pending_facts}."
+                    f"Guest fact '{name}' remains blocked by required facts {pending_requires}."
                 )
 
             # Ok, first time resolving requirements of this fact: mark

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -662,10 +662,14 @@ class guest_fact(Generic[T]):  # noqa: N801
     #: the descriptor API.
     name: Optional[str]
 
+    #: If set, the listed guest facts must be discovered before this one.
+    requires: tuple[str, ...]
+
     def __init__(
         self,
         probe: Union[str, Callable[[], str]],
         extract: Callable[[str], T],
+        *requires: str,
     ) -> None:
         """
         Initialize a fact collector.
@@ -679,6 +683,9 @@ class guest_fact(Generic[T]):  # noqa: N801
             the shell snippet, and returns the actual value of the fact,
             to be assigned to the corresponding :py:class:`GuestFacts`
             attribute.
+        :param requires: if set, the listed guest facts must be
+            discovered before this one. Fact discovery will reorder
+            snippets to honor the given requirements.
         """
 
         if isinstance(probe, str):
@@ -690,6 +697,8 @@ class guest_fact(Generic[T]):  # noqa: N801
         self.extract = extract
 
         self.name = None
+
+        self.requires = requires
 
     def __set_name__(self, owner: type, name: str) -> None:
         """
@@ -746,9 +755,11 @@ class flag_guest_fact(guest_fact[Optional[bool]]):  # noqa: N801
     A guest fact whose value is a booleab flag.
     """
 
-    def __init__(self, probe: str) -> None:
+    def __init__(self, probe: str, *requires: str) -> None:
         super().__init__(
-            probe, lambda output: output.strip() == 'true' if output.strip() != 'unknown' else None
+            probe,
+            lambda output: output.strip() == 'true' if output.strip() != 'unknown' else None,
+            *requires,
         )
 
 
@@ -788,8 +799,8 @@ class keyval_guest_fact(guest_fact[dict[str, str]]):  # noqa: N801
 
         return result
 
-    def __init__(self, path: Path) -> None:
-        super().__init__(f"cat {shlex.quote(str(path))}", keyval_guest_fact._parse)
+    def __init__(self, path: Path, *requires: str) -> None:
+        super().__init__(f"cat {shlex.quote(str(path))}", keyval_guest_fact._parse, *requires)
 
 
 class package_manager_guest_fact(guest_fact[Optional['tmt.package_managers.GuestPackageManager']]):  # noqa: N801
@@ -799,6 +810,7 @@ class package_manager_guest_fact(guest_fact[Optional['tmt.package_managers.Guest
 
     def __init__(
         self,
+        *requires: str,
         predicate: Optional[
             Callable[[type['tmt.package_managers.PackageManager[Any]']], bool]
         ] = None,
@@ -826,7 +838,7 @@ class package_manager_guest_fact(guest_fact[Optional['tmt.package_managers.Guest
 
             return output.splitlines()[0]
 
-        super().__init__(_snippet_creator, _extract)
+        super().__init__(_snippet_creator, _extract, *requires)
 
 
 @container
@@ -853,8 +865,8 @@ class GuestFacts(SerializableContainer):
 
     For example, a probe for the :py:attr:`arch` fact is simple, it calls
     the ``arch`` command. The corresponding extractor is also trivial,
-    and takes the output produced by the probe - a raw output of
-    ``arch`` - and returns it as the value of the ``arch`` fact.
+    and takes the output produced by the probe - a raw output of the
+    ``arch`` command - and returns it as the value of the ``arch`` fact.
 
     Probes of flag-like facts, :py:attr:`has_selinux` for example, usually
     test some system property, and echo ``true`` or ``false``. The
@@ -866,6 +878,15 @@ class GuestFacts(SerializableContainer):
     the actual values, and updates :py:attr:`_raw_facts` mapping.
     Descriptors then return values from this mapping instead of running
     any additional code on the guest.
+
+    In the collection shell script, every probe output is is assigned to
+    a variable of the same name as the fact (``arch`` shell variable
+    holds the output of the ``arch``  probe snippet, and so on). Probes
+    invoked later in the sequence can use previously probed facts in
+    their own probes; to make sure the required variables have been set,
+    the fact must enumerate required facts in its
+    :py:attr:`guest_fact.requires` attribute - the collectionshell script
+    will then run probes in the necessary order.
     """
 
     #: Store the actual values of facts. This mapping serves as a
@@ -890,7 +911,7 @@ class GuestFacts(SerializableContainer):
         }
 
     @functools.cached_property
-    def _fact_snippets(self) -> dict[str, str]:
+    def _fact_snippets(self) -> list[tuple[str, guest_fact[Any], str]]:
         """
         Collect all fact collection snippets from the facts.
 
@@ -898,10 +919,14 @@ class GuestFacts(SerializableContainer):
             as values.
         """
 
-        return {
-            name: (value.snippet if hasattr(value, 'snippet') else value.snippet_creator())
+        return [
+            (
+                name,
+                value,
+                (value.snippet if hasattr(value, 'snippet') else value.snippet_creator()),
+            )
             for name, value in self._facts().items()
-        }
+        ]
 
     def _create_collection_script(self, *facts: str) -> ShellScript:
         """
@@ -911,15 +936,84 @@ class GuestFacts(SerializableContainer):
             them with markers for the future parsing.
         """
 
-        scripts: list[str] = []
+        # Since facts may have requirements, we need some basic ordering.
+        # It is really trivial: facts are processed in a queue-like
+        # fashion; if a fact requires facts that have not been yet emitted
+        # into the collection script, the fact is put at the end of the
+        # queue, and we try to continue with the next fact in the queue.
+        # Hopefully, we would then emit the required facts first, then
+        # reaching those that were blocked.
 
-        for fact, snippet in self._fact_snippets.items():
-            if fact not in facts:
-                continue
+        # Facts that remain to be emitted into the collection script.
+        pending_facts = [
+            (name, fact, snippet)
+            for name, fact, snippet in self._fact_snippets[:]
+            if name in facts
+        ]
+        # Facts that were already emitted into the collection script.
+        # If a pending fact requires these, it can be emitted as well
+        # since its requirements are already ready.
+        emitted_facts: set[str] = set()
+        # Facts that cannot be emitted into the collection script because
+        # one or more of their requirements are still pending.
+        blocked_facts: set[str] = set()
 
+        scripts: list[str] = [f'unset {name}' for name, _, _ in pending_facts if name in facts]
+
+        def _emit_fact_probe(name: str, fact: guest_fact[Any], snippet: str) -> None:
             # The extra `echo` is there to enforce at least one empty line
             # in the output.
-            scripts.append(f'echo ">>> {fact}"\n{snippet}\necho\necho "<<<"\n')
+            scripts.append(
+                '\n'.join(
+                    [
+                        f'{name}=$({snippet})',
+                        f'echo ">>> {name}"',
+                        f'echo "${name}"',
+                        'echo "<<<"',
+                    ]
+                )
+            )
+
+            # Let others know this fact is done, ...
+            emitted_facts.add(name)
+
+            # ... and if it was blocked, clear the flag.
+            blocked_facts.discard(name)
+
+        while pending_facts:
+            name, fact, snippet = pending_facts.pop(0)
+
+            # No requirements? Cool, emit the snippet.
+            if not fact.requires:
+                _emit_fact_probe(name, fact, snippet)
+                continue
+
+            # Let's see which requirements are still pending.
+            pending_requires = {
+                required_fact
+                for required_fact in fact.requires
+                if required_fact not in emitted_facts
+            }
+
+            # No pending requirements? Also nice, emit the snippet.
+            if not pending_requires:
+                _emit_fact_probe(name, fact, snippet)
+                continue
+
+            # If we already saw this fact, and we already mark it as
+            # blocked, landing here means we processed all requirements
+            # positioned in the queue before it, and yet we are still
+            # left with one or more pending requirements. Moving it at
+            # the end of the queue and trying again will not help.
+            if name in blocked_facts:
+                raise GeneralError(
+                    f"Guest fact '{name}' remains blocked by required facts {pending_facts}."
+                )
+
+            # Ok, first time resolving requirements of this fact: mark
+            # it as blocked, and move it to the end of the queue.
+            blocked_facts.add(name)
+            pending_facts.append((name, fact, snippet))
 
         return ShellScript('\n\n'.join(scripts))
 
@@ -1138,7 +1232,7 @@ class GuestFacts(SerializableContainer):
     is_image_mode = flag_guest_fact(
         """
         if type bootc &> /dev/null; then
-            image="$(sudo bootc status --format yaml | grep -Po 'image: \\K(.*)')"
+            image="$($sudo_prefix bootc status --format yaml | grep -Po 'image: \\K(.*)')"
 
             if [ -n "$image" ]; then
                 if [ "$image" = "null" ]; then echo 'false'; else echo 'true'; fi
@@ -1148,7 +1242,8 @@ class GuestFacts(SerializableContainer):
         else
             echo 'false'
         fi
-        """
+        """,
+        'sudo_prefix',
     )
 
     #: Whether the guest is a toolbox container
@@ -1180,7 +1275,7 @@ class GuestFacts(SerializableContainer):
     package_manager = package_manager_guest_fact()
 
     #: name of the bootc builder available on the guest.
-    bootc_builder = package_manager_guest_fact(lambda pm: pm.bootc_builder)
+    bootc_builder = package_manager_guest_fact(predicate=lambda pm: pm.bootc_builder)
 
     #: Various Linux capabilities and whether they are permitted.
     capabilities: dict[GuestCapability, bool] = field(

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -5,6 +5,7 @@ import dataclasses
 import enum
 import functools
 import hashlib
+import inspect
 import os
 import re
 import secrets
@@ -13,6 +14,7 @@ import shutil
 import signal as _signal
 import string
 import subprocess
+import textwrap
 import threading
 from collections.abc import Iterable, Iterator, Sequence
 from shlex import quote
@@ -20,6 +22,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Generic,
     Literal,
     NewType,
     Optional,
@@ -632,6 +635,200 @@ class GuestCapability(enum.Enum):
     SYSLOG_ACTION_READ_CLEAR = 'syslog-action-read-clear'
 
 
+class guest_fact(Generic[T]):  # noqa: N801
+    """
+    A descriptor that associates a shell snippet with a guest fact attribute.
+
+    This descriptor allows facts to be collected efficiently by registering
+    shell snippets that can be combined into a single script execution.
+    """
+
+    #: A shell snippet responsible for discovering a fact. Its standard
+    #: output is passed to :py:attr:`extract`, standard error output is
+    #: ignored.
+    snippet: str
+
+    #: If set, it is used instead of :py:attr:`snippet`. The callable
+    #: is invoked during the construction of the discover script, and
+    #: its return value must comply with the rules for :py:attr:`snippet`.
+    snippet_creator: Callable[[], str]
+
+    #: A callable that receives the standard output of the shell snippet,
+    #: and returns the actual value of the fact, to be assigned to the
+    #: corresponding :py:class:`GuestFacts` attribute.
+    extract: Callable[[str], T]
+
+    #: Name of the attribute which owns this descriptor. Needed to support
+    #: the descriptor API.
+    name: Optional[str]
+
+    def __init__(
+        self,
+        probe: Union[str, Callable[[], str]],
+        extract: Callable[[str], T],
+    ) -> None:
+        """
+        Initialize a fact collector.
+
+        :param snippet: a shell snippet responsible for discovering the
+            fact. Its standard output is passed to :py:attr:`extract`,
+            standard error output is ignored. If a callable is used,
+            its return value is supposed to be the snippet, and must
+            comply with the rules above.
+        :param extract: a callable that receives the standard output of
+            the shell snippet, and returns the actual value of the fact,
+            to be assigned to the corresponding :py:class:`GuestFacts`
+            attribute.
+        """
+
+        if isinstance(probe, str):
+            self.snippet = textwrap.dedent(probe).strip()
+
+        else:
+            self.snippet_creator = probe
+
+        self.extract = extract
+
+        self.name = None
+
+    def __set_name__(self, owner: type, name: str) -> None:
+        """
+        Called when the descriptor is assigned to a class attribute.
+        """
+
+        self.name = name
+
+    @overload
+    def __get__(self, obj: None, objtype: Optional[type] = None) -> 'guest_fact[T]':
+        pass
+
+    @overload
+    def __get__(self, obj: 'GuestFacts', objtype: Optional[type] = None) -> T:
+        pass
+
+    def __get__(
+        self, obj: Optional['GuestFacts'], objtype: Optional[type] = None
+    ) -> Union['guest_fact[T]', T]:
+        """
+        Get the fact value from the instance.
+        """
+
+        if obj is None:
+            return self
+
+        assert self.name
+
+        return cast(T, obj._raw_facts.get(self.name))
+
+    def __set__(self, obj: 'GuestFacts', value: T) -> None:
+        """
+        Set the fact value on the instance.
+        """
+
+        assert self.name
+
+        obj._raw_facts[self.name] = value
+
+
+class string_guest_fact(guest_fact[Optional[str]]):  # noqa: N801
+    """
+    A guest fact whose value is a simple string.
+    """
+
+    def __init__(self, probe: str) -> None:
+        super().__init__(
+            probe, lambda output: output.strip() if output.strip() != 'unknown' else None
+        )
+
+
+class flag_guest_fact(guest_fact[Optional[bool]]):  # noqa: N801
+    """
+    A guest fact whose value is a booleab flag.
+    """
+
+    def __init__(self, probe: str) -> None:
+        super().__init__(
+            probe, lambda output: output.strip() == 'true' if output.strip() != 'unknown' else None
+        )
+
+
+class keyval_guest_fact(guest_fact[dict[str, str]]):  # noqa: N801
+    """
+    A guest fact whose value is a key/value mapping.
+    """
+
+    @staticmethod
+    def _parse(content: str) -> dict[str, str]:
+        """
+        Parse key=value content (like os-release or lsb-release).
+
+        :param content: File content with key=value pairs.
+        :returns: Dictionary of parsed key/value pairs.
+        """
+
+        result: dict[str, str] = {}
+
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+
+            if '=' not in line:
+                continue
+
+            key, value = line.split('=', 1)
+
+            # Remove quotes if present
+            if value and value[0] in '"\'':
+                # If ast.literal_eval fails, keep the original value
+                with contextlib.suppress(ValueError, SyntaxError):
+                    value = ast.literal_eval(value)
+
+            result[key] = value
+
+        return result
+
+    def __init__(self, path: Path) -> None:
+        super().__init__(f"cat {shlex.quote(str(path))}", keyval_guest_fact._parse)
+
+
+class package_manager_guest_fact(guest_fact[Optional['tmt.package_managers.GuestPackageManager']]):  # noqa: N801
+    """
+    A guest fact whose value is a package manager name.
+    """
+
+    def __init__(
+        self,
+        predicate: Optional[
+            Callable[[type['tmt.package_managers.PackageManager[Any]']], bool]
+        ] = None,
+    ) -> None:
+        def _snippet_creator() -> str:
+            probes: list[str] = []
+
+            for package_manager_class in sorted(
+                tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.iter_plugins(),
+                key=lambda pm: pm.probe_priority,
+                reverse=True,
+            ):
+                if predicate and not predicate(package_manager_class):
+                    continue
+
+                probes.append(
+                    f"({package_manager_class.probe_command.to_element()}) 1>&2 && echo '{package_manager_class.NAME}'"  # noqa: E501
+                )
+
+            return '\n'.join(probes)
+
+        def _extract(output: str) -> Optional['tmt.package_managers.GuestPackageManager']:
+            if not output:
+                return None
+
+            return output.splitlines()[0]
+
+        super().__init__(_snippet_creator, _extract)
+
+
 @container
 class GuestFacts(SerializableContainer):
     """
@@ -640,447 +837,129 @@ class GuestFacts(SerializableContainer):
     Inspired by Ansible or Puppet facts, interesting guest facts tmt
     discovers while managing the guest are stored in this container,
     plus the code performing the discovery of these facts.
+
+    Each fact is represented as an attribute with the proper type
+    annotation, assigned an instance of :py:class:`guest_fact` class, or
+    one of its subclasses.
+
+    * ``guest_fact`` classes implement the Python descriptor API, see
+      https://docs.python.org/3/howto/descriptor.html, which allows us
+      to attach interesting information to each fact.
+    * the information we attach is 1. a shell script snippet, "probe",
+      to be executed on the guest, whose responsibility is to print
+      something to its standard output, and 2. a callable, "extractor",
+      that is given this standard output, and is expected to produce the
+      actual value of the corresponding fact.
+
+    For example, a probe for the :py:attr:`arch` fact is simple, it calls
+    the ``arch`` command. The corresponding extractor is also trivial,
+    and takes the output produced by the probe - a raw output of
+    ``arch`` - and returns it as the value of the ``arch`` fact.
+
+    Probes of flag-like facts, :py:attr:`has_selinux` for example, usually
+    test some system property, and echo ``true`` or ``false``. The
+    corresponding extractor turns it into a proper ``bool`` value.
+
+    When discovering facts, i.e. when :py:meth:`sync` is called, relevant
+    probes are collected and joined into a single shell script that is
+    then executed on the guest. :py:meth:`_extract_facts` then extracts
+    the actual values, and updates :py:attr:`_raw_facts` mapping.
+    Descriptors then return values from this mapping instead of running
+    any additional code on the guest.
     """
+
+    #: Store the actual values of facts. This mapping serves as a
+    #: storage for descriptors, see :py:meth:`guest_fact.__get__`.
+    #: It is this mapping that is refreshed by :py:meth:`sync`.
+    _raw_facts: dict[str, Any] = field(default_factory=dict)
 
     #: Set to ``True`` by the first call to :py:meth:`sync`.
     in_sync: bool = False
 
-    arch: Optional[str] = None
-    distro: Optional[str] = None
-    kernel_release: Optional[str] = None
-    package_manager: Optional['tmt.package_managers.GuestPackageManager'] = field(
-        # cast: since the default is None, mypy cannot infere the full type,
-        # and reports `package_manager` parameter to be `object`.
-        default=cast(Optional['tmt.package_managers.GuestPackageManager'], None)
-    )
-    bootc_builder: Optional['tmt.package_managers.GuestPackageManager'] = field(
-        # cast: since the default is None, mypy cannot infere the full type,
-        # and reports `bootc_builder` parameter to be `object`.
-        default=cast(Optional['tmt.package_managers.GuestPackageManager'], None)
-    )
-
-    has_selinux: Optional[bool] = None
-    has_systemd: Optional[bool] = None
-    has_rsync: Optional[bool] = None
-    is_superuser: Optional[bool] = None
-    can_sudo: Optional[bool] = None
-    sudo_prefix: Optional[str] = None
-    is_ostree: Optional[bool] = None
-    is_image_mode: Optional[bool] = None
-    distro_id: Optional[str] = None
-    distro_major_version: Optional[int] = None
-    is_toolbox: Optional[bool] = None
-    toolbox_container_name: Optional[str] = None
-    is_container: Optional[bool] = None
-    systemd_soft_reboot: Optional[bool] = None
-
-    #: Various Linux capabilities and whether they are permitted to
-    #: commands executed on this guest.
-    capabilities: dict[GuestCapability, bool] = field(
-        default_factory=cast(Callable[[], dict[GuestCapability, bool]], dict),
-        serialize=lambda capabilities: (
-            {capability.value: enabled for capability, enabled in capabilities.items()}
-            if capabilities
-            else {}
-        ),
-        unserialize=lambda raw_value: {
-            GuestCapability(raw_capability): enabled
-            for raw_capability, enabled in raw_value.items()
-        },
-    )
-
-    os_release_content: dict[str, str] = field(default_factory=dict)
-    lsb_release_content: dict[str, str] = field(default_factory=dict)
-
-    def has_capability(self, cap: GuestCapability) -> bool:
-        if not self.capabilities:
-            return False
-
-        return self.capabilities.get(cap, False)
-
-    def _execute(self, guest: 'Guest', command: Command) -> Optional[tmt.utils.CommandOutput]:
+    @classmethod
+    def _facts(cls) -> dict[str, guest_fact[Any]]:
         """
-        Run a command on the given guest, ignoring :py:class:`tmt.utils.RunError`.
+        Find all defined facts and their descriptors.
 
-        On image mode systems execute the commands immediately.
-
-        :returns: command output if the command quit with a zero exit code,
-            ``None`` otherwise.
+        :returns: a mapping with fact names as keys, and fact descriptors
+            as values.
         """
 
-        try:
-            return guest.execute(command, silent=True)
+        return {
+            name: value for name, value in inspect.getmembers(cls) if isinstance(value, guest_fact)
+        }
 
-        except tmt.utils.RunError:
-            pass
-
-        return None
-
-    def _fetch_keyval_file(self, guest: 'Guest', filepath: Path) -> dict[str, str]:
+    @functools.cached_property
+    def _fact_snippets(self) -> dict[str, str]:
         """
-        Load key/value pairs from a file on the given guest.
+        Collect all fact collection snippets from the facts.
 
-        Converts file with ``key=value`` pairs into a mapping. Some values might
-        be wrapped with quotes.
-
-        .. code:: shell
-
-           $ cat /etc/os-release
-           NAME="Ubuntu"
-           VERSION="20.04.5 LTS (Focal Fossa)"
-           ID=ubuntu
-           ID_LIKE=debian
-           ...
-
-        See https://www.freedesktop.org/software/systemd/man/os-release.html for
-        more details on syntax of these files.
-
-        :returns: mapping with key/value pairs loaded from ``filepath``, or an
-            empty mapping if it was impossible to load the content.
+        :returns: a mapping with fact names as keys, and shell snippets
+            as values.
         """
 
-        content: dict[str, str] = {}
+        return {
+            name: (value.snippet if hasattr(value, 'snippet') else value.snippet_creator())
+            for name, value in self._facts().items()
+        }
 
-        output = self._execute(guest, Command('cat', filepath))
+    def _create_collection_script(self, *facts: str) -> ShellScript:
+        """
+        Generate a comprehensive shell script to collect all facts.
 
-        if not output or not output.stdout:
-            return content
+        :returns: a shell script that invokes all probes, and "wraps"
+            them with markers for the future parsing.
+        """
 
-        def _iter_pairs() -> Iterator[tuple[str, str]]:
-            assert output  # narrow type in a closure
-            assert output.stdout  # narrow type in a closure
+        scripts: list[str] = []
 
-            line_pattern = re.compile(r'([A-Z][A-Z_0-9]+)=(.*)')
+        for fact, snippet in self._fact_snippets.items():
+            if fact not in facts:
+                continue
 
-            for line_number, line in enumerate(output.stdout.splitlines(keepends=False), start=1):
-                line = line.rstrip()
+            # The extra `echo` is there to enforce at least one empty line
+            # in the output.
+            scripts.append(f'echo ">>> {fact}"\n{snippet}\necho\necho "<<<"\n')
 
-                if not line or line.startswith('#'):
-                    continue
+        return ShellScript('\n\n'.join(scripts))
 
-                match = line_pattern.match(line)
+    def _extract_facts(self, output: str) -> dict[str, str]:
+        """
+        Parse the output of the fact collection script.
 
-                if not match:
-                    raise tmt.utils.ProvisionError(
-                        f"Cannot parse line {line_number} in '{filepath}' on guest '{guest.name}':"
-                        f" {line}"
+        :param output: raw output from the fact collection script.
+        :returns: a mapping between fact names and their values, as
+            extracted from the output.
+        """
+
+        facts = {}
+
+        current_fact: Optional[str] = None
+        current_fact_content: list[str] = []
+
+        for line in output.splitlines():
+            line = line.strip()
+
+            if line.startswith('>>> '):
+                current_fact = line[4:]
+
+            elif line.startswith('<<<'):
+                if current_fact is None:
+                    raise GeneralError(
+                        "Malformed fact probe output: closing marker '<<<' without opening marker"
                     )
 
-                key, value = match.groups()
-
-                if value and value[0] in '"\'':
-                    value = ast.literal_eval(value)
-
-                yield key, value
-
-        return dict(_iter_pairs())
-
-    def _probe(self, guest: 'Guest', probes: list[tuple[Command, T]]) -> Optional[T]:
-        """
-        Find a first successful command.
-
-        :param guest: the guest to run commands on.
-        :param probes: list of command/mark pairs.
-        :returns: "mark" corresponding to the first command to quit with
-            a zero exit code.
-        :raises tmt.utils.GeneralError: when no command succeeded.
-        """
-
-        for command, outcome in probes:
-            if self._execute(guest, command):
-                return outcome
-
-        return None
-
-    def _query(self, guest: 'Guest', probes: list[tuple[Command, str]]) -> Optional[str]:
-        """
-        Find a first successful command, and extract info from its output.
-
-        :param guest: the guest to run commands on.
-        :param probes: list of command/pattenr pairs.
-        :returns: substring extracted by the first matching pattern.
-        :raises tmt.utils.GeneralError: when no command succeeded, or when no
-            pattern matched.
-        """
-
-        for command, pattern in probes:
-            output = self._execute(guest, command)
-
-            if not output or not output.stdout:
-                guest.debug('query', f"Command '{command!s}' produced no usable output.")
-                continue
-
-            match = re.search(pattern, output.stdout)
-
-            if not match:
-                guest.debug('query', f"Command '{command!s}' produced no usable output.")
-                continue
-
-            return match.group(1)
-
-        return None
-
-    def _query_arch(self, guest: 'Guest') -> Optional[str]:
-        return self._query(guest, [(Command('uname', '-m'), r'(.+)')])
-
-    def _query_distro(self, guest: 'Guest') -> Optional[str]:
-        # Try some low-hanging fruits first. We already might have the answer,
-        # provided by some standardized locations.
-        if 'PRETTY_NAME' in self.os_release_content:
-            return self.os_release_content['PRETTY_NAME']
-
-        if 'DISTRIB_DESCRIPTION' in self.lsb_release_content:
-            return self.lsb_release_content['DISTRIB_DESCRIPTION']
-
-        # Nope, inspect more files.
-        return self._query(
-            guest,
-            [
-                (Command('cat', '/etc/redhat-release'), r'(.*)'),
-                (Command('cat', '/etc/fedora-release'), r'(.*)'),
-            ],
-        )
-
-    def _query_distro_id(self, guest: 'Guest') -> Optional[str]:
-        return self.os_release_content.get('ID')
-
-    def _query_distro_major_version(self, guest: 'Guest') -> Optional[int]:
-        version_id = self.os_release_content.get('VERSION_ID')
-        if version_id:
-            try:
-                return int(version_id.split('.')[0])
-            except ValueError:
-                return None
-        return None
-
-    def _query_kernel_release(self, guest: 'Guest') -> Optional[str]:
-        return self._query(guest, [(Command('uname', '-r'), r'(.+)')])
-
-    def _discover_package_manager(
-        self,
-        guest: 'Guest',
-        plugin_classes: Iterable[
-            type[tmt.package_managers.PackageManager[tmt.package_managers.PackageManagerEngine]]
-        ],
-        *,
-        debug_label: str,
-    ) -> Optional['tmt.package_managers.GuestPackageManager']:
-        # Sort available package managers by priority and probe them one by one,
-        # break after the first one is detected.
-
-        for package_manager_class in sorted(
-            plugin_classes, key=lambda pm: pm.probe_priority, reverse=True
-        ):
-            if self._execute(guest, package_manager_class.probe_command):
-                guest.debug(
-                    f'Discovered {debug_label}',
-                    package_manager_class.NAME,
-                    level=4,
+                facts[current_fact] = self._facts()[current_fact].extract(
+                    '\n'.join(current_fact_content)
                 )
-                return package_manager_class.NAME
 
-        return None
+                current_fact = None
+                current_fact_content = []
 
-    def _query_package_manager(
-        self, guest: 'Guest'
-    ) -> Optional['tmt.package_managers.GuestPackageManager']:
-        return self._discover_package_manager(
-            guest,
-            plugin_classes=(
-                package_manager_class
-                for package_manager_class in (
-                    tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.iter_plugins()
-                )
-            ),
-            debug_label='package manager',
-        )
+            else:
+                current_fact_content.append(line)
 
-    def _query_bootc_builder(
-        self, guest: 'Guest'
-    ) -> Optional['tmt.package_managers.GuestPackageManager']:
-        return self._discover_package_manager(
-            guest,
-            plugin_classes=(
-                pm
-                for pm in tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.iter_plugins()
-                if pm.bootc_builder
-            ),
-            debug_label='bootc builder',
-        )
-
-    def _query_has_selinux(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether guest has SELinux and it is enabled.
-
-        For detection ``/sys/fs/selinux/enforce`` is used. This file exists
-        only when SELinux is actually available and mounted (regardless of
-        enforcing/permissive mode).
-        """
-        try:
-            guest.execute(Command('test', '-e', '/sys/fs/selinux/enforce'), silent=True)
-            return True
-        except tmt.utils.RunError:
-            return False
-
-    def _query_has_systemd(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether guest uses systemd.
-        For detection we check if systemctl exists and is executable.
-        """
-        try:
-            guest.execute(Command('systemctl', '--version'), silent=True)
-            return True
-        except tmt.utils.RunError:
-            return False
-
-    def _query_systemd_soft_reboot(self, guest: 'Guest') -> Optional[bool]:
-        output = self._execute(
-            guest,
-            (
-                ShellScript('systemctl --help | grep -q "soft-reboot"')
-                & ShellScript('cat /proc/sys/kernel/random/boot_id')
-            ).to_shell_command(),
-        )
-
-        return output is not None and output.stdout is not None
-
-    def _query_has_rsync(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether ``rsync`` is available.
-        """
-
-        try:
-            guest.execute(Command('rsync', '--version'), silent=True)
-
-            return True
-
-        except tmt.utils.RunError:
-            return False
-
-    def _query_is_superuser(self, guest: 'Guest') -> Optional[bool]:
-        output = self._execute(guest, Command('whoami'))
-
-        if output is None or output.stdout is None:
-            return None
-
-        return output.stdout.strip() == 'root'
-
-    def _query_can_sudo(self, guest: 'Guest') -> Optional[bool]:
-        try:
-            guest.execute(Command("sudo", "-n", "true"), silent=True)
-        except tmt.utils.RunError:
-            # Failed non-interactive sudo, so we can't sudo
-            return False
-        # Otherwise we may use sudo
-        return True
-
-    def _query_sudo_prefix(self, guest: 'Guest') -> str:
-        # Note: we cannot reuse `is_superuser` or `can_sudo` fact so we just recall the query
-        # functions for now
-        if self._query_is_superuser(guest):
-            # Root user does not need sudo
-            return ""
-        if self._query_can_sudo(guest):
-            return "sudo"
-        return ""
-
-    def _query_is_ostree(self, guest: 'Guest') -> Optional[bool]:
-        # https://github.com/vrothberg/chkconfig/commit/538dc7edf0da387169d83599fe0774ea080b4a37#diff-562b9b19cb1cd12a7343ce5c739745ebc8f363a195276ca58e926f22927238a5R1334
-        output = self._execute(
-            guest,
-            ShellScript(
-                """
-                ( [ -e /run/ostree-booted ] || [ -L /ostree ] ) && echo yes || echo no
-                """
-            ).to_shell_command(),
-        )
-
-        if output is None or output.stdout is None:
-            return None
-
-        return output.stdout.strip() == 'yes'
-
-    def _query_is_image_mode(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether guest is an image mode based system.
-
-        An image mode based system has the image set to a image reference.
-        In case ``bootc`` is installed on a non image mode system, it
-        reports ``null``.
-        """
-
-        # Note: we cannot reuse `sudo_prefix` fact so we just recall the query
-        # function for now
-        sudo_prefix = self._query_sudo_prefix(guest)
-
-        command = Command("bootc", "status", "--format", "yaml")
-        if sudo_prefix:
-            command = Command(sudo_prefix) + command
-
-        image = self._query(guest, [(command, r'image: (.+)')])
-
-        # if bootc reports status and the image is not `image: null`, we are in image mode
-        if image and image != "null":
-            return True
-
-        return False
-
-    def _query_is_toolbox(self, guest: 'Guest') -> Optional[bool]:
-        # https://www.reddit.com/r/Fedora/comments/g6flgd/toolbox_specific_environment_variables/
-        output = self._execute(
-            guest,
-            ShellScript('[ -e /run/.toolboxenv ] && echo yes || echo no').to_shell_command(),
-        )
-
-        if output is None or output.stdout is None:
-            return None
-
-        return output.stdout.strip() == 'yes'
-
-    def _query_toolbox_container_name(self, guest: 'Guest') -> Optional[str]:
-        output = self._execute(
-            guest,
-            ShellScript('[ -e /run/.containerenv ] && echo yes || echo no').to_shell_command(),
-        )
-
-        if output is None or output.stdout is None:
-            return None
-
-        if output.stdout.strip() == 'no':
-            return None
-
-        output = self._execute(guest, Command('cat', '/run/.containerenv'))
-
-        if output is None or output.stdout is None:
-            return None
-
-        for line in output.stdout.splitlines():
-            if line.startswith('name="'):
-                return line[6:-1]
-
-        return None
-
-    def _query_is_container(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether guest is a container (running systemd)
-
-        In containers running systemd pid 1 has environment variable ``container`` set
-        (e.g. container=podman). See https://systemd.io/CONTAINER_INTERFACE/ for more details.
-        """
-        output = self._execute(guest, ShellScript('echo -n "$container"').to_shell_command())
-
-        if output is None or output.stdout is None:
-            return None
-
-        return len(output.stdout) > 0
-
-    def _query_capabilities(self, guest: 'Guest') -> dict[GuestCapability, bool]:
-        # TODO: there must be a canonical way of getting permitted capabilities.
-        # For now, we're interested in whether we can access kernel message buffer.
-        return {
-            GuestCapability.SYSLOG_ACTION_READ_ALL: True,
-            GuestCapability.SYSLOG_ACTION_READ_CLEAR: True,
-        }
+        return facts
 
     def sync(self, guest: 'Guest', *facts: str) -> None:
         """
@@ -1092,44 +971,15 @@ class GuestFacts(SerializableContainer):
             ``is_container`` - will be synced.
         """
 
-        if facts:
-            for fact in facts:
-                if not hasattr(self, fact):
-                    raise GeneralError(f"Cannot sync unknown guest fact '{fact}'.")
+        output = guest.execute(
+            self._create_collection_script(*(facts or self._facts().keys())).to_shell_command(),
+            silent=True,
+        )
 
-                method_name = f'_query_{fact}'
+        if not output.stdout:
+            return
 
-                if not hasattr(self, method_name):
-                    raise GeneralError(
-                        f"Cannot sync guest fact '{fact}', query method '{method_name}' not found."
-                    )
-
-                setattr(self, fact, getattr(self, method_name)(guest))
-
-        else:
-            self.os_release_content = self._fetch_keyval_file(guest, Path('/etc/os-release'))
-            self.lsb_release_content = self._fetch_keyval_file(guest, Path('/etc/lsb-release'))
-
-            self.arch = self._query_arch(guest)
-            self.distro = self._query_distro(guest)
-            self.kernel_release = self._query_kernel_release(guest)
-            self.package_manager = self._query_package_manager(guest)
-            self.bootc_builder = self._query_bootc_builder(guest)
-            self.has_selinux = self._query_has_selinux(guest)
-            self.has_systemd = self._query_has_systemd(guest)
-            self.systemd_soft_reboot = self._query_systemd_soft_reboot(guest)
-            self.has_rsync = self._query_has_rsync(guest)
-            self.is_superuser = self._query_is_superuser(guest)
-            self.can_sudo = self._query_can_sudo(guest)
-            self.sudo_prefix = self._query_sudo_prefix(guest)
-            self.is_ostree = self._query_is_ostree(guest)
-            self.is_image_mode = self._query_is_image_mode(guest)
-            self.distro_id = self._query_distro_id(guest)
-            self.distro_major_version = self._query_distro_major_version(guest)
-            self.is_toolbox = self._query_is_toolbox(guest)
-            self.toolbox_container_name = self._query_toolbox_container_name(guest)
-            self.is_container = self._query_is_container(guest)
-            self.capabilities = self._query_capabilities(guest)
+        self._raw_facts.update(self._extract_facts(output.stdout))
 
         self.in_sync = True
 
@@ -1137,46 +987,222 @@ class GuestFacts(SerializableContainer):
         """
         Format facts for pretty printing.
 
-        :yields: three-item tuples: the field name, its pretty label, and formatted representation
-            of its value.
+        :yields: three-item tuples: the field name, its pretty label,
+            and formatted representation of its value.
         """
 
-        def _value(field: str, label: str) -> tuple[str, str, str]:
-            v = getattr(self, field)
+        for fact in self._facts():
+            label = fact.replace('_', ' ')
+            value = getattr(self, fact)
 
-            return field, label, v or 'unknown'
+            if value is None:
+                yield fact, label, 'unknown'
 
-        def _flag(field: str, label: str) -> tuple[str, str, str]:
-            v = getattr(self, field)
+            elif isinstance(value, bool):
+                yield fact, label, 'yes' if value else 'no'
 
-            return field, label, 'yes' if v else 'no'
+            elif isinstance(value, str):
+                yield fact, label, value
 
-        yield _value('arch', 'arch')
-        yield _value('distro', 'distro')
-        yield _value('kernel_release', 'kernel')
-        yield _value('package_manager', 'package manager')
-        yield _value('bootc_builder', 'bootc builder')
-        yield _flag('is_container', 'is container')
-        yield _flag('is_ostree', 'is ostree')
-        yield _flag('is_image_mode', 'is image mode')
-        yield _value('distro_id', 'distro id')
-        yield _value('distro_major_version', 'distro major version')
-        yield _flag('is_toolbox', 'is toolbox')
-        yield _flag('has_selinux', 'selinux')
-        yield _flag('has_systemd', 'systemd')
-        yield _flag('systemd_soft_reboot', 'systemd soft-reboot')
-        yield _flag('has_rsync', 'rsync')
-        yield _flag('is_superuser', 'is superuser')
-        yield _flag('can_sudo', 'can sudo')
+            elif isinstance(value, dict):
+                pass
+
+            else:
+                raise GeneralError(f"Undefined formatting of guest fact '{fact}'.")
+
+    def has_capability(self, cap: GuestCapability) -> bool:
+        """Check if the guest has a specific capability."""
+        if not self.capabilities:
+            return False
+        return self.capabilities.get(cap, False)
+
+    #: Content of the ``/etc/os-release`` file. If the file does not
+    #: exist, the mapping will be empty.
+    os_release_content = keyval_guest_fact(Path('/etc/os-release'))
+
+    #: Content of the ``/etc/lsb-release`` file. If the file does not
+    #: exist, the mapping will be empty.
+    lsb_release_content = keyval_guest_fact(Path('/etc/lsb-release'))
+
+    #: Architecture of the guest, as reported by the ``arch`` command.
+    arch = string_guest_fact("uname -m || echo 'unknown'")
+
+    #: Name of the distribution on the guest.
+    distro = string_guest_fact(
+        """
+        if [ -f /etc/os-release ] && grep -q 'PRETTY_NAME=' /etc/os-release; then
+            grep '^PRETTY_NAME=' /etc/os-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/'
+
+        elif [ -f /etc/lsb-release ] && grep -q 'DISTRIB_DESCRIPTION=' /etc/lsb-release; then
+            grep '^DISTRIB_DESCRIPTION=' /etc/lsb-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/'
+
+        elif [ -f /etc/redhat-release ]; then
+            cat /etc/redhat-release
+
+        elif [ -f /etc/fedora-release ]; then
+            cat /etc/fedora-release
+
+        else
+            echo 'unknown'
+        fi
+        """  # noqa: E501
+    )
+
+    distro_id = string_guest_fact(
+        """
+        if [ -f /etc/os-release ] && grep -q 'ID=' /etc/os-release; then
+            grep '^ID=' /etc/os-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/'
+
+        elif [ -f /etc/lsb-release ] && grep -q 'DISTRIB_ID=' /etc/lsb-release; then
+            grep '^DISTRIB_ID=' /etc/lsb-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/'
+
+        else
+            echo 'unknown'
+        fi
+        """
+    )
+
+    distro_major_version = string_guest_fact(
+        """
+        if [ -f /etc/os-release ] && grep -q 'VERSION_ID=' /etc/os-release; then
+            grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/' | cut -d'.' -f1
+
+        elif [ -f /etc/lsb-release ] && grep -q 'DISTRIB_ID=' /etc/lsb-release; then
+            grep '^DISTRIB_ID=' /etc/lsb-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/' | cut -d'.' -f1
+
+        else
+            echo 'unknown'
+        fi
+        """
+    )
+
+    #: Release of the running kernel, as reported by the ``uname -r``
+    #: command.
+    kernel_release = string_guest_fact("uname -r || echo 'unknown'")
+
+    #: Whether SELinux is present and enabled.
+    has_selinux = flag_guest_fact(
+        "if [ -e /sys/fs/selinux/enforce ]; then echo 'true'; else echo 'false'; fi",
+    )
+
+    #: Whether systemd is available.
+    has_systemd = flag_guest_fact(
+        "if systemctl --version 1>&2; then echo 'true'; else echo 'false'; fi",
+    )
+
+    #: Whether systemd soft-reboot is supported.
+    systemd_soft_reboot = flag_guest_fact(
+        """
+        if systemctl --help | grep -q 'soft-reboot' && [ -f /proc/sys/kernel/random/boot_id ]; then
+            echo 'true'
+        else
+            echo 'false'
+        fi
+        """
+    )
+
+    #: Whether rsync is available.
+    has_rsync = flag_guest_fact("if rsync --version 1>&2; then echo 'true'; else echo 'false'; fi")
+
+    #: Whether the current user is superuser.
+    is_superuser = flag_guest_fact(
+        'if [ "$(whoami)" = "root" ]; then echo \'true\'; else echo \'false\'; fi'
+    )
+
+    #: Whether the current user can use ``sudo``.
+    can_sudo = flag_guest_fact("if sudo -n true 1>&2; then echo 'true'; else echo 'false'; fi")
+
+    #: A prefix to use when invoking commands with ``sudo``.
+    sudo_prefix = string_guest_fact(
+        """
+        if [ "$(whoami)" = "root" ]; then
+            echo ''
+        elif sudo -n true 1>&2; then
+            echo 'sudo'
+        else
+            echo ''
+        fi
+        """
+    )
+
+    #: Whether the guest is an OSTree-based system.
+    is_ostree = flag_guest_fact(
+        "if [ -e /run/ostree-booted ] || [ -L /ostree ]; then echo 'true'; else echo 'false'; fi",
+    )
+
+    #: Whether the guest is an image-mode system.
+    #:
+    #: An image mode based system has the image set to a image reference.
+    #: In case ``bootc`` is installed on a non image mode system, it
+    #: reports ``null``.
+    is_image_mode = flag_guest_fact(
+        """
+        if type bootc &> /dev/null; then
+            image="$(sudo bootc status --format yaml | grep -Po 'image: \\K(.*)')"
+
+            if [ -n "$image" ]; then
+                if [ "$image" = "null" ]; then echo 'false'; else echo 'true'; fi
+            else
+                echo 'unknown'
+            fi
+        else
+            echo 'false'
+        fi
+        """
+    )
+
+    #: Whether the guest is a toolbox container
+    is_toolbox = flag_guest_fact(
+        "if [ -e /run/.toolboxenv ]; then echo 'true'; else echo 'false'; fi"
+    )
+
+    #: Name of the toolbox container (if applicable).
+    toolbox_container_name = string_guest_fact(
+        """
+        if [ -e /run/.containerenv ]; then
+            if grep -q '^name=' /run/.containerenv; then
+                grep '^name=' /run/.containerenv | sed 's/^name=\\"\\(.*\\)\\"$/\\1/'
+            else
+                echo 'unknown'
+            fi
+        else
+            echo 'unknown'
+        fi
+        """
+    )
+
+    #: Whether the guest is a container.
+    is_container = flag_guest_fact(
+        'if [ -n "${container:-}" ]; then echo \'true\'; else echo \'false\'; fi'
+    )
+
+    #: Name of the package manager available on the guest.
+    package_manager = package_manager_guest_fact()
+
+    #: name of the bootc builder available on the guest.
+    bootc_builder = package_manager_guest_fact(lambda pm: pm.bootc_builder)
+
+    #: Various Linux capabilities and whether they are permitted.
+    capabilities: dict[GuestCapability, bool] = field(
+        default_factory=lambda: {
+            GuestCapability.SYSLOG_ACTION_READ_ALL: True,
+            GuestCapability.SYSLOG_ACTION_READ_CLEAR: True,
+        },
+        serialize=lambda capabilities: (
+            {capability.value: enabled for capability, enabled in capabilities.items()}
+            if capabilities
+            else {}
+        ),
+        unserialize=lambda raw_value: {
+            GuestCapability(raw_capability): enabled
+            for raw_capability, enabled in raw_value.items()
+        },
+    )
 
 
 GUEST_FACTS_INFO_FIELDS: list[str] = ['arch', 'distro']
 GUEST_FACTS_VERBOSE_FIELDS: list[str] = [
-    # SIM118: Use `{key} in {dict}` instead of `{key} in {dict}.keys()`
-    # "NormalizeKeysMixin" has no attribute "__iter__" (not iterable)
-    key
-    for key in GuestFacts.keys()  # noqa: SIM118
-    if key not in GUEST_FACTS_INFO_FIELDS
+    key for key in GuestFacts._facts() if key not in GUEST_FACTS_INFO_FIELDS
 ]
 
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1314,7 +1314,7 @@ class GuestFacts(SerializableContainer):
             if [ -n "$image" ]; then
                 if [ "$image" = "null" ]; then echo 'false'; else echo 'true'; fi
             else
-                echo 'unknown'
+                echo 'false'
             fi
         else
             echo 'false'

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -750,6 +750,17 @@ class string_guest_fact(guest_fact[Optional[str]]):  # noqa: N801
         )
 
 
+class int_guest_fact(guest_fact[Optional[int]]):  # noqa: N801
+    """
+    A guest fact whose value is an integer.
+    """
+
+    def __init__(self, probe: str) -> None:
+        super().__init__(
+            probe, lambda output: int(output.strip()) if output.strip() != 'unknown' else None
+        )
+
+
 class flag_guest_fact(guest_fact[Optional[bool]]):  # noqa: N801
     """
     A guest fact whose value is a booleab flag.
@@ -1100,6 +1111,9 @@ class GuestFacts(SerializableContainer):
             elif isinstance(value, bool):
                 yield fact, label, 'yes' if value else 'no'
 
+            elif isinstance(value, int):
+                yield fact, label, str(value)
+
             elif isinstance(value, str):
                 yield fact, label, value
 
@@ -1161,7 +1175,7 @@ class GuestFacts(SerializableContainer):
         """
     )
 
-    distro_major_version = string_guest_fact(
+    distro_major_version = int_guest_fact(
         """
         if [ -f /etc/os-release ] && grep -q 'VERSION_ID=' /etc/os-release; then
             grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/' | cut -d'.' -f1
@@ -1172,7 +1186,7 @@ class GuestFacts(SerializableContainer):
         else
             echo 'unknown'
         fi
-        """
+        """  # noqa: E501
     )
 
     #: Release of the running kernel, as reported by the ``uname -r``

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1007,7 +1007,7 @@ class GuestFacts(SerializableContainer):
             # the end of the queue and trying again will not help.
             if name in blocked_facts:
                 raise GeneralError(
-                    f"Guest fact '{name}' remains blocked by required facts {pending_facts}."
+                    f"Guest fact '{name}' remains blocked by required facts {pending_requires}."
                 )
 
             # Ok, first time resolving requirements of this fact: mark

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -947,6 +947,55 @@ class GuestFacts(SerializableContainer):
             them with markers for the future parsing.
         """
 
+        # Add required facts as well. If we are given a subset of facts,
+        # make sure we include all their requirements.
+        #
+        # We just care about adding them to the list of facts to emit;
+        # the correct order will be resolved below, when emitting snippets.
+
+        if facts:
+            # Facts that already have their requirements resolved. Starting
+            # as an empty set, and facts - initial and required - will be
+            # added as we encounter them.
+            facts_with_resolved_requires = set()
+
+            # Facts with unresolved requirements. All initial facts start
+            # here, and all requirements are added as we go, to resolve
+            # their requirements as well.
+            facts_with_unresolved_requires = set(facts)
+
+            while facts_with_unresolved_requires:
+                name = facts_with_unresolved_requires.pop()
+                fact = self._facts()[name]
+
+                # No requirements? Cool, resolved.
+                if not fact.requires:
+                    facts_with_resolved_requires.add(name)
+                    continue
+
+                # Let's see which requirements are still pending.
+                pending_requires = {
+                    name for name in fact.requires if name not in facts_with_resolved_requires
+                }
+
+                # No pending requirements? Also nice, resolved.
+                if not pending_requires:
+                    facts_with_resolved_requires.add(name)
+                    continue
+
+                # We are left with some pending requirements, add them
+                # to the stack, and resolve their requirements as well.
+                facts_with_unresolved_requires.update(pending_requires)
+
+            facts = tuple(facts_with_resolved_requires)
+
+        # Facts that remain to be emitted into the collection script.
+        pending_facts = [
+            (name, fact, snippet)
+            for name, fact, snippet in self._fact_snippets[:]
+            if name in facts
+        ]
+
         # Since facts may have requirements, we need some basic ordering.
         # It is really trivial: facts are processed in a queue-like
         # fashion; if a fact requires facts that have not been yet emitted
@@ -955,12 +1004,6 @@ class GuestFacts(SerializableContainer):
         # Hopefully, we would then emit the required facts first, then
         # reaching those that were blocked.
 
-        # Facts that remain to be emitted into the collection script.
-        pending_facts = [
-            (name, fact, snippet)
-            for name, fact, snippet in self._fact_snippets[:]
-            if name in facts
-        ]
         # Facts that were already emitted into the collection script.
         # If a pending fact requires these, it can be emitted as well
         # since its requirements are already ready.

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1081,10 +1081,25 @@ class GuestFacts(SerializableContainer):
             ``is_container`` - will be synced.
         """
 
-        output = guest.execute(
-            self._create_collection_script(*(facts or self._facts().keys())).to_shell_command(),
-            silent=True,
-        )
+        facts = facts or tuple(self._facts().keys())
+
+        guest.debug('syncing facts', fmf.utils.listed(facts))
+
+        try:
+            output = guest.execute(
+                self._create_collection_script(*facts).to_shell_command(),
+                silent=True,
+            )
+
+        except tmt.utils.RunError as exc:
+            tmt.utils.show_exception_as_warning(
+                exception=exc,
+                message='Guest fact sync failed',
+                include_logfiles=True,
+                logger=guest._logger,
+            )
+
+            return
 
         if not output.stdout:
             return

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1040,7 +1040,7 @@ class GuestFacts(SerializableContainer):
             elif line.startswith('<<<'):
                 if current_fact is None:
                     raise GeneralError(
-                        "Malformed fact probe output: closing marker '<<<' without opening marker"
+                        "Malformed fact probe output: closing marker '<<<' without opening marker."
                     )
 
                 facts[current_fact] = self._facts()[current_fact].extract(
@@ -1052,6 +1052,11 @@ class GuestFacts(SerializableContainer):
 
             else:
                 current_fact_content.append(line)
+
+        if current_fact is not None:
+            raise GeneralError(
+                f"Malformed fact probe output: fact '{current_fact}' was opened but never closed."
+            )
 
         return facts
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -16,7 +16,7 @@ import string
 import subprocess
 import textwrap
 import threading
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterator, Sequence
 from re import Pattern
 from shlex import quote
 from typing import (

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -805,6 +805,17 @@ class string_guest_fact(guest_fact[Optional[str]]):  # noqa: N801
         )
 
 
+class int_guest_fact(guest_fact[Optional[int]]):  # noqa: N801
+    """
+    A guest fact whose value is an integer.
+    """
+
+    def __init__(self, probe: str) -> None:
+        super().__init__(
+            probe, lambda output: int(output.strip()) if output.strip() != 'unknown' else None
+        )
+
+
 class flag_guest_fact(guest_fact[Optional[bool]]):  # noqa: N801
     """
     A guest fact whose value is a booleab flag.
@@ -1155,6 +1166,9 @@ class GuestFacts(SerializableContainer):
             elif isinstance(value, bool):
                 yield fact, label, 'yes' if value else 'no'
 
+            elif isinstance(value, int):
+                yield fact, label, str(value)
+
             elif isinstance(value, str):
                 yield fact, label, value
 
@@ -1216,7 +1230,7 @@ class GuestFacts(SerializableContainer):
         """
     )
 
-    distro_major_version = string_guest_fact(
+    distro_major_version = int_guest_fact(
         """
         if [ -f /etc/os-release ] && grep -q 'VERSION_ID=' /etc/os-release; then
             grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/' | cut -d'.' -f1
@@ -1227,7 +1241,7 @@ class GuestFacts(SerializableContainer):
         else
             echo 'unknown'
         fi
-        """
+        """  # noqa: E501
     )
 
     #: Release of the running kernel, as reported by the ``uname -r``

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1136,10 +1136,25 @@ class GuestFacts(SerializableContainer):
             ``is_container`` - will be synced.
         """
 
-        output = guest.execute(
-            self._create_collection_script(*(facts or self._facts().keys())).to_shell_command(),
-            silent=True,
-        )
+        facts = facts or tuple(self._facts().keys())
+
+        guest.debug('syncing facts', fmf.utils.listed(facts))
+
+        try:
+            output = guest.execute(
+                self._create_collection_script(*facts).to_shell_command(),
+                silent=True,
+            )
+
+        except tmt.utils.RunError as exc:
+            tmt.utils.show_exception_as_warning(
+                exception=exc,
+                message='Guest fact sync failed',
+                include_logfiles=True,
+                logger=guest._logger,
+            )
+
+            return
 
         if not output.stdout:
             return

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1062,7 +1062,7 @@ class GuestFacts(SerializableContainer):
             # the end of the queue and trying again will not help.
             if name in blocked_facts:
                 raise GeneralError(
-                    f"Guest fact '{name}' remains blocked by required facts {pending_facts}."
+                    f"Guest fact '{name}' remains blocked by required facts {pending_requires}."
                 )
 
             # Ok, first time resolving requirements of this fact: mark

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1371,7 +1371,7 @@ class GuestFacts(SerializableContainer):
     #: reports ``null``.
     is_image_mode = flag_guest_fact(
         """
-        if type bootc &> /dev/null; then
+        set -x; if type bootc &> /dev/null; then
             image="$($sudo_prefix bootc status --format yaml | grep -Po 'image: \\K(.*)')"
 
             if [ -n "$image" ]; then

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -977,6 +977,10 @@ class GuestFacts(SerializableContainer):
         }
 
     @functools.cached_property
+    def _delimiters(self) -> tuple[str, str]:
+        return (f'# start-marker-tmt-{os.getpid()} #', f'# end-marker-tmt-{os.getpid()} #')
+
+    @functools.cached_property
     def _fact_snippets(self) -> list[tuple[str, guest_fact[Any], str]]:
         """
         Collect all fact collection snippets from the facts.
@@ -1067,6 +1071,8 @@ class GuestFacts(SerializableContainer):
         # one or more of their requirements are still pending.
         blocked_facts: set[str] = set()
 
+        start_delimiter, end_delimiter = self._delimiters
+
         scripts: list[str] = [f'unset {name}' for name, _, _ in pending_facts if name in facts]
 
         def _emit_fact_probe(name: str, fact: guest_fact[Any], snippet: str) -> None:
@@ -1076,9 +1082,9 @@ class GuestFacts(SerializableContainer):
                 '\n'.join(
                     [
                         f'{name}=$({snippet})',
-                        f'echo ">>> {name}"',
+                        f'echo "{start_delimiter} {name}"',
                         f'echo "${name}"',
-                        'echo "<<<"',
+                        f'echo "{end_delimiter} {name}"',
                     ]
                 )
             )
@@ -1137,19 +1143,21 @@ class GuestFacts(SerializableContainer):
 
         facts = {}
 
+        start_delimiter, end_delimiter = self._delimiters
+
         current_fact: Optional[str] = None
         current_fact_content: list[str] = []
 
         for line in output.splitlines():
             line = line.strip()
 
-            if line.startswith('>>> '):
-                current_fact = line[4:]
+            if line.startswith(start_delimiter):
+                current_fact = line.split('#')[2].strip()
 
-            elif line.startswith('<<<'):
+            elif line.startswith(end_delimiter):
                 if current_fact is None:
                     raise GeneralError(
-                        "Malformed fact probe output: closing marker '<<<' without opening marker."
+                        "Malformed fact probe output: closing marker without opening marker."
                     )
 
                 facts[current_fact] = self._facts()[current_fact].extract(

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1369,7 +1369,7 @@ class GuestFacts(SerializableContainer):
             if [ -n "$image" ]; then
                 if [ "$image" = "null" ]; then echo 'false'; else echo 'true'; fi
             else
-                echo 'unknown'
+                echo 'false'
             fi
         else
             echo 'false'

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1095,7 +1095,7 @@ class GuestFacts(SerializableContainer):
             elif line.startswith('<<<'):
                 if current_fact is None:
                     raise GeneralError(
-                        "Malformed fact probe output: closing marker '<<<' without opening marker"
+                        "Malformed fact probe output: closing marker '<<<' without opening marker."
                     )
 
                 facts[current_fact] = self._facts()[current_fact].extract(
@@ -1107,6 +1107,11 @@ class GuestFacts(SerializableContainer):
 
             else:
                 current_fact_content.append(line)
+
+        if current_fact is not None:
+            raise GeneralError(
+                f"Malformed fact probe output: fact '{current_fact}' was opened but never closed."
+            )
 
         return facts
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -5,6 +5,7 @@ import dataclasses
 import enum
 import functools
 import hashlib
+import inspect
 import os
 import re
 import secrets
@@ -13,6 +14,7 @@ import shutil
 import signal as _signal
 import string
 import subprocess
+import textwrap
 import threading
 from collections.abc import Iterable, Iterator, Sequence
 from re import Pattern
@@ -21,6 +23,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Generic,
     Literal,
     NewType,
     Optional,
@@ -687,6 +690,200 @@ class GuestCapability(enum.Enum):
     SYSLOG_ACTION_READ_CLEAR = 'syslog-action-read-clear'
 
 
+class guest_fact(Generic[T]):  # noqa: N801
+    """
+    A descriptor that associates a shell snippet with a guest fact attribute.
+
+    This descriptor allows facts to be collected efficiently by registering
+    shell snippets that can be combined into a single script execution.
+    """
+
+    #: A shell snippet responsible for discovering a fact. Its standard
+    #: output is passed to :py:attr:`extract`, standard error output is
+    #: ignored.
+    snippet: str
+
+    #: If set, it is used instead of :py:attr:`snippet`. The callable
+    #: is invoked during the construction of the discover script, and
+    #: its return value must comply with the rules for :py:attr:`snippet`.
+    snippet_creator: Callable[[], str]
+
+    #: A callable that receives the standard output of the shell snippet,
+    #: and returns the actual value of the fact, to be assigned to the
+    #: corresponding :py:class:`GuestFacts` attribute.
+    extract: Callable[[str], T]
+
+    #: Name of the attribute which owns this descriptor. Needed to support
+    #: the descriptor API.
+    name: Optional[str]
+
+    def __init__(
+        self,
+        probe: Union[str, Callable[[], str]],
+        extract: Callable[[str], T],
+    ) -> None:
+        """
+        Initialize a fact collector.
+
+        :param snippet: a shell snippet responsible for discovering the
+            fact. Its standard output is passed to :py:attr:`extract`,
+            standard error output is ignored. If a callable is used,
+            its return value is supposed to be the snippet, and must
+            comply with the rules above.
+        :param extract: a callable that receives the standard output of
+            the shell snippet, and returns the actual value of the fact,
+            to be assigned to the corresponding :py:class:`GuestFacts`
+            attribute.
+        """
+
+        if isinstance(probe, str):
+            self.snippet = textwrap.dedent(probe).strip()
+
+        else:
+            self.snippet_creator = probe
+
+        self.extract = extract
+
+        self.name = None
+
+    def __set_name__(self, owner: type, name: str) -> None:
+        """
+        Called when the descriptor is assigned to a class attribute.
+        """
+
+        self.name = name
+
+    @overload
+    def __get__(self, obj: None, objtype: Optional[type] = None) -> 'guest_fact[T]':
+        pass
+
+    @overload
+    def __get__(self, obj: 'GuestFacts', objtype: Optional[type] = None) -> T:
+        pass
+
+    def __get__(
+        self, obj: Optional['GuestFacts'], objtype: Optional[type] = None
+    ) -> Union['guest_fact[T]', T]:
+        """
+        Get the fact value from the instance.
+        """
+
+        if obj is None:
+            return self
+
+        assert self.name
+
+        return cast(T, obj._raw_facts.get(self.name))
+
+    def __set__(self, obj: 'GuestFacts', value: T) -> None:
+        """
+        Set the fact value on the instance.
+        """
+
+        assert self.name
+
+        obj._raw_facts[self.name] = value
+
+
+class string_guest_fact(guest_fact[Optional[str]]):  # noqa: N801
+    """
+    A guest fact whose value is a simple string.
+    """
+
+    def __init__(self, probe: str) -> None:
+        super().__init__(
+            probe, lambda output: output.strip() if output.strip() != 'unknown' else None
+        )
+
+
+class flag_guest_fact(guest_fact[Optional[bool]]):  # noqa: N801
+    """
+    A guest fact whose value is a booleab flag.
+    """
+
+    def __init__(self, probe: str) -> None:
+        super().__init__(
+            probe, lambda output: output.strip() == 'true' if output.strip() != 'unknown' else None
+        )
+
+
+class keyval_guest_fact(guest_fact[dict[str, str]]):  # noqa: N801
+    """
+    A guest fact whose value is a key/value mapping.
+    """
+
+    @staticmethod
+    def _parse(content: str) -> dict[str, str]:
+        """
+        Parse key=value content (like os-release or lsb-release).
+
+        :param content: File content with key=value pairs.
+        :returns: Dictionary of parsed key/value pairs.
+        """
+
+        result: dict[str, str] = {}
+
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+
+            if '=' not in line:
+                continue
+
+            key, value = line.split('=', 1)
+
+            # Remove quotes if present
+            if value and value[0] in '"\'':
+                # If ast.literal_eval fails, keep the original value
+                with contextlib.suppress(ValueError, SyntaxError):
+                    value = ast.literal_eval(value)
+
+            result[key] = value
+
+        return result
+
+    def __init__(self, path: Path) -> None:
+        super().__init__(f"cat {shlex.quote(str(path))}", keyval_guest_fact._parse)
+
+
+class package_manager_guest_fact(guest_fact[Optional['tmt.package_managers.GuestPackageManager']]):  # noqa: N801
+    """
+    A guest fact whose value is a package manager name.
+    """
+
+    def __init__(
+        self,
+        predicate: Optional[
+            Callable[[type['tmt.package_managers.PackageManager[Any]']], bool]
+        ] = None,
+    ) -> None:
+        def _snippet_creator() -> str:
+            probes: list[str] = []
+
+            for package_manager_class in sorted(
+                tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.iter_plugins(),
+                key=lambda pm: pm.probe_priority,
+                reverse=True,
+            ):
+                if predicate and not predicate(package_manager_class):
+                    continue
+
+                probes.append(
+                    f"({package_manager_class.probe_command.to_element()}) 1>&2 && echo '{package_manager_class.NAME}'"  # noqa: E501
+                )
+
+            return '\n'.join(probes)
+
+        def _extract(output: str) -> Optional['tmt.package_managers.GuestPackageManager']:
+            if not output:
+                return None
+
+            return output.splitlines()[0]
+
+        super().__init__(_snippet_creator, _extract)
+
+
 @container
 class GuestFacts(SerializableContainer):
     """
@@ -695,447 +892,129 @@ class GuestFacts(SerializableContainer):
     Inspired by Ansible or Puppet facts, interesting guest facts tmt
     discovers while managing the guest are stored in this container,
     plus the code performing the discovery of these facts.
+
+    Each fact is represented as an attribute with the proper type
+    annotation, assigned an instance of :py:class:`guest_fact` class, or
+    one of its subclasses.
+
+    * ``guest_fact`` classes implement the Python descriptor API, see
+      https://docs.python.org/3/howto/descriptor.html, which allows us
+      to attach interesting information to each fact.
+    * the information we attach is 1. a shell script snippet, "probe",
+      to be executed on the guest, whose responsibility is to print
+      something to its standard output, and 2. a callable, "extractor",
+      that is given this standard output, and is expected to produce the
+      actual value of the corresponding fact.
+
+    For example, a probe for the :py:attr:`arch` fact is simple, it calls
+    the ``arch`` command. The corresponding extractor is also trivial,
+    and takes the output produced by the probe - a raw output of
+    ``arch`` - and returns it as the value of the ``arch`` fact.
+
+    Probes of flag-like facts, :py:attr:`has_selinux` for example, usually
+    test some system property, and echo ``true`` or ``false``. The
+    corresponding extractor turns it into a proper ``bool`` value.
+
+    When discovering facts, i.e. when :py:meth:`sync` is called, relevant
+    probes are collected and joined into a single shell script that is
+    then executed on the guest. :py:meth:`_extract_facts` then extracts
+    the actual values, and updates :py:attr:`_raw_facts` mapping.
+    Descriptors then return values from this mapping instead of running
+    any additional code on the guest.
     """
+
+    #: Store the actual values of facts. This mapping serves as a
+    #: storage for descriptors, see :py:meth:`guest_fact.__get__`.
+    #: It is this mapping that is refreshed by :py:meth:`sync`.
+    _raw_facts: dict[str, Any] = field(default_factory=dict)
 
     #: Set to ``True`` by the first call to :py:meth:`sync`.
     in_sync: bool = False
 
-    arch: Optional[str] = None
-    distro: Optional[str] = None
-    kernel_release: Optional[str] = None
-    package_manager: Optional['tmt.package_managers.GuestPackageManager'] = field(
-        # cast: since the default is None, mypy cannot infere the full type,
-        # and reports `package_manager` parameter to be `object`.
-        default=cast(Optional['tmt.package_managers.GuestPackageManager'], None)
-    )
-    bootc_builder: Optional['tmt.package_managers.GuestPackageManager'] = field(
-        # cast: since the default is None, mypy cannot infere the full type,
-        # and reports `bootc_builder` parameter to be `object`.
-        default=cast(Optional['tmt.package_managers.GuestPackageManager'], None)
-    )
-
-    has_selinux: Optional[bool] = None
-    has_systemd: Optional[bool] = None
-    has_rsync: Optional[bool] = None
-    is_superuser: Optional[bool] = None
-    can_sudo: Optional[bool] = None
-    sudo_prefix: Optional[str] = None
-    is_ostree: Optional[bool] = None
-    is_image_mode: Optional[bool] = None
-    distro_id: Optional[str] = None
-    distro_major_version: Optional[int] = None
-    is_toolbox: Optional[bool] = None
-    toolbox_container_name: Optional[str] = None
-    is_container: Optional[bool] = None
-    systemd_soft_reboot: Optional[bool] = None
-
-    #: Various Linux capabilities and whether they are permitted to
-    #: commands executed on this guest.
-    capabilities: dict[GuestCapability, bool] = field(
-        default_factory=cast(Callable[[], dict[GuestCapability, bool]], dict),
-        serialize=lambda capabilities: (
-            {capability.value: enabled for capability, enabled in capabilities.items()}
-            if capabilities
-            else {}
-        ),
-        unserialize=lambda raw_value: {
-            GuestCapability(raw_capability): enabled
-            for raw_capability, enabled in raw_value.items()
-        },
-    )
-
-    os_release_content: dict[str, str] = field(default_factory=dict)
-    lsb_release_content: dict[str, str] = field(default_factory=dict)
-
-    def has_capability(self, cap: GuestCapability) -> bool:
-        if not self.capabilities:
-            return False
-
-        return self.capabilities.get(cap, False)
-
-    def _execute(self, guest: 'Guest', command: Command) -> Optional[tmt.utils.CommandOutput]:
+    @classmethod
+    def _facts(cls) -> dict[str, guest_fact[Any]]:
         """
-        Run a command on the given guest, ignoring :py:class:`tmt.utils.RunError`.
+        Find all defined facts and their descriptors.
 
-        On image mode systems execute the commands immediately.
-
-        :returns: command output if the command quit with a zero exit code,
-            ``None`` otherwise.
+        :returns: a mapping with fact names as keys, and fact descriptors
+            as values.
         """
 
-        try:
-            return guest.execute(command, silent=True)
+        return {
+            name: value for name, value in inspect.getmembers(cls) if isinstance(value, guest_fact)
+        }
 
-        except tmt.utils.RunError:
-            pass
-
-        return None
-
-    def _fetch_keyval_file(self, guest: 'Guest', filepath: Path) -> dict[str, str]:
+    @functools.cached_property
+    def _fact_snippets(self) -> dict[str, str]:
         """
-        Load key/value pairs from a file on the given guest.
+        Collect all fact collection snippets from the facts.
 
-        Converts file with ``key=value`` pairs into a mapping. Some values might
-        be wrapped with quotes.
-
-        .. code:: shell
-
-           $ cat /etc/os-release
-           NAME="Ubuntu"
-           VERSION="20.04.5 LTS (Focal Fossa)"
-           ID=ubuntu
-           ID_LIKE=debian
-           ...
-
-        See https://www.freedesktop.org/software/systemd/man/os-release.html for
-        more details on syntax of these files.
-
-        :returns: mapping with key/value pairs loaded from ``filepath``, or an
-            empty mapping if it was impossible to load the content.
+        :returns: a mapping with fact names as keys, and shell snippets
+            as values.
         """
 
-        content: dict[str, str] = {}
+        return {
+            name: (value.snippet if hasattr(value, 'snippet') else value.snippet_creator())
+            for name, value in self._facts().items()
+        }
 
-        output = self._execute(guest, Command('cat', filepath))
+    def _create_collection_script(self, *facts: str) -> ShellScript:
+        """
+        Generate a comprehensive shell script to collect all facts.
 
-        if not output or not output.stdout:
-            return content
+        :returns: a shell script that invokes all probes, and "wraps"
+            them with markers for the future parsing.
+        """
 
-        def _iter_pairs() -> Iterator[tuple[str, str]]:
-            assert output  # narrow type in a closure
-            assert output.stdout  # narrow type in a closure
+        scripts: list[str] = []
 
-            line_pattern = re.compile(r'([A-Z][A-Z_0-9]+)=(.*)')
+        for fact, snippet in self._fact_snippets.items():
+            if fact not in facts:
+                continue
 
-            for line_number, line in enumerate(output.stdout.splitlines(keepends=False), start=1):
-                line = line.rstrip()
+            # The extra `echo` is there to enforce at least one empty line
+            # in the output.
+            scripts.append(f'echo ">>> {fact}"\n{snippet}\necho\necho "<<<"\n')
 
-                if not line or line.startswith('#'):
-                    continue
+        return ShellScript('\n\n'.join(scripts))
 
-                match = line_pattern.match(line)
+    def _extract_facts(self, output: str) -> dict[str, str]:
+        """
+        Parse the output of the fact collection script.
 
-                if not match:
-                    raise tmt.utils.ProvisionError(
-                        f"Cannot parse line {line_number} in '{filepath}' on guest '{guest.name}':"
-                        f" {line}"
+        :param output: raw output from the fact collection script.
+        :returns: a mapping between fact names and their values, as
+            extracted from the output.
+        """
+
+        facts = {}
+
+        current_fact: Optional[str] = None
+        current_fact_content: list[str] = []
+
+        for line in output.splitlines():
+            line = line.strip()
+
+            if line.startswith('>>> '):
+                current_fact = line[4:]
+
+            elif line.startswith('<<<'):
+                if current_fact is None:
+                    raise GeneralError(
+                        "Malformed fact probe output: closing marker '<<<' without opening marker"
                     )
 
-                key, value = match.groups()
-
-                if value and value[0] in '"\'':
-                    value = ast.literal_eval(value)
-
-                yield key, value
-
-        return dict(_iter_pairs())
-
-    def _probe(self, guest: 'Guest', probes: list[tuple[Command, T]]) -> Optional[T]:
-        """
-        Find a first successful command.
-
-        :param guest: the guest to run commands on.
-        :param probes: list of command/mark pairs.
-        :returns: "mark" corresponding to the first command to quit with
-            a zero exit code.
-        :raises tmt.utils.GeneralError: when no command succeeded.
-        """
-
-        for command, outcome in probes:
-            if self._execute(guest, command):
-                return outcome
-
-        return None
-
-    def _query(self, guest: 'Guest', probes: list[tuple[Command, str]]) -> Optional[str]:
-        """
-        Find a first successful command, and extract info from its output.
-
-        :param guest: the guest to run commands on.
-        :param probes: list of command/pattenr pairs.
-        :returns: substring extracted by the first matching pattern.
-        :raises tmt.utils.GeneralError: when no command succeeded, or when no
-            pattern matched.
-        """
-
-        for command, pattern in probes:
-            output = self._execute(guest, command)
-
-            if not output or not output.stdout:
-                guest.debug('query', f"Command '{command!s}' produced no usable output.")
-                continue
-
-            match = re.search(pattern, output.stdout)
-
-            if not match:
-                guest.debug('query', f"Command '{command!s}' produced no usable output.")
-                continue
-
-            return match.group(1)
-
-        return None
-
-    def _query_arch(self, guest: 'Guest') -> Optional[str]:
-        return self._query(guest, [(Command('uname', '-m'), r'(.+)')])
-
-    def _query_distro(self, guest: 'Guest') -> Optional[str]:
-        # Try some low-hanging fruits first. We already might have the answer,
-        # provided by some standardized locations.
-        if 'PRETTY_NAME' in self.os_release_content:
-            return self.os_release_content['PRETTY_NAME']
-
-        if 'DISTRIB_DESCRIPTION' in self.lsb_release_content:
-            return self.lsb_release_content['DISTRIB_DESCRIPTION']
-
-        # Nope, inspect more files.
-        return self._query(
-            guest,
-            [
-                (Command('cat', '/etc/redhat-release'), r'(.*)'),
-                (Command('cat', '/etc/fedora-release'), r'(.*)'),
-            ],
-        )
-
-    def _query_distro_id(self, guest: 'Guest') -> Optional[str]:
-        return self.os_release_content.get('ID')
-
-    def _query_distro_major_version(self, guest: 'Guest') -> Optional[int]:
-        version_id = self.os_release_content.get('VERSION_ID')
-        if version_id:
-            try:
-                return int(version_id.split('.')[0])
-            except ValueError:
-                return None
-        return None
-
-    def _query_kernel_release(self, guest: 'Guest') -> Optional[str]:
-        return self._query(guest, [(Command('uname', '-r'), r'(.+)')])
-
-    def _discover_package_manager(
-        self,
-        guest: 'Guest',
-        plugin_classes: Iterable[
-            type[tmt.package_managers.PackageManager[tmt.package_managers.PackageManagerEngine]]
-        ],
-        *,
-        debug_label: str,
-    ) -> Optional['tmt.package_managers.GuestPackageManager']:
-        # Sort available package managers by priority and probe them one by one,
-        # break after the first one is detected.
-
-        for package_manager_class in sorted(
-            plugin_classes, key=lambda pm: pm.probe_priority, reverse=True
-        ):
-            if self._execute(guest, package_manager_class.probe_command):
-                guest.debug(
-                    f'Discovered {debug_label}',
-                    package_manager_class.NAME,
-                    level=3,
+                facts[current_fact] = self._facts()[current_fact].extract(
+                    '\n'.join(current_fact_content)
                 )
-                return package_manager_class.NAME
 
-        return None
+                current_fact = None
+                current_fact_content = []
 
-    def _query_package_manager(
-        self, guest: 'Guest'
-    ) -> Optional['tmt.package_managers.GuestPackageManager']:
-        return self._discover_package_manager(
-            guest,
-            plugin_classes=(
-                package_manager_class
-                for package_manager_class in (
-                    tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.iter_plugins()
-                )
-            ),
-            debug_label='package manager',
-        )
+            else:
+                current_fact_content.append(line)
 
-    def _query_bootc_builder(
-        self, guest: 'Guest'
-    ) -> Optional['tmt.package_managers.GuestPackageManager']:
-        return self._discover_package_manager(
-            guest,
-            plugin_classes=(
-                pm
-                for pm in tmt.package_managers._PACKAGE_MANAGER_PLUGIN_REGISTRY.iter_plugins()
-                if pm.bootc_builder
-            ),
-            debug_label='bootc builder',
-        )
-
-    def _query_has_selinux(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether guest has SELinux and it is enabled.
-
-        For detection ``/sys/fs/selinux/enforce`` is used. This file exists
-        only when SELinux is actually available and mounted (regardless of
-        enforcing/permissive mode).
-        """
-        try:
-            guest.execute(Command('test', '-e', '/sys/fs/selinux/enforce'), silent=True)
-            return True
-        except tmt.utils.RunError:
-            return False
-
-    def _query_has_systemd(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether guest uses systemd.
-        For detection we check if systemctl exists and is executable.
-        """
-        try:
-            guest.execute(Command('systemctl', '--version'), silent=True)
-            return True
-        except tmt.utils.RunError:
-            return False
-
-    def _query_systemd_soft_reboot(self, guest: 'Guest') -> Optional[bool]:
-        output = self._execute(
-            guest,
-            (
-                ShellScript('systemctl --help | grep -q "soft-reboot"')
-                & ShellScript('cat /proc/sys/kernel/random/boot_id')
-            ).to_shell_command(),
-        )
-
-        return output is not None and output.stdout is not None
-
-    def _query_has_rsync(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether ``rsync`` is available.
-        """
-
-        try:
-            guest.execute(Command('rsync', '--version'), silent=True)
-
-            return True
-
-        except tmt.utils.RunError:
-            return False
-
-    def _query_is_superuser(self, guest: 'Guest') -> Optional[bool]:
-        output = self._execute(guest, Command('whoami'))
-
-        if output is None or output.stdout is None:
-            return None
-
-        return output.stdout.strip() == 'root'
-
-    def _query_can_sudo(self, guest: 'Guest') -> Optional[bool]:
-        try:
-            guest.execute(Command("sudo", "-n", "true"), silent=True)
-        except tmt.utils.RunError:
-            # Failed non-interactive sudo, so we can't sudo
-            return False
-        # Otherwise we may use sudo
-        return True
-
-    def _query_sudo_prefix(self, guest: 'Guest') -> str:
-        # Note: we cannot reuse `is_superuser` or `can_sudo` fact so we just recall the query
-        # functions for now
-        if self._query_is_superuser(guest):
-            # Root user does not need sudo
-            return ""
-        if self._query_can_sudo(guest):
-            return "sudo"
-        return ""
-
-    def _query_is_ostree(self, guest: 'Guest') -> Optional[bool]:
-        # https://github.com/vrothberg/chkconfig/commit/538dc7edf0da387169d83599fe0774ea080b4a37#diff-562b9b19cb1cd12a7343ce5c739745ebc8f363a195276ca58e926f22927238a5R1334
-        output = self._execute(
-            guest,
-            ShellScript(
-                """
-                ( [ -e /run/ostree-booted ] || [ -L /ostree ] ) && echo yes || echo no
-                """
-            ).to_shell_command(),
-        )
-
-        if output is None or output.stdout is None:
-            return None
-
-        return output.stdout.strip() == 'yes'
-
-    def _query_is_image_mode(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether guest is an image mode based system.
-
-        An image mode based system has the image set to a image reference.
-        In case ``bootc`` is installed on a non image mode system, it
-        reports ``null``.
-        """
-
-        # Note: we cannot reuse `sudo_prefix` fact so we just recall the query
-        # function for now
-        sudo_prefix = self._query_sudo_prefix(guest)
-
-        command = Command("bootc", "status", "--format", "yaml")
-        if sudo_prefix:
-            command = Command(sudo_prefix) + command
-
-        image = self._query(guest, [(command, r'image: (.+)')])
-
-        # if bootc reports status and the image is not `image: null`, we are in image mode
-        if image and image != "null":
-            return True
-
-        return False
-
-    def _query_is_toolbox(self, guest: 'Guest') -> Optional[bool]:
-        # https://www.reddit.com/r/Fedora/comments/g6flgd/toolbox_specific_environment_variables/
-        output = self._execute(
-            guest,
-            ShellScript('[ -e /run/.toolboxenv ] && echo yes || echo no').to_shell_command(),
-        )
-
-        if output is None or output.stdout is None:
-            return None
-
-        return output.stdout.strip() == 'yes'
-
-    def _query_toolbox_container_name(self, guest: 'Guest') -> Optional[str]:
-        output = self._execute(
-            guest,
-            ShellScript('[ -e /run/.containerenv ] && echo yes || echo no').to_shell_command(),
-        )
-
-        if output is None or output.stdout is None:
-            return None
-
-        if output.stdout.strip() == 'no':
-            return None
-
-        output = self._execute(guest, Command('cat', '/run/.containerenv'))
-
-        if output is None or output.stdout is None:
-            return None
-
-        for line in output.stdout.splitlines():
-            if line.startswith('name="'):
-                return line[6:-1]
-
-        return None
-
-    def _query_is_container(self, guest: 'Guest') -> Optional[bool]:
-        """
-        Detect whether guest is a container (running systemd)
-
-        In containers running systemd pid 1 has environment variable ``container`` set
-        (e.g. container=podman). See https://systemd.io/CONTAINER_INTERFACE/ for more details.
-        """
-        output = self._execute(guest, ShellScript('echo -n "$container"').to_shell_command())
-
-        if output is None or output.stdout is None:
-            return None
-
-        return len(output.stdout) > 0
-
-    def _query_capabilities(self, guest: 'Guest') -> dict[GuestCapability, bool]:
-        # TODO: there must be a canonical way of getting permitted capabilities.
-        # For now, we're interested in whether we can access kernel message buffer.
-        return {
-            GuestCapability.SYSLOG_ACTION_READ_ALL: True,
-            GuestCapability.SYSLOG_ACTION_READ_CLEAR: True,
-        }
+        return facts
 
     def sync(self, guest: 'Guest', *facts: str) -> None:
         """
@@ -1147,44 +1026,15 @@ class GuestFacts(SerializableContainer):
             ``is_container`` - will be synced.
         """
 
-        if facts:
-            for fact in facts:
-                if not hasattr(self, fact):
-                    raise GeneralError(f"Cannot sync unknown guest fact '{fact}'.")
+        output = guest.execute(
+            self._create_collection_script(*(facts or self._facts().keys())).to_shell_command(),
+            silent=True,
+        )
 
-                method_name = f'_query_{fact}'
+        if not output.stdout:
+            return
 
-                if not hasattr(self, method_name):
-                    raise GeneralError(
-                        f"Cannot sync guest fact '{fact}', query method '{method_name}' not found."
-                    )
-
-                setattr(self, fact, getattr(self, method_name)(guest))
-
-        else:
-            self.os_release_content = self._fetch_keyval_file(guest, Path('/etc/os-release'))
-            self.lsb_release_content = self._fetch_keyval_file(guest, Path('/etc/lsb-release'))
-
-            self.arch = self._query_arch(guest)
-            self.distro = self._query_distro(guest)
-            self.kernel_release = self._query_kernel_release(guest)
-            self.package_manager = self._query_package_manager(guest)
-            self.bootc_builder = self._query_bootc_builder(guest)
-            self.has_selinux = self._query_has_selinux(guest)
-            self.has_systemd = self._query_has_systemd(guest)
-            self.systemd_soft_reboot = self._query_systemd_soft_reboot(guest)
-            self.has_rsync = self._query_has_rsync(guest)
-            self.is_superuser = self._query_is_superuser(guest)
-            self.can_sudo = self._query_can_sudo(guest)
-            self.sudo_prefix = self._query_sudo_prefix(guest)
-            self.is_ostree = self._query_is_ostree(guest)
-            self.is_image_mode = self._query_is_image_mode(guest)
-            self.distro_id = self._query_distro_id(guest)
-            self.distro_major_version = self._query_distro_major_version(guest)
-            self.is_toolbox = self._query_is_toolbox(guest)
-            self.toolbox_container_name = self._query_toolbox_container_name(guest)
-            self.is_container = self._query_is_container(guest)
-            self.capabilities = self._query_capabilities(guest)
+        self._raw_facts.update(self._extract_facts(output.stdout))
 
         self.in_sync = True
 
@@ -1192,46 +1042,222 @@ class GuestFacts(SerializableContainer):
         """
         Format facts for pretty printing.
 
-        :yields: three-item tuples: the field name, its pretty label, and formatted representation
-            of its value.
+        :yields: three-item tuples: the field name, its pretty label,
+            and formatted representation of its value.
         """
 
-        def _value(field: str, label: str) -> tuple[str, str, str]:
-            v = getattr(self, field)
+        for fact in self._facts():
+            label = fact.replace('_', ' ')
+            value = getattr(self, fact)
 
-            return field, label, v or 'unknown'
+            if value is None:
+                yield fact, label, 'unknown'
 
-        def _flag(field: str, label: str) -> tuple[str, str, str]:
-            v = getattr(self, field)
+            elif isinstance(value, bool):
+                yield fact, label, 'yes' if value else 'no'
 
-            return field, label, 'yes' if v else 'no'
+            elif isinstance(value, str):
+                yield fact, label, value
 
-        yield _value('arch', 'arch')
-        yield _value('distro', 'distro')
-        yield _value('kernel_release', 'kernel')
-        yield _value('package_manager', 'package manager')
-        yield _value('bootc_builder', 'bootc builder')
-        yield _flag('is_container', 'is container')
-        yield _flag('is_ostree', 'is ostree')
-        yield _flag('is_image_mode', 'is image mode')
-        yield _value('distro_id', 'distro id')
-        yield _value('distro_major_version', 'distro major version')
-        yield _flag('is_toolbox', 'is toolbox')
-        yield _flag('has_selinux', 'selinux')
-        yield _flag('has_systemd', 'systemd')
-        yield _flag('systemd_soft_reboot', 'systemd soft-reboot')
-        yield _flag('has_rsync', 'rsync')
-        yield _flag('is_superuser', 'is superuser')
-        yield _flag('can_sudo', 'can sudo')
+            elif isinstance(value, dict):
+                pass
+
+            else:
+                raise GeneralError(f"Undefined formatting of guest fact '{fact}'.")
+
+    def has_capability(self, cap: GuestCapability) -> bool:
+        """Check if the guest has a specific capability."""
+        if not self.capabilities:
+            return False
+        return self.capabilities.get(cap, False)
+
+    #: Content of the ``/etc/os-release`` file. If the file does not
+    #: exist, the mapping will be empty.
+    os_release_content = keyval_guest_fact(Path('/etc/os-release'))
+
+    #: Content of the ``/etc/lsb-release`` file. If the file does not
+    #: exist, the mapping will be empty.
+    lsb_release_content = keyval_guest_fact(Path('/etc/lsb-release'))
+
+    #: Architecture of the guest, as reported by the ``arch`` command.
+    arch = string_guest_fact("uname -m || echo 'unknown'")
+
+    #: Name of the distribution on the guest.
+    distro = string_guest_fact(
+        """
+        if [ -f /etc/os-release ] && grep -q 'PRETTY_NAME=' /etc/os-release; then
+            grep '^PRETTY_NAME=' /etc/os-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/'
+
+        elif [ -f /etc/lsb-release ] && grep -q 'DISTRIB_DESCRIPTION=' /etc/lsb-release; then
+            grep '^DISTRIB_DESCRIPTION=' /etc/lsb-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/'
+
+        elif [ -f /etc/redhat-release ]; then
+            cat /etc/redhat-release
+
+        elif [ -f /etc/fedora-release ]; then
+            cat /etc/fedora-release
+
+        else
+            echo 'unknown'
+        fi
+        """  # noqa: E501
+    )
+
+    distro_id = string_guest_fact(
+        """
+        if [ -f /etc/os-release ] && grep -q 'ID=' /etc/os-release; then
+            grep '^ID=' /etc/os-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/'
+
+        elif [ -f /etc/lsb-release ] && grep -q 'DISTRIB_ID=' /etc/lsb-release; then
+            grep '^DISTRIB_ID=' /etc/lsb-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/'
+
+        else
+            echo 'unknown'
+        fi
+        """
+    )
+
+    distro_major_version = string_guest_fact(
+        """
+        if [ -f /etc/os-release ] && grep -q 'VERSION_ID=' /etc/os-release; then
+            grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/' | cut -d'.' -f1
+
+        elif [ -f /etc/lsb-release ] && grep -q 'DISTRIB_ID=' /etc/lsb-release; then
+            grep '^DISTRIB_ID=' /etc/lsb-release | cut -d'=' -f2- | sed 's/^\\"\\(.*\\)\\"$/\\1/' | cut -d'.' -f1
+
+        else
+            echo 'unknown'
+        fi
+        """
+    )
+
+    #: Release of the running kernel, as reported by the ``uname -r``
+    #: command.
+    kernel_release = string_guest_fact("uname -r || echo 'unknown'")
+
+    #: Whether SELinux is present and enabled.
+    has_selinux = flag_guest_fact(
+        "if [ -e /sys/fs/selinux/enforce ]; then echo 'true'; else echo 'false'; fi",
+    )
+
+    #: Whether systemd is available.
+    has_systemd = flag_guest_fact(
+        "if systemctl --version 1>&2; then echo 'true'; else echo 'false'; fi",
+    )
+
+    #: Whether systemd soft-reboot is supported.
+    systemd_soft_reboot = flag_guest_fact(
+        """
+        if systemctl --help | grep -q 'soft-reboot' && [ -f /proc/sys/kernel/random/boot_id ]; then
+            echo 'true'
+        else
+            echo 'false'
+        fi
+        """
+    )
+
+    #: Whether rsync is available.
+    has_rsync = flag_guest_fact("if rsync --version 1>&2; then echo 'true'; else echo 'false'; fi")
+
+    #: Whether the current user is superuser.
+    is_superuser = flag_guest_fact(
+        'if [ "$(whoami)" = "root" ]; then echo \'true\'; else echo \'false\'; fi'
+    )
+
+    #: Whether the current user can use ``sudo``.
+    can_sudo = flag_guest_fact("if sudo -n true 1>&2; then echo 'true'; else echo 'false'; fi")
+
+    #: A prefix to use when invoking commands with ``sudo``.
+    sudo_prefix = string_guest_fact(
+        """
+        if [ "$(whoami)" = "root" ]; then
+            echo ''
+        elif sudo -n true 1>&2; then
+            echo 'sudo'
+        else
+            echo ''
+        fi
+        """
+    )
+
+    #: Whether the guest is an OSTree-based system.
+    is_ostree = flag_guest_fact(
+        "if [ -e /run/ostree-booted ] || [ -L /ostree ]; then echo 'true'; else echo 'false'; fi",
+    )
+
+    #: Whether the guest is an image-mode system.
+    #:
+    #: An image mode based system has the image set to a image reference.
+    #: In case ``bootc`` is installed on a non image mode system, it
+    #: reports ``null``.
+    is_image_mode = flag_guest_fact(
+        """
+        if type bootc &> /dev/null; then
+            image="$(sudo bootc status --format yaml | grep -Po 'image: \\K(.*)')"
+
+            if [ -n "$image" ]; then
+                if [ "$image" = "null" ]; then echo 'false'; else echo 'true'; fi
+            else
+                echo 'unknown'
+            fi
+        else
+            echo 'false'
+        fi
+        """
+    )
+
+    #: Whether the guest is a toolbox container
+    is_toolbox = flag_guest_fact(
+        "if [ -e /run/.toolboxenv ]; then echo 'true'; else echo 'false'; fi"
+    )
+
+    #: Name of the toolbox container (if applicable).
+    toolbox_container_name = string_guest_fact(
+        """
+        if [ -e /run/.containerenv ]; then
+            if grep -q '^name=' /run/.containerenv; then
+                grep '^name=' /run/.containerenv | sed 's/^name=\\"\\(.*\\)\\"$/\\1/'
+            else
+                echo 'unknown'
+            fi
+        else
+            echo 'unknown'
+        fi
+        """
+    )
+
+    #: Whether the guest is a container.
+    is_container = flag_guest_fact(
+        'if [ -n "${container:-}" ]; then echo \'true\'; else echo \'false\'; fi'
+    )
+
+    #: Name of the package manager available on the guest.
+    package_manager = package_manager_guest_fact()
+
+    #: name of the bootc builder available on the guest.
+    bootc_builder = package_manager_guest_fact(lambda pm: pm.bootc_builder)
+
+    #: Various Linux capabilities and whether they are permitted.
+    capabilities: dict[GuestCapability, bool] = field(
+        default_factory=lambda: {
+            GuestCapability.SYSLOG_ACTION_READ_ALL: True,
+            GuestCapability.SYSLOG_ACTION_READ_CLEAR: True,
+        },
+        serialize=lambda capabilities: (
+            {capability.value: enabled for capability, enabled in capabilities.items()}
+            if capabilities
+            else {}
+        ),
+        unserialize=lambda raw_value: {
+            GuestCapability(raw_capability): enabled
+            for raw_capability, enabled in raw_value.items()
+        },
+    )
 
 
 GUEST_FACTS_INFO_FIELDS: list[str] = ['arch', 'distro']
 GUEST_FACTS_VERBOSE_FIELDS: list[str] = [
-    # SIM118: Use `{key} in {dict}` instead of `{key} in {dict}.keys()`
-    # "NormalizeKeysMixin" has no attribute "__iter__" (not iterable)
-    key
-    for key in GuestFacts.keys()  # noqa: SIM118
-    if key not in GUEST_FACTS_INFO_FIELDS
+    key for key in GuestFacts._facts() if key not in GUEST_FACTS_INFO_FIELDS
 ]
 
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1002,6 +1002,55 @@ class GuestFacts(SerializableContainer):
             them with markers for the future parsing.
         """
 
+        # Add required facts as well. If we are given a subset of facts,
+        # make sure we include all their requirements.
+        #
+        # We just care about adding them to the list of facts to emit;
+        # the correct order will be resolved below, when emitting snippets.
+
+        if facts:
+            # Facts that already have their requirements resolved. Starting
+            # as an empty set, and facts - initial and required - will be
+            # added as we encounter them.
+            facts_with_resolved_requires = set()
+
+            # Facts with unresolved requirements. All initial facts start
+            # here, and all requirements are added as we go, to resolve
+            # their requirements as well.
+            facts_with_unresolved_requires = set(facts)
+
+            while facts_with_unresolved_requires:
+                name = facts_with_unresolved_requires.pop()
+                fact = self._facts()[name]
+
+                # No requirements? Cool, resolved.
+                if not fact.requires:
+                    facts_with_resolved_requires.add(name)
+                    continue
+
+                # Let's see which requirements are still pending.
+                pending_requires = {
+                    name for name in fact.requires if name not in facts_with_resolved_requires
+                }
+
+                # No pending requirements? Also nice, resolved.
+                if not pending_requires:
+                    facts_with_resolved_requires.add(name)
+                    continue
+
+                # We are left with some pending requirements, add them
+                # to the stack, and resolve their requirements as well.
+                facts_with_unresolved_requires.update(pending_requires)
+
+            facts = tuple(facts_with_resolved_requires)
+
+        # Facts that remain to be emitted into the collection script.
+        pending_facts = [
+            (name, fact, snippet)
+            for name, fact, snippet in self._fact_snippets[:]
+            if name in facts
+        ]
+
         # Since facts may have requirements, we need some basic ordering.
         # It is really trivial: facts are processed in a queue-like
         # fashion; if a fact requires facts that have not been yet emitted
@@ -1010,12 +1059,6 @@ class GuestFacts(SerializableContainer):
         # Hopefully, we would then emit the required facts first, then
         # reaching those that were blocked.
 
-        # Facts that remain to be emitted into the collection script.
-        pending_facts = [
-            (name, fact, snippet)
-            for name, fact, snippet in self._fact_snippets[:]
-            if name in facts
-        ]
         # Facts that were already emitted into the collection script.
         # If a pending fact requires these, it can be emitted as well
         # since its requirements are already ready.

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -717,10 +717,14 @@ class guest_fact(Generic[T]):  # noqa: N801
     #: the descriptor API.
     name: Optional[str]
 
+    #: If set, the listed guest facts must be discovered before this one.
+    requires: tuple[str, ...]
+
     def __init__(
         self,
         probe: Union[str, Callable[[], str]],
         extract: Callable[[str], T],
+        *requires: str,
     ) -> None:
         """
         Initialize a fact collector.
@@ -734,6 +738,9 @@ class guest_fact(Generic[T]):  # noqa: N801
             the shell snippet, and returns the actual value of the fact,
             to be assigned to the corresponding :py:class:`GuestFacts`
             attribute.
+        :param requires: if set, the listed guest facts must be
+            discovered before this one. Fact discovery will reorder
+            snippets to honor the given requirements.
         """
 
         if isinstance(probe, str):
@@ -745,6 +752,8 @@ class guest_fact(Generic[T]):  # noqa: N801
         self.extract = extract
 
         self.name = None
+
+        self.requires = requires
 
     def __set_name__(self, owner: type, name: str) -> None:
         """
@@ -801,9 +810,11 @@ class flag_guest_fact(guest_fact[Optional[bool]]):  # noqa: N801
     A guest fact whose value is a booleab flag.
     """
 
-    def __init__(self, probe: str) -> None:
+    def __init__(self, probe: str, *requires: str) -> None:
         super().__init__(
-            probe, lambda output: output.strip() == 'true' if output.strip() != 'unknown' else None
+            probe,
+            lambda output: output.strip() == 'true' if output.strip() != 'unknown' else None,
+            *requires,
         )
 
 
@@ -843,8 +854,8 @@ class keyval_guest_fact(guest_fact[dict[str, str]]):  # noqa: N801
 
         return result
 
-    def __init__(self, path: Path) -> None:
-        super().__init__(f"cat {shlex.quote(str(path))}", keyval_guest_fact._parse)
+    def __init__(self, path: Path, *requires: str) -> None:
+        super().__init__(f"cat {shlex.quote(str(path))}", keyval_guest_fact._parse, *requires)
 
 
 class package_manager_guest_fact(guest_fact[Optional['tmt.package_managers.GuestPackageManager']]):  # noqa: N801
@@ -854,6 +865,7 @@ class package_manager_guest_fact(guest_fact[Optional['tmt.package_managers.Guest
 
     def __init__(
         self,
+        *requires: str,
         predicate: Optional[
             Callable[[type['tmt.package_managers.PackageManager[Any]']], bool]
         ] = None,
@@ -881,7 +893,7 @@ class package_manager_guest_fact(guest_fact[Optional['tmt.package_managers.Guest
 
             return output.splitlines()[0]
 
-        super().__init__(_snippet_creator, _extract)
+        super().__init__(_snippet_creator, _extract, *requires)
 
 
 @container
@@ -908,8 +920,8 @@ class GuestFacts(SerializableContainer):
 
     For example, a probe for the :py:attr:`arch` fact is simple, it calls
     the ``arch`` command. The corresponding extractor is also trivial,
-    and takes the output produced by the probe - a raw output of
-    ``arch`` - and returns it as the value of the ``arch`` fact.
+    and takes the output produced by the probe - a raw output of the
+    ``arch`` command - and returns it as the value of the ``arch`` fact.
 
     Probes of flag-like facts, :py:attr:`has_selinux` for example, usually
     test some system property, and echo ``true`` or ``false``. The
@@ -921,6 +933,15 @@ class GuestFacts(SerializableContainer):
     the actual values, and updates :py:attr:`_raw_facts` mapping.
     Descriptors then return values from this mapping instead of running
     any additional code on the guest.
+
+    In the collection shell script, every probe output is is assigned to
+    a variable of the same name as the fact (``arch`` shell variable
+    holds the output of the ``arch``  probe snippet, and so on). Probes
+    invoked later in the sequence can use previously probed facts in
+    their own probes; to make sure the required variables have been set,
+    the fact must enumerate required facts in its
+    :py:attr:`guest_fact.requires` attribute - the collectionshell script
+    will then run probes in the necessary order.
     """
 
     #: Store the actual values of facts. This mapping serves as a
@@ -945,7 +966,7 @@ class GuestFacts(SerializableContainer):
         }
 
     @functools.cached_property
-    def _fact_snippets(self) -> dict[str, str]:
+    def _fact_snippets(self) -> list[tuple[str, guest_fact[Any], str]]:
         """
         Collect all fact collection snippets from the facts.
 
@@ -953,10 +974,14 @@ class GuestFacts(SerializableContainer):
             as values.
         """
 
-        return {
-            name: (value.snippet if hasattr(value, 'snippet') else value.snippet_creator())
+        return [
+            (
+                name,
+                value,
+                (value.snippet if hasattr(value, 'snippet') else value.snippet_creator()),
+            )
             for name, value in self._facts().items()
-        }
+        ]
 
     def _create_collection_script(self, *facts: str) -> ShellScript:
         """
@@ -966,15 +991,84 @@ class GuestFacts(SerializableContainer):
             them with markers for the future parsing.
         """
 
-        scripts: list[str] = []
+        # Since facts may have requirements, we need some basic ordering.
+        # It is really trivial: facts are processed in a queue-like
+        # fashion; if a fact requires facts that have not been yet emitted
+        # into the collection script, the fact is put at the end of the
+        # queue, and we try to continue with the next fact in the queue.
+        # Hopefully, we would then emit the required facts first, then
+        # reaching those that were blocked.
 
-        for fact, snippet in self._fact_snippets.items():
-            if fact not in facts:
-                continue
+        # Facts that remain to be emitted into the collection script.
+        pending_facts = [
+            (name, fact, snippet)
+            for name, fact, snippet in self._fact_snippets[:]
+            if name in facts
+        ]
+        # Facts that were already emitted into the collection script.
+        # If a pending fact requires these, it can be emitted as well
+        # since its requirements are already ready.
+        emitted_facts: set[str] = set()
+        # Facts that cannot be emitted into the collection script because
+        # one or more of their requirements are still pending.
+        blocked_facts: set[str] = set()
 
+        scripts: list[str] = [f'unset {name}' for name, _, _ in pending_facts if name in facts]
+
+        def _emit_fact_probe(name: str, fact: guest_fact[Any], snippet: str) -> None:
             # The extra `echo` is there to enforce at least one empty line
             # in the output.
-            scripts.append(f'echo ">>> {fact}"\n{snippet}\necho\necho "<<<"\n')
+            scripts.append(
+                '\n'.join(
+                    [
+                        f'{name}=$({snippet})',
+                        f'echo ">>> {name}"',
+                        f'echo "${name}"',
+                        'echo "<<<"',
+                    ]
+                )
+            )
+
+            # Let others know this fact is done, ...
+            emitted_facts.add(name)
+
+            # ... and if it was blocked, clear the flag.
+            blocked_facts.discard(name)
+
+        while pending_facts:
+            name, fact, snippet = pending_facts.pop(0)
+
+            # No requirements? Cool, emit the snippet.
+            if not fact.requires:
+                _emit_fact_probe(name, fact, snippet)
+                continue
+
+            # Let's see which requirements are still pending.
+            pending_requires = {
+                required_fact
+                for required_fact in fact.requires
+                if required_fact not in emitted_facts
+            }
+
+            # No pending requirements? Also nice, emit the snippet.
+            if not pending_requires:
+                _emit_fact_probe(name, fact, snippet)
+                continue
+
+            # If we already saw this fact, and we already mark it as
+            # blocked, landing here means we processed all requirements
+            # positioned in the queue before it, and yet we are still
+            # left with one or more pending requirements. Moving it at
+            # the end of the queue and trying again will not help.
+            if name in blocked_facts:
+                raise GeneralError(
+                    f"Guest fact '{name}' remains blocked by required facts {pending_facts}."
+                )
+
+            # Ok, first time resolving requirements of this fact: mark
+            # it as blocked, and move it to the end of the queue.
+            blocked_facts.add(name)
+            pending_facts.append((name, fact, snippet))
 
         return ShellScript('\n\n'.join(scripts))
 
@@ -1193,7 +1287,7 @@ class GuestFacts(SerializableContainer):
     is_image_mode = flag_guest_fact(
         """
         if type bootc &> /dev/null; then
-            image="$(sudo bootc status --format yaml | grep -Po 'image: \\K(.*)')"
+            image="$($sudo_prefix bootc status --format yaml | grep -Po 'image: \\K(.*)')"
 
             if [ -n "$image" ]; then
                 if [ "$image" = "null" ]; then echo 'false'; else echo 'true'; fi
@@ -1203,7 +1297,8 @@ class GuestFacts(SerializableContainer):
         else
             echo 'false'
         fi
-        """
+        """,
+        'sudo_prefix',
     )
 
     #: Whether the guest is a toolbox container
@@ -1235,7 +1330,7 @@ class GuestFacts(SerializableContainer):
     package_manager = package_manager_guest_fact()
 
     #: name of the bootc builder available on the guest.
-    bootc_builder = package_manager_guest_fact(lambda pm: pm.bootc_builder)
+    bootc_builder = package_manager_guest_fact(predicate=lambda pm: pm.bootc_builder)
 
     #: Various Linux capabilities and whether they are permitted.
     capabilities: dict[GuestCapability, bool] = field(

--- a/tmt/steps/scripts.py
+++ b/tmt/steps/scripts.py
@@ -204,7 +204,7 @@ TMT_ETC_PROFILE_D = ScriptTemplate(
         )
     },
     # ignore[has-type]: mypy seems to not understand annotations here.
-    enabled=lambda guest: guest.facts.is_ostree is True,
+    enabled=lambda guest: guest.facts.is_ostree is True,  # type: ignore[has-type]
 )
 
 

--- a/tmt/steps/scripts.py
+++ b/tmt/steps/scripts.py
@@ -211,7 +211,7 @@ TMT_ETC_PROFILE_D = ScriptTemplate(
         )
     },
     # ignore[has-type]: mypy seems to not understand annotations here.
-    enabled=lambda guest: guest.facts.is_ostree is True,
+    enabled=lambda guest: guest.facts.is_ostree is True,  # type: ignore[has-type]
 )
 
 

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1134,7 +1134,7 @@ class ShellScript:
             wrapper.
         """
 
-        self._script = textwrap.dedent(script)
+        self._script = textwrap.dedent(script).strip()
 
     def __str__(self) -> str:
         return self._script

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -566,7 +566,7 @@ class ShellScript:
             wrapper.
         """
 
-        self._script = textwrap.dedent(script)
+        self._script = textwrap.dedent(script).strip()
 
     def __str__(self) -> str:
         return self._script


### PR DESCRIPTION
TL;DR: guest fact discovery now runs as a single remote command, whose
output is then parsed into values of individual facts.

* Each fact attribute is now defined with a descriptor (see [1]). It
  keeps the proper type annotation, but we can attach more information.
* Each probe is now a shell script snippet, and is attached to its
  owning fact.
* Snippets are collected, joined, and the resulting script is executed.
  `GuestFacts` then processes the output, delivers discovered values to
  the right attributes.
* No Python code in probes, custom Python code to handle decoding of the
  script output fully supported (and used, see package manager facts).

For the tmt code, nothing changes, `GuestFacts` API remains the same.

[1] https://docs.python.org/3/howto/descriptor.html

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation