### PR TITLE
Introduce  `guest.download()` to centralise downloads on guest

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -541,8 +541,8 @@ TMT_DOWNLOAD_ATTEMPTS
     By default, 3 attempts are made.
 
 TMT_DOWNLOAD_INTERVAL
-    Number of seconds to wait between download attempts.
-    By default, it is 5 seconds.
+    Number of seconds to wait before retrying after an unsuccessful
+    attempt to download a file from a URL to guest.
 
 TMT_RETRY_SESSION_RETRIES
     The number of retries for HTTP/HTTPS requests when encountering

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -543,6 +543,7 @@ TMT_DOWNLOAD_ATTEMPTS
 TMT_DOWNLOAD_INTERVAL
     Number of seconds to wait before retrying after an unsuccessful
     attempt to download a file from a URL to guest.
+    By default, 5 seconds.
 
 TMT_RETRY_SESSION_RETRIES
     The number of retries for HTTP/HTTPS requests when encountering

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -536,6 +536,14 @@ TMT_REBOOT_TIMEOUT
     How many seconds to wait for a connection to succeed after
     guest reboot. By default, it is 10 minutes.
 
+TMT_DOWNLOAD_ATTEMPTS
+    Number of attempts to download a file from a URL to guest.
+    By default, 3 attempts are made.
+
+TMT_DOWNLOAD_INTERVAL
+    Number of seconds to wait between download attempts.
+    By default, it is 5 seconds.
+
 TMT_RETRY_SESSION_RETRIES
     The number of retries for HTTP/HTTPS requests when encountering
     retriable errors (such as 503 Service Unavailable). By default,

--- a/tests/unit/artifact/test_file.py
+++ b/tests/unit/artifact/test_file.py
@@ -60,7 +60,7 @@ def test_download_artifact(tmp_path, artifact_provider):
         guest,
         Path("/remote/foo-1.0-1.fc43.x86_64.rpm"),
     )
-    guest.execute.assert_called_once()
+    guest.download.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/artifact/test_repository.py
+++ b/tests/unit/artifact/test_repository.py
@@ -231,23 +231,10 @@ def test_url_no_path(root_logger):
 
 
 @pytest.fixture
-def mock_repo_file_fetch():
-    with patch(
-        'tmt.steps.prepare.artifact.providers.tmt.utils.retry_session'
-    ) as mock_retry_session:
-        mock_session = MagicMock()
-        mock_response = MagicMock()
-        mock_response.text = VALID_REPO_CONTENT
-        mock_response.raise_for_status.return_value = None
-        mock_session.get.return_value = mock_response
-        mock_retry_session.return_value.__enter__.return_value = mock_session
-        yield mock_session
-
-
-@pytest.fixture
 def mock_guest_and_pm(mock_package_manager):
     mock_guest = MagicMock()
     mock_guest.package_manager = mock_package_manager
+    mock_guest.execute.return_value.stdout = VALID_REPO_CONTENT
     return mock_guest, mock_package_manager
 
 
@@ -260,7 +247,7 @@ def test_id_extraction(artifact_provider):
     assert provider.id == "https://download.docker.com/linux/centos/docker-ce.repo"
 
 
-def test_artifacts_before_fetch(mock_repo_file_fetch, artifact_provider):
+def test_artifacts_before_fetch(artifact_provider):
     """Test that repository provider artifacts returns empty list"""
 
     provider = artifact_provider("repository-file:https://example.com/test.repo")
@@ -270,7 +257,7 @@ def test_artifacts_before_fetch(mock_repo_file_fetch, artifact_provider):
     assert provider.artifacts == []
 
 
-def test_fetch_contents(mock_repo_file_fetch, mock_guest_and_pm, artifact_provider, tmppath):
+def test_fetch_contents(mock_guest_and_pm, artifact_provider, tmppath):
     """Test that fetch_contents is a no-op for repository providers"""
 
     mock_guest, _ = mock_guest_and_pm
