### PR TITLE
Fix install requirements of disabled checks

### DIFF
--- a/tests/test/check/data/main.fmf
+++ b/tests/test/check/data/main.fmf
@@ -244,3 +244,13 @@
         /reboot:
             summary: Test should fail due to reboot timeout
             test: '[ "$TMT_REBOOT_COUNT" == "0" ] && tmt-reboot -t 1 -c reboot || echo'
+
+/essential-requires:
+    test: /bin/true
+
+    /enabled:
+        check: dmesg
+    /disabled:
+        check:
+          - how: dmesg
+            enabled: false

--- a/tests/test/check/main.fmf
+++ b/tests/test/check/main.fmf
@@ -60,3 +60,10 @@ duration: 20m
     tag+:
       - provision-only
       - provision-virtual
+
+/essential-requires:
+    summary: Disabled checks should not install their essential requirements
+    test: ./test-essential-requires.sh
+    tag+:
+      - provision-only
+      - provision-virtual

--- a/tests/test/check/test-essential-requires.sh
+++ b/tests/test/check/test-essential-requires.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+rlJournalStart
+    rlPhaseStartSetup
+        rlRun "PROVISION_HOW=${PROVISION_HOW:-virtual}"
+        rlRun "run=\$(mktemp -d)" 0 "Create run directory"
+        rlRun "log=$run/log.txt"
+        rlRun "pushd data"
+        rlRun "set -o pipefail"
+    rlPhaseEnd
+
+    tmt_command="tmt run --id $run --scratch -a -vv provision -h $PROVISION_HOW test -n"
+
+    rlPhaseStartTest "Enabled dmesg check requests /bin/dmesg with $PROVISION_HOW"
+        rlRun "$tmt_command /essential-requires/enabled"
+        rlAssertGrep "/bin/dmesg" "$log"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Disabled dmesg check skips /bin/dmesg with $PROVISION_HOW"
+        rlRun "$tmt_command /essential-requires/disabled"
+        rlAssertNotGrep "/bin/dmesg" "$log"
+    rlPhaseEnd
+
+    rlPhaseStartCleanup
+        rlRun "popd"
+        rlRun "rm -rf $run"
+    rlPhaseEnd
+rlJournalEnd

--- a/tests/unit/test_steps_prepare.py
+++ b/tests/unit/test_steps_prepare.py
@@ -1,7 +1,16 @@
+import shutil
+import tempfile
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 from tmt.base.core import DependencySimple
 from tmt.steps.prepare.install import PrepareInstall
+from tmt.utils import Path
+
+if TYPE_CHECKING:
+    from tests import RunTmt
+
+DISABLED_CHECK_DATA = Path(__file__).resolve().parent / 'disabled_check_data'
 
 
 def test_debuginfo(root_logger):
@@ -35,3 +44,21 @@ def test_debuginfo(root_logger):
         "grep",
         "elfutils-debuginfod",
     ]
+
+
+def test_disabled_check_skips_essential_requires(run_tmt: 'RunTmt'):
+    """
+    Disabled check must not contribute its essential requirements
+    to the prepare step's package list.
+    """
+
+    tmp = tempfile.mkdtemp()
+    result = run_tmt(
+        '--feeling-safe', '--root', str(DISABLED_CHECK_DATA),
+        'run', '-i', tmp, '-vvv',
+        'plan', '--name', '/disabled-only',
+    )
+    shutil.rmtree(tmp)
+
+    assert result.exit_code == 0
+    assert '/usr/bin/dmesg' not in result.output

--- a/tests/unit/test_steps_prepare.py
+++ b/tests/unit/test_steps_prepare.py
@@ -1,16 +1,7 @@
-import shutil
-import tempfile
-from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 from tmt.base.core import DependencySimple
 from tmt.steps.prepare.install import PrepareInstall
-from tmt.utils import Path
-
-if TYPE_CHECKING:
-    from tests import RunTmt
-
-DISABLED_CHECK_DATA = Path(__file__).resolve().parent / 'disabled_check_data'
 
 
 def test_debuginfo(root_logger):
@@ -44,21 +35,3 @@ def test_debuginfo(root_logger):
         "grep",
         "elfutils-debuginfod",
     ]
-
-
-def test_disabled_check_skips_essential_requires(run_tmt: 'RunTmt'):
-    """
-    Disabled check must not contribute its essential requirements
-    to the prepare step's package list.
-    """
-
-    tmp = tempfile.mkdtemp()
-    result = run_tmt(
-        '--feeling-safe', '--root', str(DISABLED_CHECK_DATA),
-        'run', '-i', tmp, '-vvv',
-        'plan', '--name', '/disabled-only',
-    )
-    shutil.rmtree(tmp)
-
-    assert result.exit_code == 0
-    assert '/usr/bin/dmesg' not in result.output

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -500,6 +500,8 @@ class ExecuteUpgrade(ExecuteInternal):
                 required_packages += test.test_framework.get_requirements(test, self._logger)
 
                 for check in test.check:
+                    if not check.enabled:
+                        continue
                     required_packages += check.plugin.essential_requires(guest, test, self._logger)
 
             self._install_dependencies(guest, required_packages)

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -501,6 +501,8 @@ class ExecuteUpgrade(ExecuteInternal):
                 required_packages += test.test_framework.get_requirements(test, self._logger)
 
                 for check in test.check:
+                    if not check.enabled:
+                        continue
                     required_packages += check.plugin.essential_requires(guest, test, self._logger)
 
             self._install_dependencies(guest, required_packages)

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -285,6 +285,8 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
                 )
 
                 for check in test.check:
+                    if not check.enabled:
+                        continue
                     collected_requires[guest].dependencies += check.plugin.essential_requires(
                         guest, test, self._logger
                     )

--- a/tmt/steps/prepare/distgit.py
+++ b/tmt/steps/prepare/distgit.py
@@ -336,6 +336,8 @@ class PrepareDistGit(tmt.steps.prepare.PreparePlugin[DistGitData]):
                     collected_requires += test.test_framework.get_requirements(test, self._logger)
 
                     for check in test.check:
+                        if not check.enabled:
+                            continue
                         collected_requires += check.plugin.essential_requires(
                             guest, test, self._logger
                         )

--- a/tmt/steps/prepare/distgit.py
+++ b/tmt/steps/prepare/distgit.py
@@ -340,6 +340,8 @@ class PrepareDistGit(tmt.steps.prepare.PreparePlugin[DistGitData]):
                     collected_requires += test.test_framework.get_requirements(test, self._logger)
 
                     for check in test.check:
+                        if not check.enabled:
+                            continue
                         collected_requires += check.plugin.essential_requires(
                             guest, test, self._logger
                         )


### PR DESCRIPTION
Skip essential requirements collection for disabled checks in prepare and execute steps. Previously, even checks with `enabled: false` contributed their requirements, causing unnecessary package installations on the guest.

Fixes #4860

Pull Request Checklist

* [x] implement the feature
* [x] add test case