### PR TITLE
Limit verbose/debug levels

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -378,9 +378,9 @@ The following environment variables can be used to modify
 behaviour of the ``tmt`` command.
 
 TMT_DEBUG
-    Enable the desired debug level. Most of the commands support
-    levels from 1 to 3. However, some of the plugins go even
-    deeper when needed.
+    Emit debugging information. Using this environment variable has the
+    same effect as the equal number of ``-d`` options. The value can go
+    from ``0`` to ``4`` for increasingly detailed logging.
 
 TMT_PLUGINS
     Path to a directory with additional plugins. Multiple paths

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -380,7 +380,7 @@ behaviour of the ``tmt`` command.
 TMT_DEBUG
     Make the developer-focused debugging output more verbose. Using this
     environment variable has the same effect as the equal number of
-    ``-d`` options. The value go from ``0`` to ``3`` for increasingly
+    ``-d`` options. The value goes from ``0`` to ``3`` for increasingly
     detailed logging:
 
     * ``-d``/``TMT_DEBUG=1``: High-level info. Framework choice,

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -378,9 +378,19 @@ The following environment variables can be used to modify
 behaviour of the ``tmt`` command.
 
 TMT_DEBUG
-    Emit debugging information. Using this environment variable has the
-    same effect as the equal number of ``-d`` options. The value can go
-    from ``0`` to ``4`` for increasingly detailed logging.
+    Make the developer-focused debugging output more verbose. Using this
+    environment variable has the same effect as the equal number of
+    ``-d`` options. The value go from ``0`` to ``3`` for increasingly
+    detailed logging:
+
+    * ``-d``/``TMT_DEBUG=1``: High-level info. Framework choice,
+      policy application or reboot actions.
+    * ``-dd``/``TMT_DEBUG=2``: Detailed operations. Actions
+      such as step load, wake up, guest pull/push or playbook
+      paths.
+    * ``-ddd``/``TMT_DEBUG=3``: Internal plumbing. The
+      low-level implementation details such as workdir handling,
+      process termination, key normalization and similar.
 
 TMT_PLUGINS
     Path to a directory with additional plugins. Multiple paths

--- a/tests/core/environment/test.sh
+++ b/tests/core/environment/test.sh
@@ -14,7 +14,7 @@ rlJournalStart
         rlRun -s "TMT_DEBUG=3 tmt plan show"
         rlAssertGrep "Using the 'DiscoverFmf' plugin" $rlRun_LOG
         rlRun -s "TMT_DEBUG=weird tmt plan show" 2
-        rlAssertGrep "Invalid debug level" $rlRun_LOG
+        rlAssertGrep "Debug level 'weird' is invalid." $rlRun_LOG
     rlPhaseEnd
 
     for execute in 'tmt'; do

--- a/tests/core/fmf-id/test.sh
+++ b/tests/core/fmf-id/test.sh
@@ -7,7 +7,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun -s "tmt plan  show /plan-with-valid-ref"
+        rlRun -s "tmt plan show /plan-with-valid-ref"
         rlAssertNotGrep "warn:" $rlRun_LOG
         rlAssertGrep "ref branch-or-tag-ref" $rlRun_LOG
         rlAssertGrep "ref 8deadbeaf8" $rlRun_LOG

--- a/tests/core/fmf-id/test.sh
+++ b/tests/core/fmf-id/test.sh
@@ -7,27 +7,27 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun -s "tmt plan -vvvv show /plan-with-valid-ref"
+        rlRun -s "tmt plan  show /plan-with-valid-ref"
         rlAssertNotGrep "warn:" $rlRun_LOG
         rlAssertGrep "ref branch-or-tag-ref" $rlRun_LOG
         rlAssertGrep "ref 8deadbeaf8" $rlRun_LOG
 
-        rlRun -s "tmt plan -vvvv show /plan-with-invalid-ref" 2
+        rlRun -s "tmt plan -vvv show /plan-with-invalid-ref" 2
         rlAssertGrep "warn: /plan-with-invalid-ref:discover .* is not valid under any of the given schemas" $rlRun_LOG
         rlAssertGrep "Failed to load step data for DiscoverFmfStepData." $rlRun_LOG
 
-        rlRun -s "tmt plan -vvvv show /remote-plan-with-valid-ref"
+        rlRun -s "tmt plan -vvv show /remote-plan-with-valid-ref"
 
-        rlRun -s "tmt plan -vvvv show /remote-plan-with-invalid-ref" 2
+        rlRun -s "tmt plan -vvv show /remote-plan-with-invalid-ref" 2
         rlAssertGrep "warn: /remote-plan-with-invalid-ref:plan.import.ref - 12345678 is not of type 'string'" $rlRun_LOG
 
-        rlRun -s "tmt test -vvvv show /test-with-valid-ref"
+        rlRun -s "tmt test -vvv show /test-with-valid-ref"
         rlAssertNotGrep "warn:" $rlRun_LOG
         rlRun "grep -Pzo \"(?s)- url:.*?\\s*ref: branch-or-tag-ref.*?\\s*type: library\" $rlRun_LOG > /dev/null"
         rlRun "grep -Pzo \"(?s)- url:.*?\\s*ref: 8deadbeaf8.*?\\s*type: library\" $rlRun_LOG > /dev/null"
         rlAssertGrep "- some-package" $rlRun_LOG
 
-        rlRun -s "tmt test -vvvv show /test-with-invalid-ref" 2
+        rlRun -s "tmt test -vvv show /test-with-invalid-ref" 2
         rlAssertGrep "warn: /test-with-invalid-ref:require .* is not valid under any of the given schemas" $rlRun_LOG
         rlAssertGrep "Field 'ref' must be unset or a string, 'int' found." $rlRun_LOG
     rlPhaseEnd

--- a/tests/core/logging/test.sh
+++ b/tests/core/logging/test.sh
@@ -7,11 +7,11 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Logging topics"
-        rlRun -s "tmt -dddd plan show /plans/features/core > /dev/null"
+        rlRun -s "tmt -ddd plan show /plans/features/core > /dev/null"
         rlAssertNotGrep "key source" $rlRun_LOG
         rlAssertNotGrep "normalized fields" $rlRun_LOG
 
-        rlRun -s "tmt --log-topic=key-normalization -dddd plan show /plans/features/core > /dev/null"
+        rlRun -s "tmt --log-topic=key-normalization -ddd plan show /plans/features/core > /dev/null"
         rlAssertGrep "key source" $rlRun_LOG
         rlAssertGrep "normalized fields" $rlRun_LOG
     rlPhaseEnd

--- a/tests/execute/duration/test.sh
+++ b/tests/execute/duration/test.sh
@@ -40,7 +40,7 @@ rlJournalStart
                     rlAssertNotGrep "00:02:.. errr /test/long/shell (timeout)" $rlRun_LOG
 
                     if [ "$interactive" = "" ]; then
-                        rlRun -s "tmt --log-topic=command-events run --last report -fvvvv" 2
+                        rlRun -s "tmt --log-topic=command-events run --last report -fvvv" 2
 
                         rlAssertGrep "Maximum test time '30s' exceeded." $rlRun_LOG
                         rlAssertGrep "Adjust the test 'duration' attribute" $rlRun_LOG
@@ -53,7 +53,7 @@ rlJournalStart
                         rlRun "grep -E ' [[:digit:]]{1,2}\.[[:digit:]]+ waiting for stream readers' $rlRun_LOG"
                         rlRun "grep -E ' [[:digit:]]{1,2}\.[[:digit:]]+ stdout reader done' $rlRun_LOG"
                     else
-                        rlRun -s "tmt --log-topic=command-events run --last report -fvvvv" 0
+                        rlRun -s "tmt --log-topic=command-events run --last report -fvvv" 0
 
                         rlAssertNotGrep "Maximum test time '30s' exceeded." $rlRun_LOG
                         rlAssertNotGrep "Adjust the test 'duration' attribute" $rlRun_LOG

--- a/tests/execute/framework/selection.sh
+++ b/tests/execute/framework/selection.sh
@@ -7,7 +7,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Combine shell and beakerlib"
-        rlRun -s "tmt run -avvvvdddr"
+        rlRun -s "tmt run -avvvdddr"
         # The default test framework should be 'shell'
         rlAssertGrep "Execute '/tests/shell/default' as a 'shell' test." $rlRun_LOG
         # Explicit framework in test should always override default

--- a/tests/execute/tty/test.sh
+++ b/tests/execute/tty/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "With $PROVISION_HOW provision method (tty:false)"
-        rlRun -s "tmt run -avvvvddd provision -h $PROVISION_HOW"
+        rlRun -s "tmt run -avvvddd provision -h $PROVISION_HOW"
 
         rlAssertGrep "stdout: prepare: stdin: False" $rlRun_LOG
         rlAssertGrep "stdout: prepare: stdout: False" $rlRun_LOG
@@ -43,7 +43,7 @@ rlJournalStart
     # NOTE: Our local provisioner cannot execute commands with a pty allocated
     if [ "$PROVISION_HOW" != "local" ]; then
             rlPhaseStartTest "With $PROVISION_HOW provision method (tty:true)"
-                rlRun -s "NO_COLOR=1 ../ptty-wrapper tmt -c tty=true run -avvvvddd provision -h $PROVISION_HOW" 1
+                rlRun -s "NO_COLOR=1 ../ptty-wrapper tmt -c tty=true run -avvvddd provision -h $PROVISION_HOW" 1
 
                 rlAssertGrep "stdout: prepare: stdin: False" $rlRun_LOG
                 rlAssertGrep "stdout: prepare: stdout: False" $rlRun_LOG
@@ -72,7 +72,7 @@ rlJournalStart
     fi
 
     rlPhaseStartTest "With $PROVISION_HOW provision method, interactive tests"
-        rlRun -s "NO_COLOR=1 ../ptty-wrapper tmt run -avvvvddd provision -h $PROVISION_HOW execute -h tmt --interactive" 1
+        rlRun -s "NO_COLOR=1 ../ptty-wrapper tmt run -avvvddd provision -h $PROVISION_HOW execute -h tmt --interactive" 1
 
         rlAssertGrep "stdout: prepare: stdin: False" $rlRun_LOG
         rlAssertGrep "stdout: prepare: stdout: False" $rlRun_LOG

