### PR TITLE
Rename various `env` parameters to `environment`

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -701,7 +701,9 @@ def test_run_interactive_not_joined(tmppath, root_logger):
     output = (
         ShellScript("echo abc; echo def >2")
         .to_shell_command()
-        .run(shell=True, interactive=True, cwd=tmppath, env={}, log=None, logger=root_logger)
+        .run(
+            shell=True, interactive=True, cwd=tmppath, environment={}, log=None, logger=root_logger
+        )
     )
     assert output.stdout is None
     assert output.stderr is None
@@ -715,7 +717,7 @@ def test_run_interactive_joined(tmppath, root_logger):
             shell=True,
             interactive=True,
             cwd=tmppath,
-            env={},
+            environment={},
             join=True,
             log=None,
             logger=root_logger,
@@ -727,7 +729,7 @@ def test_run_interactive_joined(tmppath, root_logger):
 
 def test_run_not_joined_stdout(root_logger):
     output = Command("ls", "/").run(
-        shell=False, cwd=Path.cwd(), env={}, log=None, logger=root_logger
+        shell=False, cwd=Path.cwd(), environment={}, log=None, logger=root_logger
     )
     assert "sbin" in output.stdout
 
@@ -736,7 +738,7 @@ def test_run_not_joined_stderr(root_logger):
     output = (
         ShellScript("ls non_existing || true")
         .to_shell_command()
-        .run(shell=False, cwd=Path.cwd(), env={}, log=None, logger=root_logger)
+        .run(shell=False, cwd=Path.cwd(), environment={}, log=None, logger=root_logger)
     )
     assert "ls: cannot access" in output.stderr
 
@@ -745,7 +747,7 @@ def test_run_joined(root_logger):
     output = (
         ShellScript("ls non_existing / || true")
         .to_shell_command()
-        .run(shell=False, cwd=Path.cwd(), env={}, log=None, join=True, logger=root_logger)
+        .run(shell=False, cwd=Path.cwd(), environment={}, log=None, join=True, logger=root_logger)
     )
     assert "ls: cannot access" in output.stdout
     assert "sbin" in output.stdout
@@ -764,7 +766,7 @@ def test_run_big(root_logger):
     output = (
         ShellScript(textwrap.dedent(script))
         .to_shell_command()
-        .run(shell=False, cwd=Path.cwd(), env={}, log=None, join=True, logger=root_logger)
+        .run(shell=False, cwd=Path.cwd(), environment={}, log=None, join=True, logger=root_logger)
     )
     assert "n n" in output.stdout
     assert len(output.stdout) == 200000

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -698,7 +698,9 @@ def test_run_interactive_not_joined(tmppath, root_logger):
     output = (
         ShellScript("echo abc; echo def >2")
         .to_shell_command()
-        .run(shell=True, interactive=True, cwd=tmppath, env={}, log=None, logger=root_logger)
+        .run(
+            shell=True, interactive=True, cwd=tmppath, environment={}, log=None, logger=root_logger
+        )
     )
     assert output.stdout is None
     assert output.stderr is None
@@ -712,7 +714,7 @@ def test_run_interactive_joined(tmppath, root_logger):
             shell=True,
             interactive=True,
             cwd=tmppath,
-            env={},
+            environment={},
             join=True,
             log=None,
             logger=root_logger,
@@ -724,7 +726,7 @@ def test_run_interactive_joined(tmppath, root_logger):
 
 def test_run_not_joined_stdout(root_logger):
     output = Command("ls", "/").run(
-        shell=False, cwd=Path.cwd(), env={}, log=None, logger=root_logger
+        shell=False, cwd=Path.cwd(), environment={}, log=None, logger=root_logger
     )
     assert "sbin" in output.stdout
 
@@ -733,7 +735,7 @@ def test_run_not_joined_stderr(root_logger):
     output = (
         ShellScript("ls non_existing || true")
         .to_shell_command()
-        .run(shell=False, cwd=Path.cwd(), env={}, log=None, logger=root_logger)
+        .run(shell=False, cwd=Path.cwd(), environment={}, log=None, logger=root_logger)
     )
     assert "ls: cannot access" in output.stderr
 
@@ -742,7 +744,7 @@ def test_run_joined(root_logger):
     output = (
         ShellScript("ls non_existing / || true")
         .to_shell_command()
-        .run(shell=False, cwd=Path.cwd(), env={}, log=None, join=True, logger=root_logger)
+        .run(shell=False, cwd=Path.cwd(), environment={}, log=None, join=True, logger=root_logger)
     )
     assert "ls: cannot access" in output.stdout
     assert "sbin" in output.stdout
