### PR TITLE
Allow and skip empty elements in Command construction

### DIFF
--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1096,7 +1096,7 @@ CommonDerivedType = TypeVar('CommonDerivedType', bound='Common')
 #: A single element of command-line.
 _CommandElement = str
 #: A single element of raw command line in its ``list`` form.
-RawCommandElement = Union[str, Path]
+RawCommandElement = Union[str, Path, None]
 #: A raw command line form, a list of elements.
 RawCommand = list[RawCommandElement]
 
@@ -1197,7 +1197,7 @@ class Command:
     """
 
     def __init__(self, *elements: RawCommandElement) -> None:
-        self._command = [str(element) for element in elements]
+        self._command = [str(element) for element in elements if element]
 
     def __str__(self) -> str:
         return self.to_element()


### PR DESCRIPTION
Technically a bug because if the first element is `""` it will become `" actual_command"` which can have some tricky consequences

Pull Request Checklist

* [x] implement the feature
