### PR TITLE
only try to install dmesg if not installed

### DIFF
--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -203,7 +203,11 @@ class Dmesg(CheckPlugin[DmesgCheck]):
         # Avoid circular imports
         import tmt.base.core
 
-        return [tmt.base.core.DependencySimple('/usr/bin/dmesg')]
+        try:
+            guest.execute(tmt.utils.ShellScript('command -v dmesg'), silent=True)
+            return []
+        except tmt.utils.RunError:
+            return [tmt.base.core.DependencySimple('/usr/bin/dmesg')]
 
     @classmethod
     def before_test(


### PR DESCRIPTION
dmesg should be installed by default in most environments.

on older OS like rhel-6, the binary can be located on different path.

This should fix https://github.com/teemtee/tmt/issues/4751