### PR TITLE
Make documentation building more deterministic

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,86 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import importlib
-import os
 import sys
 from pathlib import Path
-from typing import Optional
-
-import tmt.utils
-
-_POSSIBLE_THEMES: list[tuple[Optional[str], str]] = [
-    # Use renku as the default theme
-    ('renku_sphinx_theme', 'renku'),
-    # Fall back to sphinx_rtd_theme if available
-    ('sphinx_rtd_theme', 'sphinx_rtd_theme'),
-    # The default theme
-    (None, 'default'),
-]
-
-# NOTE: this one is defined somewhere below, among original Sphinx config fields,
-# but we need it as early as possible to be set when loading themes.
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = []
-
-
-def _load_theme(theme_package_name: str, theme_name: str) -> bool:
-    try:
-        theme_package = importlib.import_module(theme_package_name)
-
-    except ModuleNotFoundError:
-        return False
-
-    global HTML_THEME
-
-    HTML_THEME = theme_name
-
-    if hasattr(theme_package, 'get_html_theme_path'):
-        global html_theme_path
-
-        path = theme_package.get_html_theme_path()
-
-        html_theme_path = path if isinstance(path, list) else [path]
-
-        return True
-
-    return True
-
-
-if 'TMT_DOCS_THEME' in os.environ:
-    theme_package_name: Optional[str]
-    theme_name: str
-
-    theme_specs = os.environ['TMT_DOCS_THEME']
-
-    try:
-        theme_package_name, theme_name = theme_specs.split(':', 1)
-
-    except ValueError as error:
-        raise tmt.utils.GeneralError(
-            f"Cannot split TMT_DOCS_THEME '{theme_specs}' into theme package and theme name."
-        ) from error
-
-    if not _load_theme(theme_package_name, theme_name):
-        raise tmt.utils.GeneralError(f"Cannot load theme from TMT_DOCS_THEME, '{theme_specs}'.")
-
-else:
-    for theme_package_name, theme_name in _POSSIBLE_THEMES:
-        if not theme_package_name:
-            HTML_THEME = theme_name
-            break
-
-        if _load_theme(theme_package_name, theme_name):
-            break
-
-    else:
-        raise tmt.utils.GeneralError('Cannot find usable theme.')
-
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../'))
 
 # -- General configuration ------------------------------------------------
 
@@ -103,7 +25,6 @@ sys.path.insert(0, os.path.abspath('../'))
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autodoc.typehints',
-    'sphinx_rtd_theme',
     'sphinx_reredirects',
     # Custom extensions defined in ext
     'tmt_setup',
@@ -201,7 +122,7 @@ autodoc_typehints_description_target = 'all'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = HTML_THEME
+html_theme = "renku"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -231,7 +152,7 @@ html_favicon = (
 html_static_path = ['_static']
 
 # Include custom style.
-html_style = os.getenv('TMT_DOCS_CUSTOM_HTML_STYLE', 'tmt-custom.css')
+html_style = 'tmt-custom.css'
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -511,44 +511,6 @@ Building documentation is then quite straightforward:
 Find the resulting html pages under the ``docs/_build/html``
 folder.
 
-Visual themes
-------------------------------------------------------------------
-
-Use the ``TMT_DOCS_THEME`` variable to easily pick custom theme.
-If specified, ``make docs`` would use this theme for documentation
-rendering by Sphinx. The theme must be installed manually, ``make
-docs`` will not do so. Variable expects two strings, separated by
-a colon (``:``): theme package name, and theme name.
-
-.. code-block:: shell
-
-    # Sphinx book theme, sphinx-book-theme:
-    TMT_DOCS_THEME="sphinx_book_theme:sphinx_book_theme" make docs
-
-    # Renku theme, renku-sphinx-theme - note that package name
-    # and theme name are *not* the same string:
-    TMT_DOCS_THEME="renku_sphinx_theme:renku" make docs
-
-By default, ``docs/_static/tmt-custom.css`` provides additional tweaks
-to the documentation theme. Use the ``TMT_DOCS_CUSTOM_HTML_STYLE``
-variable to include additional file:
-
-.. code-block:: shell
-
-    $ cat docs/_static/custom.local.css
-    /* Make content wider on my wider screen */
-    .wy-nav-content {
-        max-width: 1200px !important;
-    }
-
-    TMT_DOCS_CUSTOM_HTML_STYLE=custom.local.css make docs
-
-.. note::
-
-    The custom CSS file specified by ``TMT_DOCS_CUSTOM_HTML_STYLE``
-    is included **before** the built-in ``tmt-custom.css``, therefore to
-    override theme CSS, it is recommended to add ``!important`` flag.
-
 
 tldr pages
 ------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,6 @@ all = [
 # Needed for readthedocs and man page build. Not being packaged in rpm.
 docs = [
     "renku-sphinx-theme",
-    "readthedocs-sphinx-ext",
     "docutils>=0.18.1",
     "Sphinx",
     "fmf>=1.7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2558,21 +2558,6 @@ wheels = [
 ]
 
 [[package]]
-name = "readthedocs-sphinx-ext"
-version = "2.2.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/ce/38130d8dec600bf5413eb89a3413dd38f204c7c728c4947e12ff8cb793b7/readthedocs-sphinx-ext-2.2.5.tar.gz", hash = "sha256:ee5fd5b99db9f0c180b2396cbce528aa36671951b9526bb0272dbfce5517bd27", size = 12303, upload-time = "2023-12-19T10:00:49.573Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/71/c89e7709a0d4f93af1848e9855112299a820b470d84f917b4dd5998bdd07/readthedocs_sphinx_ext-2.2.5-py2.py3-none-any.whl", hash = "sha256:f8c56184ea011c972dd45a90122568587cc85b0127bc9cf064d17c68bc809daa", size = 11332, upload-time = "2023-12-19T10:00:43.972Z" },
-]
-
-[[package]]
 name = "referencing"
 version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3508,7 +3493,6 @@ ansible = [
 docs = [
     { name = "docutils" },
     { name = "fmf" },
-    { name = "readthedocs-sphinx-ext" },
     { name = "renku-sphinx-theme" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
@@ -3589,7 +3573,6 @@ requires-dist = [
     { name = "pylero", marker = "extra == 'report-polarion'", specifier = ">=0.1.0" },
     { name = "python-bugzilla", marker = "extra == 'all'", specifier = ">=3.2.0" },
     { name = "python-bugzilla", marker = "extra == 'test-convert'", specifier = ">=3.2.0" },
-    { name = "readthedocs-sphinx-ext", marker = "extra == 'docs'" },
     { name = "renku-sphinx-theme", marker = "extra == 'docs'" },
     { name = "requests", specifier = ">=2.25.1" },
     { name = "ruamel-yaml", specifier = ">=0.16.6" },


### PR DESCRIPTION
I don't really think we have useful usecases for this and it would be better to be able to replicate the exact documentation state we see in RTD. If the user wants to play around with the themes, they should do it by changing the dependencies, files live.