### PR TITLE
Filter noisy `oneOf` schema warnings during tmt lint

### DIFF
--- a/tests/lint/plan/data/missing_required.fmf
+++ b/tests/lint/plan/data/missing_required.fmf
@@ -1,4 +1,4 @@
 execute:
     how: tmt
 report:
-    how: polarion
+    how: reportportal

--- a/tests/lint/plan/test.sh
+++ b/tests/lint/plan/test.sh
@@ -69,7 +69,20 @@ rlJournalStart
         rlAssertGrep "fail P001 unknown key \"summaryABCDEF\" is used" $rlRun_LOG
 
         rlRun -s "$tmt plan lint invalid-plugin-key" 0
-        rlAssertGrep 'warn C000 key "wrong" not recognized by schema$' $rlRun_LOG
+
+        # Make sure the noise is not there.
+        rlAssertNotGrep 'warn C000 key "wrong" not recognized by schema$' $rlRun_LOG
+        rlAssertNotGrep 'warn C000 value of "how" is not "ansible"' $rlRun_LOG
+        rlAssertNotGrep 'warn C000 key "wrong" not recognized by schema /schemas/prepare/errata' $rlRun_LOG
+        rlAssertNotGrep 'warn C000 value of "how" is not "errata"' $rlRun_LOG
+        rlAssertNotGrep 'warn C000 key "wrong" not recognized by schema /schemas/prepare/install' $rlRun_LOG
+        rlAssertNotGrep 'warn C000 value of "how" is not "install"' $rlRun_LOG
+        rlAssertNotGrep 'warn C000 value of "how" is not "shell"' $rlRun_LOG
+        rlAssertNotGrep 'warn C000 key "name" not recognized by schema /schemas/prepare/artifact' $rlRun_LOG
+        rlAssertNotGrep 'warn C000 key "wrong" not recognized by schema /schemas/prepare/artifact' $rlRun_LOG
+        rlAssertNotGrep 'warn C000 value of "how" is not "artifact"' $rlRun_LOG
+
+        # this is the relevant warning
         rlAssertGrep 'warn C000 key "wrong" not recognized by schema /schemas/prepare/feature' $rlRun_LOG
 
         rlRun -s "$tmt plan lint empty_env_file" 1
@@ -97,8 +110,17 @@ rlJournalStart
 
     rlPhaseStartTest "Lint of missing required property"
         rlRun -s "$tmt plan lint missing_required" 0
-        rlAssertGrep "warn C000 \"project-id\" is a required property by schema /schemas/report/polarion" "$rlRun_LOG"
-        rlAssertGrep "warn C000 fmf node failed schema validation" "$rlRun_LOG"
+
+        # Make sure the noise is not there.
+        rlAssertNotGrep "warn C000 value of \"how\" is not \"display\"" $rlRun_LOG
+        rlAssertNotGrep "warn C000 value of \"how\" is not \"html\"" $rlRun_LOG
+        rlAssertNotGrep "warn C000 value of \"how\" is not \"junit\"" $rlRun_LOG
+        rlAssertNotGrep "warn C000 value of \"how\" is not \"polarion\"" $rlRun_LOG
+        rlAssertNotGrep "warn C000 \"project-id\" is a required property by schema /schemas/report/polarion" $rlRun_LOG
+
+        # Make sure the relevant warning is there.
+        rlAssertGrep "warn C000 \"project\" is a required property by schema /schemas/report/reportportal" $rlRun_LOG
+        rlAssertGrep "warn C000 fmf node failed schema validation" $rlRun_LOG
     rlPhaseEnd
 
     rlPhaseStartTest "Lint of duplicate ids"

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -1158,7 +1158,32 @@ class Core(
                 # Validation errors can have "context", a list of "sub" errors encountered during
                 # validation. Interesting ones are identified & added to our error message.
                 if error.context:
-                    for suberror in error.context:
+                    # For oneOf validation (e.g., report step with multiple plugin schemas),
+                    # we only want to show errors from the schema that matches the 'how' value.
+                    relevant_suberrors: list[jsonschema.ValidationError] = []
+                    if (
+                        isinstance(error.validator, str)
+                        and error.validator == 'oneOf'
+                        and isinstance(instance := error.instance, dict)
+                        and 'how' in instance
+                    ):
+                        how_value = instance['how']
+                        # Look for errors that have a schema $id containing the how value.
+                        relevant_suberrors = [
+                            suberror
+                            for suberror in error.context
+                            if (
+                                isinstance(sub_schema := suberror.schema, dict)
+                                and '$id' in sub_schema
+                                and sub_schema['$id'].endswith(f'/{how_value}')
+                            )
+                        ]
+
+                    # No specific suberrors were identified, show them all.
+                    if not relevant_suberrors:
+                        relevant_suberrors = list(error.context)
+
+                    for suberror in relevant_suberrors:
                         yield from detect_errors(suberror)
 
             yield LinterOutcome.WARN, 'fmf node failed schema validation'

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -1119,7 +1119,32 @@ class Core(
                 # Validation errors can have "context", a list of "sub" errors encountered during
                 # validation. Interesting ones are identified & added to our error message.
                 if error.context:
-                    for suberror in error.context:
+                    # For oneOf validation (e.g., report step with multiple plugin schemas),
+                    # we only want to show errors from the schema that matches the 'how' value.
+                    relevant_suberrors: list[jsonschema.ValidationError] = []
+                    if (
+                        isinstance(error.validator, str)
+                        and error.validator == 'oneOf'
+                        and isinstance(instance := error.instance, dict)
+                        and 'how' in instance
+                    ):
+                        how_value = instance['how']
+                        # Look for errors that have a schema $id containing the how value.
+                        relevant_suberrors = [
+                            suberror
+                            for suberror in error.context
+                            if (
+                                isinstance(sub_schema := suberror.schema, dict)
+                                and '$id' in sub_schema
+                                and sub_schema['$id'].endswith(f'/{how_value}')
+                            )
+                        ]
+
+                    # No specific suberrors were identified, show them all.
+                    if not relevant_suberrors:
+                        relevant_suberrors = list(error.context)
+
+                    for suberror in relevant_suberrors:
                         yield from detect_errors(suberror)
 
             yield LinterOutcome.WARN, 'fmf node failed schema validation'


### PR DESCRIPTION
When validating steps that use `oneOf` schemas (e.g., report plugins), the linter was showing validation errors from all alternative schemas rather than just the one matching the 'how' value. This created confusing noise like warnings about missing polarion fields when using reportportal.

Now, when a `oneOf` validation fails, only errors from the schema matching the specified 'how' value are shown.

Updated tests to verify that irrelevant schema warnings are filtered out while relevant ones are still displayed.

Assisted-by: Cursor AI

Fixes: #4680

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [ ] include a release note
