### PR TITLE
Set `/bin/dmesg` as essential-requires for dmesg plugin

### DIFF
--- a/tests/test/check/test-dmesg.sh
+++ b/tests/test/check/test-dmesg.sh
@@ -47,7 +47,7 @@ Saving of the kernel ring buffer was skipped because of missing privileges.
 Saving of the kernel ring buffer was skipped because of missing privileges."
 
         else
-            # verify centos-6 compatible path
+            # verify pre-usr-merge compatible path
             rlAssertGrep "/bin/dmesg" "$log"
             rlAssertNotGrep "/usr/bin/dmesg" "$log"
 

--- a/tests/test/check/test-dmesg.sh
+++ b/tests/test/check/test-dmesg.sh
@@ -17,6 +17,7 @@ rlJournalStart
         rlRun "run=\$(mktemp -d)" 0 "Create run directory"
 
         rlRun "results=$run/plan/execute/results.yaml"
+        rlRun "log=$run/log.txt"
         rlRun "harmless=$run/plan/execute/data/guest/default-0/dmesg/harmless-1"
         rlRun "segfault=$run/plan/execute/data/guest/default-0/dmesg/segfault-1"
         rlRun "custom_patterns=$run/plan/execute/data/guest/default-0/dmesg/custom-patterns-1"
@@ -46,6 +47,10 @@ Saving of the kernel ring buffer was skipped because of missing privileges.
 Saving of the kernel ring buffer was skipped because of missing privileges."
 
         else
+            # verify centos-6 compatible path
+            rlAssertGrep "/bin/dmesg" "$log"
+            rlAssertNotGrep "/usr/bin/dmesg" "$log"
+
             assert_check_result "dmesg as a before-test should pass" "pass" "before-test" "harmless"
 
             rlAssertExists "$dump_before"

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -203,7 +203,7 @@ class Dmesg(CheckPlugin[DmesgCheck]):
         # Avoid circular imports
         import tmt.base.core
 
-        return [tmt.base.core.DependencySimple('/usr/bin/dmesg')]
+        return [tmt.base.core.DependencySimple('/bin/dmesg')]
 
     @classmethod
     def before_test(


### PR DESCRIPTION
This adds support for pre-usr-merge systems. usr-merge systems symlink `/bin` to `/usr/bin`, so support should remain for these systems

Fixes: #4751 

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
