### PR TITLE
Improve help text of `user` key of provision plugins

### DIFF
--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2830,7 +2830,11 @@ class GuestSshData(GuestData):
         default=DEFAULT_USER,
         option=('-u', '--user'),
         metavar='NAME',
-        help='A username to use for all guest operations.',
+        help="""
+             Username to use when connecting to the guest via SSH. Unless
+             ``become`` is used, tests and other user-provided commands
+             will be invoked under this user account.
+             """,
     )
     key: list[Path] = field(
         default_factory=list,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -52,7 +52,13 @@ class PodmanGuestData(tmt.guest.GuestData):
         default=DEFAULT_USER,
         option=('-u', '--user'),
         metavar='USERNAME',
-        help='Username to use for all guest operations.',
+        help="""
+             Username to pass to ``podman run`` command when starting the
+             container representing the guest. It will override ``USER``
+             directive from the image. Unless ``become`` is used, tests
+             and other user-provided commands will be invoked under this
+             user account.
+             """,
     )
     force_pull: bool = field(
         default=False,


### PR DESCRIPTION
The current text is very wide-reaching, this patch makes it more precise and describes what effects it has.

Pull Request Checklist

* [x] implement the feature