### PR TITLE
Move `config-manager` install to package manager abstraction

### DIFF
--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1,7 +1,7 @@
 import re
 from collections.abc import Iterator
 from inspect import isclass
-from typing import Optional
+from typing import Optional, Union
 
 import _pytest.logging
 import pytest
@@ -479,7 +479,7 @@ def test_refresh_metadata(
 
 
 def _parametrize_test_assert_config_manager() -> Iterator[
-    tuple[Container, PackageManagerClass, str | Exception]
+    tuple[Container, PackageManagerClass, Union[str, Exception]]
 ]:
     for container, package_manager_class in CONTAINER_BASE_MATRIX:
         if package_manager_class is tmt.package_managers.dnf.Yum:

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Iterator
 from inspect import isclass
 from typing import Optional
@@ -24,6 +25,7 @@ from tmt.package_managers import (
     PackageManager,
     PackageManagerClass,
     PackagePath,
+    PrepareError,
 )
 from tmt.steps.provision.podman import GuestContainer
 from tmt.utils import ShellScript
@@ -476,8 +478,8 @@ def test_refresh_metadata(
     assert_output(expected_output, output.stdout, output.stderr)
 
 
-def _parametrize_test_install_config_manager() -> Iterator[
-    tuple[Container, PackageManagerClass, str]
+def _parametrize_test_assert_config_manager() -> Iterator[
+    tuple[Container, PackageManagerClass, str | Exception]
 ]:
     for container, package_manager_class in CONTAINER_BASE_MATRIX:
         if package_manager_class is tmt.package_managers.dnf.Yum:
@@ -491,14 +493,14 @@ def _parametrize_test_install_config_manager() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides dnf-command\(config-manager\) \|\| dnf install -y  dnf-command\(config-manager\)",  # noqa: E501
+                r"""rpm -q --whatprovides '"'"'dnf-command\(config-manager\)'"'"' \|\| dnf install -y  '"'"'dnf-command\(config-manager\)'"'"'""",  # noqa: E501
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf5:
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides dnf5-command\(config-manager\) \|\| dnf5 install -y  dnf5-command\(config-manager\)",  # noqa: E501
+                r"""rpm -q --whatprovides '"'"'dnf5-command\(config-manager\)'"'"' \|\| dnf5 install -y  '"'"'dnf5-command\(config-manager\)'"'"'""",  # noqa: E501
             )
 
         elif package_manager_class in (
@@ -506,41 +508,30 @@ def _parametrize_test_install_config_manager() -> Iterator[
             tmt.package_managers.rpm_ostree.RpmOstree,
             tmt.package_managers.apk.Apk,
         ):
-            continue
+            yield (
+                container,
+                package_manager_class,
+                PrepareError(
+                    f"Package manager '{package_manager_class.NAME}' does not support config-manager."  # noqa: E501
+                ),
+            )
 
         else:
             pytest.fail(f"Unhandled package manager class '{package_manager_class}'.")
 
 
-CONTAINER_CONFIG_MANAGER_MATRIX = [
-    (container, pm_class)
-    for container, pm_class in CONTAINER_BASE_MATRIX
-    if pm_class
-    in (
-        tmt.package_managers.dnf.Dnf,
-        tmt.package_managers.dnf.Dnf5,
-        tmt.package_managers.dnf.Yum,
-    )
-]
-
-CONTAINER_CONFIG_MANAGER_MATRIX_IDS = [
-    f'{container.url} / {package_manager_class.__name__.lower()}'
-    for container, package_manager_class in CONTAINER_CONFIG_MANAGER_MATRIX
-]
-
-
 @pytest.mark.containers
 @pytest.mark.parametrize(
-    ('container_per_test', 'package_manager_class', 'expected_command'),
-    list(_parametrize_test_install_config_manager()),
+    ('container_per_test', 'package_manager_class', 'expected_command_or_exception'),
+    list(_parametrize_test_assert_config_manager()),
     indirect=["container_per_test"],
-    ids=CONTAINER_CONFIG_MANAGER_MATRIX_IDS,
+    ids=CONTAINER_MATRIX_IDS,
 )
-def test_install_config_manager(
+def test_assert_config_manager(
     container_per_test: ContainerData,
     guest_per_test: GuestContainer,
     package_manager_class: PackageManagerClass,
-    expected_command: str,
+    expected_command_or_exception: str | Exception,
     root_logger: tmt.log.Logger,
     caplog: _pytest.logging.LogCaptureFixture,
 ) -> None:
@@ -548,9 +539,15 @@ def test_install_config_manager(
         container_per_test, guest_per_test, package_manager_class, root_logger
     )
 
-    package_manager.install_config_manager()
-
-    assert_expected_command(caplog, expected_command)
+    if isinstance(expected_command_or_exception, str):
+        package_manager.assert_config_manager()
+        assert_expected_command(caplog, expected_command_or_exception)
+    else:
+        with pytest.raises(
+            type(expected_command_or_exception),
+            match=re.escape(str(expected_command_or_exception)),
+        ):
+            package_manager.assert_config_manager()
 
 
 def _parametrize_test_install_nonexistent() -> Iterator[

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -531,7 +531,7 @@ def test_assert_config_manager(
     container_per_test: ContainerData,
     guest_per_test: GuestContainer,
     package_manager_class: PackageManagerClass,
-    expected_command_or_exception: str | Exception,
+    expected_command_or_exception: Union[str, Exception],
     root_logger: tmt.log.Logger,
     caplog: _pytest.logging.LogCaptureFixture,
 ) -> None:

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -476,6 +476,83 @@ def test_refresh_metadata(
     assert_output(expected_output, output.stdout, output.stderr)
 
 
+def _parametrize_test_install_config_manager() -> Iterator[
+    tuple[Container, PackageManagerClass, str]
+]:
+    for container, package_manager_class in CONTAINER_BASE_MATRIX:
+        if package_manager_class is tmt.package_managers.dnf.Yum:
+            yield (
+                container,
+                package_manager_class,
+                r"rpm -q --whatprovides yum-utils \|\| yum install -y  yum-utils && rpm -q --whatprovides yum-utils",  # noqa: E501
+            )
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf:
+            yield (
+                container,
+                package_manager_class,
+                r"rpm -q --whatprovides dnf-command\(config-manager\) \|\| dnf install -y  dnf-command\(config-manager\)",  # noqa: E501
+            )
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf5:
+            yield (
+                container,
+                package_manager_class,
+                r"rpm -q --whatprovides dnf5-command\(config-manager\) \|\| dnf5 install -y  dnf5-command\(config-manager\)",  # noqa: E501
+            )
+
+        elif package_manager_class in (
+            tmt.package_managers.apt.Apt,
+            tmt.package_managers.rpm_ostree.RpmOstree,
+            tmt.package_managers.apk.Apk,
+        ):
+            continue
+
+        else:
+            pytest.fail(f"Unhandled package manager class '{package_manager_class}'.")
+
+
+CONTAINER_CONFIG_MANAGER_MATRIX = [
+    (container, pm_class)
+    for container, pm_class in CONTAINER_BASE_MATRIX
+    if pm_class
+    in (
+        tmt.package_managers.dnf.Dnf,
+        tmt.package_managers.dnf.Dnf5,
+        tmt.package_managers.dnf.Yum,
+    )
+]
+
+CONTAINER_CONFIG_MANAGER_MATRIX_IDS = [
+    f'{container.url} / {package_manager_class.__name__.lower()}'
+    for container, package_manager_class in CONTAINER_CONFIG_MANAGER_MATRIX
+]
+
+
+@pytest.mark.containers
+@pytest.mark.parametrize(
+    ('container_per_test', 'package_manager_class', 'expected_command'),
+    list(_parametrize_test_install_config_manager()),
+    indirect=["container_per_test"],
+    ids=CONTAINER_CONFIG_MANAGER_MATRIX_IDS,
+)
+def test_install_config_manager(
+    container_per_test: ContainerData,
+    guest_per_test: GuestContainer,
+    package_manager_class: PackageManagerClass,
+    expected_command: str,
+    root_logger: tmt.log.Logger,
+    caplog: _pytest.logging.LogCaptureFixture,
+) -> None:
+    package_manager = create_package_manager(
+        container_per_test, guest_per_test, package_manager_class, root_logger
+    )
+
+    package_manager.install_config_manager()
+
+    assert_expected_command(caplog, expected_command)
+
+
 def _parametrize_test_install_nonexistent() -> Iterator[
     tuple[Container, PackageManagerClass, str, Optional[str]]
 ]:

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -670,6 +670,12 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         """
         return self.install(*installables, options=options)
 
+    def install_config_manager(self) -> None:
+        """
+        Install the config-manager plugin for repository management.
+        """
+        raise PrepareError(f"Package manager '{self.NAME}' does not support config-manager.")
+
     def enable_copr(self, *repositories: str) -> None:
         """
         Enable requested copr repositories

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -670,9 +670,9 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         """
         return self.install(*installables, options=options)
 
-    def install_config_manager(self) -> None:
+    def assert_config_manager(self) -> None:
         """
-        Install the config-manager plugin for repository management.
+        Make sure the ``config-manager`` plugin for repository management is installed.
         """
         raise PrepareError(f"Package manager '{self.NAME}' does not support config-manager.")
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -333,7 +333,7 @@ class Dnf(PackageManager[DnfEngine]):
 
         return results
 
-    def install_config_manager(self) -> None:
+    def assert_config_manager(self) -> None:
         self.debug('Make sure the config-manager plugin is available.')
         self.install(Package(self.config_manager_plugin))
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -253,6 +253,9 @@ class Dnf(PackageManager[DnfEngine]):
     #: Package name of the COPR plugin for this package manager.
     copr_plugin: ClassVar[str] = 'dnf-plugins-core'
 
+    #: Package name of the config-manager plugin for this package manager.
+    config_manager_plugin: ClassVar[str] = 'dnf-command(config-manager)'
+
     # Compiled regex patterns for DNF/YUM error messages
     _FAILED_PACKAGE_INSTALLATION_PATTERNS = [
         re.compile(r'Unable to find a match:\s+([^\s\n]+)', re.IGNORECASE),
@@ -330,6 +333,10 @@ class Dnf(PackageManager[DnfEngine]):
 
         return results
 
+    def install_config_manager(self) -> None:
+        self.debug('Make sure the config-manager plugin is available.')
+        self.install(Package(self.config_manager_plugin))
+
     def enable_copr(self, *repositories: str) -> None:
         """
         Enable requested copr repositories
@@ -393,6 +400,7 @@ class Dnf5(Dnf):
     _engine_class = Dnf5Engine
 
     copr_plugin: ClassVar[str] = 'dnf5-command(copr)'
+    config_manager_plugin: ClassVar[str] = 'dnf5-command(config-manager)'
 
     probe_command = Command('dnf5', '--version')
     probe_priority = 60
@@ -482,6 +490,7 @@ class Yum(Dnf):
     _engine_class = YumEngine
 
     copr_plugin: ClassVar[str] = 'yum-plugin-copr'
+    config_manager_plugin: ClassVar[str] = 'yum-utils'
 
     bootc_builder = False
 

--- a/tmt/steps/prepare/feature/crb.py
+++ b/tmt/steps/prepare/feature/crb.py
@@ -58,7 +58,7 @@ class Crb(ToggleableFeature):
             logger.warning('CRB prepare feature is supported on RHEL/CentOS-Stream 8, 9 or 10.')
             return
 
-        guest.package_manager.install_config_manager()
+        guest.package_manager.assert_config_manager()
 
         logger.info(f"{action.capitalize()} CRB repository.")
 

--- a/tmt/steps/prepare/feature/crb.py
+++ b/tmt/steps/prepare/feature/crb.py
@@ -4,7 +4,6 @@ from typing import Any, Optional
 import tmt.log
 from tmt.container import container, field
 from tmt.guest import Guest
-from tmt.package_managers import Package
 from tmt.steps.prepare.feature import PrepareFeatureData, ToggleableFeature, provides_feature
 from tmt.utils import ShellScript
 
@@ -59,7 +58,7 @@ class Crb(ToggleableFeature):
             logger.warning('CRB prepare feature is supported on RHEL/CentOS-Stream 8, 9 or 10.')
             return
 
-        guest.package_manager.install(Package("dnf-command(config-manager)"))
+        guest.package_manager.install_config_manager()
 
         logger.info(f"{action.capitalize()} CRB repository.")
 

--- a/tmt/steps/prepare/feature/epel.py
+++ b/tmt/steps/prepare/feature/epel.py
@@ -69,4 +69,3 @@ class Epel(ToggleableFeature):
     @classmethod
     def disable(cls, guest: Guest, logger: tmt.log.Logger) -> None:
         cls._run_playbook('disable', "epel-disable.yaml", guest, logger)
-

--- a/tmt/steps/prepare/feature/epel.py
+++ b/tmt/steps/prepare/feature/epel.py
@@ -69,3 +69,4 @@ class Epel(ToggleableFeature):
     @classmethod
     def disable(cls, guest: Guest, logger: tmt.log.Logger) -> None:
         cls._run_playbook('disable', "epel-disable.yaml", guest, logger)
+


### PR DESCRIPTION
Follow the `copr_plugin` / `enable_copr()` pattern: add a `config_manager_plugin` ClassVar and `install_config_manager()` method to the package manager layer instead of duplicating `dnf-command(config-manager)` installation in feature plugins.

- `Dnf`: `dnf-command(config-manager)`
- `Dnf5`: `dnf5-command(config-manager)`
- `Yum`: `yum-utils`

Closes: #4847

Assisted-by: Claude Code

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