@@ -761,7 +763,7 @@ def test_run_big(root_logger):
     output = (
         ShellScript(textwrap.dedent(script))
         .to_shell_command()
-        .run(shell=False, cwd=Path.cwd(), env={}, log=None, join=True, logger=root_logger)
+        .run(shell=False, cwd=Path.cwd(), environment={}, log=None, join=True, logger=root_logger)
     )
     assert "n n" in output.stdout
     assert len(output.stdout) == 200000

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -1451,7 +1451,7 @@ class Plan(
                     url=str(reference.url),
                     destination=tmpdirname,
                     shallow=True,
-                    env=None,
+                    environment=None,
                     logger=self._logger,
                 )
 

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -1449,7 +1449,7 @@ class Plan(
                     url=str(reference.url),
                     destination=tmpdirname,
                     shallow=True,
-                    env=None,
+                    environment=None,
                     logger=self._logger,
                 )
 

--- a/tmt/cli/_root.py
+++ b/tmt/cli/_root.py
@@ -1994,7 +1994,11 @@ def setup_completion(shell: str, install: bool, context: Context, logger: tmt.lo
 
     completions = (
         Command('tmt')
-        .run(env=tmt.utils.Environment.from_dict(env_var), cwd=None, logger=context.obj.logger)
+        .run(
+            environment=tmt.utils.Environment.from_dict(env_var),
+            cwd=None,
+            logger=context.obj.logger,
+        )
         .stdout
     )
     if not completions:

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1603,14 +1603,14 @@ class CommandCollector(abc.ABC):
         *,
         sourced_files: Optional[list[Path]] = None,
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
     ) -> None:
         """
         Collect a command for later batch execution.
 
         :param command: the command to collect.
         :param cwd: working directory for the command.
-        :param env: environment variables for the command.
+        :param environment: environment variables for the command.
         """
 
         raise NotImplementedError
