### PR TITLE
Enable partial test for prepare shell

### DIFF
--- a/tests/prepare/shell/test.sh
+++ b/tests/prepare/shell/test.sh
@@ -57,15 +57,16 @@ rlJournalStart
             fi
         rlPhaseEnd
 
-        # TODO: #4785 Preparing from a remote script is broken in Image Mode
-        if [ "$IMAGE_MODE" != "yes" ]; then
-            rlPhaseStartTest "Remote Script"
-                rlRun -s "tmt -vvv run provision --how=$PROVISION_HOW $image_opt prepare finish cleanup plan -n url" 0 "Prepare using a remote script"
-                rlAssertGrep "Hello world" "$rlRun_LOG" #check for the prepare script
+        rlPhaseStartTest "Remote Script"
+            rlRun -s "tmt -vvv run provision --how=$PROVISION_HOW $image_opt prepare finish cleanup plan -n url" 0 "Prepare using a remote script"
+            rlAssertGrep "Hello world" "$rlRun_LOG" #check for the prepare script
+            # TODO: #4785 Preparing from a remote script is broken in Image Mode (finish)
+            # https://github.com/teemtee/tmt/issues/4917
+            if [ "$IMAGE_MODE" != "yes" ]; then
                 rlAssertGrep "third" "$rlRun_LOG" # check for the finish script
-                assert_image_mode
-            rlPhaseEnd
-        fi
+            fi
+            assert_image_mode
+        rlPhaseEnd
     done <<< "$IMAGES"
 
     rlPhaseStartCleanup


### PR DESCRIPTION
Enable a previously disabled test in `/tests/prepare/shell` for Image mode. The test was blocked by a bug, which was fixed by #4793. The check for finish step remains disabled as it is still broken in Image mode due to #4917.

Pull Request Checklist

* [x] extend the test coverage
