### PR TITLE
Add `zizmor` pre-commit hook and pin GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/build-and-publish-renovate.yml
+++ b/.github/workflows/build-and-publish-renovate.yml
@@ -18,14 +18,15 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.ref }}
-      - uses: redhat-actions/buildah-build@v2.13
+          persist-credentials: false
+      - uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
           image: renovate-tmt
           containerfiles: ./containers/Containerfile.renovate
-      - uses: redhat-actions/push-to-registry@v2.8
+      - uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
         with:
           image: renovate-tmt
           tags: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,6 @@ jobs:
     needs: [ pre-commit, build-wheel, shellcheck, doc-tests ]
     runs-on: ubuntu-slim
     steps:
-      - uses: re-actors/alls-green@release/v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe  # release/v1
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,6 @@ jobs:
     needs: [ pre-commit, build-wheel, shellcheck, doc-tests ]
     runs-on: ubuntu-slim
     steps:
-      - uses: re-actors/alls-green@v1.2.2
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -6,24 +6,27 @@ permissions: {}
 jobs:
   publish-images:
     runs-on: ubuntu-latest
+    environment: quay.io
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
       - name: Build - tmt
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056  # v2
         id: build-image-tmt
         with:
           image: tmt
           containerfiles: ./containers/Containerfile.mini
       - name: Build - tmt-all
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056  # v2
         id: build-image-tmt-all
         with:
           image: tmt-all
           containerfiles: ./containers/Containerfile.full
       - name: Push To quay.io - tmt
         id: push-to-quay-tmt
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c  # v2
         with:
           image: ${{ steps.build-image-tmt.outputs.image }}
           tags: ${{ steps.build-image-tmt.outputs.tags }}
