### PR TITLE
Add missing imports

### DIFF
--- a/examples/plugins/example/provision.py
+++ b/examples/plugins/example/provision.py
@@ -1,5 +1,7 @@
 import tmt
 import tmt.steps
+import tmt.steps.provision
+import tmt.utils
 from tmt.options import option
 
 # See the online documentation for more details about writing plugins

--- a/tests/core/path/test.py
+++ b/tests/core/path/test.py
@@ -2,6 +2,7 @@ import pytest
 
 import tmt
 import tmt.log
+import tmt.utils
 from tmt.utils import Path
 
 logger = tmt.log.Logger.create()

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -10,6 +10,7 @@ import pytest
 
 import tmt
 import tmt.result
+import tmt.utils
 from tmt.base.core import FmfId, Link, LinkNeedle, Links, expand_node_data
 from tmt.utils import Path, SpecificationError
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -8,6 +8,7 @@ import _pytest.monkeypatch
 import pytest
 
 import tmt.log
+import tmt.utils
 from tests import CliRunner
 from tmt.container import container
 from tmt.utils import Path

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -9,6 +9,7 @@ import fmf
 import pytest
 
 import tmt.config
+import tmt.utils
 from tmt._compat.pydantic import PYDANTIC_V1
 from tmt.log import Logger
 from tmt.utils import Path

--- a/tests/unit/test_id.py
+++ b/tests/unit/test_id.py
@@ -5,6 +5,7 @@ import fmf
 import pytest
 
 import tmt
+import tmt.log
 from tests.conftest import create_path_helper
 from tmt.identifier import ID_KEY, add_uuid_if_not_defined
 from tmt.utils import Path

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -16,10 +16,13 @@ import fmf
 import pytest
 
 import tmt
+import tmt.base.core
+import tmt.base.plan
 import tmt.log
 import tmt.plugins
 import tmt.steps.discover
 import tmt.utils
