### PR TITLE
Artifact interface cleanups (round 1)

### DIFF
--- a/tests/unit/artifact/test_base.py
+++ b/tests/unit/artifact/test_base.py
@@ -1,4 +1,3 @@
-import re
 from unittest.mock import MagicMock
 
 import pytest
@@ -44,11 +43,6 @@ def mock_provider(root_logger):
         logger=root_logger,
         parent=mock_prepare_artifact,
     )
-
-
-def test_filter_artifacts(mock_provider):
-    artifacts = list(mock_provider._filter_artifacts([re.compile("mock")]))
-    assert artifacts == []
 
 
 def test_download_artifacts(tmp_path, root_logger, mock_provider):

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -14,7 +14,6 @@ from tmt.steps.prepare.artifact.providers import (
     _PROVIDER_REGISTRY,
     SHARED_REPO_NAME,
     ArtifactProvider,
-    Repository,
 )
 
 # ``@provides_method`` causes pyright to lose the class type, which is the
@@ -293,22 +292,14 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
         # This aggregates all local artifacts from file-based providers.
         # If this prepare step runs multiple times in the same plan, artifacts
         # accumulate in the same directory and createrepo updates the metadata.
-
         guest.package_manager.create_repository(shared_repo_dir)
+        guest.package_manager.install_repository(shared_repository)
 
-        # Collect all repositories (shared repository + provider repositories)
-        repositories: list[Repository] = [shared_repository]
+        # Install and enumerate all artifacts
         for provider in providers:
-            repositories.extend(provider.get_repositories())
-
-        # Install all repositories centrally
-        # This ensures consistent handling across all providers
-        for repo in repositories:
-            guest.package_manager.install_repository(repo)
-
-        # Enumerate artifacts from installed repositories.
-        for provider in providers:
-            provider.enumerate_artifacts(guest)
+            for repo in provider.get_repositories():
+                guest.package_manager.install_repository(repo)
+                provider.enumerate_artifacts(guest, repository=repo)
 
         # Persist artifact metadata to YAML
         self._save_artifacts_metadata(providers)

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -305,7 +305,6 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
         # This ensures consistent handling across all providers
         for repo in repositories:
             guest.package_manager.install_repository(repo)
-            logger.debug(f"Installed repository '{repo.name}'.")
 
         # Enumerate artifacts from installed repositories.
         for provider in providers:
@@ -317,12 +316,6 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
         # Verify phase injection
         if self.data.verify:
             self._inject_verify_phase(providers, guest)
-
-        # Report configuration summary
-        logger.info(
-            f"Configured artifact preparation with {len(self.data.provide)} provider(s) "
-            f"and {len(repositories)} repository(ies)."
-        )
 
         return outcome
 

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -4,7 +4,7 @@ Abstract base class for artifact providers.
 
 import re
 from abc import ABC, abstractmethod
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator
 from functools import cached_property
 from re import Pattern
 from shlex import quote
@@ -110,7 +110,7 @@ class ArtifactProvider(ABC):
     #: repository, and so on.
     id: ArtifactProviderId = simple_field(init=False)
 
-    #: All artifacts known to this provider. Populated by
+    #: Writable internal field of :py:attr:`artifacts`. To be populated by
     #: :py:meth:`_download_artifact` and/or :py:meth:`enumerate_artifacts`.
     _artifacts: list[ArtifactInfo] = simple_field(init=False, default_factory=list)
 
@@ -138,14 +138,12 @@ class ArtifactProvider(ABC):
         raise NotImplementedError
 
     @property
-    def artifacts(self) -> Sequence[ArtifactInfo]:
+    def artifacts(self) -> Iterator[ArtifactInfo]:
         """
-        Collect all artifacts available from this provider.
-
-        :returns: a list of provided artifacts.
+        All artifacts known to this provider.
         """
 
