### PR TITLE
Pick words only when searching for Jira issues

### DIFF
--- a/scripts/sprint-sync
+++ b/scripts/sprint-sync
@@ -198,7 +198,7 @@ def find_jira_issues(
         return sort_by_key(results)
 
     # Fall back to title search and verify via remote links
-    title = github_item.title.replace('\\', '\\\\').replace("'", "\\'").replace('"', '')
+    title = " ".join(re.findall(r'\w+', github_item.title))
     query = f'project = "{JIRA_PROJECT}" AND summary ~ "{title}"'
     candidates = jira.search_issues(query, maxResults=False, json_result=False)
     assert isinstance(candidates, list)


### PR DESCRIPTION
The issue / pull request summaries can contain various funny characters which can break the search, e.g. #4873, `#!/bin/bash` or `\back\slash` plus various quotes. Let's pick just the words to prevent similar problems. Both jql and Lucene seem to tokenize the query into individual words so exact match is not possible.

Pull Request Checklist

* [x] implement the feature