### PR TITLE
Do not populate the default command environment with tmt process envvars

### DIFF
--- a/tests/test/check/test-avc.sh
+++ b/tests/test/check/test-avc.sh
@@ -23,7 +23,7 @@ rlJournalStart
         if [ "$method" = "checkpoint" ] && [ "$PROVISION_HOW" = "local" ]; then continue; fi
 
         rlPhaseStartTest "Run /avc tests with $PROVISION_HOW ($method method)"
-            rlRun "tmt -c provision_method=$PROVISION_HOW run --id $run --scratch -a -vvv provision -h $PROVISION_HOW test -n /avc/$method" "1"
+            rlRun "tmt -c provision_method=$PROVISION_HOW run --id $run --scratch -a -vvvvdddd provision -h $PROVISION_HOW test -n /avc/$method" "1"
             rlRun "cat $results"
         rlPhaseEnd
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -701,9 +701,7 @@ def test_run_interactive_not_joined(tmppath, root_logger):
     output = (
         ShellScript("echo abc; echo def >2")
         .to_shell_command()
-        .run(
-            shell=True, interactive=True, cwd=tmppath, environment={}, log=None, logger=root_logger
-        )
+        .run(shell=True, interactive=True, cwd=tmppath, log=None, logger=root_logger)
     )
     assert output.stdout is None
     assert output.stderr is None
@@ -717,7 +715,6 @@ def test_run_interactive_joined(tmppath, root_logger):
             shell=True,
             interactive=True,
             cwd=tmppath,
-            environment={},
             join=True,
             log=None,
             logger=root_logger,
@@ -728,9 +725,7 @@ def test_run_interactive_joined(tmppath, root_logger):
 
 
 def test_run_not_joined_stdout(root_logger):
-    output = Command("ls", "/").run(
-        shell=False, cwd=Path.cwd(), environment={}, log=None, logger=root_logger
-    )
+    output = Command("ls", "/").run(shell=False, cwd=Path.cwd(), log=None, logger=root_logger)
     assert "sbin" in output.stdout
 
 
@@ -738,7 +733,7 @@ def test_run_not_joined_stderr(root_logger):
     output = (
         ShellScript("ls non_existing || true")
         .to_shell_command()
-        .run(shell=False, cwd=Path.cwd(), environment={}, log=None, logger=root_logger)
+        .run(shell=False, cwd=Path.cwd(), log=None, logger=root_logger)
     )
     assert "ls: cannot access" in output.stderr
 
@@ -747,7 +742,7 @@ def test_run_joined(root_logger):
     output = (
         ShellScript("ls non_existing / || true")
         .to_shell_command()
-        .run(shell=False, cwd=Path.cwd(), environment={}, log=None, join=True, logger=root_logger)
+        .run(shell=False, cwd=Path.cwd(), log=None, join=True, logger=root_logger)
     )
     assert "ls: cannot access" in output.stdout
     assert "sbin" in output.stdout
@@ -766,7 +761,7 @@ def test_run_big(root_logger):
     output = (
         ShellScript(textwrap.dedent(script))
         .to_shell_command()
-        .run(shell=False, cwd=Path.cwd(), environment={}, log=None, join=True, logger=root_logger)
+        .run(shell=False, cwd=Path.cwd(), log=None, join=True, logger=root_logger)
     )
     assert "n n" in output.stdout
     assert len(output.stdout) == 200000

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -1419,7 +1419,6 @@ class Plan(
                     url=str(reference.url),
                     destination=tmpdirname,
                     shallow=True,
-                    environment=None,
                     logger=self._logger,
                 )
 

--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -362,11 +362,15 @@ class BeakerLibFromUrl(BeakerLib):
             )
         else:
             self.parent.debug(f"Cloning '{self.identifier}' for '{self}'.", level=3)
+
+            environment = Environment.from_environ()
+            environment["GIT_ASKPASS"] = EnvVarValue("echo")
+
             tmt.utils.git.git_clone(
                 url=self.url,
                 destination=clone_dir,
                 shallow=self.ref is None,
-                environment=Environment({"GIT_ASKPASS": EnvVarValue("echo")}),
+                environment=environment,
                 logger=self._logger,
             )
             self._git_clone_cache[clone_dir] = self

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -284,11 +284,15 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT, None]):
         self.info('url', url, 'green')
         if self.data.url_content_type == "git":
             self.debug(f"Clone '{url}' to '{self.test_dir}'.")
+
+            environment = Environment.from_environ()
+            environment["GIT_ASKPASS"] = EnvVarValue("echo")
+
             tmt.utils.git.git_clone(
                 url=url,
                 destination=self.test_dir,
                 shallow=self.data.ref is None,
-                environment=Environment({"GIT_ASKPASS": EnvVarValue("echo")}),
+                environment=environment,
                 logger=self._logger,
             )
         elif self.data.url_content_type == "archive":

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -167,7 +167,6 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
                         url=self.data.url,
                         destination=repo_path,
                         shallow=False,
-                        environment=environment,
                         logger=self._logger,
                     )
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -13,7 +13,14 @@ import tmt.utils
 from tmt.container import container
 from tmt.guest import RebootMode, TransferOptions
 from tmt.steps.provision import Provision
-from tmt.utils import Command, OnProcessEndCallback, OnProcessStartCallback, Path, ShellScript
+from tmt.utils import (
+    Command,
+    EnvVarValue,
+    OnProcessEndCallback,
+    OnProcessStartCallback,
+    Path,
+    ShellScript,
+)
 from tmt.utils.hints import get_hint
 from tmt.utils.wait import Waiting
 
