### PR TITLE
Make FmfContext read-only

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1539,7 +1539,7 @@ _test_format_value_big_list = list(range(1, 20))
         (tmt.utils.Environment.from_dict({'FOO': 'BAR'}), None, 'FOO\033[0m: BAR'),
         # fmf context
         (
-            tmt.utils.FmfContext({'foo': ['bar', 'baz']}),
+            tmt.utils.FmfContext(foo=['bar', 'baz']),
             None,
             """
             foo\033[0m:

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -601,7 +601,7 @@ class Plan(
         """
 
         return FmfContext(
-            {**self.context, **self._fmf_context_from_importing, **self._fmf_context_from_cli}
+            **self.context, **self._fmf_context_from_importing, **self._fmf_context_from_cli
         )
 
     @property
@@ -617,10 +617,8 @@ class Plan(
         """
 
         return FmfContext(
-            {
-                **self.context,
-                **self._fmf_context_from_importing,
-            }
+            **self.context,
+            **self._fmf_context_from_importing,
         )
 
     @property
@@ -1516,15 +1514,13 @@ class Plan(
             # For final context inheritance, respect inherit_context setting
             if reference.inherit_context:
                 alteration_fmf_context = FmfContext(
-                    {
-                        **imported_fmf_context,
-                        **self._inheritable_fmf_context,
-                        **self._noninheritable_fmf_context,
-                    }
+                    **imported_fmf_context,
+                    **self._inheritable_fmf_context,
+                    **self._noninheritable_fmf_context,
                 )
             else:
                 alteration_fmf_context = FmfContext(
-                    {**imported_fmf_context, **self._noninheritable_fmf_context}
+                    **imported_fmf_context, **self._noninheritable_fmf_context
                 )
 
             # Adjust the imported tree, to let any `adjust` rules defined in it take

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -333,7 +333,7 @@ class Result(BaseResult):
     context: tmt.utils.FmfContext = field(
         default_factory=tmt.utils.FmfContext,
         serialize=lambda context: context.to_spec(),
-        unserialize=lambda serialized: tmt.utils.FmfContext(serialized),
+        unserialize=lambda serialized: tmt.utils.FmfContext(**serialized),
     )
     ids: ResultIds = field(default_factory=cast(Callable[[], ResultIds], dict))
     guest: ResultGuestData = field(

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -28,7 +28,7 @@ import unicodedata
 import urllib.parse
 import warnings
 from collections import Counter
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from math import ceil
 from re import Pattern
 from threading import RLock, Thread
@@ -330,7 +330,7 @@ def effective_workdir_root(workdir_root_option: Optional[Path] = None) -> Path:
     return WORKDIR_ROOT
 
 
-class FmfContext(dict[str, list[str]]):
+class FmfContext(Mapping[str, list[str]]):
     """
     Represents an fmf context.
 
@@ -338,8 +338,19 @@ class FmfContext(dict[str, list[str]]):
     and https://fmf.readthedocs.io/en/latest/context.html.
     """
 
+    _data: dict[str, list[str]]
+
     def __init__(self, data: Optional[dict[str, list[str]]] = None) -> None:
-        super().__init__(data or {})
+        self._data = data or {}
+
+    def __getitem__(self, key: str) -> list[str]:
+        return self._data[key]
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self) -> Iterator[str]:
+        yield from self._data
 
     @classmethod
     def _normalize_command_line(cls, spec: list[str], logger: tmt.log.Logger) -> 'FmfContext':
@@ -378,15 +389,14 @@ class FmfContext(dict[str, list[str]]):
                 - ppc64
         """
 
-        normalized: FmfContext = FmfContext()
-
-        for dimension, values in spec.items():
-            if isinstance(values, list):
-                normalized[str(dimension)] = [str(v) for v in values]
-            else:
-                normalized[str(dimension)] = [str(values)]
-
-        return normalized
+        return FmfContext(
+            {
+                str(dimension): [str(v) for v in values]
+                if isinstance(values, list)
+                else [str(values)]
+                for dimension, values in spec.items()
+            }
+        )
 
     @classmethod
     def from_spec(cls, key_address: str, spec: Any, logger: tmt.log.Logger) -> 'FmfContext':
@@ -4573,7 +4583,7 @@ def format_value(
 
 def format(
     key: str,
-    value: Union[None, float, bool, str, list[Any], dict[Any, Any]] = None,
+    value: Union[None, float, bool, str, list[Any], Mapping[Any, Any]] = None,
     indent: int = 24,
     window_size: int = OUTPUT_WIDTH,
     wrap: FormatWrap = 'auto',

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -340,8 +340,8 @@ class FmfContext(Mapping[str, list[str]]):
 
     _data: dict[str, list[str]]
 
-    def __init__(self, data: Optional[dict[str, list[str]]] = None) -> None:
-        self._data = data or {}
+    def __init__(self, **kwargs: list[str]) -> None:
+        self._data = kwargs
 
     def __getitem__(self, key: str) -> list[str]:
         return self._data[key]
@@ -371,7 +371,7 @@ class FmfContext(Mapping[str, list[str]]):
                     f"Use 'KEY=VALUE' format or remove the dimension entirely."
                 )
             raw_fmf_context[key] = value.split(',')
-        return FmfContext(raw_fmf_context)
+        return FmfContext(**raw_fmf_context)
 
     @classmethod
     def _normalize_fmf(
@@ -390,7 +390,7 @@ class FmfContext(Mapping[str, list[str]]):
         """
 
         return FmfContext(
-            {
+            **{
                 str(dimension): [str(v) for v in values]
                 if isinstance(values, list)
                 else [str(values)]
@@ -433,7 +433,7 @@ class FmfContext(Mapping[str, list[str]]):
         Convert from a serialized form.
         """
 
-        return FmfContext(serialized)
+        return FmfContext(**serialized)
 
 
 #: A type of environment variable name.


### PR DESCRIPTION
First step towards unifying this with `fmf.context.Context`. Will make an fmf PR equivalent to have a similar `Mapping` interface (`Mapping[str, set[ContextValue]]`) and then try to unify the types and constructors.

fmf counterpart https://github.com/teemtee/fmf/pull/300