### PR TITLE
Add `web-link` field to `Result` for browsable test links

### DIFF
--- a/docs/releases/pending/4878.fmf
+++ b/docs/releases/pending/4878.fmf
@@ -1,0 +1,6 @@
+description: |
+  Test results now include a ``web-link`` field containing a browsable
+  URL that points to the test's fmf metadata source. This is the same
+  URL shown by ``tmt test show`` under the ``web`` key. Downstream
+  consumers such as reporting tools can use this link directly instead
+  of reconstructing it from the ``fmf-id`` mapping.

--- a/spec/results.fmf
+++ b/spec/results.fmf
@@ -73,6 +73,10 @@ description: |
        # Integer, serial number of the test in the sequence of all tests of a plan.
        serial-number: 1
 
+       # String, a browsable URL pointing to the test's fmf metadata source.
+       # Matches the value produced by ``tmt test show`` under the ``web`` key.
+       web-link: https://github.com/teemtee/tmt/-/blob/main/tests/core/smoke/main.fmf
+
        # Mapping, describes the guest on which the test was executed.
        guest:
          name: client-1

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -1045,3 +1045,42 @@ def test_save_failures(tmppath: Path, root_logger) -> None:
     assert tmt.utils.from_yaml(read_yaml) == ['foo', _GOOD_STRING, 'bar']
     assert tmt.utils.from_yaml(read_yaml, yaml_type='safe') == ['foo', _GOOD_STRING, 'bar']
     assert tmt.utils.yaml_to_list(read_yaml) == ['foo', _GOOD_STRING, 'bar']
+
+
+def test_result_web_link_default() -> None:
+    """Verify that web_link defaults to None for backward compatibility."""
+    result = Result(name="/test", result=ResultOutcome.PASS)
+    assert result.web_link is None
+
+
+def test_result_web_link_roundtrip() -> None:
+    """Verify that web_link survives serialization and deserialization."""
+    url = "https://gitlab.example.com/repo/-/blob/main/tests/test.fmf"
+    result = Result(name="/test", result=ResultOutcome.PASS, web_link=url)
+
+    serialized = result.to_serialized()
+    assert serialized["web-link"] == url
+
+    restored = Result.from_serialized(serialized)
+    assert restored.web_link == url
+
+
+def test_result_web_link_none_roundtrip() -> None:
+    """Verify that web_link=None serializes and deserializes correctly."""
+    result = Result(name="/test", result=ResultOutcome.PASS, web_link=None)
+
+    serialized = result.to_serialized()
+    assert serialized["web-link"] is None
+
+    restored = Result.from_serialized(serialized)
+    assert restored.web_link is None
+
+
+def test_result_web_link_missing_in_serialized() -> None:
+    """Verify backward compat: old results without web-link deserialize with None."""
+    result = Result(name="/test", result=ResultOutcome.PASS)
+    serialized = result.to_serialized()
+    del serialized["web-link"]
+
+    restored = Result.from_serialized(serialized)
+    assert restored.web_link is None

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -325,6 +325,7 @@ class Result(BaseResult):
     """
 
     serial_number: int = 0
+    web_link: Optional[str] = None
     fmf_id: Optional['tmt.base.core.FmfId'] = field(
         default=cast(Optional['tmt.base.core.FmfId'], None),
         serialize=lambda fmf_id: fmf_id.to_minimal_spec() if fmf_id is not None else {},
@@ -395,6 +396,7 @@ class Result(BaseResult):
         _result = Result(
             name=invocation.test.name,
             serial_number=invocation.test.serial_number,
+            web_link=invocation.test.web_link(),
             fmf_id=invocation.test.fmf_id,
             context=invocation.phase.step.plan.fmf_context,
             result=result,

--- a/tmt/schemas/results.yaml
+++ b/tmt/schemas/results.yaml
@@ -123,6 +123,12 @@ items:
     serial-number:
       type: integer
 
+    web-link:
+      oneOf:
+        - type: "null"
+        - type: string
+          format: uri
+
     result:
       $ref: "/schemas/common#/definitions/result_outcome"
 


### PR DESCRIPTION
## Summary

Add a `web_link` field to the `Result` dataclass in `tmt/result.py` that serializes
the browsable test source URL directly into `results.yaml` as `web-link`, so downstream
consumers (gluetools, kcidb) get a ready-to-use link instead of having to reconstruct it
from `fmf-id`.

- The field name is consistent with the existing `Core.web_link()` method and `tmt test show` output
- Populated via `Test.web_link()` in `from_test_invocation()`
- Returns `None` for local tests / shell discover (no URL available)
- Returns a browsable URL for tests from Git repos (GitLab, GitHub, Pagure, etc.)

### Example output in results.yaml

```yaml
- name: /tests/nvidia/driver-install
  result: pass
  fmf-id:
    url: https://gitlab.cee.redhat.com/gpu-accelerators/tests
    ref: main
    name: /tests/nvidia/driver-install
    path: .
  web-link: https://gitlab.cee.redhat.com/gpu-accelerators/tests/-/blob/main/tests/nvidia/driver-install/main.fmf
  duration: 00:05:23
  serial-number: 1
```

Ref: TFT-2683

## Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [x] update the specification
* [x] modify the json schema
* [x] include a release note