### PR TITLE
Delay the creation of the LogfileHandler

### DIFF
--- a/docs/releases/pending/4642.fmf
+++ b/docs/releases/pending/4642.fmf
@@ -1,0 +1,4 @@
+description: |
+  All warnings encountered in a run are now saved in a
+  :tmt:story:`warnings.yaml</stories/cli/run/logs/warnings.yaml>` file under
+  the run workdir.

--- a/stories/cli/run.fmf
+++ b/stories/cli/run.fmf
@@ -265,3 +265,18 @@ story: 'As a user I want to execute tests easily'
         example: |
             tmt run provision login
             tmt run --last finish
+
+/logs:
+    /warnings.yaml:
+        story: As a CI runner I want to forward the warnings to the user.
+        description: |
+            All warnings encountered during a run are recorded in a
+            ``warnings.yaml`` file under the run workdir.
+        example: |
+            - logger: tmt.run
+              msg: User is feeling safe.
+              trace: 'tmt/base/core.py#3322: go()'
+
+            - logger: tmt.run.logger0
+              msg: '/: - ''invalid'' does not match any of the regexes: ''^extra-'''
+              trace: 'tmt/utils/__init__.py#5385: _validate_fmf_node()'

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -2871,6 +2871,8 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
 
     data: Optional[RunData] = None
 
+    WARNINGS_FILE_NAME: ClassVar[str] = "warnings.yaml"
+
     def __init__(
         self,
         *,
@@ -2929,6 +2931,12 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
             )
 
         return self.workdir
+
+    def _workdir_init(self, id_: WorkdirArgumentType = None) -> None:
+        super()._workdir_init(id_)
+        warnings_file = self.run_workdir / self.WARNINGS_FILE_NAME
+        warnings_file.touch(exist_ok=True)
+        self._logger.add_runwarnings_handler(warnings_file)
 
     @functools.cached_property
     def runner(self) -> 'tmt.steps.provision.local.GuestLocal':

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -2932,10 +2932,16 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
 
         return self.workdir
 
-    def _workdir_init(self, id_: WorkdirArgumentType = None) -> None:
-        super()._workdir_init(id_)
-        warnings_file = self.run_workdir / self.WARNINGS_FILE_NAME
-        self._logger.add_runwarnings_handler(warnings_file)
+    def load_workdir(self, *, with_logfiles: bool = True) -> None:
+        """
+        Prepare the run workdir and associated.
+
+        :param with_logfiles: whether to attach logfile handlers
+        """
+        self._workdir_load(self._workdir_path)
+        if with_logfiles:
+            warnings_file = self.run_workdir / self.WARNINGS_FILE_NAME
+            self._logger.add_runwarnings_handler(warnings_file)
 
     @functools.cached_property
     def runner(self) -> 'tmt.steps.provision.local.GuestLocal':
@@ -3074,7 +3080,7 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
         from tmt.base.plan import Plan
 
         self._save_tree(self._tree)