-        return self._artifacts
+        yield from self._artifacts
 
     @abstractmethod
     def _download_artifact(

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -4,7 +4,7 @@ Abstract base class for artifact providers.
 
 import re
 from abc import ABC, abstractmethod
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator
 from functools import cached_property
 from re import Pattern
 from shlex import quote
@@ -108,7 +108,7 @@ class ArtifactProvider(ABC):
     #: repository, and so on.
     id: ArtifactProviderId = simple_field(init=False)
 
-    #: All artifacts known to this provider. Populated by
+    #: Writable internal field of :py:attr:`artifacts`. To be populated by
     #: :py:meth:`_download_artifact` and/or :py:meth:`enumerate_artifacts`.
     _artifacts: list[ArtifactInfo] = simple_field(init=False, default_factory=list)
 
@@ -139,14 +139,12 @@ class ArtifactProvider(ABC):
         raise NotImplementedError
 
     @property
-    def artifacts(self) -> Sequence[ArtifactInfo]:
+    def artifacts(self) -> Iterator[ArtifactInfo]:
         """
-        Collect all artifacts available from this provider.
-
-        :returns: a list of provided artifacts.
+        All artifacts known to this provider.
         """
 
-        return self._artifacts
+        yield from self._artifacts
 
     def _download_artifact(
         self, artifact: ArtifactInfo, guest: Guest, destination: tmt.utils.Path

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -175,7 +175,7 @@ class ArtifactProvider(ABC):
             caught, logged as warnings, and ignored.
         """
 
-        self.logger.info(f"Downloading artifacts to '{download_path!s}'.")
+        self.logger.debug(f"Downloading artifacts to '{download_path!s}'.", level=2)
 
         # Ensure download directory exists on guest (create only if missing)
         guest.execute(
@@ -192,12 +192,10 @@ class ArtifactProvider(ABC):
         #  downloaded and external ones
         for artifact in self.artifacts:
             local_path = download_path / artifact.filename
-            self.logger.debug(f"Downloading '{artifact}' to '{local_path}'.")
 
             try:
                 self._download_artifact(artifact, guest, local_path)
                 downloaded_paths.append(local_path)
-                self.logger.info(f"Downloaded '{artifact}' to '{local_path}'.")
 
             except DownloadError as error:
                 # Warn about the failed download and move on
@@ -213,7 +211,6 @@ class ArtifactProvider(ABC):
                     f"Unexpected error downloading '{artifact}'."
                 ) from error
 
-        self.logger.info(f"Successfully downloaded '{len(downloaded_paths)}' artifacts.")
         return downloaded_paths
 
     def get_repositories(self) -> list['Repository']:
@@ -261,9 +258,6 @@ class ArtifactProvider(ABC):
                         repo_id=rpm_version.repo_id,
                     )
                 )
-            self.logger.debug(
-                f"Enumerated {len(packages)} packages from repository '{repository.name}'."
-            )
 
     # B027: "... is an empty method in an abstract base class, but has
     # no abstract decorator" - expected, it's a default implementation

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -219,7 +219,7 @@ class ArtifactProvider(ABC):
         """
         return []
 
-    def enumerate_artifacts(self, guest: Guest) -> None:
+    def enumerate_artifacts(self, guest: Guest, repository: 'Repository') -> None:
         """
         Enumerate artifacts from repositories returned by :py:meth:`get_repositories`
         and populate :py:attr:`_artifacts`. Call this after repositories are installed.
@@ -227,37 +227,35 @@ class ArtifactProvider(ABC):
         For repository providers only. Does not include artifacts contributed to
         the shared repository — those are handled by :py:meth:`contribute_to_shared_repo`.
         """
-        for repository in self.get_repositories():
-            try:
-                packages = guest.package_manager.list_packages(repository)
-            except tmt.utils.RunError as error:
-                tmt.utils.show_exception_as_warning(
-                    exception=error,
-                    message=f"Failed to enumerate packages from repository '{repository.name}'.",
-                    logger=self.logger,
-                )
-                continue
-            for rpm_version in packages:
-                from tmt.package_managers._rpm import RpmVersion
+        try:
+            packages = guest.package_manager.list_packages(repository)
+        except tmt.utils.RunError as error:
+            tmt.utils.show_exception_as_warning(
+                exception=error,
+                message=f"Failed to enumerate packages from repository '{repository.name}'.",
+                logger=self.logger,
+            )
+            return
+        for rpm_version in packages:
+            from tmt.package_managers._rpm import RpmVersion
 
-                if not isinstance(rpm_version, RpmVersion):
-                    raise tmt.utils.GeneralError(
-                        f"Unexpected package type '{type(rpm_version).__name__}' "
-                        f"from repository '{repository.name}'."
-                    )
-                if rpm_version.repo_id is None:
-                    raise tmt.utils.GeneralError(
-                        f"Package '{rpm_version}' from repository '{repository.name}' "
-                        f"has no repo_id."
-                    )
-                self._artifacts.append(
-                    ArtifactInfo(
-                        version=rpm_version,
-                        provider=self,
-                        location=repository.name,
-                        repo_id=rpm_version.repo_id,
-                    )
+            if not isinstance(rpm_version, RpmVersion):
+                raise tmt.utils.GeneralError(
+                    f"Unexpected package type '{type(rpm_version).__name__}' "
+                    f"from repository '{repository.name}'."
                 )
+            if rpm_version.repo_id is None:
+                raise tmt.utils.GeneralError(
+                    f"Package '{rpm_version}' from repository '{repository.name}' has no repo_id."
+                )
+            self._artifacts.append(
+                ArtifactInfo(
+                    version=rpm_version,
+                    provider=self,
+                    location=repository.name,
+                    repo_id=rpm_version.repo_id,
+                )
+            )
 
     # B027: "... is an empty method in an abstract base class, but has
     # no abstract decorator" - expected, it's a default implementation

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -6,7 +6,6 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from functools import cached_property
-from re import Pattern
 from shlex import quote
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -162,7 +161,6 @@ class ArtifactProvider(ABC):
         self,
         guest: Guest,
         download_path: tmt.utils.Path,
-        exclude_patterns: Optional[list[Pattern[str]]] = None,
     ) -> list[tmt.utils.Path]:
         """
         Fetch all artifacts to the specified destination.
@@ -171,8 +169,6 @@ class ArtifactProvider(ABC):
             downloaded.
         :param download_path: path into which the artifact should be
             downloaded.
-        :param exclude_patterns: if set, artifacts whose names match any
-            of the given regular expressions would not be downloaded.
         :returns: a list of paths to the downloaded artifacts.
         :raises GeneralError: Unexpected errors outside the download process.
         :note: Errors during individual artifact downloads are
@@ -180,8 +176,6 @@ class ArtifactProvider(ABC):
         """
 
         self.logger.info(f"Downloading artifacts to '{download_path!s}'.")
-
-        exclude_patterns = exclude_patterns or []
 
         # Ensure download directory exists on guest (create only if missing)
         guest.execute(
@@ -194,7 +188,9 @@ class ArtifactProvider(ABC):
 
         downloaded_paths: list[tmt.utils.Path] = []
 
-        for artifact in self._filter_artifacts(exclude_patterns):
+        # FIXME: This is not the correct usage of the artifacts, it mixes both artifacts to be
+        #  downloaded and external ones
+        for artifact in self.artifacts:
             local_path = download_path / artifact.filename
             self.logger.debug(f"Downloading '{artifact}' to '{local_path}'.")
 
@@ -219,19 +215,6 @@ class ArtifactProvider(ABC):
 
         self.logger.info(f"Successfully downloaded '{len(downloaded_paths)}' artifacts.")
         return downloaded_paths
-
-    def _filter_artifacts(self, exclude_patterns: list[Pattern[str]]) -> Iterator[ArtifactInfo]:
-        """
-        Filter artifacts based on exclude patterns.
-
-        :param exclude_patterns: artifact whose name matches any of
-            these patterns would be skipped.
-        :yields: artifacts that satisfy the filtering.
-        """
-
-        for artifact in self.artifacts:
-            if not any(pattern.search(artifact.id) for pattern in exclude_patterns):
-                yield artifact
 
     def get_repositories(self) -> list['Repository']:
         """
@@ -290,7 +273,6 @@ class ArtifactProvider(ABC):
         guest: Guest,
         source_path: Path,
         shared_repo_dir: Path,
-        exclude_patterns: Optional[list[Pattern[str]]] = None,
     ) -> None:
         """
         Contribute artifacts to the shared repository.
@@ -303,8 +285,6 @@ class ArtifactProvider(ABC):
         :param source_path: path where the artifacts are located (source for contribution).
         :param shared_repo_dir: path to the shared repository directory where
             artifacts should be contributed.
-        :param exclude_patterns: if set, artifacts whose names match any
-            of the given regular expressions would not be contributed.
         """
         pass
 

--- a/tmt/steps/prepare/artifact/providers/copr_build.py
+++ b/tmt/steps/prepare/artifact/providers/copr_build.py
@@ -93,6 +93,8 @@ class CoprBuildArtifactProvider(ArtifactProvider):
             self.chroot = chroot
         except (ValueError, IndexError) as error:
             raise ValueError(f"Invalid provider id '{self.id}'.") from error
+        # TODO: Find a better home for this action
+        self._populate_artifacts()
 
     @cached_property
     def build_info(self) -> Optional["Munch"]:
@@ -225,12 +227,11 @@ class CoprBuildArtifactProvider(ArtifactProvider):
             provider=self,
         )
 
-    @cached_property
-    def artifacts(self) -> Sequence[ArtifactInfo]:
+    def _populate_artifacts(self) -> None:
         self.logger.debug(f"Fetching RPMs for build '{self.build_id}' in chroot '{self.chroot}'.")
         rpm_metas = self._fetch_results_json() if self.is_pulp else self.build_packages
 
-        return [self.make_rpm_artifact(rpm_meta) for rpm_meta in rpm_metas]
+        self._artifacts.extend([self.make_rpm_artifact(rpm_meta) for rpm_meta in rpm_metas])
 
     def contribute_to_shared_repo(
         self,

--- a/tmt/steps/prepare/artifact/providers/copr_build.py
+++ b/tmt/steps/prepare/artifact/providers/copr_build.py
@@ -92,6 +92,8 @@ class CoprBuildArtifactProvider(ArtifactProvider):
             self.chroot = chroot
         except (ValueError, IndexError) as error:
             raise ValueError(f"Invalid provider id '{self.id}'.") from error
+        # TODO: Find a better home for this action
+        self._populate_artifacts()
 
     @cached_property
     def build_info(self) -> Optional["Munch"]:
@@ -210,12 +212,11 @@ class CoprBuildArtifactProvider(ArtifactProvider):
             provider=self,
         )
 
-    @cached_property
-    def artifacts(self) -> Sequence[ArtifactInfo]:
+    def _populate_artifacts(self) -> None:
         self.logger.debug(f"Fetching RPMs for build '{self.build_id}' in chroot '{self.chroot}'.")
         rpm_metas = self._fetch_results_json() if self.is_pulp else self.build_packages
 
-        return [self.make_rpm_artifact(rpm_meta) for rpm_meta in rpm_metas]
+        self._artifacts.extend([self.make_rpm_artifact(rpm_meta) for rpm_meta in rpm_metas])
 
     def contribute_to_shared_repo(
         self,

--- a/tmt/steps/prepare/artifact/providers/copr_build.py
+++ b/tmt/steps/prepare/artifact/providers/copr_build.py
@@ -223,7 +223,6 @@ class CoprBuildArtifactProvider(ArtifactProvider):
         guest: Guest,
         source_path: tmt.utils.Path,
         shared_repo_dir: tmt.utils.Path,
-        exclude_patterns: Optional[list[tmt.utils.Pattern[str]]] = None,
     ) -> None:
         guest.execute(
             ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")

--- a/tmt/steps/prepare/artifact/providers/copr_build.py
+++ b/tmt/steps/prepare/artifact/providers/copr_build.py
@@ -175,7 +175,6 @@ class CoprBuildArtifactProvider(ArtifactProvider):
         :returns: list of package dictionaries containing NEVRA info.
         """
         results_url = urljoin(self.result_url + "/", "results.json")
-        self.logger.debug(f"Fetching results.json from '{results_url}'.")
         try:
             with tmt.utils.retry_session(logger=self.logger) as session:
                 response = session.get(results_url)
@@ -213,7 +212,6 @@ class CoprBuildArtifactProvider(ArtifactProvider):
         )
 
     def _populate_artifacts(self) -> None:
-        self.logger.debug(f"Fetching RPMs for build '{self.build_id}' in chroot '{self.chroot}'.")
         rpm_metas = self._fetch_results_json() if self.is_pulp else self.build_packages
 
         self._artifacts.extend([self.make_rpm_artifact(rpm_meta) for rpm_meta in rpm_metas])
@@ -227,4 +225,6 @@ class CoprBuildArtifactProvider(ArtifactProvider):
         guest.execute(
             ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
         )
-        self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")
+        self.logger.debug(
+            f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.", level=2
+        )

--- a/tmt/steps/prepare/artifact/providers/copr_repository.py
+++ b/tmt/steps/prepare/artifact/providers/copr_repository.py
@@ -3,7 +3,6 @@ Copr Repository Artifact Provider
 """
 
 import re
-from re import Pattern
 from typing import Optional
 
 import tmt.utils
@@ -101,7 +100,6 @@ class CoprRepositoryProvider(ArtifactProvider):
         self,
         guest: Guest,
         download_path: Path,
-        exclude_patterns: Optional[list[Pattern[str]]] = None,
     ) -> list[Path]:
         """
         Enable the Copr repository on the guest and retrieve the resulting

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -1,7 +1,5 @@
 import glob
 import urllib.parse
-from collections.abc import Sequence
-from functools import cached_property
 from shlex import quote
 from typing import ClassVar, Optional
 
@@ -57,6 +55,8 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
         parsed = urllib.parse.urlparse(source)
         self._source = source
         self._is_url = parsed.scheme in ("http", "https")
+        # TODO: Find a better home for this action
+        self._populate_artifacts()
 
     @classmethod
     def _extract_provider_id(cls, raw_id: str) -> ArtifactProviderId:
@@ -71,8 +71,7 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
             provider=self,
         )
 
-    @cached_property
-    def artifacts(self) -> Sequence[ArtifactInfo]:
+    def _populate_artifacts(self) -> None:
         artifacts: list[ArtifactInfo] = []
         seen_ids: set[str] = set()
 
@@ -102,7 +101,7 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
         if not artifacts:
             self.logger.warning(f"No artifacts found for source: '{self._source}'.")
 
-        return artifacts
+        self._artifacts.extend(artifacts)
 
     def _download_artifact(
         self, artifact: ArtifactInfo, guest: Guest, destination: tmt.utils.Path

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -122,7 +122,6 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
                         compress=True,
                     ),
                 )
