### PR TITLE
Reference `output.txt` in `results.yaml` when custom results are missing

### DIFF
--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -55,6 +55,13 @@ rlJournalStart
         rlAssertGrep "custom results file not found in '/tmp/.*/default/plan/execute/data/guest/default-0/test/missing-custom-results-1/data" $rlRun_LOG
     rlPhaseEnd
 
+    testName="/test/timed-out-custom-results"
+    rlPhaseStartTest "${testName}"
+        rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test times out before 'results.yaml' is provided"
+        rlAssertGrep "data/guest/default-0/test/timed-out-custom-results-1/output.txt" ${run}/default/plan/execute/results.yaml
+    rlPhaseEnd
+
+
     testName="/test/empty-custom-results-file"
     rlPhaseStartTest "${testName}"
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test provides empty 'results.yaml' file"

--- a/tests/execute/result/custom.sh
+++ b/tests/execute/result/custom.sh
@@ -53,14 +53,8 @@ rlJournalStart
     rlPhaseStartTest "${testName}"
         rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test does not provide 'results.yaml' file"
         rlAssertGrep "custom results file not found in '/tmp/.*/default/plan/execute/data/guest/default-0/test/missing-custom-results-1/data" $rlRun_LOG
+        rlAssertGrep "data/guest/default-0/test/missing-custom-results-1/output.txt" ${run}/default/plan/execute/results.yaml
     rlPhaseEnd
-
-    testName="/test/timed-out-custom-results"
-    rlPhaseStartTest "${testName}"
-        rlRun -s "${tmt_command} ${testName} 2>&1 >/dev/null" 2 "Test times out before 'results.yaml' is provided"
-        rlAssertGrep "data/guest/default-0/test/timed-out-custom-results-1/output.txt" ${run}/default/plan/execute/results.yaml
-    rlPhaseEnd
-
 
     testName="/test/empty-custom-results-file"
     rlPhaseStartTest "${testName}"

--- a/tests/execute/result/custom/test.fmf
+++ b/tests/execute/result/custom/test.fmf
@@ -9,6 +9,10 @@ result: custom
 /missing-custom-results:
     summary: Test provides custom results but results.yaml or results.json are not present
     test: 'true'
+/timed-out-custom-results:
+    summary: Test times out before results.yaml is created, output.txt should still be referenced
+    duration: 1s
+    test: sleep 2
 /empty-custom-results-file:
     summary: results.yaml is empty
     test: touch ${TMT_TEST_DATA}/results.yaml

--- a/tests/execute/result/custom/test.fmf
+++ b/tests/execute/result/custom/test.fmf
@@ -9,10 +9,6 @@ result: custom
 /missing-custom-results:
     summary: Test provides custom results but results.yaml or results.json are not present
     test: 'true'
-/timed-out-custom-results:
-    summary: Test times out before results.yaml is created, output.txt should still be referenced
-    duration: 1s
-    test: sleep 2
 /empty-custom-results-file:
     summary: results.yaml is empty
     test: touch ${TMT_TEST_DATA}/results.yaml

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -905,6 +905,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
                     invocation=invocation,
                     note=[f"custom results file not found in '{invocation.test_data_path}'"],
                     result=ResultOutcome.ERROR,
+                    log=[invocation.relative_path / TEST_OUTPUT_FILENAME],
                 )
             ]
 
@@ -914,6 +915,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
                     invocation=invocation,
                     note=["no custom results were provided"],
                     result=ResultOutcome.ERROR,
+                    log=[invocation.relative_path / TEST_OUTPUT_FILENAME],
                 )
             ]
 


### PR DESCRIPTION
I've used @happz solution and added a simple test scenario.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage

Fixes #4753 