### PR TITLE
Update jira integration to use Jira Cloud

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -802,8 +802,9 @@ the following format:
 
     issue-tracker:
       - type: jira
-        url: https://issues.redhat.com
+        url: https://redhat.atlassian.net
         tmt-web-url: https://tmt.testing-farm.io/
+        email: <EMAIL_ADDRESS_USED_FOR_LOGIN>
         token: <YOUR_PERSONAL_JIRA_TOKEN>
 
 The ``type`` key specifies the type of the issue tracking service

--- a/docs/releases/pending/4879.fmf
+++ b/docs/releases/pending/4879.fmf
@@ -1,0 +1,6 @@
+description:
+    The Jira integration has been updated so that the ``tmt link``
+    and the ``tmt test create`` commands correctly link tests or
+    plans to related issues in the new Jira Cloud instance. The
+    ``email`` key is now required in the ``issue-tracker`` config
+    file. See the :ref:`link-issues` section for an example.

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -86,6 +86,7 @@ def test_link_config_invalid(config_path: Path, root_logger: Logger):
           - type: jiRA
             url: invalid_url
             tmt-web-url: https://
+            email: email@example.com
             unknown: value
         additional_key:
           foo: bar
@@ -120,6 +121,7 @@ def test_link_config_valid(config_path: Path, root_logger: Logger):
           - type: jira
             url: https://issues.redhat.com
             tmt-web-url: https://tmt-web-url.com
+            email: email@example.com
             token: secret
         """).strip()
     fmf.Tree.init(path=config_path)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1683,6 +1683,7 @@ class TestJiraLink(unittest.TestCase):
                   - type: jira
                     url: https://issues.redhat.com
                     tmt-web-url: https://tmt.testing-farm.io/
+                    email: email@example.com
                     token: secret
             """.strip()
         self.config_tree = fmf.Tree(data=tmt.utils.yaml_to_dict(config_yaml))

--- a/tmt/config/models/link.py
+++ b/tmt/config/models/link.py
@@ -12,6 +12,7 @@ class IssueTracker(MetadataContainer):
     type: IssueTrackerType
     url: HttpUrl
     tmt_web_url: HttpUrl
+    email: str
     token: str
 
 

--- a/tmt/utils/jira.py
+++ b/tmt/utils/jira.py
@@ -75,6 +75,7 @@ class JiraInstance:
 
         self.url = str(issue_tracker.url)
         self.tmt_web_url = str(issue_tracker.tmt_web_url)
+        self.email = issue_tracker.email
         self.token = issue_tracker.token
 
         self.logger = logger
@@ -83,7 +84,7 @@ class JiraInstance:
         # ignore[attr-defined]: it is defined, but mypy seems to fail
         # detecting it correctly.
         self.jira = jira_module.JIRA(  # type: ignore[attr-defined]
-            server=self.url, token_auth=self.token
+            server=self.url, basic_auth=(self.email, self.token)
         )
 
     @classmethod


### PR DESCRIPTION
A different way of authentication needs to be used for the Jira Cloud instance. Use `basic_auth` with `email` and `token` and update related documentation.

Fix #4879.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] include a release note