-            self.logger.info(f"Successfully downloaded: '{artifact.id}'.")
         except Exception as error:
             raise DownloadError(f"Failed to download '{artifact}'.") from error
 
@@ -135,4 +134,6 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
         guest.execute(
             ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
         )
-        self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")
+        self.logger.debug(
+            f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.", level=2
+        )

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -73,28 +73,18 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
 
     def _populate_artifacts(self) -> None:
         artifacts: list[ArtifactInfo] = []
-        seen_ids: set[str] = set()
-
-        def add(info: ArtifactInfo) -> None:
-            if info.id not in seen_ids:
-                artifacts.append(info)
-                seen_ids.add(info.id)
-            else:
-                self.logger.warning(
-                    f"Duplicate artifact '{info.id}' found; ignoring duplicate entry."
-                )
-
         if self._is_url:
-            add(self.make_rpm_artifact(self._source))
+            artifacts.append(self.make_rpm_artifact(self._source))
         # Everything else is treated as a glob pattern
         elif matched_files := glob.glob(self._source):
-            for matched_file in sorted(matched_files):
+            for matched_file in matched_files:
                 f = tmt.utils.Path(matched_file)
                 if f.is_dir():  # find all .rpm files within it
-                    for rpm_file in sorted(f.glob("*.rpm")):
-                        add(self.make_rpm_artifact(str(rpm_file)))
+                    artifacts.extend(
+                        self.make_rpm_artifact(str(rpm_file)) for rpm_file in f.glob("*.rpm")
+                    )
                 elif f.is_file():