@@ -2162,7 +2162,7 @@ class Guest(
         friendly_command: Optional[str] = None,
         silent: bool = False,
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         interactive: bool = False,
         log: Optional[tmt.log.LoggingFunction] = None,
         **kwargs: Any,
@@ -2182,7 +2182,7 @@ class Guest(
             reduced.
         :param cwd: if set, command would be executed in the given directory,
             otherwise the current working directory is used.
-        :param env: environment variables to combine with the current environment
+        :param environment: environment variables to combine with the current environment
             before running the command.
         :param interactive: if set, the command would be executed in an interactive
             manner, i.e. with stdout and stdout connected to terminal for live
@@ -2200,7 +2200,7 @@ class Guest(
             friendly_command=friendly_command,
             silent=silent,
             cwd=cwd,
-            env=env,
+            environment=environment,
             interactive=interactive,
             log=log or self._command_verbose_logger,
             **kwargs,
@@ -2293,7 +2293,7 @@ class Guest(
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: Literal[True] = True,
@@ -2313,7 +2313,7 @@ class Guest(
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: Literal[False] = False,
@@ -2333,7 +2333,7 @@ class Guest(
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,
@@ -2351,7 +2351,7 @@ class Guest(
 
         :param command: either a command or a shell script to execute.
         :param cwd: if set, execute command in this directory on the guest.
-        :param env: if set, set these environment variables before running the command.
+        :param environment: if set, set these environment variables before running the command.
         :param friendly_command: nice, human-friendly representation of the command.
         :param immediately: if False, the command may be collected for later
             batch execution on guests that support it (e.g., bootc guests).
@@ -2865,7 +2865,7 @@ class GuestSsh(Guest, CommandCollector):
         *,
         sourced_files: Optional[list[Path]] = None,
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
     ) -> None:
         """
         Collect a command for image mode container build.
@@ -2886,7 +2886,7 @@ class GuestSsh(Guest, CommandCollector):
         # Build the command script using the same approach as execute()
         # Start with environment exports
         collected_commands: ShellScript = ShellScript.from_scripts(
-            self._prepare_command_environment(env).to_shell_exports()
+            self._prepare_command_environment(environment).to_shell_exports()
         )
 
         # Add working directory change (properly quoted like in execute())
@@ -3262,7 +3262,7 @@ class GuestSsh(Guest, CommandCollector):
                 friendly_command=friendly_command,
                 silent=silent,
                 cwd=parent.plan.worktree,
-                env=self._prepare_command_environment(),
+                environment=self._prepare_command_environment(),
                 log=log,
             )
         except tmt.utils.RunError as exc:
@@ -3316,7 +3316,7 @@ class GuestSsh(Guest, CommandCollector):
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: Literal[True] = True,
@@ -3336,7 +3336,7 @@ class GuestSsh(Guest, CommandCollector):
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: Literal[False] = False,
@@ -3355,7 +3355,7 @@ class GuestSsh(Guest, CommandCollector):
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,
@@ -3373,7 +3373,7 @@ class GuestSsh(Guest, CommandCollector):
 
         :param command: either a command or a shell script to execute.
         :param cwd: execute command in this directory on the guest.
-        :param env: if set, set these environment variables before running the command.
+        :param environment: if set, set these environment variables before running the command.
         :param friendly_command: nice, human-friendly representation of the command.
         :param test_session: if True, this is the actual test being run.
         :param immediately: if False, the command may be collected for later
@@ -3392,7 +3392,9 @@ class GuestSsh(Guest, CommandCollector):
         # For guests in image mode collect non testing commands with
         # immediately=False for later batch execution.
         if not immediately and self.facts.is_image_mode:
-            self.collect_command(command, sourced_files=sourced_files, cwd=cwd, env=env)
+            self.collect_command(
+                command, sourced_files=sourced_files, cwd=cwd, environment=environment
+            )
             return None
 
         # Abort if guest is unavailable
@@ -3417,7 +3419,7 @@ class GuestSsh(Guest, CommandCollector):
         # Accumulate all necessary commands - they will form a "shell" script, a single
         # string passed to SSH to execute on the remote machine.
         remote_commands: ShellScript = ShellScript.from_scripts(
-            self._prepare_command_environment(env).to_shell_exports()
+            self._prepare_command_environment(environment).to_shell_exports()
         )
 
         # Change to given directory on guest if cwd provided

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1649,14 +1649,14 @@ class CommandCollector(abc.ABC):
         *,
         sourced_files: Optional[list[Path]] = None,
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
     ) -> None:
         """
         Collect a command for later batch execution.
 
         :param command: the command to collect.
         :param cwd: working directory for the command.
-        :param env: environment variables for the command.
+        :param environment: environment variables for the command.
         """
 
         raise NotImplementedError
@@ -2205,7 +2205,7 @@ class Guest(
         friendly_command: Optional[str] = None,
         silent: bool = False,
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         interactive: bool = False,
         log: Optional[tmt.log.LoggingFunction] = None,
         **kwargs: Any,
@@ -2225,7 +2225,7 @@ class Guest(
             reduced.
         :param cwd: if set, command would be executed in the given directory,
             otherwise the current working directory is used.
-        :param env: environment variables to combine with the current environment
+        :param environment: environment variables to combine with the current environment
             before running the command.
         :param interactive: if set, the command would be executed in an interactive
             manner, i.e. with stdout and stdout connected to terminal for live
@@ -2243,7 +2243,7 @@ class Guest(
             friendly_command=friendly_command,
             silent=silent,
             cwd=cwd,
-            env=env,
+            environment=environment,
             interactive=interactive,
             log=log or self._command_verbose_logger,
             **kwargs,
@@ -2336,7 +2336,7 @@ class Guest(
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: Literal[True] = True,
@@ -2356,7 +2356,7 @@ class Guest(
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: Literal[False] = False,
@@ -2376,7 +2376,7 @@ class Guest(
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,
@@ -2394,7 +2394,7 @@ class Guest(
 
         :param command: either a command or a shell script to execute.
         :param cwd: if set, execute command in this directory on the guest.
-        :param env: if set, set these environment variables before running the command.
+        :param environment: if set, set these environment variables before running the command.
         :param friendly_command: nice, human-friendly representation of the command.
         :param immediately: if False, the command may be collected for later
             batch execution on guests that support it (e.g., bootc guests).
@@ -2928,7 +2928,7 @@ class GuestSsh(Guest, CommandCollector):
         *,
         sourced_files: Optional[list[Path]] = None,
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
     ) -> None:
         """
         Collect a command for image mode container build.
@@ -2949,7 +2949,7 @@ class GuestSsh(Guest, CommandCollector):
         # Build the command script using the same approach as execute()
         # Start with environment exports
         collected_commands: ShellScript = ShellScript.from_scripts(
-            self._prepare_command_environment(env).to_shell_exports()
+            self._prepare_command_environment(environment).to_shell_exports()
         )
 
         # Add working directory change (properly quoted like in execute())
@@ -3325,7 +3325,7 @@ class GuestSsh(Guest, CommandCollector):
                 friendly_command=friendly_command,
                 silent=silent,
                 cwd=parent.plan.worktree,
-                env=self._prepare_command_environment(),
+                environment=self._prepare_command_environment(),
                 log=log,
             )
         except tmt.utils.RunError as exc:
@@ -3380,7 +3380,7 @@ class GuestSsh(Guest, CommandCollector):
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: Literal[True] = True,
@@ -3400,7 +3400,7 @@ class GuestSsh(Guest, CommandCollector):
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: Literal[False] = False,
@@ -3419,7 +3419,7 @@ class GuestSsh(Guest, CommandCollector):
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,
@@ -3437,7 +3437,7 @@ class GuestSsh(Guest, CommandCollector):
 
         :param command: either a command or a shell script to execute.
         :param cwd: execute command in this directory on the guest.
-        :param env: if set, set these environment variables before running the command.
+        :param environment: if set, set these environment variables before running the command.
         :param friendly_command: nice, human-friendly representation of the command.
         :param test_session: if True, this is the actual test being run.
         :param immediately: if False, the command may be collected for later
@@ -3456,7 +3456,9 @@ class GuestSsh(Guest, CommandCollector):
         # For guests in image mode collect non testing commands with
         # immediately=False for later batch execution.
         if not immediately and self.facts.is_image_mode:
-            self.collect_command(command, sourced_files=sourced_files, cwd=cwd, env=env)
+            self.collect_command(
+                command, sourced_files=sourced_files, cwd=cwd, environment=environment
+            )
             return None
 
         # Abort if guest is unavailable
@@ -3481,7 +3483,7 @@ class GuestSsh(Guest, CommandCollector):
         # Accumulate all necessary commands - they will form a "shell" script, a single
         # string passed to SSH to execute on the remote machine.
         remote_commands: ShellScript = ShellScript.from_scripts(
-            self._prepare_command_environment(env).to_shell_exports()
+            self._prepare_command_environment(environment).to_shell_exports()
         )
 
         # Change to given directory on guest if cwd provided

--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -366,7 +366,7 @@ class BeakerLibFromUrl(BeakerLib):
                 url=self.url,
                 destination=clone_dir,
                 shallow=self.ref is None,
-                env=Environment({"GIT_ASKPASS": EnvVarValue("echo")}),
+                environment=Environment({"GIT_ASKPASS": EnvVarValue("echo")}),
                 logger=self._logger,
             )
             self._git_clone_cache[clone_dir] = self

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -3303,7 +3303,7 @@ class Login(Action):
     def _login(
         self,
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
     ) -> None:
         """
         Run the interactive command
@@ -3344,7 +3344,7 @@ class Login(Action):
                                 tmt.utils.ShellScript("/bin/true"),
                                 interactive=True,
                                 cwd=cwd,
-                                env=env,
+                                environment=environment,
                             )
                         except RunError:
                             cwd = worktree
@@ -3355,7 +3355,7 @@ class Login(Action):
             # Execute all requested commands
             for script in scripts:
                 try:
-                    guest.execute(script, interactive=True, cwd=cwd, env=env)
+                    guest.execute(script, interactive=True, cwd=cwd, environment=environment)
 
                 except RunError as exc:
                     # Interactive mode can return non-zero if the last command failed,
@@ -3367,14 +3367,14 @@ class Login(Action):
         self,
         results: list['tmt.result.Result'],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
     ) -> None:
         """
         Check and login after test execution
         """
 
         if self._enabled_by_results(results):
-            self._login(cwd, env)
+            self._login(cwd, environment)
 
 
 @container

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -3089,7 +3089,7 @@ class Login(Action):
     def _login(
         self,
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
     ) -> None:
         """
         Run the interactive command
@@ -3130,7 +3130,7 @@ class Login(Action):
                                 tmt.utils.ShellScript("/bin/true"),
                                 interactive=True,
                                 cwd=cwd,
-                                env=env,
+                                environment=environment,
                             )
                         except RunError:
                             cwd = worktree
@@ -3141,7 +3141,7 @@ class Login(Action):
             # Execute all requested commands
             for script in scripts:
                 try:
-                    guest.execute(script, interactive=True, cwd=cwd, env=env)
+                    guest.execute(script, interactive=True, cwd=cwd, environment=environment)
 
                 except RunError as exc:
                     # Interactive mode can return non-zero if the last command failed,
@@ -3153,14 +3153,14 @@ class Login(Action):
         self,
         results: list['tmt.base.core.Result'],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
     ) -> None:
         """
         Check and login after test execution
         """
 
         if self._enabled_by_results(results):
-            self._login(cwd, env)
+            self._login(cwd, environment)
 
 
 @container

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -286,7 +286,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT, None]):
                 url=url,
                 destination=self.test_dir,
                 shallow=self.data.ref is None,
