### PR TITLE
Document TMT_TREE data persistence limitations

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -630,12 +630,12 @@ TMT_TREE
 
     .. warning::
 
-        Do not use ``TMT_TREE`` for storing data that needs to persist
-        between steps. There is no guarantee that data written to this
-        directory will be preserved across steps. Use ``TMT_PLAN_DATA``
-        for data that needs to persist between steps (e.g., from
-        ``prepare`` to ``execute``). For test-specific artifacts during
-        test execution, use ``TMT_TEST_DATA`` instead.
+        Do not use ``TMT_TREE`` to store data that must persist between steps,
+        as its contents are not guaranteed to be preserved.
+
+        Use ``TMT_PLAN_DATA`` for sharing data across steps (e.g., from
+        ``prepare`` to ``execute``) and ``TMT_TEST_DATA`` for test-specific
+        artifacts.
 
 TMT_PLAN_DATA
     Path to the common directory used for storing logs and other

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -628,11 +628,22 @@ TMT_TREE
     tmt plans are located in. Notice that it might not contain tmt
     tests if tmt plans and tests are in different git repositories.
 
+    .. warning::
+
+        Do not use ``TMT_TREE`` for storing data that needs to persist
+        between steps. There is no guarantee that data written to this
+        directory will be preserved across steps. Use ``TMT_PLAN_DATA``
+        for data that needs to persist between steps (e.g., from
+        ``prepare`` to ``execute``). For test-specific artifacts during
+        test execution, use ``TMT_TEST_DATA`` instead.
+
 TMT_PLAN_DATA
     Path to the common directory used for storing logs and other
-    artifacts related to the whole plan execution. It is pulled
-    back from the guest and available for inspection after the
-    plan is completed.
+    artifacts related to the whole plan execution. This is the
+    **recommended location** for storing any data that needs to
+    persist between steps (e.g., files generated during ``prepare``
+    that are needed during ``execute``). It is pulled back from the
+    guest and available for inspection after the plan is completed.
 
 TMT_PLAN_ENVIRONMENT_FILE
     Path to the file containing environment variables that should
@@ -688,7 +699,10 @@ TMT_TEST_DATA
     Path to the directory where test can store logs and other
     artifacts generated during its execution. These will be pulled
     back from the guest and available for inspection after the
-    test execution is finished.
+    test execution is finished. Note that this directory is
+    test-specific and not shared across tests. If you need to
+    share data between steps (e.g., from ``prepare`` to ``execute``),
+    use ``TMT_PLAN_DATA`` instead.
 
 TMT_TEST_SERIAL_NUMBER
     The serial number of running test in the whole plan. Each test

--- a/docs/releases/pending/4543.fmf
+++ b/docs/releases/pending/4543.fmf
@@ -1,0 +1,6 @@
+description: |
+    Added documentation warning that ``TMT_TREE`` should not be used
+    for storing persistent data between steps. The :ref:`step-variables`
+    section now clearly guides users to use ``TMT_PLAN_DATA`` for data
+    that needs to persist across steps, and ``TMT_TEST_DATA`` for
+    test-specific artifacts.

--- a/spec/plans/prepare.fmf
+++ b/spec/plans/prepare.fmf
@@ -45,6 +45,10 @@ description: |
         move or copy them into ``${TMT_PLAN_DATA}`` directory. Only
         files in this directory are guaranteed to be preserved.
 
+        Do **not** store persistent data in ``${TMT_TREE}``. There is no
+        guarantee that data written to this directory will persist between
+        steps. See :ref:`step-variables` for more details.
+
 example: |
     # Install fresh packages from a custom copr repository
     prepare:


### PR DESCRIPTION
Add warnings and guidance about data persistence behavior in tmt:

- Add warning to TMT_TREE that data written to this directory is not guaranteed to persist between steps
- Update TMT_PLAN_DATA description to emphasize it as the recommended location for storing persistent data across steps
- Add note to TMT_TEST_DATA clarifying it is test-specific and pointing users to TMT_PLAN_DATA for cross-step data sharing
- Expand the prepare step documentation with a warning about TMT_TREE and cross-reference to the step-variables documentation

This helps users avoid a common pitfall where data stored in TMT_TREE may or may not persist depending on the provisioner used, leading to inconsistent behavior between local development and CI environments.

Assisted-by: Claude Code

Resolves #4543 

Pull Request Checklist:
* [x] write the documentation
* [x] include a release note
