### PR TITLE
Drop manually specifying copr repo in packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -63,20 +63,6 @@ _:
   - &test-base
     job: tests
     trigger: pull_request
-    tf_extra_params:
-      environments:
-        - &copr-teemtee-stable
-          artifacts:
-            # Testing Farm fails to install the repository when a multiline
-            # string is used. The script looks broken, as if one piece of
-            # the process incorrectly loads it, producing broken repo file
-            # URL.
-            - type: repository-file
-              # yamllint disable-line rule:line-length
-              id: https://copr.fedorainfracloud.org/coprs/g/teemtee/stable/repo/fedora-rawhide/group_teemtee-stable-fedora-rawhide.repo
-            - type: repository-file
-              # yamllint disable-line rule:line-length
-              id: https://copr.fedorainfracloud.org/coprs/g/teemtee/stable/repo/epel-9/group_teemtee-stable-epel-9.repo
 
   # Latest fedora & epel targets
   - &latest-targets
@@ -91,7 +77,6 @@ _:
     tf_extra_params:
       environments:
         - &tmt-cloud-resources
-          <<: *copr-teemtee-stable
           settings:
             provisioning:
               tags:


### PR DESCRIPTION
Not quite sure why this was used, but the fact that it is only set for rawhide and epel9 is fishy.

Pull Request Checklist

* [x] implement the feature