-                env=Environment({"GIT_ASKPASS": EnvVarValue("echo")}),
+                environment=Environment({"GIT_ASKPASS": EnvVarValue("echo")}),
                 logger=self._logger,
             )
         elif self.data.url_content_type == "archive":

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -288,7 +288,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT, None]):
                 url=url,
                 destination=self.test_dir,
                 shallow=self.data.ref is None,
-                env=Environment({"GIT_ASKPASS": EnvVarValue("echo")}),
+                environment=Environment({"GIT_ASKPASS": EnvVarValue("echo")}),
                 logger=self._logger,
             )
         elif self.data.url_content_type == "archive":

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -523,7 +523,7 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
                 self.guest.execute,
                 command,
                 cwd=cwd,
-                env=self.environment,
+                environment=self.environment,
                 join=True,
                 interactive=interactive,
                 tty=self.test.tty,

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -526,7 +526,7 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
                 self.guest.execute,
                 command,
                 cwd=cwd,
-                env=self.environment,
+                environment=self.environment,
                 join=True,
                 interactive=interactive,
                 tty=self.test.tty,

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -648,7 +648,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                     else:
                         cwd = self.discover.workdir / test.path.unrooted()
                     self._login_after_test.after_test(
-                        invocation.results, cwd=cwd, env=invocation.environment
+                        invocation.results, cwd=cwd, environment=invocation.environment
                     )
 
         # Pull artifacts created in the plan data directory

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -156,7 +156,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
                         url=self.data.url,
                         destination=repo_path,
                         shallow=False,
