### PR TITLE
Help plans/friends pick the correct version of tmt to test against

### DIFF
--- a/plans/friends/beakerlib.fmf
+++ b/plans/friends/beakerlib.fmf
@@ -5,9 +5,7 @@ description:
     beakerlib is working as expected. This plan is run for
     upstream pull requests in the beakerlib repository.
 
-discover:
-    how: fmf
-    url: https://github.com/teemtee/tmt
+discover+:
     filter: "tag:beakerlib & tag:-provision-only"
 
 link:

--- a/plans/friends/main.fmf
+++ b/plans/friends/main.fmf
@@ -1,6 +1,28 @@
 execute:
     how: tmt
 
+discover:
+    how: fmf
+
+adjust:
+  - when: initiator == packit
+    because: >
+      We want to test against the tmt main branch
+    prepare+:
+      - order: 40
+        how: install
+        copr: "@teemtee/latest"
+    discover+:
+      url: https://github.com/teemtee/tmt
+      ref: main
+  - when: initiator == fedora-ci
+    because: >
+      We want to test against the source in Fedora
+    discover+:
+      dist-git-source: true
+      url: https://src.fedoraproject.org/rpms/tmt.git
+      ref: $@{dist-git-branch}
+
 prepare:
     # Install jq and yq for cleaner tests
   - how: install

--- a/plans/friends/main.fmf
+++ b/plans/friends/main.fmf
@@ -1,3 +1,6 @@
+/:
+    select: true
+
 execute:
     how: tmt
 

--- a/plans/friends/podman.fmf
+++ b/plans/friends/podman.fmf
@@ -6,15 +6,13 @@ description:
     is supposed to be run for podman, crun, container-selinux and
     friends pull requests to prevent introducing breaking changes.
 
-discover:
-    how: fmf
-    url: https://github.com/teemtee/tmt
+discover+:
     filter: "tag:podman"
     adjust-tests:
       - check: avc
 
-prepare:
-    name: enable-epel
+prepare+:
+  - name: enable-epel
     how: feature
     epel: enabled
     order: 20


### PR DESCRIPTION
The issue here is that if you just do a `plans.import` of the friends plan there is a disconnect between what tmt version is installed (currently controlled by the importer) and the version of the test files used. However we have an explicit connection between `@teemtee/latest` and the `main` branch which we use here to enforce that connection. Ideally we would do that for `@teemtee/stable` also, but that requires some branch/mutable tag that follows the latest successful release, an issue to be resolved later.

The tricky part is making this also available in the dist-git testing. It seems we can actually do that since the dist-git-source supports using a different package's dist-git, although we are blocked by the restriction in #4840. It magically just works in most cases except for inter-dependent dist-git PRs (multiple PRs that need to be landed in a side-tag), but there are enough failure points there anyway.

On the side of the users of plans/friends, they would have to remove their definition of the `@teemtee/*` copr repo and let us handle it instead.

Depends-on: #4840
Fixes #4539

CC @sopos @lsm5