### PR TITLE
Fix support of inline scripts in `prepare/shell`

### DIFF
--- a/tests/prepare/shell/data/multiline.fmf
+++ b/tests/prepare/shell/data/multiline.fmf
@@ -1,0 +1,12 @@
+provision:
+    how: container
+prepare:
+    how: shell
+    script: |
+      test() {
+        echo "This is a multiline script"
+      }
+      test
+execute:
+    how: tmt
+    script: "true"

--- a/tests/prepare/shell/test.sh
+++ b/tests/prepare/shell/test.sh
@@ -44,6 +44,13 @@ rlJournalStart
             assert_image_mode
         rlPhaseEnd
 
+        rlPhaseStartTest "Multiline Shell Scripts"
+            rlRun -s "tmt run -arvvv provision --how=$PROVISION_HOW $image_opt plans -n multiline"
+            rlAssertGrep "stdout: STEP 2/2: RUN <<'_TMT_BUILD_SCRIPT'" "$rlRun_LOG"
+            rlAssertGrep "stdout: This is a multiline script" "$rlRun_LOG"
+            assert_image_mode
+        rlPhaseEnd
+
         # TODO: #4785 Preparing from a remote script is broken in Image Mode
         if [ "$IMAGE_MODE" != "yes" ]; then
             rlPhaseStartTest "Remote Script"

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2907,7 +2907,9 @@ class GuestSsh(Guest, CommandCollector):
 
         # Add to the package manager's engine
         self.package_manager.engine.open_containerfile_directives()
-        self.package_manager.engine.containerfile_directives.append(f"RUN {collected_command}")
+        self.package_manager.engine.containerfile_directives.append("RUN <<'_TMT_BUILD_SCRIPT'")
+        self.package_manager.engine.containerfile_directives.append(f"{collected_command}")
+        self.package_manager.engine.containerfile_directives.append("_TMT_BUILD_SCRIPT")
         self.debug(f"Collected command for Containerfile: {collected_command}")
 
     @property

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -259,7 +259,7 @@ class Bootc(PackageManager[BootcEngine]):
                     )
                 )
                 self.guest.execute(
-                    ShellScript(f'cat <<EOF > {containerfile_path!s} \n{containerfile} \nEOF')
+                    ShellScript(f'cat <<EOF > {containerfile_path!s}\n{containerfile}\nEOF')
                 )
 
                 self.debug(f"containerfile content: {containerfile}")


### PR DESCRIPTION
An inline script in `prepare/shell` can break easily the RUN directive. We run into this when working on profiles where we had a script with a function:

https://gitlab.com/testing-farm/profiles/-/merge_requests/85/diffs

To fix this use RUN heredoc to properly support any scripts user can throw on us.

Resolves #4868 

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [ ] include a release note
