### PR TITLE
Omit `.git` directory in `guest.pull()` during `prepare.distgit`

### DIFF
--- a/tmt/steps/prepare/distgit.py
+++ b/tmt/steps/prepare/distgit.py
@@ -6,7 +6,7 @@ import tmt.steps
 import tmt.steps.prepare
 import tmt.utils
 from tmt.container import container, field
-from tmt.guest import Guest
+from tmt.guest import DEFAULT_PULL_OPTIONS, Guest
 from tmt.package_managers import Package
 from tmt.steps.prepare import PreparePlugin
 from tmt.steps.prepare.install import PrepareInstallData
@@ -300,7 +300,11 @@ class PrepareDistGit(tmt.steps.prepare.PreparePlugin[DistGitData]):
 
         # Make sure to pull back sources ...
         # FIXME -- Do we need to? Can be lot of data...
-        guest.pull(source_dir)
+        # Exclude .git, it might be being modified by git garbage collection,
+        # leading to rsync error. And we do not need this directory.
+        opt = DEFAULT_PULL_OPTIONS.copy()
+        opt.exclude.append('.git')
+        guest.pull(source_dir, options=opt)
 
         # Mark which file/dirs were created after rpmbuild ran
         content_after = set(source_dir.iterdir())


### PR DESCRIPTION
Found by 'pcs': rpmbuild uses git to apply patches, and newer git run maintenance automatically. tmt was running into race condition where some git objects were deleted after rsync from `guest.pull` was already aware of them, which lead to broken prepare with
```sync warning: some files vanished before they could be transferred (code 24)```

We don't need the .git directory anyway so we will save few bits in the
download as well.

* https://git-scm.com/docs/git-maintenance#Documentation/git-maintenance.txt-maintenanceauto

Fixes: #4893

Pull Request Checklist

* [x] implement the feature
