### PR TITLE
Add `enable_repo()` and `disable_repo()` to package manager abstraction

### DIFF
--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1,3 +1,4 @@
+import contextlib
 import re
 from collections.abc import Iterator
 from inspect import isclass
@@ -548,6 +549,90 @@ def test_assert_config_manager(
             match=re.escape(str(expected_command_or_exception)),
         ):
             package_manager.assert_config_manager()
+
+
+def _parametrize_test_enable_disable_repo() -> Iterator[
+    tuple[Container, PackageManagerClass, str, Union[str, Exception]]
+]:
+    for container, package_manager_class in CONTAINER_BASE_MATRIX:
+        for action in ('enable', 'disable'):
+            if package_manager_class is tmt.package_managers.dnf.Yum:
+                yield (
+                    container,
+                    package_manager_class,
+                    action,
+                    rf"yum-config-manager --{action} test-repo",
+                )
+
+            elif package_manager_class is tmt.package_managers.dnf.Dnf:
+                yield (
+                    container,
+                    package_manager_class,
+                    action,
+                    rf"dnf config-manager --{action} test-repo",
+                )
+
+            elif package_manager_class is tmt.package_managers.dnf.Dnf5:
+                yield (
+                    container,
+                    package_manager_class,
+                    action,
+                    rf"dnf5 config-manager --{action} test-repo",
+                )
+
+            elif package_manager_class in (
+                tmt.package_managers.apt.Apt,
+                tmt.package_managers.rpm_ostree.RpmOstree,
+                tmt.package_managers.apk.Apk,
+            ):
+                yield (
+                    container,
+                    package_manager_class,
+                    action,
+                    PrepareError(
+                        f"Package manager '{package_manager_class.NAME}'"
+                        " does not support config-manager."
+                    ),
+                )
+
+            else:
+                pytest.fail(f"Unhandled package manager class '{package_manager_class}'.")
+
+
+@pytest.mark.containers
+@pytest.mark.parametrize(
+    ('container_per_test', 'package_manager_class', 'action', 'expected_command_or_exception'),
+    list(_parametrize_test_enable_disable_repo()),
+    indirect=["container_per_test"],
+)
+def test_enable_disable_repo(
+    container_per_test: ContainerData,
+    guest_per_test: GuestContainer,
+    package_manager_class: PackageManagerClass,
+    action: str,
+    expected_command_or_exception: Union[str, Exception],
+    root_logger: tmt.log.Logger,
+    caplog: _pytest.logging.LogCaptureFixture,
+) -> None:
+    package_manager = create_package_manager(
+        container_per_test, guest_per_test, package_manager_class, root_logger
+    )
+
+    method = package_manager.enable_repo if action == 'enable' else package_manager.disable_repo
+
+    if isinstance(expected_command_or_exception, str):
+        # The command will fail because 'test-repo' does not exist in the
+        # container, but we only care about verifying the correct command
+        # was constructed — the log records it regardless of exit code.
+        with contextlib.suppress(tmt.utils.RunError):
+            method('test-repo')
+        assert_expected_command(caplog, expected_command_or_exception)
+    else:
+        with pytest.raises(
+            type(expected_command_or_exception),
+            match=re.escape(str(expected_command_or_exception)),
+        ):
+            method('test-repo')
 
 
 def _parametrize_test_install_nonexistent() -> Iterator[

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -17,6 +17,8 @@ from typing import (
 )
 from urllib.parse import urlparse
 
+import fmf.utils
+
 import tmt.log
 import tmt.plugins
 import tmt.utils
@@ -383,6 +385,26 @@ class PackageManagerEngine(tmt.utils.Common):
     def refresh_metadata(self) -> ShellScript:
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def enable_repo(self, *repo_ids: str) -> ShellScript:
+        """
+        Enable specified repositories.
+
+        :param repo_ids: repository IDs to enable.
+        :returns: a shell script to enable the repositories.
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def disable_repo(self, *repo_ids: str) -> ShellScript:
+        """
+        Disable specified repositories.
+
+        :param repo_ids: repository IDs to disable.
+        :returns: a shell script to disable the repositories.
+        """
+        raise NotImplementedError
+
     def install_repository(self, repository: "Repository") -> ShellScript:
         """
         Install a repository by placing its configuration in /etc/yum.repos.d/.
@@ -655,6 +677,34 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         Make sure the ``config-manager`` plugin for repository management is installed.
         """
         raise PrepareError(f"Package manager '{self.NAME}' does not support config-manager.")
+
+    def enable_repo(self, *repo_ids: str) -> None:
+        """
+        Enable specified repositories.
+
+        :param repo_ids: repository IDs to enable.
+        """
+        if not repo_ids:
+            return
+
+        self.assert_config_manager()
+
+        self.verbose('enable repo', fmf.utils.listed(repo_ids), 'green')
+        self.guest.execute(self.engine.enable_repo(*repo_ids))
+
+    def disable_repo(self, *repo_ids: str) -> None:
+        """
+        Disable specified repositories.
+
+        :param repo_ids: repository IDs to disable.
+        """
+        if not repo_ids:
+            return
+
+        self.assert_config_manager()
+
+        self.verbose('disable repo', fmf.utils.listed(repo_ids), 'green')
+        self.guest.execute(self.engine.disable_repo(*repo_ids))
 
     def enable_copr(self, *repositories: str) -> None:
         """

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -98,6 +98,16 @@ class ApkEngine(PackageManagerEngine):
     def refresh_metadata(self) -> ShellScript:
         return ShellScript(f'{self.command.to_script()} update')
 
+    def enable_repo(self, *repo_ids: str) -> ShellScript:
+        raise tmt.utils.PrepareError(
+            "Package manager 'apk' does not support enabling repositories."
+        )
+
+    def disable_repo(self, *repo_ids: str) -> ShellScript:
+        raise tmt.utils.PrepareError(
+            "Package manager 'apk' does not support disabling repositories."
+        )
+
     def install(
         self,
         *installables: Installable,

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -156,6 +156,16 @@ class AptEngine(PackageManagerEngine):
             f'export DEBIAN_FRONTEND=noninteractive; {self.command.to_script()} update'
         )
 
+    def enable_repo(self, *repo_ids: str) -> ShellScript:
+        raise tmt.utils.PrepareError(
+            "Package manager 'apt' does not support enabling repositories."
+        )
+
+    def disable_repo(self, *repo_ids: str) -> ShellScript:
+        raise tmt.utils.PrepareError(
+            "Package manager 'apt' does not support disabling repositories."
+        )
+
     def install(
         self,
         *installables: Installable,

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -3,6 +3,8 @@ import uuid
 from collections.abc import Iterator
 from typing import Any, Optional
 
+import fmf.utils
+
 import tmt.utils
 from tmt.container import PYDANTIC_V1, ConfigDict, MetadataContainer
 from tmt.guest import TransferOptions
@@ -172,6 +174,20 @@ class BootcEngine(PackageManagerEngine):
         self.open_containerfile_directives()
 
         script = self.aux_engine.refresh_metadata()
+        self.containerfile_directives.append(f'RUN {script}')
+        return script
+
+    def enable_repo(self, *repo_ids: str) -> ShellScript:
+        self.open_containerfile_directives()
+
+        script = self.aux_engine.enable_repo(*repo_ids)
+        self.containerfile_directives.append(f'RUN {script}')
+        return script
+
+    def disable_repo(self, *repo_ids: str) -> ShellScript:
+        self.open_containerfile_directives()
+
+        script = self.aux_engine.disable_repo(*repo_ids)
         self.containerfile_directives.append(f'RUN {script}')
         return script
 
@@ -353,6 +369,25 @@ class Bootc(PackageManager[BootcEngine]):
         self.engine.reinstall(*installables, options=options)
 
         return CommandOutput(stdout=None, stderr=None)
+
+    def assert_config_manager(self) -> None:
+        self.guest.bootc_builder.assert_config_manager()
+
+    def enable_repo(self, *repo_ids: str) -> None:
+        if not repo_ids:
+            return
+
+        self.assert_config_manager()
+        self.verbose('enable repo', fmf.utils.listed(repo_ids), 'green')
+        self.engine.enable_repo(*repo_ids)
+
+    def disable_repo(self, *repo_ids: str) -> None:
+        if not repo_ids:
+            return
+
+        self.assert_config_manager()
+        self.verbose('disable repo', fmf.utils.listed(repo_ids), 'green')
+        self.engine.disable_repo(*repo_ids)
 
     def finalize_installation(self) -> CommandOutput:
         """

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -128,6 +128,12 @@ class DnfEngine(PackageManagerEngine):
             f'{self.command.to_script()} makecache {self.options.to_script()} --refresh'
         )
 
+    def enable_repo(self, *repo_ids: str) -> ShellScript:
+        return (self.command + Command('config-manager', '--enable', *repo_ids)).to_script()
+
+    def disable_repo(self, *repo_ids: str) -> ShellScript:
+        return (self.command + Command('config-manager', '--disable', *repo_ids)).to_script()
+
     def install(
         self,
         *installables: Installable,
@@ -408,6 +414,20 @@ class Dnf5(Dnf):
 
 class YumEngine(DnfEngine):
     _base_command = Command('yum')
+
+    def _yum_config_manager_command(self) -> Command:
+        command = Command('yum-config-manager')
+
+        if self.guest.facts.sudo_prefix:
+            command = Command(self.guest.facts.sudo_prefix) + command
+
+        return command
+
+    def enable_repo(self, *repo_ids: str) -> ShellScript:
+        return (self._yum_config_manager_command() + Command('--enable', *repo_ids)).to_script()
+
+    def disable_repo(self, *repo_ids: str) -> ShellScript:
+        return (self._yum_config_manager_command() + Command('--disable', *repo_ids)).to_script()
 
     def resolve_provides(
         self,

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -13,7 +13,7 @@ from tmt.package_managers import (
     provides_package_manager,
 )
 from tmt.steps.provision.mock import GuestMock
-from tmt.utils import Command, CommandOutput, GeneralError, RunError, ShellScript
+from tmt.utils import Command, CommandOutput, GeneralError, PrepareError, RunError, ShellScript
 
 
 class MockEngine(PackageManagerEngine):
@@ -81,6 +81,12 @@ class MockEngine(PackageManagerEngine):
 
     def refresh_metadata(self) -> ShellScript:
         return self._prepare_mock_command_script('makecache --refresh')
+
+    def enable_repo(self, *repo_ids: str) -> ShellScript:
+        raise PrepareError("Package manager 'mock' does not support enabling repositories.")
+
+    def disable_repo(self, *repo_ids: str) -> ShellScript:
+        raise PrepareError("Package manager 'mock' does not support disabling repositories.")
 
 
 class _MockPackageManager(PackageManager[MockEngine]):

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -11,7 +11,7 @@ from tmt.package_managers import (
     escape_installables,
     provides_package_manager,
 )
-from tmt.utils import Command, CommandOutput, GeneralError, RunError, ShellScript
+from tmt.utils import Command, CommandOutput, GeneralError, PrepareError, RunError, ShellScript
 
 
 class RpmOstreeEngine(PackageManagerEngine):
@@ -75,6 +75,12 @@ class RpmOstreeEngine(PackageManagerEngine):
         #
         # script = ShellScript(f'{self.command.to_script()} refresh-md --force')
         # return self.guest.execute(script)
+
+    def enable_repo(self, *repo_ids: str) -> ShellScript:
+        raise PrepareError("Package manager 'rpm-ostree' does not support enabling repositories.")
+
+    def disable_repo(self, *repo_ids: str) -> ShellScript:
+        raise PrepareError("Package manager 'rpm-ostree' does not support disabling repositories.")
 
     def install(
         self,


### PR DESCRIPTION
Add repository enable/disable API to the package manager layer so that feature plugins (e.g. `epel`, `crb`) can manage repositories without guessing which command to use for each distribution version.

- Base `PackageManager`: raises `PrepareError` for unsupported PMs
- `Dnf`/`Dnf5`: delegates to `config-manager --enable/--disable`
- `Yum`: uses standalone `yum-config-manager` binary

Assisted-by: Claude Code

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
