### PR TITLE
Drop copr epel6 enablement

### DIFF
--- a/docs/releases/pending/drop_copr_epel6.fmf
+++ b/docs/releases/pending/drop_copr_epel6.fmf
@@ -1,3 +1,4 @@
 description: |
-  Copr support for epel6 is dropped as copr.fedoraproject.org does not have
-  that chroot anymore (<https://github.com/fedora-copr/copr/issues/3357>).
+  Copr support for ``epel-6`` is dropped as that chroot has been
+  `removed <https://github.com/fedora-copr/copr/issues/3357>`_
+  from copr.fedoraproject.org a long time ago.

--- a/docs/releases/pending/drop_copr_epel6.fmf
+++ b/docs/releases/pending/drop_copr_epel6.fmf
@@ -1,0 +1,3 @@
+description: |
+  Copr support for epel6 is dropped as copr.fedoraproject.org does not have
+  that chroot anymore (<https://github.com/fedora-copr/copr/issues/3357>).

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -23,10 +23,7 @@ if TYPE_CHECKING:
 else:
     Repository: Any = None  # type: ignore[assignment]
 
-from tmt.utils import Command, CommandOutput, GeneralError, PrepareError, RunError, ShellScript
-
-COPR_URL = 'https://copr.fedorainfracloud.org/coprs'
-COPR_REPO_PATTERN = re.compile(r'^(@)?([^/]+)/([^/]+)$')
+from tmt.utils import Command, CommandOutput, GeneralError, RunError, ShellScript
 
 
 class DnfEngine(PackageManagerEngine):
@@ -281,34 +278,6 @@ class Dnf(PackageManager[DnfEngine]):
 
         return results
 
-    def _enable_copr_epel6(self, copr: str) -> None:
-        """
-        Manually enable copr repositories for epel6
-        """
-
-        # Parse the copr repo name
-        matched = COPR_REPO_PATTERN.match(copr)
-        if not matched:
-            raise PrepareError(f"Invalid copr repository '{copr}'.")
-        group, name, project = matched.groups()
-        group = 'group_' if group else ''
-        # Prepare the repo file url
-        parts = [COPR_URL] + (['g'] if group else [])
-        parts += [name, project, 'repo', 'epel-6']
-        parts += [f"{group}{name}-{project}-epel-6.repo"]
-        url = '/'.join(parts)
-        # Download the repo file on guest
-        try:
-            self.guest.execute(
-                Command('curl', '-LOf', url),
-                cwd=Path('/etc/yum.repos.d'),
-                silent=True,
-            )
-        except RunError as error:
-            if error.stderr and 'not found' in error.stderr.lower():
-                raise PrepareError(f"Copr repository '{copr}' not found.") from error
-            raise
-
     def enable_copr(self, *repositories: str) -> None:
         """
         Enable requested copr repositories
@@ -319,25 +288,15 @@ class Dnf(PackageManager[DnfEngine]):
 
         # Try to install copr plugin
         self.debug('Make sure the copr plugin is available.')
-        try:
-            self.install(Package(self.copr_plugin))
-
-        # Enable repositories manually for epel6
-        except RunError:
-            for repository in repositories:
-                self.info('copr', repository, 'green')
-                self._enable_copr_epel6(repository)
-
-        # Enable repositories using copr plugin
-        else:
-            for repository in repositories:
-                self.info('copr', repository, 'green')
-                self.guest.execute(
-                    ShellScript(
-                        f"{self.engine.command.to_script()} copr "
-                        f"{self.engine.options.to_script()} enable -y {repository}"
-                    )
+        self.install(Package(self.copr_plugin))
+        for repository in repositories:
+            self.info('copr', repository, 'green')
+            self.guest.execute(
+                ShellScript(
+                    f"{self.engine.command.to_script()} copr "
+                    f"{self.engine.options.to_script()} enable -y {repository}"
                 )
+            )
 
     def install_local(
         self,


### PR DESCRIPTION
Epel6 chroot on copr has been dropped for a while now. Seems like we can clean up some code with this.

Extracted from: https://github.com/teemtee/tmt/pull/4695#discussion_r2931523776

---

Pull Request Checklist

* [x] implement the feature
* [x] include a release note