-                    add(self.make_rpm_artifact(str(f)))
+                    artifacts.append(self.make_rpm_artifact(str(f)))
         else:
             self.logger.warning(f"No files matched pattern: '{self._source}'.")
 

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -1,7 +1,7 @@
 import glob
 import urllib.parse
 from shlex import quote
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 import tmt.utils
 from tmt.container import container, simple_field
@@ -131,7 +131,6 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
         guest: Guest,
         source_path: tmt.utils.Path,
         shared_repo_dir: tmt.utils.Path,
-        exclude_patterns: Optional[list[tmt.utils.Pattern[str]]] = None,
     ) -> None:
         guest.execute(
             ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -4,7 +4,7 @@ Koji Artifact Provider
 
 import types
 from abc import abstractmethod
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator
 from functools import cached_property
 from shlex import quote
 from typing import Any, Optional, TypeVar
@@ -234,7 +234,13 @@ class KojiArtifactProvider(ArtifactProvider):
 
 
 @provides_artifact_provider("koji.task")
+@container
 class KojiTask(KojiArtifactProvider):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        # TODO: Find a better home for this action
+        self._populate_artifacts()
+
     @cached_property
     def build_id(self) -> Optional[int]:
         task_id = int(self.id)
@@ -276,8 +282,7 @@ class KojiTask(KojiArtifactProvider):
             provider=self,
         )
 
