### PR TITLE
Add proper `Command.__iadd__` method to correctly support `+=` operator

### DIFF
--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1209,6 +1209,13 @@ class Command:
 
         return Command(*self._command, *other)
 
+    # While the outcome of `+=` can be emulated by `__add__`, it would
+    # return new object. Often we just want to add to the existing object,
+    # `__iadd__` would made that action very, very slightly less
+    # memory-consuming.
+    # Plus, it is a clean and explicit in-place modification, and prevents
+    # any confusing outcomes should we begin passing commands between
+    # callables and modify them in said callables.
     def __iadd__(self, other: Union['Command', RawCommand]) -> Self:
         if isinstance(other, Command):
             self._command += other._command

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1209,6 +1209,15 @@ class Command:
 
         return Command(*self._command, *other)
 
+    def __iadd__(self, other: Union['Command', RawCommand]) -> Self:
+        if isinstance(other, Command):
+            self._command += other._command
+
+        else:
+            self._command += [str(element) for element in other]
+
+        return self
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Command):
             return False


### PR DESCRIPTION
`command += [...]` is often used in the code, but proper magic method was missing. In our code, it is probably not needed, as `__iadd__` can be emulated by `__add__`, but there is a trap waiting to spring:

```python
class Foo:
    def __init__(self):
        self.content = []

    def __add__(self, other):
        new = Foo()
        new.content = [*self.content, *other.content]
        return new


A = Foo()
A.content.append(1)

B = Foo()
B.content.append(2)

C = A

print('Setup:')
print('A', id(A))
print('B', id(B))
print('C', id(C))
print()

D = A + B
A += B

print('After additions:')
print('A', id(A), A.content)
print('B', id(B), B.content)
print('C', id(C), C.content)
print('D', id(D), D.content)
```

Without `__iadd__`, one gets the following output:

```
Setup:
A 140545939960704
B 140545939149904
C 140545939960704

After additions:
A 140545940415168 [1, 2]
B 140545939149904 [2]
C 140545939960704 [1]
D 140545939150224 [1, 2]
```

Note that `A` and `C` have different content, isn't that surprising? We added `1` to `A` to begin with, and `C` is just another name for `A`, right? Yes, it is, but then `A += B` invokes `__add__` which returns completely new object, and `A` and `C` no longer label the same object. While `A += B` can be emulated by `__add__` alone, in the sense that `A` name will keep pointing at the sum of `A` and `B`, without `__iadd__` new object is created, and all other names remain pointing at the original object.

With `__iadd__` returning `self`:

```
Setup:
A 139761787630464
B 139761552938064
C 139761787630464

After additions:
A 139761787630464 [1, 2]
B 139761552938064 [2]
C 139761787630464 [1, 2]
D 139761552938384 [1, 2]
```

It's clearly visible that `A` and `C` remain pointing at the very same object. Low risk, we rarely label one command with different names in the same scope, but it's just waiting for some poor soul to spend a week on debugging.