### PR TITLE
Refresh the linkcheck cache everyday

### DIFF
--- a/.github/workflows/step-doc-tests.yml
+++ b/.github/workflows/step-doc-tests.yml
@@ -44,11 +44,18 @@ jobs:
         run: uv pip install sphinx-lint
         if: ${{ matrix.builder == 'lint' }}
 
+      - name: Get date
+        id: date
+        run: |
+          echo "date=$(/usr/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
+        if: ${{ matrix.builder == 'linkcheck' }}
       - name: Cache linkcheck results
         uses: actions/cache@v5
         with:
           path: docs/_build/linkcheck_cache.json
-          key: linkcheck
+          key: linkcheck-${{ steps.date.outputs.date }}
+          restore-keys: |
+            linkcheck-
         if: ${{ matrix.builder == 'linkcheck' }}
 
       - name: Run sphinx builder ${{ matrix.sphinx_builder || matrix.builder }}


### PR DESCRIPTION
Without this we were using the same linkcheck cache from 6 months ago https://github.com/teemtee/tmt/actions/caches. No wonder we had so many flaky linkcheck failures even after https://github.com/teemtee/tmt/pull/4730.

I was also considering [always pushing the cache](https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache) instead of doing it once a day, but I don't know what the race condition for that would imply. It would not be disastrous because it just picks the nearest cache, but the uncertainty does not feel right to me. If others give the thumb up for that approach though, happy to try it out.