-                        env=environment,
+                        environment=environment,
                         logger=self._logger,
                     )
 
@@ -225,7 +225,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             return guest.execute(
                 command=command,
                 cwd=worktree,
-                env=environment,
+                environment=environment,
                 sourced_files=[self.step.plan.plan_source_script],
                 immediately=False,
             )

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -159,7 +159,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
                         url=self.data.url,
                         destination=repo_path,
                         shallow=False,
-                        env=environment,
+                        environment=environment,
                         logger=self._logger,
                     )
 
@@ -228,7 +228,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             return guest.execute(
                 command=command,
                 cwd=worktree,
-                env=environment,
+                environment=environment,
                 sourced_files=[self.step.plan.plan_source_script],
                 immediately=False,
             )

--- a/tmt/steps/provision/bootc.py
+++ b/tmt/steps/provision/bootc.py
@@ -79,7 +79,7 @@ class GuestBootc(GuestTestcloud):
                 cwd=self.guest_workdir,
                 stream_output=True,
                 logger=self._logger,
-                env=PODMAN_ENV if self._rootless else None,
+                environment=PODMAN_ENV if self._rootless else None,
             )
 
         try:
@@ -283,7 +283,7 @@ class ProvisionBootc(tmt.steps.provision.ProvisionPlugin[BootcData]):
             cwd=self.phase_workdir,
             stream_output=True,
             logger=self._logger,
-            env=PODMAN_ENV if self._rootless else None,
+            environment=PODMAN_ENV if self._rootless else None,
         )
 
         return image_tag
@@ -307,7 +307,7 @@ class ProvisionBootc(tmt.steps.provision.ProvisionPlugin[BootcData]):
             cwd=self.phase_workdir,
             stream_output=True,
             logger=self._logger,
-            env=PODMAN_ENV if self._rootless else None,
+            environment=PODMAN_ENV if self._rootless else None,
         )
         return image_tag
 
@@ -341,7 +341,7 @@ class ProvisionBootc(tmt.steps.provision.ProvisionPlugin[BootcData]):
             cwd=self.phase_workdir,
             stream_output=True,
             logger=self._logger,
-            env=PODMAN_ENV if self._rootless else None,
+            environment=PODMAN_ENV if self._rootless else None,
         )
 
     def _init_podman_machine(self) -> None:

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -132,8 +132,7 @@ class GuestLocal(tmt.Guest):
         sourced_files = sourced_files or []
 
         # Prepare the environment (plan/cli variables override)
-        environment = tmt.utils.Environment()
-        environment.update(environment or {})
+        environment = environment or tmt.utils.Environment()
         if self.parent:
             environment.update(self.parent.plan.environment)
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -94,7 +94,7 @@ class GuestLocal(tmt.Guest):
                     '-i', 'localhost,',
                     playbook,
                 ),
-                env=self._prepare_command_environment(),
+                environment=self._prepare_command_environment(),
                 friendly_command=friendly_command,
                 log=log,
                 silent=silent,
