### PR TITLE
Make plan environment file guest-specific

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -671,6 +671,9 @@ TMT_PLAN_ENVIRONMENT_FILE
     **not** allowed, use ``TMT_PLAN_SOURCE_SCRIPT`` instead to include
     other bash commands.
 
+    Note that this is not shared between guests of the given plan, each
+    guest has its own dedicated file.
+
     Example of the file content::
 
         COUNT=1

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -662,6 +662,9 @@ TMT_PLAN_ENVIRONMENT_FILE
     **not** allowed, use ``TMT_PLAN_SOURCE_SCRIPT`` instead to include
     other bash commands.
 
+    Note that this is not shared between guests of the given plan, each
+    guest has its own dedicated file.
+
     Example of the file content::
 
         COUNT=1

--- a/docs/releases/pending/4772.fmf
+++ b/docs/releases/pending/4772.fmf
@@ -1,0 +1,7 @@
+description: |
+    The :ref:`plan environment file <step-variables>` is now
+    guest-specific, it is no longer shared by all guests. Being shared
+    made the file open to race conditions, as tmt would fetch it from
+    all guests, saving all input files under the same name - the last
+    one saved wins. The filename is now guest specific, files do not
+    overwrite each other.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,9 @@ def target_dir(tmppath_factory: TempPathFactory) -> Path:
     return tmppath_factory.mktemp('target')
 
 
-def _construct_fixture_guest(container: 'ContainerData', logger: Logger) -> GuestContainer:
+def _construct_fixture_guest(
+    container: 'ContainerData', plan_workdir: Path, logger: Logger
+) -> GuestContainer:
     """
     Construct a container guest for ``guest`` and ``guest_per_test`` fixtures.
 
@@ -124,7 +126,9 @@ def _construct_fixture_guest(container: 'ContainerData', logger: Logger) -> Gues
     # We need a significant group of internal objects: a plan to host
     # the `provision` step to hold the guest. Without this, some
     # functionality will not work correctly, e.g. dry-run detection.
-    plan = Plan(node=fmf.base.Tree(data={'execute': {'how': 'tmt'}}), logger=logger)
+    plan = Plan(
+        node=fmf.base.Tree(data={'execute': {'how': 'tmt'}}), workdir=plan_workdir, logger=logger
+    )
 
     step = Provision(plan=plan, raw_data=[], logger=logger)
 
@@ -138,12 +142,14 @@ def _construct_fixture_guest(container: 'ContainerData', logger: Logger) -> Gues
 
 
 @pytest.fixture(name='guest')
-def fixture_guest(container: 'ContainerData', root_logger: Logger) -> GuestContainer:
-    return _construct_fixture_guest(container, root_logger)
+def fixture_guest(
+    container: 'ContainerData', tmppath: Path, root_logger: Logger
+) -> GuestContainer:
+    return _construct_fixture_guest(container, tmppath, root_logger)
 
 
 @pytest.fixture(name='guest_per_test')
 def fixture_guest_per_test(
-    container_per_test: 'ContainerData', root_logger: Logger
+    container_per_test: 'ContainerData', tmppath: Path, root_logger: Logger
 ) -> GuestContainer:
-    return _construct_fixture_guest(container_per_test, root_logger)
+    return _construct_fixture_guest(container_per_test, tmppath, root_logger)

--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -156,6 +156,11 @@ def test_execute_no_connection_closed(
 
     monkeypatch.setattr(
         guest,
+        '_prepare_environment',
+        MagicMock(return_value=Environment()),
+    )
+    monkeypatch.setattr(
+        guest,
         '_run_guest_command',
         MagicMock(return_value=CommandOutput(stdout=stdout, stderr=None)),
     )

--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -156,7 +156,7 @@ def test_execute_no_connection_closed(
 
     monkeypatch.setattr(
         guest,
-        '_prepare_environment',
+        '_prepare_command_environment',
         MagicMock(return_value=Environment()),
     )
     monkeypatch.setattr(

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -471,7 +471,6 @@ class Plan(
 
         if self.my_run:
             environment['TMT_PLAN_DATA'] = EnvVarValue(self.data_directory)
-            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_file)
             environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(self.plan_source_script)
 
         return environment
@@ -505,25 +504,6 @@ class Plan(
         )
 
     @property
-    def _environment_from_plan_environment_file(self) -> Environment:
-        """
-        Environment sourced from the :ref:`plan environment file <step-variables>`.
-        """
-
-        if (
-            self.my_run
-            and self.plan_environment_file.exists()
-            and self.plan_environment_file.stat().st_size > 0
-        ):
-            return tmt.utils.Environment.from_file(
-                filename=self.plan_environment_file.name,
-                root=self.plan_environment_file.parent,
-                logger=self._logger,
-            )
-
-        return Environment()
-
-    @property
     def environment(self) -> Environment:
         """
         Environment variables of the plan.