-    @cached_property
-    def artifacts(self) -> Sequence[ArtifactInfo]:
+    def _populate_artifacts(self) -> None:
         self.logger.debug(f"Fetching RPMs for task '{self.id}'.")
         # If task produced a build, reuse build path
         if self.build_id is not None:
@@ -285,7 +290,8 @@ class KojiTask(KojiArtifactProvider):
                 f"Task '{self.id}' produced build '{self.build_id}', fetching RPMs from the build."
             )
             assert self.build_provider is not None
-            return list(self.build_provider.artifacts)
+            self._artifacts.extend(self.build_provider.artifacts)
+            return
 
         # Otherwise, list the task output files for scratch builds
         self.logger.debug(f"Task '{self.id}' did not produce a build, fetching scratch RPMs.")
@@ -307,27 +313,40 @@ class KojiTask(KojiArtifactProvider):
                         f"Skipping redundant RPM '{rpm.id}' from task '{child_task}'"
                     )
 
-        return artifacts
+        self._artifacts.extend(artifacts)
 
 
 @provides_artifact_provider('koji.build')
+@container
 class KojiBuild(KojiArtifactProvider):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        # TODO: Find a better home for this action
+        self._populate_artifacts()
+
     @cached_property
     def build_id(self) -> int:
         return int(self.id)
 
-    @cached_property
-    def artifacts(self) -> Sequence[ArtifactInfo]:
+    def _populate_artifacts(self) -> None:
         self.logger.debug(f"Fetching RPMs for build '{self.build_id}'.")
 