-        self._workdir_load(self._workdir_path)
+        self.load_workdir()
         try:
             self.data = RunData.from_serialized(
                 tmt.utils.yaml_to_dict(self.read(Path('run.yaml')))
@@ -3289,7 +3295,7 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
         """
         self.tree = tree
         self._save_tree(self.tree)
-        self._workdir_load(self._workdir_path)
+        self.load_workdir()
         self.config.last_run = self.run_workdir
         self.info(str(self.run_workdir), color='magenta')
 
@@ -3304,7 +3310,7 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
 
         # Create the workdir and save last run
         self._save_tree(self._tree)
-        self._workdir_load(self._workdir_path)
+        self.load_workdir()
         assert self.tree is not None  # narrow type
         assert self._workdir is not None  # narrow type
         if self.tree.root and self._workdir.is_relative_to(self.tree.root):
@@ -3748,7 +3754,7 @@ class Clean(tmt.utils.Common):
             # Pass the context containing --last to Run to choose
             # the correct one.
             last_run = Run(logger=self._logger, cli_invocation=self.cli_invocation)
-            last_run._workdir_load(last_run._workdir_path)
+            last_run.load_workdir(with_logfiles=False)
             return self._clean_workdir(last_run.run_workdir)
         all_workdirs = list(tmt.utils.generate_runs(self.workdir_root, id_, all_=True))
         if keep is not None:

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -2935,7 +2935,6 @@ class Run(HasRunWorkdir, HasEnvironment, tmt.utils.Common):
     def _workdir_init(self, id_: WorkdirArgumentType = None) -> None:
         super()._workdir_init(id_)
         warnings_file = self.run_workdir / self.WARNINGS_FILE_NAME
-        warnings_file.touch(exist_ok=True)
         self._logger.add_runwarnings_handler(warnings_file)
 
     @functools.cached_property

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -292,6 +292,13 @@ class LogRecordDetails:
     logger_topics: set[Topic] = simple_field(default_factory=set[Topic])
     message_topic: Optional[Topic] = None
 
+    #: The source related to the log message. This is different from the stacktrace
+    #: which is automatically handled. This is meant to track sources such as those
+    #: from fmf file
+    source: Optional[str] = None
+    #: The reason for triggering the log.
+    reason: Optional[str] = None
+
 
 class RunWarningsHandler(logging.FileHandler):
     def __init__(self, filepath: Path) -> None:
@@ -378,6 +385,8 @@ class RunWarningEntry:
     msg: str
     logger: str
     trace: str
+    source: Optional[str]
+    reason: Optional[str]
 
 
 class RunWarningsFormatter(logging.Formatter):
@@ -415,6 +424,8 @@ class RunWarningsFormatter(logging.Formatter):
                     msg=warning_msg,
                     logger=record.name,
                     trace=f"{record.pathname}#{record.lineno}: {record.funcName}()",
+                    source=details.source if details else "(external)",
+                    reason=details.reason if details else None,
                 )
             ),
         ]
@@ -984,10 +995,19 @@ class Logger:
         message: str,
         shift: int = 0,
         stacklevel: int = 1,
+        source: Optional[str] = None,
+        reason: Optional[str] = None,
     ) -> None:
         self._log(
             logging.WARNING,
-            LogRecordDetails(key='warn', value=message, color='yellow', shift=shift),
+            LogRecordDetails(
+                key='warn',
+                value=message,
+                color='yellow',
+                shift=shift,
+                source=source,
+                reason=reason,
+            ),
             stacklevel=stacklevel,
         )
 

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -293,33 +293,8 @@ class LogRecordDetails:
 
 
 class RunWarningsHandler(logging.FileHandler):
-    #: Yaml handler for formatting the content.
-    #:
-    #: We do not use roundtrip loader here because that would require rewriting
-    #: the whole content each time, but the streaming nature of the logger
-    #: assumes that we will be appending when ``emit()`` is called. Instead we
-    #: make use of the document is composed of direct list items so we can
-    #: simply append each item as a new list.
-    _yaml_handler: YAML
-    #: String IO handler for constructing the file content
-    _string_io: io.StringIO
-
     def __init__(self, filepath: Path) -> None:
-        from tmt.utils import _yaml
-
-        self._yaml_handler = _yaml(yaml_type="safe")
-        self._string_io = io.StringIO()
         super().__init__(filepath, mode="a")
-
-    def format(self, record: logging.LogRecord) -> str:
-        # TODO: make this in a better yaml with a schema
-        warning_msg = super().format(record)
-        # The yaml content to be appended is always a single list item so that
-        # it can be appended with the previous content
-        yaml_content = [warning_msg]
-        # Format and dump the yaml content
-        self._yaml_handler.dump(yaml_content, self._string_io)
-        return self._string_io.getvalue()
 
 
 class LogfileHandler(logging.FileHandler):
@@ -397,6 +372,34 @@ class ConsoleFormatter(_Formatter):
         )
 
 
+class RunWarningsFormatter(_Formatter):
+    #: Yaml handler for formatting the content.
+    #:
+    #: We do not use roundtrip loader here because that would require rewriting
+    #: the whole content each time, but the streaming nature of the logger
+    #: assumes that we will be appending when ``emit()`` is called. Instead we
+    #: make use of the document is composed of direct list items so we can
+    #: simply append each item as a new list.
+    _yaml_handler: YAML
+
+    def __init__(self) -> None:
+        from tmt.utils import _yaml
+
+        self._yaml_handler = _yaml(yaml_type="safe")
+        super().__init__('%(message)s', apply_colors=False)
+
+    def format(self, record: logging.LogRecord) -> str:
+        # TODO: make this in a better yaml with a schema
+        warning_msg = super().format(record)
+        # The yaml content to be appended is always a single list item so that
+        # it can be appended with the previous content
+        yaml_content = [warning_msg]
+        # Format and dump the yaml content
+        string_io = io.StringIO()
+        self._yaml_handler.dump(yaml_content, string_io)
+        return string_io.getvalue()
+
+
 class VerbosityLevelFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         if record.levelno != logging.INFO:
@@ -462,6 +465,14 @@ class TopicFilter(logging.Filter):
             return True
 
         if details.message_topic in details.logger_topics:
+            return True
+
+        return False
+
+
+class RunWarningsFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno == logging.WARNING:
             return True
 
         return False
@@ -683,9 +694,9 @@ class Logger:
 
         handler = RunWarningsHandler(filepath)
 
-        handler.setFormatter(LogfileFormatter())
+        handler.setFormatter(RunWarningsFormatter())
 
-        handler.addFilter(TopicFilter())
+        handler.addFilter(RunWarningsFilter())
 
         self._logger.addHandler(handler)
 

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -46,7 +46,7 @@ from ruamel.yaml import YAML
 
 from tmt._compat.pathlib import Path
 from tmt._compat.warnings import deprecated
-from tmt.container import container, simple_field
+from tmt.container import asdict, container, simple_field
 
 if TYPE_CHECKING:
     import tmt.cli
@@ -373,6 +373,13 @@ class ConsoleFormatter(_Formatter):
         )
 
 
+@container
+class RunWarningEntry:
+    msg: str
+    logger: str
+    trace: str
+
+
 class RunWarningsFormatter(logging.Formatter):
     #: Yaml handler for formatting the content.
     #:
@@ -402,7 +409,15 @@ class RunWarningsFormatter(logging.Formatter):
             warning_msg = super().format(record_copy)
         # The yaml content to be appended is always a single list item so that
         # it can be appended with the previous content
-        yaml_content = [warning_msg]
+        yaml_content = [
+            asdict(
+                RunWarningEntry(
+                    msg=warning_msg,
+                    logger=record.name,
+                    trace=f"{record.pathname}#{record.lineno}: {record.funcName}()",
+                )
+            ),
+        ]
         # Format and dump the yaml content
         string_io = io.StringIO()
         self._yaml_handler.dump(yaml_content, string_io)
@@ -700,7 +715,6 @@ class Logger:
         self._logger.addHandler(handler)
 
     def add_runwarnings_handler(self, filepath: Path) -> None:
-
         handler = RunWarningsHandler(filepath)
 
         handler.setFormatter(RunWarningsFormatter())

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -25,6 +25,7 @@ managing handlers themselves, which would be very messy given the propagation of
 """
 
 import enum
+import io
 import itertools
 import logging
 import os
@@ -39,6 +40,8 @@ from typing import (
     Union,
     cast,
 )
+
+from ruamel.yaml import YAML
 
 from tmt._compat.pathlib import Path
 from tmt._compat.warnings import deprecated
@@ -287,6 +290,36 @@ class LogRecordDetails:
 
     logger_topics: set[Topic] = simple_field(default_factory=set[Topic])
     message_topic: Optional[Topic] = None
+
+
+class RunWarningsHandler(logging.FileHandler):
+    #: Yaml handler for formatting the content.
+    #:
+    #: We do not use roundtrip loader here because that would require rewriting
+    #: the whole content each time, but the streaming nature of the logger
+    #: assumes that we will be appending when ``emit()`` is called. Instead we
+    #: make use of the document is composed of direct list items so we can
+    #: simply append each item as a new list.
+    _yaml_handler: YAML
+    #: String IO handler for constructing the file content
+    _string_io: io.StringIO
+
+    def __init__(self, filepath: Path) -> None:
+        from tmt.utils import _yaml
+
+        self._yaml_handler = _yaml(yaml_type="safe")
+        self._string_io = io.StringIO()
+        super().__init__(filepath, mode="a")
+
+    def format(self, record: logging.LogRecord) -> str:
+        # TODO: make this in a better yaml with a schema
+        warning_msg = super().format(record)
+        # The yaml content to be appended is always a single list item so that
+        # it can be appended with the previous content
+        yaml_content = [warning_msg]
+        # Format and dump the yaml content
+        self._yaml_handler.dump(yaml_content, self._string_io)
+        return self._string_io.getvalue()
 
 
 class LogfileHandler(logging.FileHandler):
@@ -639,6 +672,16 @@ class Logger:
         """
 
         handler = LogfileHandler(filepath)
+
+        handler.setFormatter(LogfileFormatter())
+
+        handler.addFilter(TopicFilter())
+
+        self._logger.addHandler(handler)
+
+    def add_runwarnings_handler(self, filepath: Path) -> None:
+
+        handler = RunWarningsHandler(filepath)
 
         handler.setFormatter(LogfileFormatter())
 

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -305,13 +305,52 @@ class LogRecordDetails:
 class LogfileHandler(logging.FileHandler):
     #: Paths of all log files to which ``LogfileHandler`` was attached.
     logfiles_with_stacktrace: ClassVar[list[Path]] = []
+    #: Temporary buffer until the file is created
+    _log_buffer: Optional[io.StringIO] = None
+    #: Path reference to the file being written to
+    _file: Path
 
     def __init__(self, filepath: Path, with_stacktrace: bool = False) -> None:
         # mode="a": We want to keep the old log file if we are running a new run on top of it
-        # delay=True: Open the file as soon as we actually have something to log
-        super().__init__(filepath, mode="a", delay=True)
+        # delay: If the file was not present don't try to open it
+        super().__init__(filepath, mode="a", delay=not filepath.exists())
+        self._file = filepath
+        if not filepath.exists():
+            self._log_buffer = io.StringIO()
+            # logging.FileHandler always checks `self.stream` before opening or writing to it. We
+            # switch this to the buffer so that it just writes to it immediately instead of
+            # skipping the messages
+            # ignore[assignment]: Intentional because we are using a different stream type in the
+            #  meantime
+            self.stream = self._log_buffer  # type: ignore[assignment]
         if with_stacktrace:
             LogfileHandler.logfiles_with_stacktrace.append(filepath)
+
+    def _check_file(self) -> None:
+        """
+        Check for the presence of :py:attr:`_file` and switch to it when it becomes
+        available.
+        """
+        if not self._log_buffer:
+            # We do not have any temporary buffer (anymore). Nothing to do here.
+            return
+        if not self._file.exists():
+            # File is not yet available continue as-is
+            return
+        # See logic in `logging.FileHandler.emit` when `stream is None` aka `delay=True`. So far
+        # the only thing we need to do is to run `_open`
+        self.stream = self._open()
+        # Write everything we have accumulated so far
+        content = self._log_buffer.getvalue()
+        if content:
+            self.stream.write(content)
+        # Cleanup after ourselves
+        self._log_buffer = None
+
+    def emit(self, record: logging.LogRecord) -> None:
+        # Check if the file is created in the meantime
+        self._check_file()
+        super().emit(record)
 
 
 # ignore[type-arg]: StreamHandler is a generic type, but such expression would be incompatible
@@ -720,7 +759,7 @@ class Logger:
         Attach a log file handler to this logger
         """
 
-        handler = LogfileHandler(filepath, with_stacktrace=True)
+        handler = LogfileHandler(filepath)
 
         handler.setFormatter(LogfileFormatter())
 

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -35,6 +35,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ClassVar,
     Optional,
     Protocol,
     TextIO,
@@ -301,21 +302,16 @@ class LogRecordDetails:
     reason: Optional[str] = None
 
 
-class RunWarningsHandler(logging.FileHandler):
-    def __init__(self, filepath: Path) -> None:
-        # mode="a": We want to keep the old warnings.yaml if we are running a new run on top
-        # delay=True: If we did not have any warnings then we do not create the file at all
-        super().__init__(filepath, mode="a", delay=True)
-
-
 class LogfileHandler(logging.FileHandler):
     #: Paths of all log files to which ``LogfileHandler`` was attached.
-    emitting_to: list[Path] = []
+    logfiles_with_stacktrace: ClassVar[list[Path]] = []
 
-    def __init__(self, filepath: 'tmt.utils.Path') -> None:
-        super().__init__(filepath, mode='a')
-
-        LogfileHandler.emitting_to.append(filepath)
+    def __init__(self, filepath: Path, with_stacktrace: bool = False) -> None:
+        # mode="a": We want to keep the old log file if we are running a new run on top of it
+        # delay=True: Open the file as soon as we actually have something to log
+        super().__init__(filepath, mode="a", delay=True)
+        if with_stacktrace:
+            LogfileHandler.logfiles_with_stacktrace.append(filepath)
 
 
 # ignore[type-arg]: StreamHandler is a generic type, but such expression would be incompatible
@@ -724,7 +720,7 @@ class Logger:
         Attach a log file handler to this logger
         """
 
-        handler = LogfileHandler(filepath)
+        handler = LogfileHandler(filepath, with_stacktrace=True)
 
         handler.setFormatter(LogfileFormatter())
 
@@ -733,7 +729,7 @@ class Logger:
         self._logger.addHandler(handler)
 
     def add_runwarnings_handler(self, filepath: Path) -> None:
-        handler = RunWarningsHandler(filepath)
+        handler = LogfileHandler(filepath)
 
         handler.setFormatter(RunWarningsFormatter())
 

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -24,6 +24,7 @@ but all-capturing log files while keeping implementation simple - the other opti
 managing handlers themselves, which would be very messy given the propagation of messages.
 """
 
+import copy
 import enum
 import io
 import itertools
@@ -372,7 +373,7 @@ class ConsoleFormatter(_Formatter):
         )
 
 