@@ -291,9 +278,7 @@ def test_fetch_contents(mock_repo_file_fetch, mock_guest_and_pm, artifact_provid
     assert len(artifacts) == 0
 
 
-def test_contribute_to_shared_repo(
-    mock_repo_file_fetch, mock_guest_and_pm, artifact_provider, tmppath
-):
+def test_contribute_to_shared_repo(mock_guest_and_pm, artifact_provider, tmppath):
     """Test that contribute_to_shared_repo does nothing for repository providers"""
 
     mock_guest, mock_package_manager = mock_guest_and_pm
@@ -316,7 +301,7 @@ def test_contribute_to_shared_repo(
     assert provider.artifacts == []
 
 
-def test_get_repositories(mock_repo_file_fetch, mock_guest_and_pm, artifact_provider, tmppath):
+def test_get_repositories(mock_guest_and_pm, artifact_provider, tmppath):
     """Test that get_repositories returns the initialized repository"""
 
     mock_guest, _ = mock_guest_and_pm

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -116,9 +116,22 @@ DEFAULT_REBOOT_TIMEOUT: int = 10 * 60
 REBOOT_TIMEOUT: int = configure_constant(DEFAULT_REBOOT_TIMEOUT, 'TMT_REBOOT_TIMEOUT')
 
 #: Number of attempts to download a file from a URL.
-DOWNLOAD_ATTEMPTS = 3
+#: This is the default value tmt would use unless told otherwise.
+DEFAULT_DOWNLOAD_ATTEMPTS: int = 3
+
+#: Number of attempts to download a file from a URL.
+#: This is the effective value, combining the default and optional envvar,
+#: ``TMT_DOWNLOAD_ATTEMPTS``.
+DOWNLOAD_ATTEMPTS: int = configure_constant(DEFAULT_DOWNLOAD_ATTEMPTS, 'TMT_DOWNLOAD_ATTEMPTS')
+
 #: Number of seconds to wait between download attempts.
-DOWNLOAD_INTERVAL = 5
+#: This is the default value tmt would use unless told otherwise.
+DEFAULT_DOWNLOAD_INTERVAL: int = 5
+
+#: Number of seconds to wait between download attempts.
+#: This is the effective value, combining the default and optional envvar,
+#: ``TMT_DOWNLOAD_INTERVAL``.
+DOWNLOAD_INTERVAL: int = configure_constant(DEFAULT_DOWNLOAD_INTERVAL, 'TMT_DOWNLOAD_INTERVAL')
 
 
 def default_reboot_waiting() -> Waiting:

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -115,6 +115,11 @@ DEFAULT_REBOOT_TIMEOUT: int = 10 * 60
 #: ``TMT_REBOOT_TIMEOUT``.
 REBOOT_TIMEOUT: int = configure_constant(DEFAULT_REBOOT_TIMEOUT, 'TMT_REBOOT_TIMEOUT')
 
+#: Number of attempts to download a file from a URL.
+DOWNLOAD_ATTEMPTS = 3
+#: Number of seconds to wait between download attempts.
+DOWNLOAD_INTERVAL = 5
+
 
 def default_reboot_waiting() -> Waiting:
     """
@@ -2399,19 +2404,24 @@ class Guest(
 
         :param url: URL to download from.
         :param destination: path on the guest to save the file to.
-        :raises GeneralError: if the download fails.
+        :raises DownloadError: if the download fails after all attempts.
         """
 
-        try:
-            self.execute(
-                ShellScript(
-                    f"{self.facts.sudo_prefix} curl -L --fail"
-                    f" -o {quote(str(destination))} {quote(url)}"
-                ),
-                silent=True,
-            )
-        except tmt.utils.RunError as error:
-            raise DownloadError(f"Failed to download '{url}' to '{destination}'.") from error
+        def _do_download() -> None:
+            try:
+                self.execute(
+                    ShellScript(
+                        f"{self.facts.sudo_prefix} curl -L --fail"
+                        f" -o {quote(str(destination))} {quote(url)}"
+                    ),
+                    silent=True,
+                )
+            except tmt.utils.RunError as error:
+                raise DownloadError(f"Failed to download '{url}' to '{destination}'.") from error
+
+        tmt.utils.retry(
+            _do_download, DOWNLOAD_ATTEMPTS, DOWNLOAD_INTERVAL, f"Download '{url}'", self._logger
+        )
 
     @abc.abstractmethod
     def stop(self) -> None:

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2398,7 +2398,10 @@ class Guest(
 
         try:
             self.execute(
-                ShellScript(f"curl -L --fail -o {quote(str(destination))} {quote(url)}"),
+                ShellScript(
+                    f"{self.facts.sudo_prefix} curl -L --fail"
+                    f" -o {quote(str(destination))} {quote(url)}"
+                ),
                 silent=True,
             )
         except tmt.utils.RunError as error:

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -133,37 +133,6 @@ DEFAULT_DOWNLOAD_INTERVAL: int = 5
 #: ``TMT_DOWNLOAD_INTERVAL``.
 DOWNLOAD_INTERVAL: int = configure_constant(DEFAULT_DOWNLOAD_INTERVAL, 'TMT_DOWNLOAD_INTERVAL')
 
-#: Seconds curl waits for the connection phase to succeed during a download.
-#: This is the default value tmt would use unless told otherwise.
-DEFAULT_DOWNLOAD_CONNECT_TIMEOUT: int = 30
-
-#: Seconds curl waits for the connection phase to succeed during a download.
-#: This is the effective value, combining the default and optional envvar,
-#: ``TMT_DOWNLOAD_CONNECT_TIMEOUT``.
-DOWNLOAD_CONNECT_TIMEOUT: int = configure_constant(
-    DEFAULT_DOWNLOAD_CONNECT_TIMEOUT, 'TMT_DOWNLOAD_CONNECT_TIMEOUT'
-)
-#: Minimum transfer rate (bytes/sec) below which a download is considered stalled.
-#: This is the default value tmt would use unless told otherwise.
-DEFAULT_DOWNLOAD_SPEED_LIMIT: int = 1000
-
-#: Minimum transfer rate (bytes/sec) below which a download is considered stalled.
-#: This is the effective value, combining the default and optional envvar,
-#: ``TMT_DOWNLOAD_SPEED_LIMIT``.
-DOWNLOAD_SPEED_LIMIT: int = configure_constant(
-    DEFAULT_DOWNLOAD_SPEED_LIMIT, 'TMT_DOWNLOAD_SPEED_LIMIT'
-)
-#: Seconds the transfer rate must stay below the speed limit before curl aborts.
-#: This is the default value tmt would use unless told otherwise.
-DEFAULT_DOWNLOAD_SPEED_TIME: int = 60
-
-#: Seconds the transfer rate must stay below the speed limit before curl aborts.
-#: This is the effective value, combining the default and optional envvar,
-#: ``TMT_DOWNLOAD_SPEED_TIME``.
-DOWNLOAD_SPEED_TIME: int = configure_constant(
-    DEFAULT_DOWNLOAD_SPEED_TIME, 'TMT_DOWNLOAD_SPEED_TIME'
-)
-
 
 def default_reboot_waiting() -> Waiting:
     """
@@ -2445,7 +2414,6 @@ class Guest(
     def download(self, url: str, destination: Path) -> None:
         """
         Download a file from a URL to a path on the guest.
-
         :param url: URL to download from.
         :param destination: path on the guest to save the file to.
         :raises DownloadError: if the download fails after all attempts.
@@ -2454,12 +2422,8 @@ class Guest(
             self.execute(
                 ShellScript(
                     f"{self.facts.sudo_prefix} curl -L --fail"
-                    f" --connect-timeout {DOWNLOAD_CONNECT_TIMEOUT}"
-                    f" --speed-time {DOWNLOAD_SPEED_TIME}"
-                    f" --speed-limit {DOWNLOAD_SPEED_LIMIT}"
                     f" --retry {DOWNLOAD_ATTEMPTS - 1}"
                     f" --retry-delay {DOWNLOAD_INTERVAL}"
-                    f" --retry-connrefused"
                     f" -o {quote(str(destination))} {quote(url)}"
                 ),
                 silent=True,

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -133,6 +133,37 @@ DEFAULT_DOWNLOAD_INTERVAL: int = 5
 #: ``TMT_DOWNLOAD_INTERVAL``.
 DOWNLOAD_INTERVAL: int = configure_constant(DEFAULT_DOWNLOAD_INTERVAL, 'TMT_DOWNLOAD_INTERVAL')
 
+#: Seconds curl waits for the connection phase to succeed during a download.
+#: This is the default value tmt would use unless told otherwise.
+DEFAULT_DOWNLOAD_CONNECT_TIMEOUT: int = 30
+
+#: Seconds curl waits for the connection phase to succeed during a download.
+#: This is the effective value, combining the default and optional envvar,
+#: ``TMT_DOWNLOAD_CONNECT_TIMEOUT``.
+DOWNLOAD_CONNECT_TIMEOUT: int = configure_constant(
+    DEFAULT_DOWNLOAD_CONNECT_TIMEOUT, 'TMT_DOWNLOAD_CONNECT_TIMEOUT'
+)
+#: Minimum transfer rate (bytes/sec) below which a download is considered stalled.
+#: This is the default value tmt would use unless told otherwise.
+DEFAULT_DOWNLOAD_SPEED_LIMIT: int = 1000
+
+#: Minimum transfer rate (bytes/sec) below which a download is considered stalled.
+#: This is the effective value, combining the default and optional envvar,
+#: ``TMT_DOWNLOAD_SPEED_LIMIT``.
+DOWNLOAD_SPEED_LIMIT: int = configure_constant(
+    DEFAULT_DOWNLOAD_SPEED_LIMIT, 'TMT_DOWNLOAD_SPEED_LIMIT'
+)
+#: Seconds the transfer rate must stay below the speed limit before curl aborts.
+#: This is the default value tmt would use unless told otherwise.
+DEFAULT_DOWNLOAD_SPEED_TIME: int = 60
+
+#: Seconds the transfer rate must stay below the speed limit before curl aborts.
+#: This is the effective value, combining the default and optional envvar,
+#: ``TMT_DOWNLOAD_SPEED_TIME``.
+DOWNLOAD_SPEED_TIME: int = configure_constant(
+    DEFAULT_DOWNLOAD_SPEED_TIME, 'TMT_DOWNLOAD_SPEED_TIME'
+)
+
 
 def default_reboot_waiting() -> Waiting:
     """
@@ -2419,25 +2450,21 @@ class Guest(
         :param destination: path on the guest to save the file to.
         :raises DownloadError: if the download fails after all attempts.
         """
-
-        def _do_download() -> None:
+        try:
             self.execute(
                 ShellScript(
                     f"{self.facts.sudo_prefix} curl -L --fail"
+                    f" --connect-timeout {DOWNLOAD_CONNECT_TIMEOUT}"
+                    f" --speed-time {DOWNLOAD_SPEED_TIME}"
+                    f" --speed-limit {DOWNLOAD_SPEED_LIMIT}"
+                    f" --retry {DOWNLOAD_ATTEMPTS - 1}"
+                    f" --retry-delay {DOWNLOAD_INTERVAL}"
+                    f" --retry-connrefused"
                     f" -o {quote(str(destination))} {quote(url)}"
                 ),
                 silent=True,
             )
-
-        try:
-            tmt.utils.retry(
-                _do_download,
-                DOWNLOAD_ATTEMPTS,
-                DOWNLOAD_INTERVAL,
-                f"Download '{url}'",
-                self._logger,
-            )
-        except tmt.utils.RetryError as error:
+        except tmt.utils.RunError as error:
             raise DownloadError(f"Failed to download '{url}' to '{destination}'.") from error
 
     @abc.abstractmethod

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2422,7 +2422,7 @@ class Guest(
             self.execute(
                 ShellScript(
                     f"{self.facts.sudo_prefix} curl -L --fail"
-                    f" --retry {DOWNLOAD_ATTEMPTS - 1}"
+                    f" --retry {max(DOWNLOAD_ATTEMPTS - 1, 0)}"
                     f" --retry-delay {DOWNLOAD_INTERVAL}"
                     f" -o {quote(str(destination))} {quote(url)}"
                 ),

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2408,20 +2408,24 @@ class Guest(
         """
 
         def _do_download() -> None:
-            try:
-                self.execute(
-                    ShellScript(
-                        f"{self.facts.sudo_prefix} curl -L --fail"
-                        f" -o {quote(str(destination))} {quote(url)}"
-                    ),
-                    silent=True,
-                )
-            except tmt.utils.RunError as error:
-                raise DownloadError(f"Failed to download '{url}' to '{destination}'.") from error
+            self.execute(
+                ShellScript(
+                    f"{self.facts.sudo_prefix} curl -L --fail"
+                    f" -o {quote(str(destination))} {quote(url)}"
+                ),
+                silent=True,
+            )
 
-        tmt.utils.retry(
-            _do_download, DOWNLOAD_ATTEMPTS, DOWNLOAD_INTERVAL, f"Download '{url}'", self._logger
-        )
+        try:
+            tmt.utils.retry(
+                _do_download,
+                DOWNLOAD_ATTEMPTS,
+                DOWNLOAD_INTERVAL,
+                f"Download '{url}'",
+                self._logger,
+            )
+        except tmt.utils.RetryError as error:
+            raise DownloadError(f"Failed to download '{url}' to '{destination}'.") from error
 
     @abc.abstractmethod
     def stop(self) -> None:

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2387,6 +2387,25 @@ class Guest(
 
         raise NotImplementedError
 
+    def download(self, url: str, destination: Path) -> None:
+        """
+        Download a file from a URL to a path on the guest.
+
+        :param url: URL to download from.
+        :param destination: path on the guest to save the file to.
+        :raises GeneralError: if the download fails.
+        """
+
+        try:
+            self.execute(
+                ShellScript(f"curl -L --fail -o {quote(str(destination))} {quote(url)}"),
+                silent=True,
+            )
+        except tmt.utils.RunError as error:
+            raise tmt.utils.GeneralError(
+                f"Failed to download '{url}' to '{destination}'."
+            ) from error
+
     @abc.abstractmethod
     def stop(self) -> None:
         """

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -460,6 +460,12 @@ SoftRebootModes = Literal[RebootMode.SOFT, RebootMode.SYSTEMD_SOFT]
 HardRebootModes = Literal[RebootMode.HARD]
 
 
+class DownloadError(tmt.utils.GeneralError):
+    """
+    Raised when download fails.
+    """
+
+
 class RebootModeNotSupportedError(ProvisionError):
     """A requested reboot mode is not supported by the guest"""
 
@@ -2405,9 +2411,7 @@ class Guest(
                 silent=True,
             )
         except tmt.utils.RunError as error:
-            raise tmt.utils.GeneralError(
-                f"Failed to download '{url}' to '{destination}'."
-            ) from error
+            raise DownloadError(f"Failed to download '{url}' to '{destination}'.") from error
 
     @abc.abstractmethod
     def stop(self) -> None:

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -35,6 +35,10 @@ if TYPE_CHECKING:
     PackageOrigin: TypeAlias = Union[str, 'SpecialPackageOrigin']
 
 
+#: Directory where DNF/YUM repository files are stored.
+YUM_REPOS_DIR = Path("/etc/yum.repos.d")
+
+
 class _ResolvedEntry(TypedDict):
     """
     Single entry from the YAML output of :py:meth:`PackageManagerEngine.resolve_provides`.

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -4,6 +4,7 @@ from typing import ClassVar, Optional, cast
 
 from tmt._compat.pathlib import Path
 from tmt.package_managers import (
+    YUM_REPOS_DIR,
     FileSystemPath,
     Installable,
     Options,
@@ -180,7 +181,7 @@ class DnfEngine(PackageManagerEngine):
         return script
 
     def install_repository(self, repository: Repository) -> ShellScript:
-        repo_path = f"/etc/yum.repos.d/{repository.filename}"
+        repo_path = YUM_REPOS_DIR / repository.filename
         return ShellScript(
             f"{self.guest.facts.sudo_prefix} tee {repo_path} <<'EOF'\n{repository.content}\nEOF"
         )

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -150,13 +150,8 @@ class ArtifactProvider(ABC):
         :param artifact: the artifact to download.
         :param guest: the guest on which the artifact should be downloaded.
         :param destination: path into which the artifact should be downloaded.
-        :raises DownloadError: if the download fails.
         """
-
-        try:
-            guest.download(artifact.location, destination)
-        except tmt.utils.GeneralError as error:
-            raise DownloadError(f"Failed to download '{artifact}'.") from error
+        guest.download(artifact.location, destination)
 
     def fetch_contents(
         self,

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -14,7 +14,7 @@ import tmt.log
 import tmt.utils
 from tmt._compat.typing import TypeAlias
 from tmt.container import container, simple_field
-from tmt.guest import Guest
+from tmt.guest import DownloadError, Guest
 from tmt.package_managers import Repository, Version
 from tmt.plugins import PluginRegistry
 from tmt.utils import Path, ShellScript
@@ -25,12 +25,6 @@ NEVRA_PATTERN = re.compile(
 
 #: Name of the shared repository that download providers contribute RPMs into.
 SHARED_REPO_NAME: str = 'tmt-artifact-shared'
-
-
-class DownloadError(tmt.utils.GeneralError):
-    """
-    Raised when download fails.
-    """
 
 
 class UnsupportedOperationError(RuntimeError):

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -147,18 +147,22 @@ class ArtifactProvider(ABC):
 
         return self._artifacts
 
-    @abstractmethod
     def _download_artifact(
         self, artifact: ArtifactInfo, guest: Guest, destination: tmt.utils.Path
     ) -> None:
         """
         Download a single artifact to the specified destination on a given guest.
 
+        :param artifact: the artifact to download.
         :param guest: the guest on which the artifact should be downloaded.
         :param destination: path into which the artifact should be downloaded.
+        :raises DownloadError: if the download fails.
         """
 
-        raise NotImplementedError
+        try:
+            guest.download(artifact.location, destination)
+        except tmt.utils.GeneralError as error:
+            raise DownloadError(f"Failed to download '{artifact}'.") from error
 
     def fetch_contents(
         self,

--- a/tmt/steps/prepare/artifact/providers/copr_build.py
+++ b/tmt/steps/prepare/artifact/providers/copr_build.py
@@ -19,7 +19,6 @@ from tmt.steps.prepare.artifact.providers import (
     ArtifactInfo,
     ArtifactProvider,
     ArtifactProviderId,
-    DownloadError,
     provides_artifact_provider,
 )
 from tmt.utils import ShellScript
@@ -135,20 +134,6 @@ class CoprBuildArtifactProvider(ArtifactProvider):
                 f"Provider id '{raw_id}' is invalid, how did we get here?"
             ) from error
         return value
-
-    def _download_artifact(
-        self, artifact: ArtifactInfo, guest: Guest, destination: tmt.utils.Path
-    ) -> None:
-        try:
-            # Destination directory is guaranteed to exist, download the artifact
-            guest.execute(
-                tmt.utils.ShellScript(
-                    f"curl -L --fail -o {quote(str(destination))} {quote(artifact.location)}"
-                ),
-                silent=True,
-            )
-        except Exception as error:
-            raise DownloadError(f"Failed to download '{artifact}'.") from error
 
     @cached_property
     def result_url(self) -> str:

--- a/tmt/steps/prepare/artifact/providers/copr_repository.py
+++ b/tmt/steps/prepare/artifact/providers/copr_repository.py
@@ -10,6 +10,7 @@ import tmt.utils
 from tmt._compat.typing import Self
 from tmt.container import container
 from tmt.guest import Guest
+from tmt.package_managers import YUM_REPOS_DIR
 from tmt.steps.prepare.artifact.providers import (
     ArtifactInfo,
     ArtifactProvider,
@@ -114,9 +115,7 @@ class CoprRepositoryProvider(ArtifactProvider):
         repo_filename = f"_copr:copr.fedorainfracloud.org:{owner}:{repo.project}.repo"
 
         try:
-            output = guest.execute(
-                tmt.utils.Command("cat", Path(f"/etc/yum.repos.d/{repo_filename}"))
-            )
+            output = guest.execute(tmt.utils.Command("cat", YUM_REPOS_DIR / repo_filename))
         except tmt.utils.RunError as error:
             raise tmt.utils.PrepareError(
                 f"Failed to read '{repo_filename}' from the guest."

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -109,12 +109,7 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
     ) -> None:
         try:
             if self._is_url:  # Remote file, download it
-                guest.execute(
-                    tmt.utils.ShellScript(
-                        f"curl -L --fail -o {quote(str(destination))} {quote(artifact.location)}"
-                    ),
-                    silent=True,
-                )
+                guest.download(artifact.location, destination)
             else:  # Local file, push it to the guest
                 # When pushing a single file, use recursive=False. The default recursive=True
                 # treats the source as a directory (appending "/."), which only works for

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -20,7 +20,6 @@ from tmt.steps.prepare.artifact.providers import (
     ArtifactInfo,
     ArtifactProvider,
     ArtifactProviderId,
-    DownloadError,
     provides_artifact_provider,
 )
 from tmt.utils import ShellScript
@@ -177,27 +176,6 @@ class KojiArtifactProvider(ArtifactProvider):
                 f"Provider id '{raw_id}' is invalid, how did we get here?"
             ) from exc
         return value
-
-    def _download_artifact(
-        self, artifact: ArtifactInfo, guest: Guest, destination: tmt.utils.Path
-    ) -> None:
-        """
-        Download the specified artifact to the given destination on the guest.
-
-        :param artifact: The artifact to download
-        :param guest: The guest where the artifact should be downloaded
-        :param destination: The destination path on the guest
-        """
-        try:
-            # Destination directory is guaranteed to exist, download the artifact
-            guest.execute(
-                tmt.utils.ShellScript(
-                    f"curl -L --fail -o {quote(str(destination))} {quote(artifact.location)}"
-                ),
-                silent=True,
-            )
-        except Exception as error:
-            raise DownloadError(f"Failed to download '{artifact}'.") from error
 
     def contribute_to_shared_repo(
         self,

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -10,6 +10,7 @@ import tmt.log
 import tmt.utils
 from tmt.container import container, simple_field
 from tmt.guest import Guest
+from tmt.package_managers import YUM_REPOS_DIR
 from tmt.steps import DefaultNameGenerator
 from tmt.steps.prepare.artifact.providers import (
     ArtifactInfo,
@@ -83,8 +84,13 @@ class RepositoryFileProvider(ArtifactProvider):
             self.repository = Repository.from_file_path(file_path=parsed_path, logger=self.logger)
         else:
             repo_filename = parsed_path.name
-            remote_path = Path(f"/etc/yum.repos.d/{repo_filename}")
-            guest.download(self.id, remote_path)
+            remote_path = YUM_REPOS_DIR / repo_filename
+            try:
+                guest.download(self.id, remote_path)
+            except tmt.utils.GeneralError as error:
+                raise PrepareError(
+                    f"Failed to download repository file '{self.id}' to the guest."
+                ) from error
             try:
                 output = guest.execute(tmt.utils.Command("cat", remote_path))
             except tmt.utils.RunError as error:

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -75,18 +75,23 @@ class RepositoryFileProvider(ArtifactProvider):
         self.logger.info(f"Initializing repository provider with URL: {self.id}")
 
         parsed = urlparse(self.id)
+        parsed_path = Path(parsed.path)
         if parsed.scheme == 'file':
             # Read .repo file from the local (controller) filesystem.
-            self.logger.info(f"Reading repository file from local path: {parsed.path}")
-            self.logger.debug(
-                f"Absolute path of the repository file: '{Path(parsed.path).resolve()}'"
-            )
-            self.repository = Repository.from_file_path(
-                file_path=Path(parsed.path), logger=self.logger
-            )
+            self.logger.info(f"Reading repository file from local path: {parsed_path}")
+            self.logger.debug(f"Absolute path of the repository file: '{parsed_path.resolve()}'")
+            self.repository = Repository.from_file_path(file_path=parsed_path, logger=self.logger)
         else:
-            # TODO: This should not be using Repository.from_url
-            self.repository = Repository.from_url(url=self.id, logger=self.logger)
+            repo_filename = parsed_path.name
+            remote_path = Path(f"/etc/yum.repos.d/{repo_filename}")
+            guest.download(self.id, remote_path)
+            try:
+                output = guest.execute(tmt.utils.Command("cat", remote_path))
+            except tmt.utils.RunError as error:
+                raise PrepareError(f"Failed to read '{repo_filename}' from the guest.") from error
+            self.repository = Repository.from_content(
+                output.stdout or '', repo_filename.removesuffix('.repo'), self.logger
+            )
 
         self.logger.info(
             f"Repository initialized: {self.repository.name} "

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 import tmt.log
 import tmt.utils
 from tmt.container import container, simple_field
-from tmt.guest import Guest
+from tmt.guest import DownloadError, Guest
 from tmt.package_managers import YUM_REPOS_DIR
 from tmt.steps import DefaultNameGenerator
 from tmt.steps.prepare.artifact.providers import (
@@ -87,7 +87,7 @@ class RepositoryFileProvider(ArtifactProvider):
             remote_path = YUM_REPOS_DIR / repo_filename
             try:
                 guest.download(self.id, remote_path)
-            except tmt.utils.GeneralError as error:
+            except DownloadError as error:
                 raise PrepareError(
                     f"Failed to download repository file '{self.id}' to the guest."
                 ) from error


### PR DESCRIPTION
Added `download(url, destination)` method to Guest - this de-duplicates the `_download_artifact()`  on koji.py, copr_build.py & calls it from with file.py. Also, the repository.py now follows the same pattern as copr_repository.py