@@ -49,6 +56,36 @@ class GuestLocal(tmt.Guest):
         """
 
         return True
+
+    # TODO: the existence of this method is very questionable, it may
+    # go away while works on https://github.com/teemtee/tmt/pull/4364
+    # continue.
+    #
+    # `local` plugin has its own implementation as it needs to populate
+    # the environment with the tmt process environment, since the guest
+    # is the same as the runner.
+    def _prepare_command_environment(
+        self, environment: Optional[tmt.utils.Environment] = None
+    ) -> tmt.utils.Environment:
+        if environment is None:
+            environment = tmt.utils.Environment.from_environ()
+
+            environment.update(self.environment)
+
+            if isinstance(self.parent, tmt.steps.Step):
+                environment.update(self.parent.plan)
+
+            # TODO: this was owned by plan, but at wrong position, and it will
+            # be owned by plan again once the dust of environment untangling
+            # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
+            # more.
+            if self.plan_environment_path:
+                environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+
+        else:
+            environment = super()._prepare_command_environment(environment=environment)
+
+        return environment
 
     def _run_ansible(
         self,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -485,7 +485,13 @@ class GuestContainer(tmt.Guest):
         """
 
         try:
-            return self._run_guest_command(Command('podman') + command, silent=silent, **kwargs)
+            return self._run_guest_command(
+                Command('podman') + command,
+                environment=tmt.utils.Environment.from_environ(),
+                silent=silent,
+                **kwargs,
+            )
+
         except tmt.utils.RunError as error:
             if (
                 "File 'podman' not found." in error.message

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1285,8 +1285,10 @@ class Command:
         :param cwd: if set, command would be executed in the given directory,
             otherwise the current working directory is used.
         :param shell: if set, the command would be executed in a shell.
-        :param environment: environment variables to combine with the current environment
-            before running the command.
+        :param environment: if set, expose these environment variables
+            to the command. If not set, an empty environment is used,
+            resulting in command running with no environment variables
+            in its environment.
         :param dry: if set, the command would not be actually executed.
         :param join: if set, stdout and stderr of the command would be merged into
             a single output text.
@@ -1343,14 +1345,8 @@ class Command:
         # use the given logger & emit to debug log.
         output_logger = (log or logger.debug) if not silent else logger.debug
 
-        # Prepare the environment: use the current process environment, but do
-        # not modify it if caller wants something extra, make a copy.
-        actual_environment: Optional[Environment] = None
-
-        # Do not modify current process environment
-        if environment is not None:
-            actual_environment = Environment.from_environ()
-            actual_environment.update(environment)
+        # Prepare the environment: create an empty one if needed.
+        actual_environment = environment if environment is not None else Environment()
 
         logger.debug('environment', actual_environment, level=4)
 
@@ -1364,7 +1360,7 @@ class Command:
                     self.to_popen(),
                     cwd=cwd,
                     shell=shell,
-                    env=actual_environment.to_popen() if actual_environment is not None else None,
+                    env=actual_environment.to_popen(),
                     # Disabling for now: When used together with the
                     # local provision this results into errors such as:
                     # 'cannot set terminal process group: Inappropriate
@@ -1384,7 +1380,7 @@ class Command:
                     self.to_popen(),
                     cwd=cwd,
                     shell=shell,
-                    env=actual_environment.to_popen() if actual_environment is not None else None,
+                    env=actual_environment.to_popen(),
                     start_new_session=True,
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.PIPE,

--- a/tmt/utils/git.py
+++ b/tmt/utils/git.py
@@ -753,7 +753,9 @@ def git_clone(
         the whole history.
     :param can_change: URL can be modified with hardcoded rules. Use
         ``can_change=False`` to disable rewrite rules.
-    :param environment: Environment provided to the ``git clone`` process.
+    :param environment: if set, expose these environment variables
+        to the ``git clone`` command. If not set, environment of the
+        tmt process is used.
     :param attempts: Number of tries to call the function.
     :param interval: Amount of seconds to wait before a new try.
     :param timeout: Overall maximum time in seconds to clone the repo.
@@ -761,11 +763,13 @@ def git_clone(
     :returns: Command output, bundled in a :py:class:`CommandOutput` tuple.
     """
 
+    environment = environment if environment is not None else Environment.from_environ()
+
     def clone_the_repo(
         url: str,
         destination: Path,
+        environment: Environment,
         shallow: bool = False,
-        environment: Optional[Environment] = None,
         timeout: Optional[int] = None,
     ) -> CommandOutput:
         """


### PR DESCRIPTION
This partially happened by accident in https://github.com/teemtee/tmt/pull/4852, this patch makes it
official: commands do not inherit `os.environ`. If a caller wishes to
include `os.environ` in command environment, it is their responsibility
to do so.

It seems the only affected command is `git clone`, as this would hurt
commands executed on the runner, and we do not have that many of such
commands. There are loose ends: checks, their docstrings, how they do
(or do not) pass environment correctly, they use `invocation` rather
than the `environment` parameters; also docstrings and how `environment`
is handled in `Guest.execute()` methods - but neither of these should
change the existing behavior. They are just annoying and need to be
resolved, and it would make this pach harder to process.

Pull Request Checklist

* [x] implement the feature