@@ -112,7 +112,7 @@ class GuestLocal(tmt.Guest):
         self,
         command: Union[Command, ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,
@@ -133,7 +133,7 @@ class GuestLocal(tmt.Guest):
 
         # Prepare the environment (plan/cli variables override)
         environment = tmt.utils.Environment()
-        environment.update(env or {})
+        environment.update(environment or {})
         if self.parent:
             environment.update(self.parent.plan.environment)
 
@@ -155,7 +155,7 @@ class GuestLocal(tmt.Guest):
         # Run the command under the prepared environment
         return self._run_guest_command(
             actual_command,
-            env=environment,
+            environment=environment,
             log=log,
             friendly_command=friendly_command or str(command),
             silent=silent,

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -94,7 +94,7 @@ class GuestLocal(tmt.Guest):
                     '-i', 'localhost,',
                     playbook,
                 ),
-                env=self._prepare_command_environment(),
+                environment=self._prepare_command_environment(),
                 friendly_command=friendly_command,
                 log=log,
                 silent=silent,
@@ -112,7 +112,7 @@ class GuestLocal(tmt.Guest):
         self,
         command: Union[Command, ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,
@@ -135,7 +135,7 @@ class GuestLocal(tmt.Guest):
         # Accumulate all necessary commands - they will form a "shell" script, a single
         # string passed to a shell executed on the local host.
         script = ShellScript.from_scripts(
-            self._prepare_command_environment(env).to_shell_exports()
+            self._prepare_command_environment(environment).to_shell_exports()
         )
 
         for file in reversed(sourced_files or []):

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -311,7 +311,7 @@ class MockShell:
         command: Command,
         *,
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         log: Optional[tmt.log.LoggingFunction] = None,
         silent: bool = False,
@@ -353,9 +353,9 @@ class MockShell:
 
         shell_command_components: list[str] = [str(command)]
 
-        if env is not None:
+        if environment is not None:
             shell_command_components = [
-                *env.to_shell(),
+                *environment.to_shell(),
                 *shell_command_components,
             ]
 
@@ -547,7 +547,7 @@ class GuestMock(tmt.Guest):
         self,
         command: Union[Command, ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,
@@ -596,7 +596,7 @@ class GuestMock(tmt.Guest):
             *self.mock_shell.execute(
                 actual_command,
                 cwd=cwd,
-                env=env,
+                env=environment,
                 friendly_command=friendly_command or str(command),
                 logger=self._logger,
                 **kwargs,

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -312,7 +312,7 @@ class MockShell:
         command: Command,
         *,
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         log: Optional[tmt.log.LoggingFunction] = None,
         silent: bool = False,
@@ -354,9 +354,9 @@ class MockShell:
 
         shell_command_components: list[str] = [str(command)]
 
-        if env is not None:
+        if environment is not None:
             shell_command_components = [
-                *env.to_shell(),
+                *environment.to_shell(),
                 *shell_command_components,
             ]
 
@@ -548,7 +548,7 @@ class GuestMock(tmt.Guest):
         self,
         command: Union[Command, ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,
@@ -597,7 +597,7 @@ class GuestMock(tmt.Guest):
             *self.mock_shell.execute(
                 actual_command,
                 cwd=cwd,
-                env=env,
+                environment=environment,
                 friendly_command=friendly_command or str(command),
                 logger=self._logger,
                 **kwargs,

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -596,7 +596,7 @@ class GuestMock(tmt.Guest):
             *self.mock_shell.execute(
                 actual_command,
                 cwd=cwd,
-                env=environment,
+                environment=environment,
                 friendly_command=friendly_command or str(command),
                 logger=self._logger,
                 **kwargs,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -454,7 +454,7 @@ class GuestContainer(tmt.Guest):
             return self._run_guest_command(
                 podman_command,
                 cwd=self.parent.plan.worktree,
-                environment=_prepare_command_environment(),
+                environment=self._prepare_command_environment(),
                 friendly_command=friendly_command,
                 log=log,
                 silent=silent,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -251,7 +251,7 @@ class GuestContainer(tmt.Guest):
 
         # Filter out variables with newlines - podman's env-file format
         # does not support multiline values (one line = one variable)
-        filtered_env = tmt.utils.Environment()
+        filtered_environment = tmt.utils.Environment()
         for key, value in environment.items():
             if '\n' in value:
                 self.warn(
@@ -260,15 +260,15 @@ class GuestContainer(tmt.Guest):
                     "skipping this variable."
                 )
             else:
-                filtered_env[key] = value
+                filtered_environment[key] = value
 
-        if not filtered_env:
+        if not filtered_environment:
             return []
 
         # Write environment to a file in the guest workdir
         # Format: KEY=VALUE per line, no quoting (podman takes values literally)
         env_file = self.guest_workdir / 'podman-run-environment'
-        env_file.write_text('\n'.join(f'{k}={v}' for k, v in filtered_env.items()))
+        env_file.write_text('\n'.join(f'{k}={v}' for k, v in filtered_environment.items()))
 
         self.debug(f"Podman run environment file written to '{env_file}'.")
 
@@ -454,7 +454,7 @@ class GuestContainer(tmt.Guest):
             return self._run_guest_command(
                 podman_command,
                 cwd=self.parent.plan.worktree,
-                env=self._prepare_command_environment(),
+                environment=_prepare_command_environment(),
                 friendly_command=friendly_command,
                 log=log,
                 silent=silent,
@@ -493,7 +493,7 @@ class GuestContainer(tmt.Guest):
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,
@@ -520,7 +520,7 @@ class GuestContainer(tmt.Guest):
         # Accumulate all necessary commands - they will form a "shell" script, a single
         # string passed to a shell executed inside the container.
         script = ShellScript.from_scripts(
-            self._prepare_command_environment(env).to_shell_exports()
+            self._prepare_command_environment(environment).to_shell_exports()
         )
 
         # Change to given directory on guest if cwd provided

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -252,7 +252,7 @@ class GuestContainer(tmt.Guest):
 
         # Filter out variables with newlines - podman's env-file format
         # does not support multiline values (one line = one variable)
-        filtered_env = tmt.utils.Environment()
+        filtered_environment = tmt.utils.Environment()
         for key, value in environment.items():
             if '\n' in value:
                 self.warn(
@@ -261,15 +261,15 @@ class GuestContainer(tmt.Guest):
                     "skipping this variable."
                 )
             else:
-                filtered_env[key] = value
+                filtered_environment[key] = value
 
-        if not filtered_env:
+        if not filtered_environment:
             return []
 
         # Write environment to a file in the guest workdir
         # Format: KEY=VALUE per line, no quoting (podman takes values literally)
         env_file = self.guest_workdir / 'podman-run-environment'
-        env_file.write_text('\n'.join(f'{k}={v}' for k, v in filtered_env.items()))
+        env_file.write_text('\n'.join(f'{k}={v}' for k, v in filtered_environment.items()))
 
         self.debug(f"Podman run environment file written to '{env_file}'.")
 
@@ -455,7 +455,7 @@ class GuestContainer(tmt.Guest):
             return self._run_guest_command(
                 podman_command,
                 cwd=self.parent.plan.worktree,
-                env=self._prepare_command_environment(),
+                environment=self._prepare_command_environment(),
                 friendly_command=friendly_command,
                 log=log,
                 silent=silent,
@@ -494,7 +494,7 @@ class GuestContainer(tmt.Guest):
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        env: Optional[tmt.utils.Environment] = None,
+        environment: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,
@@ -521,7 +521,7 @@ class GuestContainer(tmt.Guest):
         # Accumulate all necessary commands - they will form a "shell" script, a single
         # string passed to a shell executed inside the container.
         script = ShellScript.from_scripts(
-            self._prepare_command_environment(env).to_shell_exports()
+            self._prepare_command_environment(environment).to_shell_exports()
         )
 
         # Change to given directory on guest if cwd provided

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1246,7 +1246,7 @@ class Command:
         *,
         cwd: Optional[Path],
         shell: bool = False,
-        env: Optional[Environment] = None,
+        environment: Optional[Environment] = None,
         dry: bool = False,
         join: bool = False,
         interactive: bool = False,
@@ -1268,7 +1268,7 @@ class Command:
         :param cwd: if set, command would be executed in the given directory,
             otherwise the current working directory is used.
         :param shell: if set, the command would be executed in a shell.
-        :param env: environment variables to combine with the current environment
+        :param environment: environment variables to combine with the current environment
             before running the command.
         :param dry: if set, the command would not be actually executed.
         :param join: if set, stdout and stderr of the command would be merged into
@@ -1328,14 +1328,14 @@ class Command:
 
         # Prepare the environment: use the current process environment, but do
         # not modify it if caller wants something extra, make a copy.
-        actual_env: Optional[Environment] = None
+        actual_environment: Optional[Environment] = None
 
         # Do not modify current process environment
-        if env is not None:
-            actual_env = Environment.from_environ()
-            actual_env.update(env)
+        if environment is not None:
+            actual_environment = Environment.from_environ()
+            actual_environment.update(environment)
 
-        logger.debug('environment', actual_env, level=4)
+        logger.debug('environment', actual_environment, level=4)
 
         # Set special executable only when shell was requested
         executable = DEFAULT_SHELL if shell else None
@@ -1347,7 +1347,7 @@ class Command:
                     self.to_popen(),
                     cwd=cwd,
                     shell=shell,
-                    env=actual_env.to_popen() if actual_env is not None else None,
+                    env=actual_environment.to_popen() if actual_environment is not None else None,
                     # Disabling for now: When used together with the
                     # local provision this results into errors such as:
                     # 'cannot set terminal process group: Inappropriate
@@ -1367,7 +1367,7 @@ class Command:
                     self.to_popen(),
                     cwd=cwd,
                     shell=shell,
-                    env=actual_env.to_popen() if actual_env is not None else None,
+                    env=actual_environment.to_popen() if actual_environment is not None else None,
                     start_new_session=True,
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.PIPE,
@@ -2351,7 +2351,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         cwd: Optional[Path] = None,
         ignore_dry: bool = False,
         shell: bool = False,
-        env: Optional[Environment] = None,
+        environment: Optional[Environment] = None,
         interactive: bool = False,
         join: bool = False,
         log: Optional[tmt.log.LoggingFunction] = None,
@@ -2385,7 +2385,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             cwd=cwd or self.workdir,
             dry=dryrun_actual,
             shell=shell,
-            env=env,
+            environment=environment,
             interactive=interactive,
             on_process_start=on_process_start,
             on_process_end=on_process_end,

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1263,7 +1263,7 @@ class Command:
         *,
         cwd: Optional[Path],
         shell: bool = False,
-        env: Optional[Environment] = None,
+        environment: Optional[Environment] = None,
         dry: bool = False,
         join: bool = False,
         interactive: bool = False,
@@ -1285,7 +1285,7 @@ class Command:
         :param cwd: if set, command would be executed in the given directory,
             otherwise the current working directory is used.
         :param shell: if set, the command would be executed in a shell.
-        :param env: environment variables to combine with the current environment
+        :param environment: environment variables to combine with the current environment
             before running the command.
         :param dry: if set, the command would not be actually executed.
         :param join: if set, stdout and stderr of the command would be merged into
@@ -1345,14 +1345,14 @@ class Command:
 
         # Prepare the environment: use the current process environment, but do
         # not modify it if caller wants something extra, make a copy.
-        actual_env: Optional[Environment] = None
+        actual_environment: Optional[Environment] = None
 
         # Do not modify current process environment
-        if env is not None:
-            actual_env = Environment.from_environ()
-            actual_env.update(env)
+        if environment is not None:
+            actual_environment = Environment.from_environ()
+            actual_environment.update(environment)
 
-        logger.debug('environment', actual_env, level=4)
+        logger.debug('environment', actual_environment, level=4)
 
         # Set special executable only when shell was requested
         executable = DEFAULT_SHELL if shell else None
@@ -1364,7 +1364,7 @@ class Command:
                     self.to_popen(),
                     cwd=cwd,
                     shell=shell,
-                    env=actual_env.to_popen() if actual_env is not None else None,
+                    env=actual_environment.to_popen() if actual_environment is not None else None,
                     # Disabling for now: When used together with the
                     # local provision this results into errors such as:
                     # 'cannot set terminal process group: Inappropriate
@@ -1384,7 +1384,7 @@ class Command:
                     self.to_popen(),
                     cwd=cwd,
                     shell=shell,
-                    env=actual_env.to_popen() if actual_env is not None else None,
+                    env=actual_environment.to_popen() if actual_environment is not None else None,
                     start_new_session=True,
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.PIPE,
@@ -2368,7 +2368,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         cwd: Optional[Path] = None,
         ignore_dry: bool = False,
         shell: bool = False,
-        env: Optional[Environment] = None,
+        environment: Optional[Environment] = None,
         interactive: bool = False,
         join: bool = False,
         log: Optional[tmt.log.LoggingFunction] = None,
@@ -2402,7 +2402,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             cwd=cwd or self.workdir,
             dry=dryrun_actual,
             shell=shell,
-            env=env,
+            environment=environment,
             interactive=interactive,
             on_process_start=on_process_start,
             on_process_end=on_process_end,

--- a/tmt/utils/git.py
+++ b/tmt/utils/git.py
@@ -737,7 +737,7 @@ def git_clone(
     destination: Path,
     shallow: bool = False,
     can_change: bool = True,
-    env: Optional[Environment] = None,
+    environment: Optional[Environment] = None,
     attempts: Optional[int] = None,
     interval: Optional[int] = None,
     timeout: Optional[int] = None,
@@ -753,7 +753,7 @@ def git_clone(
         the whole history.
     :param can_change: URL can be modified with hardcoded rules. Use
         ``can_change=False`` to disable rewrite rules.
-    :param env: Environment provided to the ``git clone`` process.
+    :param environment: Environment provided to the ``git clone`` process.
     :param attempts: Number of tries to call the function.
     :param interval: Amount of seconds to wait before a new try.
     :param timeout: Overall maximum time in seconds to clone the repo.
@@ -765,7 +765,7 @@ def git_clone(
         url: str,
         destination: Path,
         shallow: bool = False,
-        env: Optional[Environment] = None,
+        environment: Optional[Environment] = None,
         timeout: Optional[int] = None,
     ) -> CommandOutput:
         """
@@ -774,7 +774,7 @@ def git_clone(
 
         depth = ['--depth=1'] if shallow else []
         output = Command('git', 'clone', *depth, url, destination).run(
-            cwd=Path('/'), env=env, timeout=timeout, logger=logger
+            cwd=Path('/'), environment=environment, timeout=timeout, logger=logger
         )
         logger.info(
             'cloned-commit-hash',
@@ -803,7 +803,7 @@ def git_clone(
                 shallow=True,
                 url=url,
                 destination=destination,
-                env=env,
+                environment=environment,
                 timeout=timeout,
             )
         except RunError:
@@ -819,7 +819,7 @@ def git_clone(
             url=url,
             destination=destination,
             shallow=False,
-            env=env,
+            environment=environment,
             timeout=timeout,
             logger=logger,
         )


### PR DESCRIPTION
As part of the environment usage cleanup and documentation, renaming various `env` parameters to `environment`, to stick to one naming convention when speaking about environment in tmt codebase.

Pull Request Checklist

* [x] implement the feature