-        return [
-            self.make_rpm_artifact(rpm_dict)
-            for rpm_dict in self._call_api("listBuildRPMs", self.build_id)
-        ]
+        self._artifacts.extend(
+            [
+                self.make_rpm_artifact(rpm_dict)
+                for rpm_dict in self._call_api("listBuildRPMs", self.build_id)
+            ]
+        )
 
 
 @provides_artifact_provider("koji.nvr")
+@container
 class KojiNvr(KojiArtifactProvider):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        # TODO: Find a better home for this action
+        self._populate_artifacts()
+
     @cached_property
     def build_info(self) -> Optional[dict[str, Any]]:
         """
@@ -347,11 +366,10 @@ class KojiNvr(KojiArtifactProvider):
         assert isinstance(build_id, int)
         return build_id
 
-    @cached_property
-    def artifacts(self) -> Sequence[ArtifactInfo]:
+    def _populate_artifacts(self) -> None:
         """
         RPM artifacts for the given NVR.
         """
         self.logger.debug(f"Fetching RPMs for NVR '{self.id}'.")
         assert self.build_provider is not None
-        return list(self.build_provider.artifacts)
+        self._artifacts.extend(self.build_provider.artifacts)

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -183,7 +183,6 @@ class KojiArtifactProvider(ArtifactProvider):
         guest: Guest,
         source_path: tmt.utils.Path,
         shared_repo_dir: tmt.utils.Path,
-        exclude_patterns: Optional[list[tmt.utils.Pattern[str]]] = None,
     ) -> None:
         guest.execute(
             ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -4,7 +4,7 @@ Koji Artifact Provider
 
 import types
 from abc import abstractmethod
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator
 from functools import cached_property
 from shlex import quote
 from typing import Any, Optional, TypeVar
@@ -215,7 +215,13 @@ class KojiArtifactProvider(ArtifactProvider):
 
 
 @provides_artifact_provider("koji.task")
+@container
 class KojiTask(KojiArtifactProvider):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        # TODO: Find a better home for this action
+        self._populate_artifacts()
+
     @cached_property
     def build_id(self) -> Optional[int]:
         task_id = int(self.id)
@@ -257,8 +263,7 @@ class KojiTask(KojiArtifactProvider):
             provider=self,
         )
 
-    @cached_property
-    def artifacts(self) -> Sequence[ArtifactInfo]:
+    def _populate_artifacts(self) -> None:
         self.logger.debug(f"Fetching RPMs for task '{self.id}'.")
         # If task produced a build, reuse build path
         if self.build_id is not None:
@@ -266,7 +271,8 @@ class KojiTask(KojiArtifactProvider):
                 f"Task '{self.id}' produced build '{self.build_id}', fetching RPMs from the build."
             )
             assert self.build_provider is not None
-            return list(self.build_provider.artifacts)
+            self._artifacts.extend(self.build_provider.artifacts)
+            return
 
         # Otherwise, list the task output files for scratch builds
         self.logger.debug(f"Task '{self.id}' did not produce a build, fetching scratch RPMs.")
@@ -288,27 +294,40 @@ class KojiTask(KojiArtifactProvider):
                         f"Skipping redundant RPM '{rpm.id}' from task '{child_task}'"
                     )
 
-        return artifacts
+        self._artifacts.extend(artifacts)
 
 
 @provides_artifact_provider('koji.build')
+@container
 class KojiBuild(KojiArtifactProvider):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        # TODO: Find a better home for this action
+        self._populate_artifacts()
+
     @cached_property
     def build_id(self) -> int:
         return int(self.id)
 
-    @cached_property
-    def artifacts(self) -> Sequence[ArtifactInfo]:
+    def _populate_artifacts(self) -> None:
         self.logger.debug(f"Fetching RPMs for build '{self.build_id}'.")
 
-        return [
-            self.make_rpm_artifact(rpm_dict)
-            for rpm_dict in self._call_api("listBuildRPMs", self.build_id)
-        ]
+        self._artifacts.extend(
+            [
+                self.make_rpm_artifact(rpm_dict)
+                for rpm_dict in self._call_api("listBuildRPMs", self.build_id)
+            ]
+        )
 
 
 @provides_artifact_provider("koji.nvr")
+@container
 class KojiNvr(KojiArtifactProvider):
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        # TODO: Find a better home for this action
+        self._populate_artifacts()
+
     @cached_property
     def build_info(self) -> Optional[dict[str, Any]]:
         """
@@ -328,11 +347,10 @@ class KojiNvr(KojiArtifactProvider):
         assert isinstance(build_id, int)
         return build_id
 
