### PR TITLE
Remove redundant `install_*` methods

### DIFF
--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -3532,6 +3532,7 @@ class GuestSsh(Guest, CommandCollector):
             # this is needed for example on fresh Debian installs.
             self.package_manager.refresh_metadata()
             self.package_manager.install(Package('rsync'))
+            self.package_manager.finalize_installation()
 
         except Exception as exc:
             raise tmt.utils.GeneralError(

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -3346,6 +3346,7 @@ class GuestSsh(Guest, CommandCollector):
             return
         if not self.facts.is_superuser and self.become:
             self.package_manager.install(FileSystemPath('/usr/bin/setfacl'))
+            self.package_manager.finalize_installation()
             workdir_root = effective_workdir_root()
             self.execute(
                 ShellScript(

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -540,16 +540,6 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         """
         return self.guest.execute(self.engine.create_repository(directory))
 
-    def install_from_repository(
-        self,
-        *installables: Installable,
-        options: Optional[Options] = None,
-    ) -> CommandOutput:
-        """
-        Install packages from a repository
-        """
-        return self.install(*installables, options=options)
-
     def install_local(
         self,
         *installables: Installable,
@@ -557,16 +547,6 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
     ) -> CommandOutput:
         """
         Install packages stored in a local directory
-        """
-        return self.install(*installables, options=options)
-
-    def install_from_url(
-        self,
-        *installables: Installable,
-        options: Optional[Options] = None,
-    ) -> CommandOutput:
-        """
-        Install packages stored on a remote URL
         """
         return self.install(*installables, options=options)
 

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -640,16 +640,6 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         """
         return self.guest.execute(self.engine.create_repository(directory))
 
-    def install_from_repository(
-        self,
-        *installables: Installable,
-        options: Optional[Options] = None,
-    ) -> CommandOutput:
-        """
-        Install packages from a repository
-        """
-        return self.install(*installables, options=options)
-
     def install_local(
         self,
         *installables: Installable,
@@ -657,16 +647,6 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
     ) -> CommandOutput:
         """
         Install packages stored in a local directory
-        """
-        return self.install(*installables, options=options)
-
-    def install_from_url(
-        self,
-        *installables: Installable,
-        options: Optional[Options] = None,
-    ) -> CommandOutput:
-        """
-        Install packages stored on a remote URL
         """
         return self.install(*installables, options=options)
 

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -74,7 +74,9 @@ class ApkEngine(PackageManagerEngine):
                 packages.append(self.path_to_package(installable))
 
             else:
-                raise GeneralError(f"Package specification '{installable}' is not supported.")
+                raise tmt.utils.PrepareError(
+                    "Package manager 'apk' does not support installing from a remote URL."
+                )
 
         return packages
 
@@ -206,13 +208,3 @@ class Apk(PackageManager[ApkEngine]):
         options.allow_untrusted = True
         options.check_first = False
         return self.install(*installables, options=options)
-
-    def install_from_url(
-        self,
-        *installables: Installable,
-        options: Optional[Options] = None,
-    ) -> CommandOutput:
-        raise tmt.utils.PrepareError(
-            f'Package manager "{self.guest.facts.package_manager}" '
-            'does not support installing from a remote URL.'
-        )

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -75,7 +75,8 @@ class ApkEngine(PackageManagerEngine):
 
             else:
                 raise tmt.utils.PrepareError(
-                    "Package manager 'apk' does not support installing from a remote URL."
+                    f"Package manager 'apk' does not support installing from a remote "
+                    f"URL '{installable}'."
                 )
 
         return packages

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -311,7 +311,6 @@ class Bootc(PackageManager[BootcEngine]):
 
         if missing_installables:
             self.engine.install(*missing_installables, options=options)
-            return self.build_container() or CommandOutput(stdout=None, stderr=None)
 
         return CommandOutput(stdout=None, stderr=None)
 
@@ -322,7 +321,7 @@ class Bootc(PackageManager[BootcEngine]):
     ) -> CommandOutput:
         self.engine.reinstall(*installables, options=options)
 
-        return self.build_container() or CommandOutput(stdout=None, stderr=None)
+        return CommandOutput(stdout=None, stderr=None)
 
     def install_debuginfo(
         self,
@@ -330,35 +329,6 @@ class Bootc(PackageManager[BootcEngine]):
         options: Optional[Options] = None,
     ) -> CommandOutput:
         self.engine.install_debuginfo(*installables, options=options)
-        return CommandOutput(stdout=None, stderr=None)
-
-    def install_from_repository(
-        self,
-        *installables: Installable,
-        options: Optional[Options] = None,
-    ) -> CommandOutput:
-
-        # Check presence to avoid unnecessary container rebuilds
-        presence = self.check_presence(*installables)
-
-        missing_installables = {i for i, present in presence.items() if not present}
-        if missing_installables:
-            self.engine.install(*missing_installables, options=options)
-
-        return CommandOutput(stdout=None, stderr=None)
-
-    def install_from_url(
-        self,
-        *installables: Installable,
-        options: Optional[Options] = None,
-    ) -> CommandOutput:
-
-        presence = self.check_presence(*installables)
-
-        missing_installables = {i for i, present in presence.items() if not present}
-        if missing_installables:
-            self.engine.install(*missing_installables, options=options)
-
         return CommandOutput(stdout=None, stderr=None)
 
     def install_local(

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -247,7 +247,7 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
                 self.warn(f"Unable to install recommended package '{package}'.")
 
         if required:
-            return super().install(*required)
+            return super().install(*required, options=options)
 
         return CommandOutput(stdout=None, stderr=None)
 

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -241,7 +241,7 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
         for package in recommended:
             self.info('package', str(package), 'green')
             try:
-                super().install(package)
+                super().install(package, options=options)
             except RunError as error:
                 self.debug(f"Package installation failed: {error}")
                 self.warn(f"Unable to install recommended package '{package}'.")

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -218,8 +218,10 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
         required: list[Installable] = []
         recommended: list[Installable] = []
 
-        for installable in installables:
-            if all(self.check_presence(installable).values()):
+        presence = self.check_presence(*installables)
+
+        for installable, present in presence.items():
+            if present:
                 continue
             if options.skip_missing:
                 recommended.append(installable)
@@ -228,7 +230,7 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
 
         return required, recommended
 
-    def install_from_repository(
+    def install(
         self,
         *installables: Installable,
         options: Optional[Options] = None,
@@ -239,13 +241,13 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
         for package in recommended:
             self.info('package', str(package), 'green')
             try:
-                self.install(package)
+                super().install(package)
             except RunError as error:
                 self.debug(f"Package installation failed: {error}")
                 self.warn(f"Unable to install recommended package '{package}'.")
 
         if required:
-            return self.install(*required)
+            return super().install(*required)
 
         return CommandOutput(stdout=None, stderr=None)
 

--- a/tmt/steps/prepare/distgit.py
+++ b/tmt/steps/prepare/distgit.py
@@ -213,6 +213,7 @@ class PrepareDistGit(tmt.steps.prepare.PreparePlugin[DistGitData]):
 
         # Install required packages for rpm-build to work
         guest.package_manager.install(*explicit_requires)
+        guest.package_manager.finalize_installation()
 
         source_dir = self.data.source_dir
         assert source_dir

--- a/tmt/steps/prepare/feature/crb.py
+++ b/tmt/steps/prepare/feature/crb.py
@@ -60,6 +60,7 @@ class Crb(ToggleableFeature):
             return
 
         guest.package_manager.install(Package("dnf-command(config-manager)"))
+        guest.package_manager.finalize_installation()
 
         logger.info(f"{action.capitalize()} CRB repository.")
 

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -274,7 +274,7 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
 
         if self.remote_packages:
             install_outputs.append(
-                guest.package_manager.install_from_url(
+                guest.package_manager.install(
                     *self._list_installables('remote package', *self.remote_packages),
                     options=options,
                 )
@@ -282,7 +282,7 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
 
         if self.packages:
             install_outputs.append(
-                guest.package_manager.install_from_repository(
+                guest.package_manager.install(
                     *self._list_installables('package', *self.packages),
                     options=options,
                 )


### PR DESCRIPTION
originated from a comment here: https://github.com/teemtee/tmt/issues/4605#issuecomment-4031054446. Good to align before artifacts call various install methods.

also, a slight functional change in `RpmOstree.sort_packages()` which now batches the presence check.
