### PR TITLE
Fix prepare/shell and provision/local missing the plan environment

### DIFF
--- a/tests/prepare/shell/data/environment.fmf
+++ b/tests/prepare/shell/data/environment.fmf
@@ -1,0 +1,10 @@
+provision:
+    how: container
+prepare:
+  - name: Run preparation script
+    how: shell
+    script: /bin/true
+execute:
+    how: tmt
+environment:
+    DUMMY_ENVVAR: dummy_value

--- a/tests/prepare/shell/test.sh
+++ b/tests/prepare/shell/test.sh
@@ -10,7 +10,7 @@ rlJournalStart
             rlRun "IMAGES='$TEST_IMAGE_MODE_IMAGES'"
         fi
 
-        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
+        rlRun "run=\$(mktemp -d -p /var/tmp)" 0 "Create run directory"
 
         rlRun "pushd data"
     rlPhaseEnd
@@ -49,7 +49,12 @@ rlJournalStart
 
         rlPhaseStartTest "Make sure plan environment is exposed to scripts"
             rlRun -s "tmt run --id $run --scratch -v provision --how=$PROVISION_HOW $image_opt prepare cleanup plan -n environment" 0
-            rlAssertGrep "Run command: .*export DUMMY_ENVVAR=dummy_value;.*/bin/true" "$run/log.txt"
+
+            if [ "$IMAGE_MODE" = "yes" ]; then
+                rlAssertGrep "Collected command for Containerfile:.*export DUMMY_ENVVAR=dummy_value; .*/bin/true" "$run/log.txt"
+            else
+                rlAssertGrep "Run command: .*export DUMMY_ENVVAR=dummy_value;.*/bin/true" "$run/log.txt"
+            fi
         rlPhaseEnd
 
         # TODO: #4785 Preparing from a remote script is broken in Image Mode

--- a/tests/prepare/shell/test.sh
+++ b/tests/prepare/shell/test.sh
@@ -9,6 +9,9 @@ rlJournalStart
         if [ "$IMAGE_MODE" = "yes" ]; then
             rlRun "IMAGES='$TEST_IMAGE_MODE_IMAGES'"
         fi
+
+        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
+
         rlRun "pushd data"
     rlPhaseEnd
 
@@ -44,6 +47,11 @@ rlJournalStart
             assert_image_mode
         rlPhaseEnd
 
+        rlPhaseStartTest "Make sure plan environment is exposed to scripts"
+            rlRun -s "tmt run --id $run --scratch -v provision --how=$PROVISION_HOW $image_opt prepare cleanup plan -n environment" 0
+            rlAssertGrep "Run command: .*export DUMMY_ENVVAR=dummy_value;.*/bin/true" "$run/log.txt"
+        rlPhaseEnd
+
         # TODO: #4785 Preparing from a remote script is broken in Image Mode
         if [ "$IMAGE_MODE" != "yes" ]; then
             rlPhaseStartTest "Remote Script"
@@ -57,5 +65,6 @@ rlJournalStart
 
     rlPhaseStartCleanup
         rlRun "popd"
+        rlRun "rm -rf $run" 0 "Removing run directory"
     rlPhaseEnd
 rlJournalEnd

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2140,15 +2140,12 @@ class Guest(
         """
 
         if environment is None:
-            # narrow type
-            assert isinstance(self.parent, tmt.steps.Step)
-
             environment = tmt.utils.Environment()
 
-            environment.update(
-                self.environment,
-                self.parent.plan.environment,
-            )
+            environment.update(self.environment)
+
+            if isinstance(self.parent, tmt.steps.Step):
+                environment.update(self.parent.plan)
 
         else:
             # Create a copy of given environment - this prevents any

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -128,7 +128,10 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
         outcome = super().go(guest=guest, environment=environment, logger=logger)
 
         environment = environment or tmt.utils.Environment()
-        environment.update(guest.environment)
+        environment.update(
+            guest.environment,
+            self.step.plan.environment,
+        )
 
         # Give a short summary
         overview = fmf.utils.listed(self.data.script, 'script')

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -129,33 +129,27 @@ class GuestLocal(tmt.Guest):
         Execute command on localhost
         """
 
-        sourced_files = sourced_files or []
-
-        # Prepare the environment (plan/cli variables override)
-        environment = tmt.utils.Environment()
-        environment.update(env or {})
-        if self.parent:
-            environment.update(self.parent.plan.environment)
-
         if tty:
             self.warn("Ignoring requested tty, not supported by the 'local' provision plugin.")
 
-        for file in reversed(sourced_files):
-            if isinstance(command, Command):
-                command = (
-                    ShellScript(f'source {shlex.quote(str(file))}').to_shell_command()
-                    + Command("&&")
-                    + command
-                )
-            else:
-                command = ShellScript(f'source {shlex.quote(str(file))}') + command
+        # Accumulate all necessary commands - they will form a "shell" script, a single
+        # string passed to a shell executed inside the container.
+        script = ShellScript.from_scripts(
+            self._prepare_command_environment(env).to_shell_exports()
+        )
 
-        actual_command = command if isinstance(command, Command) else command.to_shell_command()
+        for file in reversed(sourced_files or []):
+            script += ShellScript(f'source {shlex.quote(str(file))}')
+
+        if isinstance(command, Command):
+            script += command.to_script()
+
+        else:
+            script += command
 
         # Run the command under the prepared environment
         return self._run_guest_command(
-            actual_command,
-            env=environment,
+            script.to_shell_command(),
             log=log,
             friendly_command=friendly_command or str(command),
             silent=silent,

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -133,7 +133,7 @@ class GuestLocal(tmt.Guest):
             self.warn("Ignoring requested tty, not supported by the 'local' provision plugin.")
 
         # Accumulate all necessary commands - they will form a "shell" script, a single
-        # string passed to a shell executed inside the container.
+        # string passed to a shell executed on the local host.
         script = ShellScript.from_scripts(
             self._prepare_command_environment(env).to_shell_exports()
         )


### PR DESCRIPTION
A regression introduced in #4613: plan environment is included as long as `Guest.execute()` is not given an actual environment, and that's exactly what `prepare/shell` does. Therefore `prepare/shell` needs to include both guest and plan environment. Similar error happens in `provision/local`.

Pull Request Checklist

* [x] implement the feature