### PR TITLE
Allow plugin-specific CLI options before `--how`

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -265,3 +265,44 @@ def test_decide_colorization(
     monkeypatch.setattr(sys.stderr, 'isatty', lambda: testcase.simulate_tty)
 
     assert tmt.log.decide_colorization(no_color, force_color) == testcase.expected
+
+
+@pytest.mark.parametrize(
+    'step_args',
+    [
+        pytest.param(
+            ['execute', '--interactive', '--how', 'tmt'],
+            id='long-option-before-long-how',
+        ),
+        pytest.param(
+            ['execute', '--interactive', '-h', 'tmt'],
+            id='long-option-before-short-how',
+        ),
+        pytest.param(
+            ['execute', '-h', 'tmt', '--interactive'],
+            id='long-option-after-how',
+        ),
+    ],
+)
+def test_plugin_option_before_how(
+    run_tmt: 'RunTmt',
+    step_args: list[str],
+) -> None:
+    """Plugin-specific flag option works regardless of position relative to --how"""
+
+    tmp = tempfile.mkdtemp()
+    try:
+        result = run_tmt(
+            '--root',
+            example('local'),
+            'run',
+            '-i',
+            tmp,
+            *step_args,
+        )
+
+        # The command should not fail with "No such option"
+        if result.exit_code != 0:
+            assert 'No such option' not in result.output
+    finally:
+        shutil.rmtree(tmp)

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -647,11 +647,34 @@ def create_method_class(methods: MethodDictType) -> type[click.Command]:
             how = None
             subcommands = tmt.steps.STEPS + tmt.steps.ACTIONS + ['tests', 'plans']
 
+            def _effective_nargs(param: click.Parameter) -> int:
+                if isinstance(param, click.core.Option) and (param.is_flag or param.count):
+                    return 0
+                return param.nargs
+
             def _find_option_by_arg(arg: str) -> Optional[click.Parameter]:
+                # Check base command params first
                 for option in self.params:
                     if arg in option.opts or arg in option.secondary_opts:
                         return option
-                return None
+
+                # Search across all plugin method commands for plugin-specific
+                # options. The same short option (e.g. `-i`) may appear in
+                # multiple plugins with different nargs (flag vs value-consuming).
+                # Collect all matches and return the one that consumes the most
+                # arguments — this is conservative and ensures _find_how properly
+                # skips over option values.
+                matches: list[click.Parameter] = []
+                for method_command in methods.values():
+                    for option in method_command.params:
+                        if arg in option.opts or arg in option.secondary_opts:
+                            matches.append(option)
+                            break
+
+                if not matches:
+                    return None
+
+                return max(matches, key=_effective_nargs)
 
             def _find_how(args: list[str]) -> Optional[str]:
                 while args:


### PR DESCRIPTION
Previously, plugin-specific options like `--interactive` had to come after `--how` on the command line. For example:

```
tmt run execute --interactive -h tmt  # failed
tmt run execute -h tmt --interactive  # worked
```

The root cause was in `_find_how()` which scans CLI args to locate `--how`. When encountering an unknown option (not in the base command params), it gave up immediately. Plugin-specific options are only registered on method subcommands, not the base command.

Fix `_find_option_by_arg()` to also search params across all plugin method commands. When the same short option appears in multiple plugins with different `nargs`, the match consuming the most arguments is used conservatively.

This is safe because `_find_how()` operates on a copy of args and Click re-parses the original args for actual option handling. The worst case is `_find_how()` returning `None` — identical to the current behavior.

Generated-by: Claude Code

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