--- a/tests/integration/test_nitrate.py
+++ b/tests/integration/test_nitrate.py
@@ -226,7 +226,7 @@ class NitrateImport(Base):
     def test_import_manual_confirmed(self):
         # TODO: import does not respect --root param anyhow (could)
         self.runner_output = CliRunner().invoke(
-            '-vvvvdddd',
+            '-vvvddd',
             '--root',
             self.tmpdir / "import_case",
             "test",

--- a/tests/plan/import/basic.sh
+++ b/tests/plan/import/basic.sh
@@ -114,7 +114,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Make sure context is applied to plan itself"
-        rlRun -s "tmt plan show - /plans/full/tmt"
+        rlRun -s "tmt plan show -vvv /plans/full/tmt"
         rlAssertGrep "enabled false" $rlRun_LOG
 
         rlRun -s "tmt -c how=full plan show -vvv /plans/full/tmt"

--- a/tests/plan/import/basic.sh
+++ b/tests/plan/import/basic.sh
@@ -114,10 +114,10 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Make sure context is applied to plan itself"
-        rlRun -s "tmt plan show -vvvv /plans/full/tmt"
+        rlRun -s "tmt plan show - /plans/full/tmt"
         rlAssertGrep "enabled false" $rlRun_LOG
 
-        rlRun -s "tmt -c how=full plan show -vvvv /plans/full/tmt"
+        rlRun -s "tmt -c how=full plan show -vvv /plans/full/tmt"
         rlAssertGrep "enabled true" $rlRun_LOG
     rlPhaseEnd
 

--- a/tests/provision/mock/fedora-rawhide-x86_64/multiple-tests/test.sh
+++ b/tests/provision/mock/fedora-rawhide-x86_64/multiple-tests/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun -s "TMT_SHOW_TRACEBACK=1 tmt -vvvvdddd --feeling-safe run --id $run"
+        rlRun -s "TMT_SHOW_TRACEBACK=1 tmt -vvvddd --feeling-safe run --id $run"
         rlAssertGrep "NAME.*Fedora Linux" $run/plan/execute/data/guest/default-0/test/os-release-3/output.txt
     rlPhaseEnd
 

--- a/tests/provision/mock/fedora-rawhide-x86_64/provision-prepare/test.sh
+++ b/tests/provision/mock/fedora-rawhide-x86_64/provision-prepare/test.sh
@@ -11,8 +11,8 @@ rlJournalStart
     # the second time finish the rest of the steps.
     # This checks that the internal objects are properly serialized or reused.
     rlPhaseStartTest
-        rlRun -s "TMT_SHOW_TRACEBACK=1 tmt -vvvvdddd --feeling-safe run --id $run test --name /test/os-release discover provision"
-        rlRun -s "TMT_SHOW_TRACEBACK=1 tmt -vvvvdddd --feeling-safe run --id $run test --name /test/os-release prepare execute report cleanup"
+        rlRun -s "TMT_SHOW_TRACEBACK=1 tmt -vvvddd --feeling-safe run --id $run test --name /test/os-release discover provision"
+        rlRun -s "TMT_SHOW_TRACEBACK=1 tmt -vvvddd --feeling-safe run --id $run test --name /test/os-release prepare execute report cleanup"
         rlAssertGrep "NAME.*Fedora Linux" $run/plan/execute/data/guest/default-0/test/os-release-1/output.txt
     rlPhaseEnd
 

--- a/tests/provision/mock/fedora-rawhide-x86_64/simple/test.sh
+++ b/tests/provision/mock/fedora-rawhide-x86_64/simple/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest
-        rlRun -s "TMT_SHOW_TRACEBACK=1 tmt --feeling-safe -vvvvdddd run --id $run test --name /test/os-release -vvv"
+        rlRun -s "TMT_SHOW_TRACEBACK=1 tmt --feeling-safe -vvvddd run --id $run test --name /test/os-release -vvv"
         rlAssertGrep "NAME.*Fedora Linux" $run/plan/execute/data/guest/default-0/test/os-release-1/output.txt
     rlPhaseEnd
 

--- a/tests/test/check/test-avc.sh
+++ b/tests/test/check/test-avc.sh
@@ -23,7 +23,7 @@ rlJournalStart
         if [ "$method" = "checkpoint" ] && [ "$PROVISION_HOW" = "local" ]; then continue; fi
 
         rlPhaseStartTest "Run /avc tests with $PROVISION_HOW ($method method)"
-            rlRun "tmt -c provision_method=$PROVISION_HOW run --id $run --scratch -a -vvvvdddd provision -h $PROVISION_HOW test -n /avc/$method" "1"
+            rlRun "tmt -c provision_method=$PROVISION_HOW run --id $run --scratch -a -vvvddd provision -h $PROVISION_HOW test -n /avc/$method" "1"
             rlRun "cat $results"
         rlPhaseEnd
 

--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -15,7 +15,7 @@ from tmt.guest import (
     GuestSshData,
     TransferOptions,
 )
-from tmt.log import Logger, LoggingFunction
+from tmt.log import Logger, VerboseLoggingFunction
 from tmt.steps.provision import Provision
 from tmt.steps.provision.podman import GuestContainer, PodmanGuestData
 from tmt.utils import (
@@ -71,7 +71,7 @@ class MockGuest(Guest):
         test_session: bool = False,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[LoggingFunction] = None,
+        log: Optional[VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -85,7 +85,7 @@ class MockGuest(Guest):
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[LoggingFunction] = None,
+        log: Optional[VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> CommandOutput:
         raise RuntimeError("Mocked but not used")

--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -15,7 +15,7 @@ from tmt.guest import (
     GuestSshData,
     TransferOptions,
 )
-from tmt.log import Logger, LoggingFunction
+from tmt.log import Logger, VerboseLoggingFunction
 from tmt.steps.provision import Provision
 from tmt.steps.provision.podman import GuestContainer, PodmanGuestData
 from tmt.utils import (
@@ -72,7 +72,7 @@ class MockGuest(Guest):
         test_session: bool = False,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[LoggingFunction] = None,
+        log: Optional[VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -86,7 +86,7 @@ class MockGuest(Guest):
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[LoggingFunction] = None,
+        log: Optional[VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> CommandOutput:
         raise RuntimeError("Mocked but not used")

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -673,7 +673,7 @@ class Plan(
         self.debug(
             "Ignoring the following paths during worktree sync",
             tmt.utils.format_value(ignore),
-            level=4,
+            level=3,
         )
 
         with (

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -141,7 +141,7 @@ def _run_script(
         value: Optional[str] = None,
         color: tmt.utils.themes.Style = None,
         shift: int = 2,
-        level: int = 3,
+        level: tmt.log.VerbosityLevel = 3,
         topic: Optional[tmt.log.Topic] = None,
         stacklevel: int = 1,
     ) -> None:

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -142,7 +142,7 @@ def _run_script(
         value: Optional[str] = None,
         color: tmt.utils.themes.Style = None,
         shift: int = 2,
-        level: int = 3,
+        level: tmt.log.VerbosityLevel = 3,
         topic: Optional[tmt.log.Topic] = None,
         stacklevel: int = 1,
     ) -> None:

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -76,7 +76,7 @@ class DmesgCheck(Check):
             value: Optional[str] = None,
             color: tmt.utils.themes.Style = None,
             shift: int = 2,
-            level: int = 3,
+            level: tmt.log.VerbosityLevel = 3,
             topic: Optional[tmt.log.Topic] = None,
             stacklevel: int = 1,
         ) -> None:

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -77,7 +77,7 @@ class DmesgCheck(Check):
             value: Optional[str] = None,
             color: tmt.utils.themes.Style = None,
             shift: int = 2,
-            level: int = 3,
+            level: tmt.log.VerbosityLevel = 3,
             topic: Optional[tmt.log.Topic] = None,
             stacklevel: int = 1,
         ) -> None:

--- a/tmt/checks/watchdog.py
+++ b/tmt/checks/watchdog.py
@@ -174,7 +174,7 @@ class WatchdogCheck(Check):
         Perform a ping check
         """
 
-        logger.debug('pinging', level=4)
+        logger.debug('pinging', level=3)
 
         log = render_report_path(invocation)
 
@@ -289,7 +289,7 @@ class WatchdogCheck(Check):
 
         assert isinstance(invocation.guest, tmt.guest.GuestSsh)
 
-        logger.debug('checking SSH port', level=4)
+        logger.debug('checking SSH port', level=3)
 
         log = render_report_path(invocation)
 

--- a/tmt/cli/__init__.py
+++ b/tmt/cli/__init__.py
@@ -224,6 +224,19 @@ class HelpFormatter(click.HelpFormatter):
     Custom help formatter capable of rendering ReST syntax
     """
 
+    def __init__(
+        self,
+        *args: Any,
+        max_width: Optional[int] = None,
+        **kwargs: Any,
+    ) -> None:
+        if max_width is None:
+            import tmt.utils
+
+            max_width = tmt.utils.OUTPUT_WIDTH
+
+        super().__init__(*args, max_width=max_width, **kwargs)  # type: ignore[misc]
+
     # Override parent implementation
     def write_dl(
         self,

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2165,7 +2165,7 @@ class Guest(
         cwd: Optional[Path] = None,
         env: Optional[tmt.utils.Environment] = None,
         interactive: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         **kwargs: Any,
     ) -> tmt.utils.CommandOutput:
         """
@@ -2214,7 +2214,7 @@ class Guest(
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> tmt.utils.CommandOutput:
         """
@@ -2244,7 +2244,7 @@ class Guest(
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> tmt.utils.CommandOutput:
         """
@@ -2300,7 +2300,7 @@ class Guest(
         immediately: Literal[True] = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -2320,7 +2320,7 @@ class Guest(
         immediately: Literal[False] = False,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -2340,7 +2340,7 @@ class Guest(
         immediately: bool = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -3211,7 +3211,7 @@ class GuestSsh(Guest, CommandCollector):
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> tmt.utils.CommandOutput:
         """
@@ -3323,7 +3323,7 @@ class GuestSsh(Guest, CommandCollector):
         immediately: Literal[True] = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -3343,7 +3343,7 @@ class GuestSsh(Guest, CommandCollector):
         immediately: Literal[False] = False,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -3362,7 +3362,7 @@ class GuestSsh(Guest, CommandCollector):
         immediately: bool = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2309,7 +2309,7 @@ class Guest(
         cwd: Optional[Path] = None,
         environment: Optional[Environment] = None,
         interactive: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         **kwargs: Any,
     ) -> tmt.utils.CommandOutput:
         """
@@ -2358,7 +2358,7 @@ class Guest(
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> tmt.utils.CommandOutput:
         """
@@ -2388,7 +2388,7 @@ class Guest(
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> tmt.utils.CommandOutput:
         """
@@ -2444,7 +2444,7 @@ class Guest(
         immediately: Literal[True] = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -2464,7 +2464,7 @@ class Guest(
         immediately: Literal[False] = False,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -2484,7 +2484,7 @@ class Guest(
         immediately: bool = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -3386,7 +3386,7 @@ class GuestSsh(Guest, CommandCollector):
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> tmt.utils.CommandOutput:
         """
@@ -3499,7 +3499,7 @@ class GuestSsh(Guest, CommandCollector):
         immediately: Literal[True] = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -3519,7 +3519,7 @@ class GuestSsh(Guest, CommandCollector):
         immediately: Literal[False] = False,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -3538,7 +3538,7 @@ class GuestSsh(Guest, CommandCollector):
         immediately: bool = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -300,7 +300,7 @@ def _socket_path_trivial(
 
     socket_path = socket_dir / f'{guest_id}.socket'
 
-    logger.debug(f"Possible SSH master socket path '{socket_path}' (trivial method).", level=4)
+    logger.debug(f"Possible SSH master socket path '{socket_path}' (trivial method).", level=3)
 
     if not limit_size:
         return socket_path
@@ -345,7 +345,7 @@ def _socket_path_hash(
         socket_path = socket_dir / f'{digest}.socket'
         socket_reservation_path = f'{socket_path}.reservation'
 
-        logger.debug(f"Possible SSH master socket path '{socket_path}' (hash method).", level=4)
+        logger.debug(f"Possible SSH master socket path '{socket_path}' (hash method).", level=3)
 
         if limit_size and len(str(socket_path)) >= SSH_MASTER_SOCKET_LENGTH_LIMIT:
             return None
@@ -357,7 +357,7 @@ def _socket_path_hash(
             fd = os.open(socket_reservation_path, flags=os.O_CREAT | os.O_EXCL)
 
         except FileExistsError:
-            logger.debug(f"Proposed SSH socket '{socket_path}' already reserved.", level=4)
+            logger.debug(f"Proposed SSH socket '{socket_path}' already reserved.", level=3)
             continue
 
         # Successfully reserved the socket path, we can close the
@@ -875,7 +875,7 @@ class GuestFacts(SerializableContainer):
                 guest.debug(
                     f'Discovered {debug_label}',
                     package_manager_class.NAME,
-                    level=4,
+                    level=3,
                 )
                 return package_manager_class.NAME
 
@@ -3200,7 +3200,7 @@ class GuestSsh(Guest, CommandCollector):
 
         if socket_path is not None:
             self.debug(
-                f"SSH master socket path will be '{socket_path}' (trivial method).", level=4
+                f"SSH master socket path will be '{socket_path}' (trivial method).", level=3
             )
 
             return socket_path
@@ -3215,7 +3215,7 @@ class GuestSsh(Guest, CommandCollector):
         )
 
         if socket_path is not None:
-            self.debug(f"SSH master socket path will be '{socket_path}' (hash method).", level=4)
+            self.debug(f"SSH master socket path will be '{socket_path}' (hash method).", level=3)
 
             return socket_path
 
@@ -3228,7 +3228,7 @@ class GuestSsh(Guest, CommandCollector):
 
         self.debug(
             f"SSH master socket path will be '{socket_path}' (trivial method, no size limit).",
-            level=4,
+            level=3,
         )
 
         return socket_path

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -31,10 +31,13 @@ import itertools
 import logging
 import os
 import sys
+import textwrap
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Literal,
+    NoReturn,
     Optional,
     Protocol,
     TextIO,
@@ -53,6 +56,7 @@ if TYPE_CHECKING:
     import tmt.cli
     import tmt.utils
     import tmt.utils.themes
+    from tmt._compat.typing import TypeAlias
 
 # Log in workdir
 LOG_FILENAME = 'log.txt'
@@ -60,8 +64,18 @@ LOG_FILENAME = 'log.txt'
 # Hierarchy indent
 INDENT = 4
 
-DEFAULT_VERBOSITY_LEVEL = 0
-DEFAULT_DEBUG_LEVEL = 0
+#: Supported verbosity levels.
+VERBOSITY_LEVELS = (0, 1, 2, 3, 4)
+#: Supported debug levels.
+DEBUG_LEVELS = (0, 1, 2, 3, 4)
+
+#: A type of verbosity level values accepted by logging functions.
+VerbosityLevel: 'TypeAlias' = Literal[0, 1, 2, 3, 4]
+#: A type of debug level values accepted by logging functions.
+DebugLevel: 'TypeAlias' = Literal[0, 1, 2, 3, 4]
+
+DEFAULT_VERBOSITY_LEVEL: VerbosityLevel = 0
+DEFAULT_DEBUG_LEVEL: DebugLevel = 0
 
 
 class Topic(enum.Enum):
@@ -114,21 +128,13 @@ def create_decolorizer(apply_colors: bool) -> Callable[[str], str]:
     return tmt.utils.remove_color
 
 
-def _debug_level_from_global_envvar() -> int:
-    import tmt.utils
-
+def _debug_level_from_global_envvar() -> Optional[DebugLevel]:
     raw_value = os.getenv('TMT_DEBUG', None)
 
     if raw_value is None:
         return 0
 
-    try:
-        return int(raw_value)
-
-    except ValueError as error:
-        raise tmt.utils.GeneralError(
-            f"Invalid debug level '{raw_value}', use an integer."
-        ) from error
+    return normalize_debug_level(raw_value)
 
 
 def decide_colorization(no_color: bool, force_color: bool) -> tuple[bool, bool]:
@@ -266,6 +272,86 @@ def indent(
     )
 
 
+# RET503: explicit return is not needed, last expression is a call of a
+# `NoReturn` function.
+def normalize_verbosity_level(raw_value: Any) -> Optional[VerbosityLevel]:  # noqa: RET503
+    def _raise(exc: Optional[Exception] = None) -> NoReturn:
+        import tmt.utils
+
+        message = (
+            textwrap.dedent(
+                f"""
+            Verbosity level '{raw_value}' is invalid. Supported verbosity levels are
+            {VERBOSITY_LEVELS[1]} (-{'v' * VERBOSITY_LEVELS[1]})
+            to
+            {VERBOSITY_LEVELS[-1]} (-{'v' * VERBOSITY_LEVELS[-1]}).
+            """
+            )
+            .replace('\n', ' ')
+            .strip()
+        )
+
+        if exc is None:
+            raise tmt.utils.GeneralError(message)
+
+        raise tmt.utils.GeneralError(message) from exc
+
+    if raw_value is None:
+        return None
+
+    if isinstance(raw_value, str):
+        try:
+            raw_value = int(raw_value)
+
+        except ValueError as exc:
+            _raise(exc=exc)
+
+    if isinstance(raw_value, int) and raw_value in VERBOSITY_LEVELS:
+        return cast(VerbosityLevel, raw_value)
+
+    _raise()
+
+
+# RET503: explicit return is not needed, last expression is a call of a
+# `NoReturn` function.
+def normalize_debug_level(raw_value: Any) -> Optional[DebugLevel]:  # noqa: RET503
+    def _raise(exc: Optional[Exception] = None) -> NoReturn:
+        import tmt.utils
+
+        message = (
+            textwrap.dedent(
+                f"""
+            Debug level '{raw_value}' is invalid. Supported debug levels are
+            {DEBUG_LEVELS[1]} (-{'d' * DEBUG_LEVELS[1]})
+            to
+            {DEBUG_LEVELS[-1]} (-{'d' * DEBUG_LEVELS[-1]}).
+            """
+            )
+            .replace('\n', ' ')
+            .strip()
+        )
+
+        if exc is None:
+            raise tmt.utils.GeneralError(message)
+
+        raise tmt.utils.GeneralError(message) from exc
+
+    if raw_value is None:
+        return None
+
+    if isinstance(raw_value, str):
+        try:
+            raw_value = int(raw_value)
+
+        except ValueError as exc:
+            _raise(exc)
+
+    if isinstance(raw_value, int) and raw_value in DEBUG_LEVELS:
+        return cast(DebugLevel, raw_value)
+
+    _raise()
+
+
 @container
 class LogRecordDetails:
     """
@@ -281,11 +367,11 @@ class LogRecordDetails:
     logger_labels: list[str] = simple_field(default_factory=list[str])
     logger_labels_padding: int = 0
 
-    logger_verbosity_level: int = 0
-    message_verbosity_level: Optional[int] = None
+    logger_verbosity_level: VerbosityLevel = 0
+    message_verbosity_level: Optional[VerbosityLevel] = None
 
-    logger_debug_level: int = 0
-    message_debug_level: Optional[int] = None
+    logger_debug_level: DebugLevel = 0
+    message_debug_level: Optional[DebugLevel] = None
 
     logger_quiet: bool = False
     ignore_quietness: bool = False
@@ -488,14 +574,14 @@ class RunWarningsFilter(logging.Filter):
         return False
 
 
-class LoggingFunction(Protocol):
+class VerboseLoggingFunction(Protocol):
     def __call__(
         self,
         key: str,
         value: Optional[str] = None,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
-        level: int = 1,
+        level: VerbosityLevel = 1,
         topic: Optional[Topic] = None,
         stacklevel: int = 1,
     ) -> None:
@@ -521,14 +607,17 @@ class Logger:
     and handlers.
     """
 
+    verbosity_level: VerbosityLevel
+    debug_level: DebugLevel
+
     def __init__(
         self,
         actual_logger: logging.Logger,
         base_shift: int = 0,
         labels: Optional[list[str]] = None,
         labels_padding: int = 0,
-        verbosity_level: int = DEFAULT_VERBOSITY_LEVEL,
-        debug_level: int = DEFAULT_DEBUG_LEVEL,
+        verbosity_level: VerbosityLevel = DEFAULT_VERBOSITY_LEVEL,
+        debug_level: DebugLevel = DEFAULT_DEBUG_LEVEL,
         quiet: bool = False,
         topics: Optional[set[Topic]] = None,
         apply_colors_output: bool = True,
@@ -751,7 +840,8 @@ class Logger:
 
         actual_kwargs.update(kwargs)
 
-        verbosity_level = cast(Optional[int], actual_kwargs.get('verbose', None))
+        verbosity_level = normalize_verbosity_level(actual_kwargs.get('verbose', None))
+
         if verbosity_level is None or verbosity_level == 0:
             pass
 
@@ -760,11 +850,11 @@ class Logger:
 
         debug_level_from_global_envvar = _debug_level_from_global_envvar()
 
-        if debug_level_from_global_envvar not in (None, 0):
+        if debug_level_from_global_envvar is not None and debug_level_from_global_envvar != 0:
             self.debug_level = debug_level_from_global_envvar
 
         else:
-            debug_level_from_option = cast(Optional[int], actual_kwargs.get('debug', None))
+            debug_level_from_option = normalize_debug_level(actual_kwargs.get('debug', None))
 
             if debug_level_from_option is None or debug_level_from_option == 0:
                 pass
@@ -925,7 +1015,7 @@ class Logger:
         value: Optional[LoggableValue] = None,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
-        level: int = 1,
+        level: VerbosityLevel = 1,
         topic: Optional[Topic] = None,
         stacklevel: int = 1,
     ) -> None:
@@ -948,7 +1038,7 @@ class Logger:
         value: Optional[LoggableValue] = None,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
-        level: int = 1,
+        level: DebugLevel = 1,
         topic: Optional[Topic] = None,
         stacklevel: int = 1,
     ) -> None:

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -32,6 +32,7 @@ import logging
 import os
 import sys
 import textwrap
+import typing
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -65,15 +66,17 @@ LOG_FILENAME = 'log.txt'
 # Hierarchy indent
 INDENT = 4
 
-#: Supported verbosity levels.
-VERBOSITY_LEVELS = (0, 1, 2, 3, 4)
-#: Supported debug levels.
-DEBUG_LEVELS = (0, 1, 2, 3, 4)
-
 #: A type of verbosity level values accepted by logging functions.
 VerbosityLevel: 'TypeAlias' = Literal[0, 1, 2, 3, 4]
+
 #: A type of debug level values accepted by logging functions.
 DebugLevel: 'TypeAlias' = Literal[0, 1, 2, 3, 4]
+
+#: Supported verbosity levels.
+VERBOSITY_LEVELS: tuple[VerbosityLevel, ...] = tuple(typing.get_args(VerbosityLevel))
+
+#: Supported debug levels.
+DEBUG_LEVELS: tuple[DebugLevel, ...] = tuple(typing.get_args(DebugLevel))
 
 DEFAULT_VERBOSITY_LEVEL: VerbosityLevel = 0
 DEFAULT_DEBUG_LEVEL: DebugLevel = 0

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -58,7 +58,6 @@ if TYPE_CHECKING:
     import tmt.utils
     import tmt.utils.environment
     import tmt.utils.themes
-    from tmt._compat.typing import TypeAlias
 
 # Log in workdir
 LOG_FILENAME = 'log.txt'

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -66,10 +66,10 @@ LOG_FILENAME = 'log.txt'
 INDENT = 4
 
 #: A type of verbosity level values accepted by logging functions.
-VerbosityLevel: 'TypeAlias' = Literal[0, 1, 2, 3, 4]
+VerbosityLevel: 'TypeAlias' = Literal[0, 1, 2, 3]
 
 #: A type of debug level values accepted by logging functions.
-DebugLevel: 'TypeAlias' = Literal[0, 1, 2, 3, 4]
+DebugLevel: 'TypeAlias' = Literal[0, 1, 2, 3]
 
 #: Supported verbosity levels.
 VERBOSITY_LEVELS: tuple[VerbosityLevel, ...] = tuple(typing.get_args(VerbosityLevel))
@@ -336,9 +336,9 @@ def normalize_debug_level(raw_value: Any) -> Optional[DebugLevel]:  # noqa: RET5
             textwrap.dedent(
                 f"""
             Debug level '{raw_value}' is invalid. Supported debug levels are
-            {DEBUG_LEVELS[1]} (-{'d' * DEBUG_LEVELS[1]})
+            {DEBUG_LEVELS[1]} (-{'d' * DEBUG_LEVELS[1]} or TMT_DEBUG={DEBUG_LEVELS[1]})
             to
-            {DEBUG_LEVELS[-1]} (-{'d' * DEBUG_LEVELS[-1]}).
+            {DEBUG_LEVELS[-1]} (-{'d' * DEBUG_LEVELS[-1]} or TMT_DEBUG={DEBUG_LEVELS[-1]}).
             """
             )
             .replace('\n', ' ')

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -31,10 +31,13 @@ import itertools
 import logging
 import os
 import sys
+import textwrap
 from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Literal,
+    NoReturn,
     Optional,
     Protocol,
     TextIO,
@@ -54,6 +57,7 @@ if TYPE_CHECKING:
     import tmt.utils
     import tmt.utils.environment
     import tmt.utils.themes
+    from tmt._compat.typing import TypeAlias
 
 # Log in workdir
 LOG_FILENAME = 'log.txt'
@@ -61,8 +65,18 @@ LOG_FILENAME = 'log.txt'
 # Hierarchy indent
 INDENT = 4
 
-DEFAULT_VERBOSITY_LEVEL = 0
-DEFAULT_DEBUG_LEVEL = 0
+#: Supported verbosity levels.
+VERBOSITY_LEVELS = (0, 1, 2, 3, 4)
+#: Supported debug levels.
+DEBUG_LEVELS = (0, 1, 2, 3, 4)
+
+#: A type of verbosity level values accepted by logging functions.
+VerbosityLevel: 'TypeAlias' = Literal[0, 1, 2, 3, 4]
+#: A type of debug level values accepted by logging functions.
+DebugLevel: 'TypeAlias' = Literal[0, 1, 2, 3, 4]
+
+DEFAULT_VERBOSITY_LEVEL: VerbosityLevel = 0
+DEFAULT_DEBUG_LEVEL: DebugLevel = 0
 
 
 class Topic(enum.Enum):
@@ -126,21 +140,13 @@ def create_decolorizer(apply_colors: bool) -> Callable[[str], str]:
     return tmt.utils.remove_color
 
 
-def _debug_level_from_global_envvar() -> int:
-    import tmt.utils
-
+def _debug_level_from_global_envvar() -> Optional[DebugLevel]:
     raw_value = os.getenv('TMT_DEBUG', None)
 
     if raw_value is None:
         return 0
 
-    try:
-        return int(raw_value)
-
-    except ValueError as error:
-        raise tmt.utils.GeneralError(
-            f"Invalid debug level '{raw_value}', use an integer."
-        ) from error
+    return normalize_debug_level(raw_value)
 
 
 def decide_colorization(no_color: bool, force_color: bool) -> tuple[bool, bool]:
@@ -278,6 +284,86 @@ def indent(
     )
 
 
+# RET503: explicit return is not needed, last expression is a call of a
+# `NoReturn` function.
+def normalize_verbosity_level(raw_value: Any) -> Optional[VerbosityLevel]:  # noqa: RET503
+    def _raise(exc: Optional[Exception] = None) -> NoReturn:
+        import tmt.utils
+
+        message = (
+            textwrap.dedent(
+                f"""
+            Verbosity level '{raw_value}' is invalid. Supported verbosity levels are
+            {VERBOSITY_LEVELS[1]} (-{'v' * VERBOSITY_LEVELS[1]})
+            to
+            {VERBOSITY_LEVELS[-1]} (-{'v' * VERBOSITY_LEVELS[-1]}).
+            """
+            )
+            .replace('\n', ' ')
+            .strip()
+        )
+
+        if exc is None:
+            raise tmt.utils.GeneralError(message)
+
+        raise tmt.utils.GeneralError(message) from exc
+
+    if raw_value is None:
+        return None
+
+    if isinstance(raw_value, str):
+        try:
+            raw_value = int(raw_value)
+
+        except ValueError as exc:
+            _raise(exc=exc)
+
+    if isinstance(raw_value, int) and raw_value in VERBOSITY_LEVELS:
+        return cast(VerbosityLevel, raw_value)
+
+    _raise()
+
+
+# RET503: explicit return is not needed, last expression is a call of a
+# `NoReturn` function.
+def normalize_debug_level(raw_value: Any) -> Optional[DebugLevel]:  # noqa: RET503
+    def _raise(exc: Optional[Exception] = None) -> NoReturn:
+        import tmt.utils
+
+        message = (
+            textwrap.dedent(
+                f"""
+            Debug level '{raw_value}' is invalid. Supported debug levels are
+            {DEBUG_LEVELS[1]} (-{'d' * DEBUG_LEVELS[1]})
+            to
+            {DEBUG_LEVELS[-1]} (-{'d' * DEBUG_LEVELS[-1]}).
+            """
+            )
+            .replace('\n', ' ')
+            .strip()
+        )
+
+        if exc is None:
+            raise tmt.utils.GeneralError(message)
+
+        raise tmt.utils.GeneralError(message) from exc
+
+    if raw_value is None:
+        return None
+
+    if isinstance(raw_value, str):
+        try:
+            raw_value = int(raw_value)
+
+        except ValueError as exc:
+            _raise(exc)
+
+    if isinstance(raw_value, int) and raw_value in DEBUG_LEVELS:
+        return cast(DebugLevel, raw_value)
+
+    _raise()
+
+
 @container
 class LogRecordDetails:
     """
@@ -293,11 +379,11 @@ class LogRecordDetails:
     logger_labels: list[str] = simple_field(default_factory=list[str])
     logger_labels_padding: int = 0
 
-    logger_verbosity_level: int = 0
-    message_verbosity_level: Optional[int] = None
+    logger_verbosity_level: VerbosityLevel = 0
+    message_verbosity_level: Optional[VerbosityLevel] = None
 
-    logger_debug_level: int = 0
-    message_debug_level: Optional[int] = None
+    logger_debug_level: DebugLevel = 0
+    message_debug_level: Optional[DebugLevel] = None
 
     logger_quiet: bool = False
     ignore_quietness: bool = False
@@ -500,14 +586,14 @@ class RunWarningsFilter(logging.Filter):
         return False
 
 
-class LoggingFunction(Protocol):
+class VerboseLoggingFunction(Protocol):
     def __call__(
         self,
         key: str,
         value: Optional[str] = None,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
-        level: int = 1,
+        level: VerbosityLevel = 1,
         topic: Optional[Topic] = None,
         stacklevel: int = 1,
     ) -> None:
@@ -533,14 +619,17 @@ class Logger:
     and handlers.
     """
 
+    verbosity_level: VerbosityLevel
+    debug_level: DebugLevel
+
     def __init__(
         self,
         actual_logger: logging.Logger,
         base_shift: int = 0,
         labels: Optional[list[str]] = None,
         labels_padding: int = 0,
-        verbosity_level: int = DEFAULT_VERBOSITY_LEVEL,
-        debug_level: int = DEFAULT_DEBUG_LEVEL,
+        verbosity_level: VerbosityLevel = DEFAULT_VERBOSITY_LEVEL,
+        debug_level: DebugLevel = DEFAULT_DEBUG_LEVEL,
         quiet: bool = False,
         topics: Optional[set[Topic]] = None,
         apply_colors_output: bool = True,
@@ -763,7 +852,8 @@ class Logger:
 
         actual_kwargs.update(kwargs)
 
-        verbosity_level = cast(Optional[int], actual_kwargs.get('verbose', None))
+        verbosity_level = normalize_verbosity_level(actual_kwargs.get('verbose', None))
+
         if verbosity_level is None or verbosity_level == 0:
             pass
 
@@ -772,11 +862,11 @@ class Logger:
 
         debug_level_from_global_envvar = _debug_level_from_global_envvar()
 
-        if debug_level_from_global_envvar not in (None, 0):
+        if debug_level_from_global_envvar is not None and debug_level_from_global_envvar != 0:
             self.debug_level = debug_level_from_global_envvar
 
         else:
-            debug_level_from_option = cast(Optional[int], actual_kwargs.get('debug', None))
+            debug_level_from_option = normalize_debug_level(actual_kwargs.get('debug', None))
 
             if debug_level_from_option is None or debug_level_from_option == 0:
                 pass
@@ -937,7 +1027,7 @@ class Logger:
         value: Optional[LoggableValue] = None,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
-        level: int = 1,
+        level: VerbosityLevel = 1,
         topic: Optional[Topic] = None,
         stacklevel: int = 1,
     ) -> None:
@@ -960,7 +1050,7 @@ class Logger:
         value: Optional[LoggableValue] = None,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
-        level: int = 1,
+        level: DebugLevel = 1,
         topic: Optional[Topic] = None,
         stacklevel: int = 1,
     ) -> None:

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -286,9 +286,7 @@ def indent(
     )
 
 
-# RET503: explicit return is not needed, last expression is a call of a
-# `NoReturn` function.
-def normalize_verbosity_level(raw_value: Any) -> Optional[VerbosityLevel]:  # noqa: RET503
+def normalize_verbosity_level(raw_value: Any) -> Optional[VerbosityLevel]:
     def _raise(exc: Optional[Exception] = None) -> NoReturn:
         import tmt.utils
 
@@ -323,12 +321,10 @@ def normalize_verbosity_level(raw_value: Any) -> Optional[VerbosityLevel]:  # no
     if isinstance(raw_value, int) and raw_value in VERBOSITY_LEVELS:
         return cast(VerbosityLevel, raw_value)
 
-    _raise()
+    return _raise()
 
 
-# RET503: explicit return is not needed, last expression is a call of a
-# `NoReturn` function.
-def normalize_debug_level(raw_value: Any) -> Optional[DebugLevel]:  # noqa: RET503
+def normalize_debug_level(raw_value: Any) -> Optional[DebugLevel]:
     def _raise(exc: Optional[Exception] = None) -> NoReturn:
         import tmt.utils
 
@@ -363,7 +359,7 @@ def normalize_debug_level(raw_value: Any) -> Optional[DebugLevel]:  # noqa: RET5
     if isinstance(raw_value, int) and raw_value in DEBUG_LEVELS:
         return cast(DebugLevel, raw_value)
 
-    _raise()
+    return _raise()
 
 
 @container

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -308,6 +308,11 @@ def normalize_verbosity_level(raw_value: Any) -> Optional[VerbosityLevel]:
 
         raise tmt.utils.GeneralError(message) from exc
 
+    # `None` is not necessarily expected, as all inputs should originate
+    # in various CLI commands that accept the correct options, but it is
+    # very hard to prove `verbose` is never `None` to type checkers. We
+    # can remove this once we narrow this e.g. by passing verbosity to
+    # `apply_verbosity_options` as a keyword parameter.
     if raw_value is None:
         return None
 
@@ -346,6 +351,11 @@ def normalize_debug_level(raw_value: Any) -> Optional[DebugLevel]:
 
         raise tmt.utils.GeneralError(message) from exc
 
+    # `None` is not necessarily expected, as all inputs should originate
+    # in various CLI commands that accept the correct options, but it is
+    # very hard to prove `debug` is never `None` to type checkers. We
+    # can remove this once we narrow this e.g. by passing debug level to
+    # `apply_verbosity_options` as a keyword parameter.
     if raw_value is None:
         return None
 

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -195,14 +195,22 @@ VERBOSITY_OPTIONS: list[ClickOptionDecoratorType] = [
         '--verbose',
         count=True,
         default=0,
-        help='Show more details. Use multiple times to raise verbosity.',
+        help="""
+             Make output more verbose, show more details. Can be used
+             up to three times (``-v`` to ``-vvv``) for even more
+             increased verbosity.
+             """,
     ),
     option(
         '-d',
         '--debug',
         count=True,
         default=0,
-        help='Provide debugging information. Repeat to see more details.',
+        help="""
+             Emit debugging information. Can be used up to four times
+             (``-d`` to ``-dddd``, or ``TMT_DEBUG=1`` to ``TMT_DEBUG=4``)
+             for increasingly detailed logging.
+             """,
     ),
     option(
         '-q',

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -197,8 +197,8 @@ VERBOSITY_OPTIONS: list[ClickOptionDecoratorType] = [
         default=0,
         help="""
              Make output more verbose, show more details. Can be used
-             up to three times (``-v`` to ``-vvv``) for even more
-             increased verbosity.
+             up to four times (``-v`` to ``-vvvv``) for increasingly
+             detailed output.
              """,
     ),
     option(

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -196,9 +196,20 @@ VERBOSITY_OPTIONS: list[ClickOptionDecoratorType] = [
         count=True,
         default=0,
         help="""
-             Make output more verbose, show more details. Can be used
-             up to four times (``-v`` to ``-vvvv``) for increasingly
-             detailed output.
+             Make the user-focused output more verbose. Can be used
+             up to three times (``-v`` to ``-vvv``) for increasingly
+             detailed output:
+
+             * ``-v``: Phase inputs and outputs are shown. The essential
+               phase input and output such as discovered test names,
+               required packages or individual test results.
+             * ``-vv``: Investigation details are shown. Details needed
+               when investigating what went wrong such as log paths,
+               remote links, external sources, guest facts, duration
+               deadlines or executed commands.
+             * ``-vvv``: Full output. Command outputs, full test output,
+               rendered script, other constructed input, queued/executed
+               tasks.
              """,
     ),
     option(
@@ -207,9 +218,19 @@ VERBOSITY_OPTIONS: list[ClickOptionDecoratorType] = [
         count=True,
         default=0,
         help="""
-             Emit debugging information. Can be used up to four times
-             (``-d`` to ``-dddd``, or ``TMT_DEBUG=1`` to ``TMT_DEBUG=4``)
-             for increasingly detailed logging.
+             Make the developer-focused debugging output more verbose.
+             Can be used up to three times (``-d`` to ``-ddd``, or
+             ``TMT_DEBUG=1`` to ``TMT_DEBUG=3``) for increasingly
+             detailed logging:
+
+             * ``-d``/``TMT_DEBUG=1``: High-level info. Framework choice,
+               policy application or reboot actions.
+             * ``-dd``/``TMT_DEBUG=2``: Detailed operations. Actions
+               such as step load, wake up, guest pull/push or playbook
+               paths.
+             * ``-ddd``/``TMT_DEBUG=3``: Internal plumbing. The
+               low-level implementation details such as workdir handling,
+               process termination, key normalization and similar.
              """,
     ),
     option(
@@ -708,7 +729,7 @@ def create_method_class(methods: MethodDictType) -> type[click.Command]:
                                 # Found a flag
                                 continue
                             if option.count:
-                                # Found options like '-ddddd'
+                                # Found options like '-ddd'
                                 continue
 
                         # Consume all remaining arguments. Think `ls /foo /bar ...`, it's not

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -590,7 +590,7 @@ class Step(
         return self.plan.run_workdir
 
     @property
-    def _cli_invocation_logger(self) -> tmt.log.LoggingFunction:
+    def _cli_invocation_logger(self) -> tmt.log.VerboseLoggingFunction:
         return functools.partial(self.debug, level=4, topic=tmt.log.Topic.CLI_INVOCATIONS)
 
     @property

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -449,7 +449,7 @@ class StepData(
         Called before normalization, useful for tweaking raw data
         """
 
-        logger.debug(f'{cls.__name__}: original raw data', str(raw_data), level=4)
+        logger.debug(f'{cls.__name__}: original raw data', str(raw_data), level=3)
 
     def post_normalization(self, raw_data: _RawStepData, logger: tmt.log.Logger) -> None:
         """
@@ -732,7 +732,7 @@ class Step(
 
     @property
     def _cli_invocation_logger(self) -> tmt.log.VerboseLoggingFunction:
-        return functools.partial(self.debug, level=4, topic=tmt.log.Topic.CLI_INVOCATIONS)
+        return functools.partial(self.debug, level=3, topic=tmt.log.Topic.CLI_INVOCATIONS)
 
     @property
     def _preserved_workdir_members(self) -> set[str]:

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -731,7 +731,7 @@ class Step(
         return self.plan.run_workdir
 
     @property
-    def _cli_invocation_logger(self) -> tmt.log.LoggingFunction:
+    def _cli_invocation_logger(self) -> tmt.log.VerboseLoggingFunction:
         return functools.partial(self.debug, level=4, topic=tmt.log.Topic.CLI_INVOCATIONS)
 
     @property

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -455,7 +455,7 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
         command: ShellScript,
         *,
         cwd: Path,
-        log: tmt.log.LoggingFunction,
+        log: tmt.log.VerboseLoggingFunction,
         interactive: bool,
         deadline: Optional[tmt.utils.wait.Deadline],
     ) -> tmt.utils.CommandOutput:

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -462,7 +462,7 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
         command: ShellScript,
         *,
         cwd: Path,
-        log: tmt.log.LoggingFunction,
+        log: tmt.log.VerboseLoggingFunction,
         interactive: bool,
         deadline: Optional[tmt.utils.wait.Deadline],
     ) -> tmt.utils.CommandOutput:

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -649,7 +649,7 @@ class ResultCollection:
         result = fmf.utils.validate_data(self.results, schema, schema_store=schema_store)
 
         if not result.errors:
-            self.invocation.logger.debug('Results successfully validated.', level=4, shift=1)
+            self.invocation.logger.debug('Results successfully validated.', level=3, shift=1)
 
             return
 

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -308,7 +308,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         value: Optional[str] = None,
         color: tmt.utils.themes.Style = None,
         shift: int = 2,
-        level: int = 3,
+        level: tmt.log.VerbosityLevel = 3,
         topic: Optional[tmt.log.Topic] = None,
     ) -> None:
         """
@@ -383,7 +383,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
             value: Optional[str] = None,
             color: tmt.utils.themes.Style = None,
             shift: int = 2,
-            level: int = 3,
+            level: tmt.log.VerbosityLevel = 3,
             topic: Optional[tmt.log.Topic] = None,
             stacklevel: int = 1,
         ) -> None:

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -309,7 +309,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         value: Optional[str] = None,
         color: tmt.utils.themes.Style = None,
         shift: int = 2,
-        level: int = 3,
+        level: tmt.log.VerbosityLevel = 3,
         topic: Optional[tmt.log.Topic] = None,
     ) -> None:
         """
@@ -384,7 +384,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
             value: Optional[str] = None,
             color: tmt.utils.themes.Style = None,
             shift: int = 2,
-            level: int = 3,
+            level: tmt.log.VerbosityLevel = 3,
             topic: Optional[tmt.log.Topic] = None,
             stacklevel: int = 1,
         ) -> None:

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -56,7 +56,7 @@ class GuestLocal(tmt.Guest):
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> tmt.utils.CommandOutput:
         """
@@ -118,7 +118,7 @@ class GuestLocal(tmt.Guest):
         immediately: bool = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -93,7 +93,7 @@ class GuestLocal(tmt.Guest):
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> tmt.utils.CommandOutput:
         """
@@ -155,7 +155,7 @@ class GuestLocal(tmt.Guest):
         immediately: bool = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -313,7 +313,7 @@ class MockShell:
         cwd: Optional[Path] = None,
         env: Optional[tmt.utils.Environment] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
         logger: tmt.log.Logger,
         join: Optional[bool] = None,
@@ -401,7 +401,7 @@ class MockShell:
             # For command output logging, use either the given logging callback, or
             # use the given logger & emit to verbose log.
             # NOTE Command.run uses debug, not verbose.
-            output_logger: tmt.log.LoggingFunction = (
+            output_logger: tmt.log.VerboseLoggingFunction = (
                 (log or logger.verbose) if not silent else logger.verbose
             )
 
@@ -519,7 +519,7 @@ class GuestMock(tmt.Guest):
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> tmt.utils.CommandOutput:
         """
@@ -553,7 +553,7 @@ class GuestMock(tmt.Guest):
         immediately: bool = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -322,7 +322,7 @@ class MockShell:
         cwd: Optional[Path] = None,
         environment: Optional[Environment] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
         logger: tmt.log.Logger,
         join: Optional[bool] = None,
@@ -410,7 +410,7 @@ class MockShell:
             # For command output logging, use either the given logging callback, or
             # use the given logger & emit to verbose log.
             # NOTE Command.run uses debug, not verbose.
-            output_logger: tmt.log.LoggingFunction = (
+            output_logger: tmt.log.VerboseLoggingFunction = (
                 (log or logger.verbose) if not silent else logger.verbose
             )
 
@@ -553,7 +553,7 @@ class GuestMock(tmt.Guest):
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> tmt.utils.CommandOutput:
         """
@@ -587,7 +587,7 @@ class GuestMock(tmt.Guest):
         immediately: bool = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1096,7 +1096,7 @@ EOF
                     },
                 ]
 
-            logger.debug('mrack request', req, level=4)
+            logger.debug('mrack request', req, level=3)
 
             logger.info('whiteboard', host.whiteboard, 'green')
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -405,7 +405,7 @@ class GuestContainer(tmt.Guest):
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> tmt.utils.CommandOutput:
         """
@@ -499,7 +499,7 @@ class GuestContainer(tmt.Guest):
         immediately: bool = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -413,7 +413,7 @@ class GuestContainer(tmt.Guest):
         playbook_root: Optional[Path] = None,
         extra_args: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
     ) -> tmt.utils.CommandOutput:
         """
@@ -513,7 +513,7 @@ class GuestContainer(tmt.Guest):
         immediately: bool = True,
         tty: bool = False,
         silent: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         interactive: bool = False,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -462,7 +462,7 @@ def _apply_hw_tpm(
     domain.tpm_configuration = None
 
     if not hardware or not hardware.constraint:
-        logger.debug('tpm.version', "not included because of no constraints", level=4)
+        logger.debug('tpm.version', "not included because of no constraints", level=3)
 
         return
 
@@ -478,7 +478,7 @@ def _apply_hw_tpm(
 
     if not tpm_constraints:
         logger.debug(
-            'tpm.version', "not included because of no 'tpm.version' constraints", level=4
+            'tpm.version', "not included because of no 'tpm.version' constraints", level=3
         )
 
         return
@@ -497,7 +497,7 @@ def _apply_hw_tpm(
             return
 
         logger.debug(
-            'tpm.version', f"set to '{constraint.value}' because of '{constraint}'", level=4
+            'tpm.version', f"set to '{constraint.value}' because of '{constraint}'", level=3
         )
 
         if TPM_CONFIG_ALLOWS_VERSIONS:
@@ -518,7 +518,7 @@ def _get_hw_boot_method(
     """
 
     if not hardware or not hardware.constraint:
-        logger.debug('boot.method', "not included because of no constraints", level=4)
+        logger.debug('boot.method', "not included because of no constraints", level=3)
 
         return None
 
@@ -534,7 +534,7 @@ def _get_hw_boot_method(
 
     if not boot_method_constraints:
         logger.debug(
-            'boot.method', "not included because of no 'boot.method' constraints", level=4
+            'boot.method', "not included because of no 'boot.method' constraints", level=3
         )
 
         return None
@@ -553,7 +553,7 @@ def _get_hw_boot_method(
         if constraint.operator == tmt.hardware.Operator.NOTCONTAINS_EXCLUSIVE:
             boot_method = 'bios' if boot_method == 'uefi' else 'uefi'
 
-        logger.debug('boot.method', f"set to '{boot_method}' because of '{constraint}'", level=4)
+        logger.debug('boot.method', f"set to '{boot_method}' because of '{constraint}'", level=3)
 
         return boot_method
 
@@ -586,7 +586,7 @@ def _apply_hw_disk_size(
     disk_filepath_generator = _generate_disk_filepaths()
 
     if not hardware or not hardware.constraint:
-        logger.debug('disk[0].size', f"set to '{final_size}' because of no constraints", level=4)
+        logger.debug('disk[0].size', f"set to '{final_size}' because of no constraints", level=3)
 
         domain.storage_devices = [
             QCow2StorageDevice(
@@ -609,7 +609,7 @@ def _apply_hw_disk_size(
 
     if not disk_size_constraints:
         logger.debug(
-            'disk[0].size', f"set to '{final_size}' because of no 'disk.size' constraints", level=4
+            'disk[0].size', f"set to '{final_size}' because of no 'disk.size' constraints", level=3
         )
 
         domain.storage_devices = [
@@ -650,7 +650,7 @@ def _apply_hw_disk_size(
             logger.debug(
                 f'disk[{peer_index}].size',
                 f"set to '{constraint.value}' because of '{constraint}'",
-                level=4,
+                level=3,
             )
 
             final_size = constraint.value
@@ -674,7 +674,7 @@ def _apply_hw_cpu_processors(
     domain.cpu_count = DEFAULT_CPU_COUNT
 
     if not hardware or not hardware.constraint:
-        logger.debug('cpu.processors', "not included because of no constraints", level=4)
+        logger.debug('cpu.processors', "not included because of no constraints", level=3)
 
         return
 
@@ -690,7 +690,7 @@ def _apply_hw_cpu_processors(
 
     if not cpu_processors_constraints:
         logger.debug(
-            'cpu.processors', "not included because of no 'cpu.processors' constraints", level=4
+            'cpu.processors', "not included because of no 'cpu.processors' constraints", level=3
         )
 
         return
@@ -702,7 +702,7 @@ def _apply_hw_cpu_processors(
             tmt.hardware.Operator.GTE,
         ):
             logger.debug(
-                'cpu.processors', f"set to '{constraint.value}' because of '{constraint}'", level=4
+                'cpu.processors', f"set to '{constraint.value}' because of '{constraint}'", level=3
             )
 
             domain.cpu_count = constraint.value
@@ -714,14 +714,14 @@ def _apply_hw_cpu_processors(
             logger.debug(
                 'cpu.processors',
                 f"kept at '{constraint.value}' because of '{constraint}'",
-                level=4,
+                level=3,
             )
 
         elif constraint.operator is tmt.hardware.Operator.LT:
             logger.debug(
                 'cpu.processors',
                 f"set to '{constraint.value - 1}' because of '{constraint}'",
-                level=4,
+                level=3,
             )
 
             domain.cpu_count = constraint.value - 1
@@ -730,7 +730,7 @@ def _apply_hw_cpu_processors(
             logger.debug(
                 'cpu.processors',
                 f"set to '{constraint.value + 1}' because of '{constraint}'",
-                level=4,
+                level=3,
             )
 
             domain.cpu_count = constraint.value + 1
@@ -1007,7 +1007,7 @@ class GuestTestcloud(tmt.GuestSsh):
         """
 
         if not self.hardware or not self.hardware.constraint:
-            self.debug('memory', f"set to '{DEFAULT_MEMORY}' because of no constraints", level=4)
+            self.debug('memory', f"set to '{DEFAULT_MEMORY}' because of no constraints", level=3)
 
             domain.memory_size = int(DEFAULT_MEMORY.to('kB').magnitude)
 
@@ -1024,7 +1024,7 @@ class GuestTestcloud(tmt.GuestSsh):
 
         if not memory_constraints:
             self.debug(
-                'memory', f"set to '{DEFAULT_MEMORY}' because of no 'memory' constraints", level=4
+                'memory', f"set to '{DEFAULT_MEMORY}' because of no 'memory' constraints", level=3
             )
 
             domain.memory_size = int(DEFAULT_MEMORY.to('kB').magnitude)
@@ -1041,7 +1041,7 @@ class GuestTestcloud(tmt.GuestSsh):
                     f"Cannot apply hardware requirement '{constraint}', operator not supported."
                 )
 
-            self.debug('memory', f"set to '{constraint.value}' because of '{constraint}'", level=4)
+            self.debug('memory', f"set to '{constraint.value}' because of '{constraint}'", level=3)
 
             domain.memory_size = int(constraint.value.to('kB').magnitude)
 
@@ -1214,7 +1214,7 @@ class GuestTestcloud(tmt.GuestSsh):
             self.verbose('effective hardware', self.hardware.to_spec(), color='green')
 
             for line in self.hardware.format_variants():
-                self._logger.debug('effective hardware', line, level=4)
+                self._logger.debug('effective hardware', line, level=3)
 
         self._apply_hw_memory(self._domain)
         _apply_hw_cpu_processors(self.hardware, self._domain, self._logger)
@@ -1540,7 +1540,7 @@ class ProvisionTestcloud(tmt.steps.provision.ProvisionPlugin[ProvisionTestcloudD
             data.hardware.report_support(check=_report_hw_requirement_support, logger=self._logger)
 
             for line in data.hardware.format_variants():
-                self._logger.debug('hardware', line, level=4)
+                self._logger.debug('hardware', line, level=3)
 
             if data.memory is not None and data.hardware.constraint.uses_constraint(
                 'memory', self._logger

--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -29,7 +29,7 @@ import tmt.utils
 from tmt import Plan
 from tmt.base.run import RunData
 from tmt.steps.prepare import PreparePlugin
-from tmt.utils import Command, GeneralError, MetadataError, Path
+from tmt.utils import Command, GeneralError, MetadataError, NormalizationError, Path
 from tmt.utils.themes import style
 
 USER_PLAN_NAME = "/user/plan"
@@ -216,7 +216,7 @@ class Try(tmt.utils.Common):
         # Use the verbosity level 3 unless user explicitly requested
         # a different level on the command line
         if self.verbosity_level == 0:
-            self.verbosity_level: int = 3
+            self.verbosity_level = 3
 
         # Use the interactive mode during test execution
         tmt.steps.execute.Execute.store_cli_invocation(
@@ -509,9 +509,16 @@ class Try(tmt.utils.Common):
             return
 
         try:
-            self.verbosity_level = int(answer)
-            self.print(f"Switched to verbose level {self.verbosity_level}.")
-        except ValueError:
+            verbosity_level = tmt.log.normalize_verbosity_level(answer)
+
+            if verbosity_level is None:
+                self.print(f"Invalid level '{answer}'.")
+
+            else:
+                self.verbosity_level = verbosity_level
+                self.print(f"Switched to verbose level {self.verbosity_level}.")
+
+        except (ValueError, NormalizationError):
             self.print(f"Invalid level '{answer}'.")
 
     @Action("verbose", shortcut="v", order=4, group=1, prompt_function=prompt_verbose)
@@ -536,8 +543,15 @@ class Try(tmt.utils.Common):
             return
 
         try:
-            self.debug_level = int(answer)
-            self.print(f"Switched to debug level {self.debug_level}.")
+            debug_level = tmt.log.normalize_debug_level(answer)
+
+            if debug_level is None:
+                self.print(f"Invalid level '{answer}'.")
+
+            else:
+                self.debug_level = debug_level
+                self.print(f"Switched to debug level {self.debug_level}.")
+
         except ValueError:
             self.print(f"Invalid level '{answer}'.")
 

--- a/tmt/trying.py
+++ b/tmt/trying.py
@@ -29,7 +29,7 @@ import tmt.utils
 from tmt import Plan
 from tmt.base.run import RunData
 from tmt.steps.prepare import PreparePlugin
-from tmt.utils import Command, GeneralError, MetadataError, NormalizationError, Path
+from tmt.utils import Command, GeneralError, MetadataError, Path
 from tmt.utils.themes import style
 
 USER_PLAN_NAME = "/user/plan"
@@ -518,7 +518,7 @@ class Try(tmt.utils.Common):
                 self.verbosity_level = verbosity_level
                 self.print(f"Switched to verbose level {self.verbosity_level}.")
 
-        except (ValueError, NormalizationError):
+        except GeneralError:
             self.print(f"Invalid level '{answer}'.")
 
     @Action("verbose", shortcut="v", order=4, group=1, prompt_function=prompt_verbose)
@@ -552,7 +552,7 @@ class Try(tmt.utils.Common):
                 self.debug_level = debug_level
                 self.print(f"Switched to debug level {self.debug_level}.")
 
-        except ValueError:
+        except GeneralError:
             self.print(f"Invalid level '{answer}'.")
 
     @Action("debug", shortcut="b", order=5, group=1, prompt_function=prompt_debug)

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -74,7 +74,7 @@ from tmt._compat.importlib.readers import MultiplexedPath
 from tmt._compat.pathlib import Path
 from tmt._compat.typing import ParamSpec, Self
 from tmt.container import container
-from tmt.log import LoggableValue
+from tmt.log import DebugLevel, LoggableValue, VerbosityLevel
 from tmt.utils.themes import style
 
 if TYPE_CHECKING:
@@ -1035,7 +1035,7 @@ class StreamLogger(Thread):
         log_header: str,
         *,
         stream: Optional[IO[bytes]] = None,
-        logger: Optional[tmt.log.LoggingFunction] = None,
+        logger: Optional[tmt.log.VerboseLoggingFunction] = None,
         click_context: Optional[click.Context] = None,
         stream_output: bool = True,
     ) -> None:
@@ -1257,7 +1257,7 @@ class Command:
         # Logging
         message: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
         stream_output: bool = True,
         caller: Optional['Common'] = None,
@@ -2059,7 +2059,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         return parent if parent is not None else local
 
     @property
-    def debug_level(self) -> int:
+    def debug_level(self) -> DebugLevel:
         """
         The current debug level applied to this object
         """
@@ -2067,7 +2067,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         return self._logger.debug_level
 
     @debug_level.setter
-    def debug_level(self, level: int) -> None:
+    def debug_level(self, level: DebugLevel) -> None:
         """
         Update the debug level attached to this object
         """
@@ -2075,7 +2075,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         self._logger.debug_level = level
 
     @property
-    def verbosity_level(self) -> int:
+    def verbosity_level(self) -> 'VerbosityLevel':
         """
         The current verbosity level applied to this object
         """
@@ -2083,7 +2083,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         return self._logger.verbosity_level
 
     @verbosity_level.setter
-    def verbosity_level(self, level: int) -> None:
+    def verbosity_level(self, level: VerbosityLevel) -> None:
         """
         Update the verbosity level attached to this object
         """
@@ -2256,7 +2256,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         value: Optional[LoggableValue] = None,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
-        level: int = 1,
+        level: 'VerbosityLevel' = 1,
         topic: Optional[tmt.log.Topic] = None,
         stacklevel: int = 1,
     ) -> None:
@@ -2282,7 +2282,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         value: Optional[LoggableValue] = None,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
-        level: int = 1,
+        level: 'DebugLevel' = 1,
         topic: Optional[tmt.log.Topic] = None,
         stacklevel: int = 1,
     ) -> None:
@@ -2322,7 +2322,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         value: Optional[str] = None,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 1,
-        level: int = 3,
+        level: VerbosityLevel = 3,
         topic: Optional[tmt.log.Topic] = None,
         stacklevel: int = 1,
     ) -> None:
@@ -2355,7 +2355,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         env: Optional[Environment] = None,
         interactive: bool = False,
         join: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         timeout: Optional[int] = None,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -2397,7 +2397,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             logger=self._logger,
         )
 
-    def read_file(self, filepath: Path, debug_level: int = 2) -> str:
+    def read_file(self, filepath: Path, debug_level: VerbosityLevel = 2) -> str:
         """
         Read a file from the workdir of this object.
 
@@ -2424,7 +2424,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         filepath: Path,
         data: str,
         mode: WriteMode = 'w',
-        debug_level: int = 2,
+        debug_level: VerbosityLevel = 2,
     ) -> None:
         """
         Write into a file in the workdir of this object.
@@ -6337,7 +6337,8 @@ class NormalizeKeysMixin(_CommonBase):
 
         from tmt.container import key_to_option
 
-        log_shift, log_level = 2, 4
+        log_shift: int = 2
+        log_level: DebugLevel = 4
 
         debug_intro = functools.partial(
             logger.debug,
@@ -6377,7 +6378,7 @@ class NormalizeKeysMixin(_CommonBase):
             value_source: FieldValueSource
 
             # Verbose, let's hide it a bit deeper.
-            debug('dict', self.__dict__, level=log_level + 1)
+            debug('dict', self.__dict__)
 
             if hasattr(self, keyname):
                 # If the key exists as instance's attribute already, it is because it's been

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1863,7 +1863,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             logger=self._logger,
         )
 
-    def read_file(self, filepath: Path, debug_level: VerbosityLevel = 2) -> str:
+    def read_file(self, filepath: Path, debug_level: DebugLevel = 2) -> str:
         """
         Read a file from the workdir of this object.
 

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -74,7 +74,7 @@ from tmt._compat.importlib.readers import MultiplexedPath
 from tmt._compat.pathlib import Path
 from tmt._compat.typing import ParamSpec, Self
 from tmt.container import container
-from tmt.log import LoggableValue
+from tmt.log import DebugLevel, LoggableValue, VerbosityLevel
 from tmt.utils.environment import Environment
 from tmt.utils.themes import style
 
@@ -466,7 +466,7 @@ class StreamLogger(Thread):
         log_header: str,
         *,
         stream: Optional[IO[bytes]] = None,
-        logger: Optional[tmt.log.LoggingFunction] = None,
+        logger: Optional[tmt.log.VerboseLoggingFunction] = None,
         click_context: Optional[click.Context] = None,
         stream_output: bool = True,
     ) -> None:
@@ -704,7 +704,7 @@ class Command:
         # Logging
         message: Optional[str] = None,
         friendly_command: Optional[str] = None,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         silent: bool = False,
         stream_output: bool = True,
         caller: Optional['Common'] = None,
@@ -1525,7 +1525,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         return parent if parent is not None else local
 
     @property
-    def debug_level(self) -> int:
+    def debug_level(self) -> DebugLevel:
         """
         The current debug level applied to this object
         """
@@ -1533,7 +1533,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         return self._logger.debug_level
 
     @debug_level.setter
-    def debug_level(self, level: int) -> None:
+    def debug_level(self, level: DebugLevel) -> None:
         """
         Update the debug level attached to this object
         """
@@ -1541,7 +1541,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         self._logger.debug_level = level
 
     @property
-    def verbosity_level(self) -> int:
+    def verbosity_level(self) -> 'VerbosityLevel':
         """
         The current verbosity level applied to this object
         """
@@ -1549,7 +1549,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         return self._logger.verbosity_level
 
     @verbosity_level.setter
-    def verbosity_level(self, level: int) -> None:
+    def verbosity_level(self, level: VerbosityLevel) -> None:
         """
         Update the verbosity level attached to this object
         """
@@ -1722,7 +1722,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         value: Optional[LoggableValue] = None,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
-        level: int = 1,
+        level: 'VerbosityLevel' = 1,
         topic: Optional[tmt.log.Topic] = None,
         stacklevel: int = 1,
     ) -> None:
@@ -1748,7 +1748,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         value: Optional[LoggableValue] = None,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
-        level: int = 1,
+        level: 'DebugLevel' = 1,
         topic: Optional[tmt.log.Topic] = None,
         stacklevel: int = 1,
     ) -> None:
@@ -1788,7 +1788,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         value: Optional[str] = None,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 1,
-        level: int = 3,
+        level: VerbosityLevel = 3,
         topic: Optional[tmt.log.Topic] = None,
         stacklevel: int = 1,
     ) -> None:
@@ -1821,7 +1821,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         environment: Optional['Environment'] = None,
         interactive: bool = False,
         join: bool = False,
-        log: Optional[tmt.log.LoggingFunction] = None,
+        log: Optional[tmt.log.VerboseLoggingFunction] = None,
         timeout: Optional[int] = None,
         on_process_start: Optional[OnProcessStartCallback] = None,
         on_process_end: Optional[OnProcessEndCallback] = None,
@@ -1863,7 +1863,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             logger=self._logger,
         )
 
-    def read_file(self, filepath: Path, debug_level: int = 2) -> str:
+    def read_file(self, filepath: Path, debug_level: VerbosityLevel = 2) -> str:
         """
         Read a file from the workdir of this object.
 
@@ -1890,7 +1890,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         filepath: Path,
         data: str,
         mode: WriteMode = 'w',
-        debug_level: int = 2,
+        debug_level: VerbosityLevel = 2,
         permissions: Optional[int] = None,
     ) -> None:
         """
@@ -5807,7 +5807,8 @@ class NormalizeKeysMixin(_CommonBase):
 
         from tmt.container import key_to_option
 
-        log_shift, log_level = 2, 4
+        log_shift: int = 2
+        log_level: DebugLevel = 4
 
         debug_intro = functools.partial(
             logger.debug,
@@ -5847,7 +5848,7 @@ class NormalizeKeysMixin(_CommonBase):
             value_source: FieldValueSource
 
             # Verbose, let's hide it a bit deeper.
-            debug('dict', self.__dict__, level=log_level + 1)
+            debug('dict', self.__dict__)
 
             if hasattr(self, keyname):
                 # If the key exists as instance's attribute already, it is because it's been

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1890,7 +1890,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         filepath: Path,
         data: str,
         mode: WriteMode = 'w',
-        debug_level: VerbosityLevel = 2,
+        debug_level: DebugLevel = 2,
         permissions: Optional[int] = None,
     ) -> None:
         """
@@ -5847,7 +5847,6 @@ class NormalizeKeysMixin(_CommonBase):
             value: Any = None
             value_source: FieldValueSource
 
-            # Verbose, let's hide it a bit deeper.
             debug('dict', self.__dict__)
 
             if hasattr(self, keyname):

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -781,7 +781,7 @@ class Command:
         # Prepare the environment: create an empty one if needed.
         actual_environment = environment if environment is not None else Environment()
 
-        logger.debug('environment', actual_environment, level=4)
+        logger.debug('environment', actual_environment, level=3)
 
         # Set special executable only when shell was requested
         executable = DEFAULT_SHELL if shell else None
@@ -868,7 +868,7 @@ class Command:
             logger.debug(
                 'Command event',
                 f'{_event_timestamp()} {msg}',
-                level=4,
+                level=3,
                 topic=tmt.log.Topic.COMMAND_EVENTS,
             )
 
@@ -5198,25 +5198,25 @@ def dataclass_normalize_field(
         logger.debug(
             f'field "{key_address}" normalized to false-ish value',
             f'{container.__class__.__name__}.{keyname}',
-            level=4,
+            level=3,
             topic=tmt.log.Topic.KEY_NORMALIZATION,
         )
 
         with_getattr = getattr(container, keyname, None)
         with_dict = container.__dict__.get(keyname, None)
 
-        logger.debug('value', str(value), level=4, shift=1, topic=tmt.log.Topic.KEY_NORMALIZATION)
+        logger.debug('value', str(value), level=3, shift=1, topic=tmt.log.Topic.KEY_NORMALIZATION)
         logger.debug(
             'current value (getattr)',
             str(with_getattr),
-            level=4,
+            level=3,
             shift=1,
             topic=tmt.log.Topic.KEY_NORMALIZATION,
         )
         logger.debug(
             'current value (__dict__)',
             str(with_dict),
-            level=4,
+            level=3,
             shift=1,
             topic=tmt.log.Topic.KEY_NORMALIZATION,
         )
@@ -5224,7 +5224,7 @@ def dataclass_normalize_field(
         if value != with_getattr or with_getattr != with_dict:
             logger.debug(
                 'known values do not match',
-                level=4,
+                level=3,
                 shift=2,
                 topic=tmt.log.Topic.KEY_NORMALIZATION,
             )
@@ -5808,7 +5808,7 @@ class NormalizeKeysMixin(_CommonBase):
         from tmt.container import key_to_option
 
         log_shift: int = 2
-        log_level: DebugLevel = 4
+        log_level: DebugLevel = 3
 
         debug_intro = functools.partial(
             logger.debug,

--- a/tmt/utils/rest.py
+++ b/tmt/utils/rest.py
@@ -86,16 +86,16 @@ class RestVisitor(docutils.nodes.NodeVisitor):
     """
 
     def log_visit(self, node: Union[docutils.nodes.Node, docutils.nodes.Body]) -> None:
-        self.logger.debug('visit ', str(node), level=4, topic=tmt.log.Topic.HELP_RENDERING)
+        self.logger.debug('visit ', str(node), level=3, topic=tmt.log.Topic.HELP_RENDERING)
 
     def log_departure(self, node: Union[docutils.nodes.Node, docutils.nodes.Body]) -> None:
-        self.logger.debug('depart', str(node), level=4, topic=tmt.log.Topic.HELP_RENDERING)
+        self.logger.debug('depart', str(node), level=3, topic=tmt.log.Topic.HELP_RENDERING)
 
     def __init__(self, document: docutils.nodes.document, logger: Logger) -> None:
         super().__init__(document)
 
         self.logger = logger
-        self.debug = functools.partial(logger.debug, level=4, topic=tmt.log.Topic.HELP_RENDERING)
+        self.debug = functools.partial(logger.debug, level=3, topic=tmt.log.Topic.HELP_RENDERING)
 
         #: Collects all rendered paragraps - text, blocks, lists, etc.
         self._rendered_paragraphs: list[str] = []
@@ -446,7 +446,7 @@ def render_rst(text: str, logger: Logger) -> str:
     Render a ReST document
     """
 
-    logger.debug('text', text, level=4, topic=tmt.log.Topic.HELP_RENDERING)
+    logger.debug('text', text, level=3, topic=tmt.log.Topic.HELP_RENDERING)
 
     document = parse_rst(text)
     visitor = RestVisitor(document, logger)


### PR DESCRIPTION
Enforced in code by the use of `Literal` type alias, runtime check follow the `normalize_*` pattern. Updated documentation and help texts to reflect the change.

Fix #4943.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] adjust the test coverage