-    @cached_property
-    def artifacts(self) -> Sequence[ArtifactInfo]:
+    def _populate_artifacts(self) -> None:
         """
         RPM artifacts for the given NVR.
         """
         self.logger.debug(f"Fetching RPMs for NVR '{self.id}'.")
         assert self.build_provider is not None
-        return list(self.build_provider.artifacts)
+        self._artifacts.extend(self.build_provider.artifacts)

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -187,7 +187,9 @@ class KojiArtifactProvider(ArtifactProvider):
         guest.execute(
             ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
         )
-        self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")
+        self.logger.debug(
+            f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.", level=2
+        )
 
     def make_rpm_artifact(self, rpm_meta: dict[str, Any]) -> ArtifactInfo:
         """
@@ -263,18 +265,22 @@ class KojiTask(KojiArtifactProvider):
         )
 
     def _populate_artifacts(self) -> None:
-        self.logger.debug(f"Fetching RPMs for task '{self.id}'.")
+        self.logger.debug(f"Fetching RPMs for task '{self.id}'.", level=2)
         # If task produced a build, reuse build path
         if self.build_id is not None:
             self.logger.debug(
-                f"Task '{self.id}' produced build '{self.build_id}', fetching RPMs from the build."
+                f"Task '{self.id}' produced build '{self.build_id}', "
+                f"fetching RPMs from the build.",
+                level=3,
             )
             assert self.build_provider is not None
             self._artifacts.extend(self.build_provider.artifacts)
             return
 
         # Otherwise, list the task output files for scratch builds
-        self.logger.debug(f"Task '{self.id}' did not produce a build, fetching scratch RPMs.")
+        self.logger.debug(
+            f"Task '{self.id}' did not produce a build, fetching scratch RPMs.", level=3
+        )
 
         artifacts: list[ArtifactInfo] = []
         seen_ids = set()  # Multiple tasks may produce the same RPM
@@ -282,7 +288,7 @@ class KojiTask(KojiArtifactProvider):
         for child_task in self._get_task_children(int(self.id)):
             for filename in self._call_api("listTaskOutput", child_task):
                 if not filename.endswith(".rpm"):
-                    self.logger.warning(f"Skipping '{filename}': not an RPM")
+                    self.logger.debug(f"Skipping '{filename}': not an RPM", level=3)
                     continue
                 rpm = self.make_rpm_artifact(child_task, filename)
                 if rpm.id not in seen_ids:
@@ -290,7 +296,7 @@ class KojiTask(KojiArtifactProvider):
                     seen_ids.add(rpm.id)
                 else:
                     self.logger.debug(
-                        f"Skipping redundant RPM '{rpm.id}' from task '{child_task}'"
+                        f"Skipping redundant RPM '{rpm.id}' from task '{child_task}'", level=3
                     )
 
         self._artifacts.extend(artifacts)
@@ -309,7 +315,7 @@ class KojiBuild(KojiArtifactProvider):
         return int(self.id)
 
     def _populate_artifacts(self) -> None:
-        self.logger.debug(f"Fetching RPMs for build '{self.build_id}'.")
+        self.logger.debug(f"Fetching RPMs for build '{self.build_id}'.", level=2)
 
         self._artifacts.extend(
             [
@@ -350,6 +356,6 @@ class KojiNvr(KojiArtifactProvider):
         """
         RPM artifacts for the given NVR.
         """
-        self.logger.debug(f"Fetching RPMs for NVR '{self.id}'.")
+        self.logger.debug(f"Fetching RPMs for NVR '{self.id}'.", level=2)
         assert self.build_provider is not None
         self._artifacts.extend(self.build_provider.artifacts)

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -71,15 +71,13 @@ class RepositoryFileProvider(ArtifactProvider):
         # then available through the package manager.
         # It returns an Empty list, as no individual artifact files are downloaded.
 
-        self.logger.info(f"Initializing repository provider with URL: {self.id}")
-
         parsed = urlparse(self.id)
         # If the file is a relative path, we need the netloc part also
         parsed_path = Path(f"{parsed.netloc}{parsed.path}")
         if parsed.scheme == 'file':
             # Normalize relative paths to be relative to user_anchor_path
             parsed_path = self.parent.step.plan.user_anchor_path / parsed_path
-            self.logger.info(f"Reading repository file from local path: {parsed_path}")
+            self.logger.debug(f"Reading repository file from local path: {parsed_path}", level=3)
             self.repository = Repository.from_file_path(file_path=parsed_path, logger=self.logger)
         else:
             repo_filename = parsed_path.name
@@ -98,14 +96,14 @@ class RepositoryFileProvider(ArtifactProvider):
                 output.stdout or '', repo_filename.removesuffix('.repo'), self.logger
             )
 
-        self.logger.info(
+        self.logger.debug(
             f"Repository initialized: {self.repository.name} "
-            f"(repo IDs: {', '.join(self.repository.repo_ids)})"
+            f"(repo IDs: {', '.join(self.repository.repo_ids)})",
+            level=2,
         )
         return []
 
     def get_repositories(self) -> list[Repository]:
-        self.logger.info(f"Providing repository '{self.repository.name}' for installation ")
         return [self.repository]
 
 
@@ -135,8 +133,6 @@ def create_repository(
     """
     repo_name = repo_name or f"tmt-repo-{_REPO_NAME_GENERATOR.get()}"
 