-class RunWarningsFormatter(_Formatter):
+class RunWarningsFormatter(logging.Formatter):
     #: Yaml handler for formatting the content.
     #:
     #: We do not use roundtrip loader here because that would require rewriting
@@ -386,11 +387,19 @@ class RunWarningsFormatter(_Formatter):
         from tmt.utils import _yaml
 
         self._yaml_handler = _yaml(yaml_type="safe")
-        super().__init__('%(message)s', apply_colors=False)
+        super().__init__('%(message)s', datefmt='%H:%M:%S')
 
     def format(self, record: logging.LogRecord) -> str:
         # TODO: make this in a better yaml with a schema
-        warning_msg = super().format(record)
+        details: Optional[LogRecordDetails] = getattr(record, 'details', None)
+        if not details:
+            # Not a tmt owned warning
+            warning_msg = super().format(record)
+        else:
+            # Tmt warning, we take the original raw value
+            record_copy = copy.copy(record)
+            record_copy.msg = details.value
+            warning_msg = super().format(record_copy)
         # The yaml content to be appended is always a single list item so that
         # it can be appended with the previous content
         yaml_content = [warning_msg]

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -432,7 +432,7 @@ class RunWarningsFormatter(logging.Formatter):
                 trace=f"{record.pathname}#{record.lineno}: {record.funcName}()",
                 source=details.source if details else "(external)",
                 reason=details.reason if details else None,
