### PR TITLE
Add a copr project for temporary external dependencies

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -50,7 +50,8 @@ _:
   - &copr-under-packit
     job: copr_build
     additional_repos:
-      - copr://@teemtee/stable
+      - copr://@teemtee/latest
+      - copr://@teemtee/_temp_dependencies
 
   # Copr jobs under the teemtee project
   - &copr-under-teemtee
@@ -58,6 +59,8 @@ _:
     list_on_homepage: true
     preserve_project: true
     owner: "@teemtee"
+    additional_repos:
+      - copr://@teemtee/_temp_dependencies
 
   # Test jobs base setup
   - &test-base


### PR DESCRIPTION
- Proposing to add a separate copr project `_temp_dependencies` where all downstream patches needed outside of tmt control can be backported. Latest example of this is needing to backport [beakerlib](https://src.fedoraproject.org/rpms/beakerlib/pull-request/93) update that adds `python3-six` dependency
- Moved the packit PR copr dependencies to depend on `latest` (so that it is simpler to unblock on updates to `fmf` for example) and the `_temp_dependencies` for the reasons above

---

Pull Request Checklist

* [x] implement the feature