-    logger.info(f"Creating repository '{repo_name}' from directory '{artifact_dir}'")
-
     # Ensure the artifact directory exists
     guest.execute(
         tmt.utils.Command('mkdir', '-p', artifact_dir),
@@ -144,7 +140,6 @@ def create_repository(
     )
 
     # Create Repository Metadata
-    logger.info(f"Creating repository metadata for '{artifact_dir}'.")
     try:
         guest.package_manager.create_repository(artifact_dir)
     except RunError as error:
@@ -158,13 +153,10 @@ enabled=1
 gpgcheck=0
 priority={priority}"""
 
-    logger.debug(f"Generated .repo file content:\n{repo_string}")
-
-    # Create Repository Object
-    created_repository = Repository.from_content(
-        content=repo_string, name=repo_name, logger=logger
+    logger.debug(
+        f"Creating repository '{repo_name}' from directory '{artifact_dir}'\n{repo_string}",
+        level=2,
     )
 
-    logger.info(f"Successfully created repository '{created_repository.name}' ")
-
-    return created_repository
+    # Create Repository Object
+    return Repository.from_content(content=repo_string, name=repo_name, logger=logger)

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -2,7 +2,6 @@
 Artifact provider for discovering RPMs from repository files.
 """
 
-from re import Pattern
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -65,7 +64,6 @@ class RepositoryFileProvider(ArtifactProvider):
         self,
         guest: Guest,
         download_path: tmt.utils.Path,
-        exclude_patterns: Optional[list[Pattern[str]]] = None,
     ) -> list[tmt.utils.Path]:
         # Fetches and initializes the repository from the URL.
         # Repository provider does not download individual artifacts. Instead, it fetches

--- a/tmt/steps/prepare/artifact/providers/repository_url.py
+++ b/tmt/steps/prepare/artifact/providers/repository_url.py
@@ -2,9 +2,6 @@
 Artifact provider for creating DNF repositories from baseurl.
 """
 
-from re import Pattern
-from typing import Optional
-
 import tmt.utils
 from tmt.container import container, simple_field
 from tmt.guest import Guest
@@ -65,7 +62,6 @@ class RepositoryUrlProvider(ArtifactProvider):
         self,
         guest: Guest,
         download_path: tmt.utils.Path,
-        exclude_patterns: Optional[list[Pattern[str]]] = None,
     ) -> list[tmt.utils.Path]:
         # Fetches and initializes the repository from the baseurl.
         # Repository provider does not download individual artifacts. Instead, it creates

--- a/tmt/steps/prepare/artifact/providers/repository_url.py
+++ b/tmt/steps/prepare/artifact/providers/repository_url.py
@@ -82,16 +82,17 @@ enabled=1
 gpgcheck=0
 priority={self.repository_priority}"""
 
-        self.logger.debug(f"Generated .repo file content:\n{repo_content}")
+        self.logger.debug(
+            f"Creating repository '{repo_name}' from baseurl: {baseurl}\n{repo_content}",
+            level=2,
+        )
 
         # Create Repository object
         self.repository = Repository.from_content(
             content=repo_content, name=repo_name, logger=self.logger
         )
 
-        self.logger.info(f"Repository initialized: {self.repository.name} (baseurl: {baseurl})")
         return []
 
     def get_repositories(self) -> list[Repository]:
-        self.logger.info(f"Providing repository '{self.repository.name}' for installation")
         return [self.repository]


### PR DESCRIPTION
This has grown to become quite the spaghetti code, let's start doing the cleanups in the todos:
- [ ] Drop the `_filter_artifacts`. We do not even have this connected to anything, and it's unclear if we would need to have it
- [ ] Clear up the population of `Provider._artifacts`
  - We have only 2 places where the artifacts will be populated `enumerate_artifacts` (external artifacts) and `contribute_to_shared_repo`/`fetch_contents` (downloaded artifacts). Let's make that contract explicit
- [ ] Figure out what to do with `_detect_duplicate_nvras`

---

Pull Request Checklist

* [ ] implement the feature