@@ -32,7 +35,7 @@ jobs:
           password: ${{ secrets.QUAY_TEEMTEE_SECRET }}
       - name: Push To quay.io - tmt-all
         id: push-to-quay-tmt-all
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c  # v2
         with:
           image: ${{ steps.build-image-tmt-all.outputs.image }}
           tags: ${{ steps.build-image-tmt-all.outputs.tags }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -6,24 +6,29 @@ permissions: {}
 jobs:
   publish-images:
     runs-on: ubuntu-latest
+    environment:
+      name: quay.io
+      url: https://quay.io/organization/teemtee
 
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Build - tmt
-        uses: redhat-actions/buildah-build@v2.13
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         id: build-image-tmt
         with:
           image: tmt
           containerfiles: ./containers/Containerfile.mini
       - name: Build - tmt-all
-        uses: redhat-actions/buildah-build@v2.13
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         id: build-image-tmt-all
         with:
           image: tmt-all
           containerfiles: ./containers/Containerfile.full
       - name: Push To quay.io - tmt
         id: push-to-quay-tmt
-        uses: redhat-actions/push-to-registry@v2.8
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
         with:
           image: ${{ steps.build-image-tmt.outputs.image }}
           tags: ${{ steps.build-image-tmt.outputs.tags }}
@@ -32,7 +37,7 @@ jobs:
           password: ${{ secrets.QUAY_TEEMTEE_SECRET }}
       - name: Push To quay.io - tmt-all
         id: push-to-quay-tmt-all
-        uses: redhat-actions/push-to-registry@v2.8
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
         with:
           image: ${{ steps.build-image-tmt-all.outputs.image }}
           tags: ${{ steps.build-image-tmt-all.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,15 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: Packages
           path: dist
 
       - name: Generate artifact attestation for sdist and wheel
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4
         with:
           subject-path: "dist/*"
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,15 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/download-artifact@v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Packages
           path: dist
 
       - name: Generate artifact attestation for sdist and wheel
-        uses: actions/attest-build-provenance@v4.1.1
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: "dist/*"
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,15 +20,17 @@ jobs:
     environment: renovate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Get GitHub App token
         id: token
-        uses: actions/create-github-app-token@v3.2.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.RENOVATE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.RENOVATE_BOT_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-      - uses: renovatebot/github-action@v46.1.17
+      - uses: renovatebot/github-action@dd5302ec17783b2fc721b19ae7209b57b1587765 # v46.1.17
         with:
           configurationFile: .github/renovate-config.json
           token: '${{ steps.token.outputs.token }}'

--- a/.github/workflows/step-build-wheel.yml
+++ b/.github/workflows/step-build-wheel.yml
@@ -13,8 +13,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@fe0a0fb1925ca263d076ca4f2c13e93a6e92a33e  # v2

--- a/.github/workflows/step-build-wheel.yml
+++ b/.github/workflows/step-build-wheel.yml
@@ -13,8 +13,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ inputs.ref }}
           persist-credentials: false
-      - uses: hynek/build-and-inspect-python-package@v2.18.0
+      - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0

--- a/.github/workflows/step-doc-tests.yml
+++ b/.github/workflows/step-doc-tests.yml
@@ -26,14 +26,14 @@ jobs:
             sphinx_builder: html
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           persist-credentials: false
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: 3.x
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           activate-environment: true
       - name: Install tmt[docs]
@@ -45,7 +45,7 @@ jobs:
         if: ${{ matrix.builder == 'lint' }}
 
       - name: Cache linkcheck results
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5
         with:
           path: docs/_build/linkcheck_cache.json
           key: linkcheck

--- a/.github/workflows/step-doc-tests.yml
+++ b/.github/workflows/step-doc-tests.yml
@@ -26,14 +26,14 @@ jobs:
             sphinx_builder: html
 
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           ref: ${{ inputs.ref }}
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.x
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           activate-environment: true
       - name: Install tmt[docs]
@@ -50,7 +50,7 @@ jobs:
           echo "date=$(/usr/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
         if: ${{ matrix.builder == 'linkcheck' }}
       - name: Cache linkcheck results
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: docs/_build/linkcheck_cache.json
           key: linkcheck-${{ steps.date.outputs.date }}

--- a/.github/workflows/step-pre-commit.yml
+++ b/.github/workflows/step-pre-commit.yml
@@ -19,11 +19,11 @@ jobs:
     - run: |
         wget -O /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
         chmod +x /usr/local/bin/hadolint
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       with:
         persist-credentials: false
         ref: ${{ inputs.ref }}
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
       with:
         # Python 3.9 is for mypy testing the lowest python version
         # Python 3.13 is for ansible-lint hard-coding the python requirement
@@ -31,4 +31,4 @@ jobs:
           3.9
           3.13
           3.x
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1

--- a/.github/workflows/step-pre-commit.yml
+++ b/.github/workflows/step-pre-commit.yml
@@ -19,11 +19,11 @@ jobs:
     - run: |
         wget -O /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/latest/download/hadolint-Linux-x86_64
         chmod +x /usr/local/bin/hadolint
-    - uses: actions/checkout@v7.0.0
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
         ref: ${{ inputs.ref }}
-    - uses: actions/setup-python@v6.3.0
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         # Python 3.9 is for mypy testing the lowest python version
         # Python 3.13 is for ansible-lint hard-coding the python requirement
@@ -31,4 +31,4 @@ jobs:
           3.9
           3.13
           3.x
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/step-shellcheck.yml
+++ b/.github/workflows/step-shellcheck.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -27,7 +27,7 @@ jobs:
 
       - id: ShellCheck
         name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v5
+        uses: redhat-plumbers-in-action/differential-shellcheck@d965e66ec0b3b2f821f75c8eff9b12442d9a7d1e  # v5
         # Note: we do not use token here to have more control of when to upload the sarif.
         #  It might be incorrect to upload them for PRs.
         #  https://github.com/github/codeql-action/issues/3578
@@ -41,7 +41,7 @@ jobs:
 
       - if: ${{ always() }}
         name: Upload artifact with ShellCheck defects in SARIF format
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
         with:
           name: Differential ShellCheck SARIF
           path: ${{ steps.ShellCheck.outputs.sarif }}
@@ -53,10 +53,10 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: Differential ShellCheck SARIF
-      - uses: github/codeql-action/upload-sarif@v4
+      - uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v4
         with:
           sarif_file: ${{ needs.lint.outputs.sarif }}
     if: ${{ inputs.upload_sarif }}

--- a/.github/workflows/step-shellcheck.yml
+++ b/.github/workflows/step-shellcheck.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -27,7 +27,7 @@ jobs:
 
       - id: ShellCheck
         name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v5.5.6
+        uses: redhat-plumbers-in-action/differential-shellcheck@d965e66ec0b3b2f821f75c8eff9b12442d9a7d1e # v5.5.6
         # Note: we do not use token here to have more control of when to upload the sarif.
         #  It might be incorrect to upload them for PRs.
         #  https://github.com/github/codeql-action/issues/3578
@@ -41,7 +41,7 @@ jobs:
 
       - if: ${{ always() }}
         name: Upload artifact with ShellCheck defects in SARIF format
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Differential ShellCheck SARIF
           path: ${{ steps.ShellCheck.outputs.sarif }}
@@ -53,10 +53,10 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/download-artifact@v8.0.1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Differential ShellCheck SARIF
-      - uses: github/codeql-action/upload-sarif@v4.36.3
+      - uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: ${{ needs.lint.outputs.sarif }}
     if: ${{ inputs.upload_sarif }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -254,6 +254,11 @@ repos:
           - '--rst-directives'
           - 'versionadded,versionchanged'
 
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: ea2eb407b4cbce87cf0d502f36578950494f5ac9  # v1.23.1
+    hooks:
+      - id: zizmor
+
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.10.9
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -254,6 +254,11 @@ repos:
           - '--rst-directives'
           - 'versionadded,versionchanged'
 
+  - repo: https://github.com/woodruffw/zizmor-pre-commit
+    rev: ea2eb407b4cbce87cf0d502f36578950494f5ac9  # v1.23.1
+    hooks:
+      - id: zizmor
+
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.11.24
     hooks:


### PR DESCRIPTION
Add `zizmor` to pre-commit hooks for auditing GitHub Actions workflows for security issues.

https://docs.zizmor.sh/

Fix all findings reported by zizmor:

- Pin all action references to commit SHAs ([unpinned-uses](https://docs.zizmor.sh/audits/#unpinned-uses))
- Add `persist-credentials: false` to checkout in `publish-images.yml` ([artipacked](https://docs.zizmor.sh/audits/#artipacked))
- Add `environment: quay.io` to the publish-images job to protect secrets access ([secrets-outside-env](https://docs.zizmor.sh/audits/#secrets-outside-env))

Assisted-by: Claude Code

Pull Request Checklist:

* [x] implement the feature