+import tmt.utils.git
 import tmt.utils.jira
 from tmt.log import Logger
 from tmt.utils import (

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -39,6 +39,7 @@ import tmt.checks
 import tmt.convert
 import tmt.export
 import tmt.frameworks
+import tmt.guest
 import tmt.identifier
 import tmt.lint
 import tmt.log

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -1291,7 +1291,7 @@ def relevancy_to_adjust(
         # Split rule
         search_result = re.search(RELEVANCY_RULE, line)
         if search_result is None:
-            raise tmt.utils.ConvertError(f"Invalid test case relevancy rule '{line}'.")
+            raise ConvertError(f"Invalid test case relevancy rule '{line}'.")
         condition, decision = search_result.groups()
 
         # Handle the decision
@@ -1301,7 +1301,7 @@ def relevancy_to_adjust(
             try:
                 rule['environment'] = tmt.utils.Environment.from_sequence(decision, logger)
             except tmt.utils.GeneralError as error:
-                raise tmt.utils.ConvertError(
+                raise ConvertError(
                     f"Invalid test case relevancy decision '{decision}'."
                 ) from error
 
@@ -1310,9 +1310,7 @@ def relevancy_to_adjust(
         for expression in re.split(r'\s*&&?\s*', condition):
             search_result = re.search(RELEVANCY_EXPRESSION, expression)
             if search_result is None:
-                raise tmt.utils.ConvertError(
-                    f"Invalid test case relevancy expression '{expression}'."
-                )
+                raise ConvertError(f"Invalid test case relevancy expression '{expression}'.")
             left, operator, right = search_result.groups()
             # Always use double == for equality comparison
             if operator == '=':
@@ -1333,7 +1331,7 @@ def relevancy_to_adjust(
                         '!defined': 'is not defined',
                     }[operator]
                 except KeyError as error:
-                    raise tmt.utils.ConvertError(
+                    raise ConvertError(
                         f"Invalid test case relevancy operator '{operator}'."
                     ) from error
             # Special handling for the '!=' operator with comma-separated

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -15,7 +15,6 @@ import fmf.utils
 from click import echo
 
 import tmt.base.core
-import tmt.export
 import tmt.identifier
 import tmt.log
 import tmt.utils
@@ -1231,7 +1230,7 @@ def adjust_runtest(path: Path) -> None:
     try:
         path.chmod(0o755)
     except OSError as error:
-        raise tmt.convert.ConvertError(f"Could not make '{path}' executable.") from error
+        raise ConvertError(f"Could not make '{path}' executable.") from error
 
 
 def write(path: Path, data: NitrateDataType, quiet: bool = False) -> None:

--- a/tmt/export/_json.py
+++ b/tmt/export/_json.py
@@ -1,6 +1,7 @@
 import tmt.base.core
 import tmt.base.plan
 import tmt.export
+import tmt.utils
 
 
 @tmt.base.core.FmfId.provides_export('json')

--- a/tmt/export/template.py
+++ b/tmt/export/template.py
@@ -3,7 +3,9 @@ from typing import Any, Optional
 import tmt.base.core
 import tmt.base.plan
 import tmt.export
+import tmt.log
 import tmt.utils
+import tmt.utils.templates
 from tmt.utils import Path
 
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -444,7 +444,9 @@ def essential_ansible_requires() -> list['tmt.base.core.Dependency']:
     Return essential requirements for running Ansible modules
     """
 
-    return [tmt.base.core.DependencySimple('/usr/bin/python3')]
+    from tmt.base.core import DependencySimple
+
+    return [DependencySimple('/usr/bin/python3')]
 
 
 def format_guest_full_name(name: str, role: Optional[str]) -> str:

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -31,11 +31,11 @@ from typing import (
 
 import fmf.utils
 
-import tmt
 import tmt.ansible
 import tmt.hardware
 import tmt.hardware.constraints
 import tmt.log
+import tmt.options
 import tmt.package_managers
 import tmt.steps
 import tmt.steps.scripts

--- a/tmt/lint.py
+++ b/tmt/lint.py
@@ -75,7 +75,6 @@ from typing import (
     TypeVar,
 )
 
-import tmt
 import tmt.utils
 from tmt.config import Config
 from tmt.container import container
@@ -212,7 +211,7 @@ class Lintable(Generic[LintableT]):
             if not name.startswith('lint_'):
                 continue
 
-            cls.get_linter_registry().append(tmt.lint.Linter(getattr(cls, name)))
+            cls.get_linter_registry().append(Linter(getattr(cls, name)))
 
     @classmethod
     def resolve_enabled_linters(

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -81,6 +81,8 @@ if TYPE_CHECKING:
     import tmt.base.core
     import tmt.cli
     import tmt.plugins
+    import tmt.steps.context.reboot
+    import tmt.steps.context.restart
     from tmt.base.plan import Plan
     from tmt.guest import Guest, TransferOptions
     from tmt.result import BaseResult, PhaseResult

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -9,6 +9,7 @@ import click
 from fmf.utils import listed
 
 import tmt
+import tmt.log
 import tmt.result
 from tmt.container import container, field, key_to_option
 

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -13,11 +13,13 @@ import fmf.utils
 import tmt
 import tmt.base.core
 import tmt.base.run
+import tmt.guest
 import tmt.log
 import tmt.steps
 import tmt.steps.scripts
 import tmt.utils
 import tmt.utils.signals
+import tmt.utils.wait
 from tmt.checks import Check, CheckEvent, CheckPlugin
 from tmt.container import container, field, simple_field
 from tmt.guest import Guest

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -5,6 +5,7 @@ import fmf.utils
 
 import tmt.base.core
 import tmt.base.plan
+import tmt.guest
 import tmt.log
 import tmt.steps
 import tmt.utils
@@ -253,7 +254,7 @@ class ExecuteUpgrade(ExecuteInternal):
     @property
     def tasks(
         self,
-    ) -> Iterator[tuple[Optional[str], list['tmt.guest.Guest']]]:
+    ) -> Iterator[tuple[Optional[str], list[tmt.guest.Guest]]]:
         # upgrade plugin is expected to execute multiple
         # discover phases on old, perform the upgrade, then execute
         # those same discover phases again on new. All of this should occur
@@ -279,7 +280,7 @@ class ExecuteUpgrade(ExecuteInternal):
     def go(
         self,
         *,
-        guest: 'tmt.guest.Guest',
+        guest: tmt.guest.Guest,
         environment: Optional[tmt.utils.Environment] = None,
         logger: tmt.log.Logger,
     ) -> None:

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -2,8 +2,9 @@ from typing import Optional, TypeVar, cast
 
 import fmf
 
-import tmt
+import tmt.log
 import tmt.steps
+import tmt.utils
 from tmt.container import container
 from tmt.guest import Guest
 from tmt.plugins import PluginRegistry

--- a/tmt/steps/finish/shell.py
+++ b/tmt/steps/finish/shell.py
@@ -1,6 +1,6 @@
 import tmt.steps
 import tmt.steps.finish
-from tmt.steps.prepare.shell import PrepareShell
+from tmt.steps.prepare.shell import PrepareShell, PrepareShellData
 
 
 @tmt.steps.provides_method('shell')
@@ -47,7 +47,7 @@ class FinishShell(tmt.steps.finish.FinishPlugin[tmt.steps.finish.FinishStepData]
     # We are reusing "prepare" step for "finish",
     # and they both have different expectations.
     # Mypy is not happy about this though.
-    _data_class = tmt.steps.prepare.shell.PrepareShellData  # type: ignore[assignment]
+    _data_class = PrepareShellData  # type: ignore[assignment]
 
     # `FinishPlugin` plugin would win the inheritance battle and provide
     # its no-op `go()`. Force the one from `PrepareShell`.

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING, Literal, Optional, TypeVar, cast
 
 import fmf.utils
 
-import tmt
 import tmt.log
 import tmt.steps
 import tmt.utils
@@ -22,6 +21,7 @@ from tmt.utils import uniq
 
 if TYPE_CHECKING:
     import tmt.base.core
+    import tmt.guest
     from tmt.base.plan import Plan
 
 

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -12,6 +12,7 @@ from typing import Any, Optional
 
 import tmt.log
 import tmt.utils
+import tmt.utils.hints
 from tmt._compat.typing import TypeAlias
 from tmt.container import container, simple_field
 from tmt.guest import DownloadError, Guest

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -17,6 +17,7 @@ import tmt.ansible
 import tmt.guest
 import tmt.hardware
 import tmt.log
+import tmt.options
 import tmt.queue
 import tmt.steps
 import tmt.utils

--- a/tmt/steps/provision/bootc.py
+++ b/tmt/steps/provision/bootc.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING, Optional, cast
 
 import click
 
-import tmt
+import tmt.guest
 import tmt.hardware
 import tmt.log
 import tmt.steps

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Optional, Union, cast
 
-import tmt
 import tmt.guest
+import tmt.log
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Optional, Union, cast
 import tmt
 import tmt.guest
 import tmt.log
+import tmt.package_managers
 import tmt.steps
 import tmt.steps.provision
 import tmt.utils

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -3,6 +3,7 @@ from shlex import quote
 from typing import Any, ClassVar, Optional, Union, cast
 
 import tmt
+import tmt.guest
 import tmt.log
 import tmt.steps
 import tmt.steps.provision

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -16,6 +16,7 @@ import click
 import requests
 
 import tmt
+import tmt.guest
 import tmt.hardware
 import tmt.log
 import tmt.steps

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -1,5 +1,7 @@
 from typing import Optional, TypeVar, Union, cast
 
+import tmt.log
+import tmt.result
 import tmt.steps
 from tmt.container import container
 from tmt.plugins import PluginRegistry

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from requests import post
 
-import tmt
+import tmt.log
 import tmt.steps
 import tmt.steps.report
 import tmt.utils

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -5,10 +5,11 @@ from re import Pattern
 from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast, overload
 
 import requests
-import urllib3
+import urllib3.exceptions
 
 import tmt.hardware
 import tmt.log
+import tmt.result
 import tmt.steps.report
 import tmt.utils
 import tmt.utils.templates

--- a/tmt/steps/scripts.py
+++ b/tmt/steps/scripts.py
@@ -1,8 +1,7 @@
 import os
 from tempfile import NamedTemporaryFile
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
-import tmt
 import tmt.log
 import tmt.utils
 from tmt.container import container
@@ -10,6 +9,10 @@ from tmt.utils import (
     Path,
 )
 from tmt.utils.templates import render_template_file
+
+if TYPE_CHECKING:
+    import tmt.guest
+
 
 #: Scripts source resource. Use `tmt.utils.resource_files` to access them.
 SCRIPTS_RESOURCE = 'steps/scripts'


### PR DESCRIPTION
Indeed, many modules were referenced without being explicitly imported. It worked because some other part of tmt already imported the module in question, but that's just a happy accident we should not rely on.

Pull Request Checklist

* [x] implement the feature