@@ -542,7 +522,6 @@ class Plan(
         if self.my_run:
             return Environment(
                 {
-                    **self._environment_from_plan_environment_file,
                     **self._environment_from_fmf,
                     **self._environment_from_importing,
                     **self._environment_from_cli,
@@ -710,17 +689,6 @@ class Plan(
         self.data_directory = self.plan_workdir / "data"
         self.debug(f"Create the data directory '{self.data_directory}'.", level=2)
         self.data_directory.mkdir(exist_ok=True, parents=True)
-
-    @functools.cached_property
-    def plan_environment_file(self) -> Path:
-        assert self.data_directory is not None  # narrow type
-
-        plan_environment_file_path = self.data_directory / "variables.env"
-        plan_environment_file_path.touch(exist_ok=True)
-
-        self.debug(f"Create the environment file '{plan_environment_file_path}'.", level=2)
-
-        return plan_environment_file_path
 
     @functools.cached_property
     def plan_source_script(self) -> Path:

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -511,7 +511,6 @@ class Plan(
         Contains all environment variables collected from multiple
         sources (in the following order):
 
-        * :ref:`plan environment file <step-variables>`,
         * plan's ``environment`` and ``environment-file`` keys,
         * importing plan's environment,
         * ``--environment`` and ``--environment-file`` options,

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -328,14 +328,12 @@ class Plan(
         # Save the run, prepare worktree and plan data directory
         self.my_run = run
         self.worktree: Optional[Path] = None
-        if self.my_run:
+        if self.my_run:  # noqa: SIM102
             # Skip to initialize the work tree if the corresponding option is
             # true. Note that 'tmt clean' consumes the option because it
             # should not initialize the work tree at all.
             if not self.my_run.opt(tmt.utils.PLAN_SKIP_WORKTREE_INIT):
                 self._initialize_worktree()
-
-            self._initialize_data_directory()
 
         # Expand all environment and context variables in the node
         with self.environment.as_environ():
@@ -677,22 +675,25 @@ class Plan(
                 )
             )
 
-    def _initialize_data_directory(self) -> None:
+    @functools.cached_property
+    def data_directory(self) -> Path:
         """
-        Create the plan data directory
+        Path to the plan data directory.
 
-        This is used for storing logs and other artifacts created during
-        prepare step, test execution or finish step and which are pulled
-        from the guest for possible future inspection.
+        The directory is used for storing logs and other artifacts created
+        during ``prepare`` step, test execution, or ``finish`` step, and
+        which are pulled from the guest for possible future inspection.
         """
-        self.data_directory = self.plan_workdir / "data"
-        self.debug(f"Create the data directory '{self.data_directory}'.", level=2)
-        self.data_directory.mkdir(exist_ok=True, parents=True)
+
+        data_directory = self.plan_workdir / "data"
+
+        self.debug(f"Create the data directory '{data_directory}'.", level=2)
+        data_directory.mkdir(exist_ok=True, parents=True)
+
+        return data_directory
 
     @functools.cached_property
     def plan_source_script(self) -> Path:
-        assert self.data_directory is not None  # narrow type
-
         plan_sourced_file_path = self.data_directory / PLAN_SOURCE_SCRIPT_NAME
         plan_sourced_file_path.touch(exist_ok=True)
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -59,6 +59,7 @@ from tmt.package_managers import (
 from tmt.utils import (
     Command,
     Environment,
+    EnvVarValue,
     GeneralError,
     OnProcessEndCallback,
     OnProcessStartCallback,
@@ -67,9 +68,6 @@ from tmt.utils import (
     ShellScript,
     configure_constant,
     effective_workdir_root,
-)
-from tmt.utils import (
-    EnvVarValue as EnvVarValue,
 )
 from tmt.utils.hints import get_hint
 from tmt.utils.wait import Deadline, Waiting
@@ -2185,6 +2183,12 @@ class Guest(
                 self.environment,
                 self.parent.plan.environment,
             )
+
+            # TODO: this was owned by plan, but at wrong position, and it will
+            # be owned by plan again once the dust of environment untangling
+            # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
+            # more.
+            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
 
         else:
             # Create a copy of given environment - this prevents any

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1829,14 +1829,15 @@ class Guest(
         )
 
     @functools.cached_property
-    def plan_environment_path(self) -> Path:
+    def plan_environment_path(self) -> Optional[Path]:
         """
         A path to the :ref:`plan environment file <step-variables>` file.
         """
 
-        parent = cast('Provision', self.parent)
+        if not isinstance(self.parent, tmt.steps.provision.Provision):
+            return None
 
-        path = parent.plan.data_directory / f'{PLAN_ENVIRONMENT_FILENAME}-{self.safe_name}'
+        path = self.parent.plan.data_directory / f'{PLAN_ENVIRONMENT_FILENAME}-{self.safe_name}'
         path.touch(exist_ok=True)
 
         self.debug(f"Create the environment file '{path}'.", level=2)
@@ -1849,7 +1850,11 @@ class Guest(
         Environment sourced from the :ref:`plan environment file <step-variables>`.
         """
 
-        if self.plan_environment_path.exists() and self.plan_environment_path.stat().st_size > 0:
+        if (
+            self.plan_environment_path
+            and self.plan_environment_path.exists()
+            and self.plan_environment_path.stat().st_size > 0
+        ):
             return tmt.utils.Environment.from_file(
                 filename=self.plan_environment_path.name,
                 root=self.plan_environment_path.parent,
@@ -2174,21 +2179,19 @@ class Guest(
         """
 
         if environment is None:
-            # narrow type
-            assert isinstance(self.parent, tmt.steps.Step)
-
             environment = tmt.utils.Environment()
 
-            environment.update(
-                self.environment,
-                self.parent.plan.environment,
-            )
+            environment.update(self.environment)
+
+            if isinstance(self.parent, tmt.steps.Step):
+                environment.update(self.parent.plan.environment)
 
             # TODO: this was owned by plan, but at wrong position, and it will
             # be owned by plan again once the dust of environment untangling
             # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
             # more.
-            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+            if self.plan_environment_path:
+                environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
 
         else:
             # Create a copy of given environment - this prevents any

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1832,6 +1832,10 @@ class Guest(
 
     @functools.cached_property
     def plan_environment_path(self) -> Path:
+        """
+        A path to the :ref:`plan environment file <step-variables>` file.
+        """
+
         parent = cast('Provision', self.parent)
 
         path = parent.plan.data_directory / f'{PLAN_ENVIRONMENT_FILENAME}-{self.safe_name}'
@@ -1843,6 +1847,10 @@ class Guest(
 
     @property
     def plan_environment(self) -> Environment:
+        """
+        Environment sourced from the :ref:`plan environment file <step-variables>`.
+        """
+
         if self.plan_environment_path.exists() and self.plan_environment_path.stat().st_size > 0:
             return tmt.utils.Environment.from_file(
                 filename=self.plan_environment_path.name,

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -58,6 +58,7 @@ from tmt.package_managers import (
 )
 from tmt.utils import (
     Command,
+    Environment,
     GeneralError,
     OnProcessEndCallback,
     OnProcessStartCallback,
@@ -66,6 +67,9 @@ from tmt.utils import (
     ShellScript,
     configure_constant,
     effective_workdir_root,
+)
+from tmt.utils import (
+    EnvVarValue as EnvVarValue,
 )
 from tmt.utils.hints import get_hint
 from tmt.utils.wait import Deadline, Waiting
@@ -77,6 +81,9 @@ if TYPE_CHECKING:
 
 
 T = TypeVar('T')
+
+#: Name of the :ref:`plan environment file <step-variables>`.
+PLAN_ENVIRONMENT_FILENAME = 'variables.env'
 
 #: How many seconds to wait for a connection to succeed after guest boot.
 #: This is the default value tmt would use unless told otherwise.
@@ -1822,6 +1829,28 @@ class Guest(
             if self.facts.is_ostree
             else tmt.steps.scripts.DEFAULT_SCRIPTS_DEST_DIR
         )
+
+    @functools.cached_property
+    def plan_environment_path(self) -> Path:
+        parent = cast('Provision', self.parent)
+
+        path = parent.plan.data_directory / f'{PLAN_ENVIRONMENT_FILENAME}-{self.safe_name}'
+        path.touch(exist_ok=True)
+
+        self.debug(f"Create the environment file '{path}'.", level=2)
+
+        return path
+
+    @property
+    def plan_environment(self) -> Environment:
+        if self.plan_environment_path.exists() and self.plan_environment_path.stat().st_size > 0:
+            return tmt.utils.Environment.from_file(
+                filename=self.plan_environment_path.name,
+                root=self.plan_environment_path.parent,
+                logger=self._logger,
+            )
+
+        return Environment()
 
     @classmethod
     def options(cls, how: Optional[str] = None) -> list[tmt.options.ClickOptionDecoratorType]:

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1876,14 +1876,15 @@ class Guest(
         )
 
     @functools.cached_property
-    def plan_environment_path(self) -> Path:
+    def plan_environment_path(self) -> Optional[Path]:
         """
         A path to the :ref:`plan environment file <step-variables>` file.
         """
 
-        parent = cast('Provision', self.parent)
+        if not isinstance(self.parent, tmt.steps.provision.Provision):
+            return None
 
-        path = parent.plan.data_directory / f'{PLAN_ENVIRONMENT_FILENAME}-{self.safe_name}'
+        path = self.parent.plan.data_directory / f'{PLAN_ENVIRONMENT_FILENAME}-{self.safe_name}'
         path.touch(exist_ok=True)
 
         self.debug(f"Create the environment file '{path}'.", level=2)
@@ -1896,7 +1897,11 @@ class Guest(
         Environment sourced from the :ref:`plan environment file <step-variables>`.
         """
 
-        if self.plan_environment_path.exists() and self.plan_environment_path.stat().st_size > 0:
+        if (
+            self.plan_environment_path
+            and self.plan_environment_path.exists()
+            and self.plan_environment_path.stat().st_size > 0
+        ):
             return tmt.utils.Environment.from_file(
                 filename=self.plan_environment_path.name,
                 root=self.plan_environment_path.parent,
@@ -2232,7 +2237,8 @@ class Guest(
             # be owned by plan again once the dust of environment untangling
             # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
             # more.
-            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+            if self.plan_environment_path:
+                environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
 
         else:
             # Create a copy of given environment - this prevents any

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -61,6 +61,7 @@ from tmt.package_managers import (
 from tmt.utils import (
     Command,
     Environment,
+    EnvVarValue,
     GeneralError,
     OnProcessEndCallback,
     OnProcessStartCallback,
@@ -69,9 +70,6 @@ from tmt.utils import (
     ShellScript,
     configure_constant,
     effective_workdir_root,
-)
-from tmt.utils import (
-    EnvVarValue as EnvVarValue,
 )
 from tmt.utils.hints import get_hint
 from tmt.utils.wait import Deadline, Waiting
@@ -2229,6 +2227,12 @@ class Guest(
 
             if isinstance(self.parent, tmt.steps.Step):
                 environment.update(self.parent.plan)
+
+            # TODO: this was owned by plan, but at wrong position, and it will
+            # be owned by plan again once the dust of environment untangling
+            # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
+            # more.
+            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
 
         else:
             # Create a copy of given environment - this prevents any

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1879,6 +1879,10 @@ class Guest(
 
     @functools.cached_property
     def plan_environment_path(self) -> Path:
+        """
+        A path to the :ref:`plan environment file <step-variables>` file.
+        """
+
         parent = cast('Provision', self.parent)
 
         path = parent.plan.data_directory / f'{PLAN_ENVIRONMENT_FILENAME}-{self.safe_name}'
@@ -1890,6 +1894,10 @@ class Guest(
 
     @property
     def plan_environment(self) -> Environment:
+        """
+        Environment sourced from the :ref:`plan environment file <step-variables>`.
+        """
+
         if self.plan_environment_path.exists() and self.plan_environment_path.stat().st_size > 0:
             return tmt.utils.Environment.from_file(
                 filename=self.plan_environment_path.name,

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -60,6 +60,7 @@ from tmt.package_managers import (
 )
 from tmt.utils import (
     Command,
+    Environment,
     GeneralError,
     OnProcessEndCallback,
     OnProcessStartCallback,
@@ -68,6 +69,9 @@ from tmt.utils import (
     ShellScript,
     configure_constant,
     effective_workdir_root,
+)
+from tmt.utils import (
+    EnvVarValue as EnvVarValue,
 )
 from tmt.utils.hints import get_hint
 from tmt.utils.wait import Deadline, Waiting
@@ -79,6 +83,9 @@ if TYPE_CHECKING:
 
 
 T = TypeVar('T')
+
+#: Name of the :ref:`plan environment file <step-variables>`.
+PLAN_ENVIRONMENT_FILENAME = 'variables.env'
 
 #: How many seconds to wait for a connection to succeed after guest boot.
 #: This is the default value tmt would use unless told otherwise.
@@ -1869,6 +1876,28 @@ class Guest(
             if self.facts.is_ostree
             else tmt.steps.scripts.DEFAULT_SCRIPTS_DEST_DIR
         )
+
+    @functools.cached_property
+    def plan_environment_path(self) -> Path:
+        parent = cast('Provision', self.parent)
+
+        path = parent.plan.data_directory / f'{PLAN_ENVIRONMENT_FILENAME}-{self.safe_name}'
+        path.touch(exist_ok=True)
+
+        self.debug(f"Create the environment file '{path}'.", level=2)
+
+        return path
+
+    @property
+    def plan_environment(self) -> Environment:
+        if self.plan_environment_path.exists() and self.plan_environment_path.stat().st_size > 0:
+            return tmt.utils.Environment.from_file(
+                filename=self.plan_environment_path.name,
+                root=self.plan_environment_path.parent,
+                logger=self._logger,
+            )
+
+        return Environment()
 
     @classmethod
     def options(cls, how: Optional[str] = None) -> list[tmt.options.ClickOptionDecoratorType]:

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -368,6 +368,7 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
             environment.update(
                 self.guest.environment,
                 self.test.environment,
+                self.guest.plan_environment,
                 self.phase.parent.plan.environment,
             )
 
@@ -386,6 +387,12 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
 
         else:
             environment = self._environment
+
+        # TODO: this was owned by plan, but at wrong position, and it will
+        # be owned by plan again once the dust of environment untangling
+        # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
+        # more.
+        environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.guest.plan_environment_path)
 
         environment.update(
             # Add variables from invocation contexts

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -365,6 +365,7 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
             environment.update(
                 self.guest.environment,
                 self.test.environment,
+                self.guest.plan_environment,
                 self.phase.parent.plan.environment,
             )
 
@@ -383,6 +384,12 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
 
         else:
             environment = self._environment
+
+        # TODO: this was owned by plan, but at wrong position, and it will
+        # be owned by plan again once the dust of environment untangling
+        # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
+        # more.
+        environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.guest.plan_environment_path)
 
         environment.update(
             # Add variables from invocation contexts

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -130,8 +130,16 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
         environment = environment or tmt.utils.Environment()
         environment.update(
             guest.environment,
+            guest.plan_environment,
             self.step.plan.environment,
         )
+
+        # TODO: this was owned by plan, but at wrong position, and it will
+        # be owned by plan again once the dust of environment untangling
+        # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
+        # more.
+        if guest.plan_environment_path:
+            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(guest.plan_environment_path)
 
         # Give a short summary
         overview = fmf.utils.listed(self.data.script, 'script')

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -132,7 +132,7 @@ class GuestLocal(tmt.Guest):
         sourced_files = sourced_files or []
 
         # Prepare the environment (plan/cli variables override)
-        environment = self._prepare_environment(env)
+        environment = self._prepare_command_environment(environment=env)
 
         if tty:
             self.warn("Ignoring requested tty, not supported by the 'local' provision plugin.")

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -132,10 +132,7 @@ class GuestLocal(tmt.Guest):
         sourced_files = sourced_files or []
 
         # Prepare the environment (plan/cli variables override)
-        environment = tmt.utils.Environment()
-        environment.update(env or {})
-        if self.parent:
-            environment.update(self.parent.plan.environment)
+        environment = self._prepare_environment(env)
 
         if tty:
             self.warn("Ignoring requested tty, not supported by the 'local' provision plugin.")

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -129,13 +129,15 @@ class GuestLocal(tmt.Guest):
         Execute command on localhost
         """
 
+        sourced_files = sourced_files or []
+
         if tty:
             self.warn("Ignoring requested tty, not supported by the 'local' provision plugin.")
 
         # Accumulate all necessary commands - they will form a "shell" script, a single
         # string passed to a shell executed on the local host.
         script = ShellScript.from_scripts(
-            self._prepare_command_environment(environment).to_shell_exports()
+            self._prepare_command_environment(environment=environment).to_shell_exports()
         )
 
         for file in reversed(sourced_files or []):


### PR DESCRIPTION
It already is, by nature: user can run `prepare/shell` on multiple guests, and populate content with different content. tmt then pulls the files from all guests, and the last one pulled overwrites all files pulled before it. That's hardly predictable.

The file is now guest specific, if user wishes to populate the file with variables for multiple guests to see, it needs to run phase populating the file on all involved guests.

Related to #4241.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] include a release note