-            ).to_dict(),
+            ).to_minimal_spec(),
         ]
         # Format and dump the yaml content
         string_io = io.StringIO()

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -303,7 +303,9 @@ class LogRecordDetails:
 
 class RunWarningsHandler(logging.FileHandler):
     def __init__(self, filepath: Path) -> None:
-        super().__init__(filepath, mode="a")
+        # mode="a": We want to keep the old warnings.yaml if we are running a new run on top
+        # delay=True: If we did not have any warnings then we do not create the file at all
+        super().__init__(filepath, mode="a", delay=True)
 
 
 class LogfileHandler(logging.FileHandler):

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -399,17 +399,16 @@ class RunWarningEntry(SpecBasedContainer[_RawRunWarningEntry, _RawRunWarningEntr
 
 class RunWarningsFormatter(logging.Formatter):
     #: Yaml handler for formatting the content.
-    #:
-    #: We do not use roundtrip loader here because that would require rewriting
-    #: the whole content each time, but the streaming nature of the logger
-    #: assumes that we will be appending when ``emit()`` is called. Instead we
-    #: make use of the document is composed of direct list items so we can
-    #: simply append each item as a new list.
     _yaml_handler: YAML
 
     def __init__(self) -> None:
         from tmt.utils import _yaml
 
+        # We do not use roundtrip loader here because that would require rewriting
+        # the whole content each time, but the streaming nature of the logger
+        # assumes that we will be appending when ``emit()`` is called. Instead we
+        # make use of the document is composed of direct list items so we can
+        # simply append each item as a new list.
         self._yaml_handler = _yaml(yaml_type="safe")
         super().__init__('%(message)s', datefmt='%H:%M:%S')
 

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -45,8 +45,9 @@ from typing import (
 from ruamel.yaml import YAML
 
 from tmt._compat.pathlib import Path
+from tmt._compat.typing import Self, TypeAlias
 from tmt._compat.warnings import deprecated
-from tmt.container import asdict, container, simple_field
+from tmt.container import SpecBasedContainer, container, simple_field
 
 if TYPE_CHECKING:
     import tmt.cli
@@ -380,13 +381,20 @@ class ConsoleFormatter(_Formatter):
         )
 
 
+_RawRunWarningEntry: TypeAlias = dict[str, Any]
+
+
 @container
-class RunWarningEntry:
+class RunWarningEntry(SpecBasedContainer[_RawRunWarningEntry, _RawRunWarningEntry]):
     msg: str
     logger: str
     trace: str
     source: Optional[str]
     reason: Optional[str]
+
+    @classmethod
+    def from_spec(cls, spec: _RawRunWarningEntry) -> Self:
+        return cls(**spec)
 
 
 class RunWarningsFormatter(logging.Formatter):
@@ -419,15 +427,13 @@ class RunWarningsFormatter(logging.Formatter):
         # The yaml content to be appended is always a single list item so that
         # it can be appended with the previous content
         yaml_content = [
-            asdict(
-                RunWarningEntry(
-                    msg=warning_msg,
-                    logger=record.name,
-                    trace=f"{record.pathname}#{record.lineno}: {record.funcName}()",
-                    source=details.source if details else "(external)",
-                    reason=details.reason if details else None,
-                )
-            ),
+            RunWarningEntry(
+                msg=warning_msg,
+                logger=record.name,
+                trace=f"{record.pathname}#{record.lineno}: {record.funcName}()",
+                source=details.source if details else "(external)",
+                reason=details.reason if details else None,
+            ).to_dict(),
         ]
         # Format and dump the yaml content
         string_io = io.StringIO()

--- a/tmt/schemas/warnings.yaml
+++ b/tmt/schemas/warnings.yaml
@@ -28,9 +28,6 @@ definitions:
       - logger
       - trace
 
-type:
-  - array
-  # null case
-  - "null"
+type: array
 items:
   $ref: "#/definitions/warning-entry"

--- a/tmt/schemas/warnings.yaml
+++ b/tmt/schemas/warnings.yaml
@@ -1,0 +1,37 @@
+---
+
+#
+# JSON Schema definition for tmt `warnings.yaml` file
+# Linked to `tmt.log.RunWarningEntry`
+#
+
+$id: /schemas/warnings
+$schema: https://json-schema.org/draft-07/schema
+
+definitions:
+  warning-entry:
+    type: object
+    additionalProperties: false
+    properties:
+      msg:
+        type: string
+      logger:
+        type: string
+      trace:
+        type: string
+      source:
+        type:
+          - string
+          - "null"
+      reason:
+        type:
+          - string
+          - "null"
+    required:
+      - msg
+      - logger
+      - trace
+
+type: array
+items:
+  $ref: "#/definitions/warning-entry"

--- a/tmt/schemas/warnings.yaml
+++ b/tmt/schemas/warnings.yaml
@@ -20,13 +20,9 @@ definitions:
       trace:
         type: string
       source:
-        type:
-          - string
-          - "null"
+        type: string
       reason:
-        type:
-          - string
-          - "null"
+        type: string
     required:
       - msg
       - logger

--- a/tmt/schemas/warnings.yaml
+++ b/tmt/schemas/warnings.yaml
@@ -28,6 +28,9 @@ definitions:
       - logger
       - trace
 
-type: array
+type:
+  - array
+  # null case
+  - "null"
 items:
   $ref: "#/definitions/warning-entry"

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -3232,7 +3232,7 @@ def _render_exception_into_files(exception: BaseException, logger: tmt.log.Logge
     logfile_streams: list[TextIO] = []
 
     with contextlib.ExitStack() as stack:
-        for path in tmt.log.LogfileHandler.emitting_to:
+        for path in tmt.log.LogfileHandler.logfiles_with_stacktrace:
             try:
                 # SIM115: all opened files are added on exit stack, and they
                 # will get collected and closed properly.


### PR DESCRIPTION
Preparation for some refactoring of the workdir initialization logic, see the comment
https://github.com/teemtee/tmt/blob/eb8ed0420e5569599f9ed242f1a0243389ecad4a/tmt/utils/__init__.py#L2463-L2470

The purpose of this is to be able to:
- move the logic of defining the `Common._workdir` is defined and make it available much earlier. Refactoring where/when to do the creation of the workdir would follow afterwards
- move where the `add_logfile_handler` is executed and do not add it unless we are in a `tmt run` loop 

---

Pull Request Checklist

* [x] implement the feature

Depends-on: #4642