### PR TITLE
Update docs and semantics of `become` key

### DIFF
--- a/tests/provision/connect/test.sh
+++ b/tests/provision/connect/test.sh
@@ -30,11 +30,11 @@ rlJournalStart
         rlAssertGrep "Reboot finished" $rlRun_LOG
         rlAssertGrep "sudo /bin/bash -c reboot" $rlRun_LOG
 
-        # Test reboot without become (should fail for non-root user)
+        # Test reboot without become (should apply sudo as well, no a user script)
         provision_no_become="provision -h connect --guest localhost --port $guest_port --key $guest_key --user $guest_user"
-        rlRun -s "tmt -vv run --scratch -i $run_connect_no_become $provision_no_become reboot --step provision" 2
-        rlAssertGrep "fail: Command 'reboot' returned 1." $rlRun_LOG
-        rlAssertGrep "Call to Reboot failed: Access denied" $rlRun_LOG
+        rlRun -s "tmt -vv run --scratch -i $run_connect_no_become $provision_no_become reboot --step provision"
+        rlAssertGrep "Reboot finished" $rlRun_LOG
+        rlAssertGrep "sudo /bin/bash -c reboot" $rlRun_LOG
 
         rlRun "tmt run -i $run cleanup"
         rlRun "tmt run -i $run_connect cleanup"

--- a/tests/provision/reboot/test.sh
+++ b/tests/provision/reboot/test.sh
@@ -124,7 +124,7 @@ rlJournalStart
                 0 "Systemd soft-reboot"
             rlAssertGrep "reboot: Rebooting guest using systemd-soft mode." $rlRun_LOG
             rlAssertGrep "reboot: Reboot finished" $rlRun_LOG
-            rlAssertGrep "cmd: systemctl soft-reboot" $rlRun_LOG
+            rlAssertGrep "cmd: /bin/bash -c 'systemctl soft-reboot'" $rlRun_LOG
 
             rlRun -s "tmt -vv run -l reboot --systemd-soft --command 'systemctl soft-reboot'" \
                 0 "Systemd soft-reboot with custom command"

--- a/tests/test/check/test-journal.sh
+++ b/tests/test/check/test-journal.sh
@@ -148,7 +148,7 @@ rlJournalStart
                 rlAssertExists "$config_test/checks/journal.txt"
 
                 rlRun -s "cat $config_test_check/output.txt"
-                rlAssertGrep "^\[Journal\]$" $rlRun_LOG
+                rlAssertGrep "\[Journal\]" $rlRun_LOG
                 rlAssertGrep "^Storage=persistent$" $rlRun_LOG
                 rlAssertGrep "^Compress=yes$" $rlRun_LOG
             rlPhaseEnd

--- a/tests/test/check/test-journal.sh
+++ b/tests/test/check/test-journal.sh
@@ -145,7 +145,7 @@ rlJournalStart
                   rlAssertGrep "Configured persistent journal storage with sudo" $rlRun_LOG
                 fi
 
-                rlFileExists "$config_test/checks/journal.txt"
+                rlAssertExists "$config_test/checks/journal.txt"
 
                 rlRun -s "cat $config_test_check/output.txt"
                 rlAssertGrep "^\[Journal\]$" $rlRun_LOG

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1311,8 +1311,7 @@ class GuestData(
         help="""
              If set, user-provided commands - ``prepare`` and ``finish``
              scripts and tests - will be invoked with elevated, superuser
-             privileges. If the access plugin has is not a superuser
-             already, passwordless ``sudo`` will be used.
+             privileges via passwordless ``sudo`` if necessary.
              """,
     )
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -3761,9 +3761,10 @@ class GuestSsh(Guest, CommandCollector):
                 f"Guest '{self.multihost_name}' does not support hard reboot."
             )
 
-        default_reboot_command = ShellScript(
-            f'{self.facts.sudo_prefix} {default_reboot_command.to_shell_command()}'
-        )
+        if self.become and not self.facts.is_superuser:
+            default_reboot_command = ShellScript(
+                f'{self.facts.sudo_prefix} {default_reboot_command.to_shell_command()}'
+            )
 
         command = command or default_reboot_command
         waiting = waiting or default_reboot_waiting()

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -3760,10 +3760,9 @@ class GuestSsh(Guest, CommandCollector):
                 f"Guest '{self.multihost_name}' does not support hard reboot."
             )
 
-        if self.become and not self.facts.is_superuser:
-            default_reboot_command = ShellScript(
-                f'{self.facts.sudo_prefix} {default_reboot_command.to_shell_command()}'
-            )
+        default_reboot_command = ShellScript(
+            f'{self.facts.sudo_prefix} {default_reboot_command.to_shell_command()}'
+        )
 
         command = command or default_reboot_command
         waiting = waiting or default_reboot_waiting()

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1309,8 +1309,10 @@ class GuestData(
         is_flag=True,
         option=('-b', '--become'),
         help="""
-             Whether to run tests and shell scripts in prepare and
-             finish steps with ``sudo``.
+             If set, user-provided commands - ``prepare`` and ``finish``
+             scripts and tests - will be invoked with elevated, superuser
+             privileges. If the access plugin has is not a superuser
+             already, passwordless ``sudo`` will be used.
              """,
     )
 
@@ -3759,10 +3761,9 @@ class GuestSsh(Guest, CommandCollector):
                 f"Guest '{self.multihost_name}' does not support hard reboot."
             )
 
-        if self.become:
-            default_reboot_command = ShellScript(
-                f'sudo {default_reboot_command.to_shell_command()}'
-            )
+        default_reboot_command = ShellScript(
+            f'{self.facts.sudo_prefix} {default_reboot_command.to_shell_command()}'
+        )
 
         command = command or default_reboot_command
         waiting = waiting or default_reboot_waiting()

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -3778,6 +3778,6 @@ def safe_filename(template: str, phase: Phase, guest: 'Guest', **variables: Any)
         rendering the filename.
     """
 
-    template += '-{{ PHASE.parent.name }}-{{ PHASE.safe_name }}-{{ GUEST.safe_name }}'
+    template += '-{{ PHASE.safe_name }}-{{ GUEST.safe_name }}'
 
     return Path(render_template(template, PHASE=phase, GUEST=guest, **variables))

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -3778,6 +3778,6 @@ def safe_filename(template: str, phase: Phase, guest: 'Guest', **variables: Any)
         rendering the filename.
     """
 
-    template += '-{{ PHASE.step.name }}-{{ PHASE.safe_name }}-{{ GUEST.safe_name }}'
+    template += '-{{ PHASE.parent.name }}-{{ PHASE.safe_name }}-{{ GUEST.safe_name }}'
 
     return Path(render_template(template, PHASE=phase, GUEST=guest, **variables))

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -3778,6 +3778,6 @@ def safe_filename(template: str, phase: Phase, guest: 'Guest', **variables: Any)
         rendering the filename.
     """
 
-    template += '-{{ PHASE.safe_name }}-{{ GUEST.safe_name }}'
+    template += '-{{ PHASE.step.name }}-{{ PHASE.safe_name }}-{{ GUEST.safe_name }}'
 
     return Path(render_template(template, PHASE=phase, GUEST=guest, **variables))

--- a/tmt/steps/context/pidfile.py
+++ b/tmt/steps/context/pidfile.py
@@ -102,13 +102,8 @@ INNER_WRAPPER_TEMPLATE = jinja2.Template("""
 OUTER_WRAPPER_TEMPLATE = jinja2.Template("""
 {% macro log_to_dmesg(msg) %}
     {%- if not GUEST.facts.is_superuser %}
-        {%- if GUEST.become %}
 # Logging test into kernel log
-sudo bash -c "echo \\\"{{ msg }}\\\" > /dev/kmsg"
-        {%- else %}
-# Not logging into kernel log: not a superuser, 'become' not enabled
-# echo \"{{ msg }}\" > /dev/kmsg
-        {%- endif %}
+{{ GUEST.facts.sudo_prefix }} bash -c "echo \\\"{{ msg }}\\\" > /dev/kmsg"
     {%- else %}
 # Logging test into kernel log
 echo "{{ msg }}" > /dev/kmsg

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -250,9 +250,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             pull_options.exclude.append(str(script_log_filepath))
 
             if guest.become and not guest.facts.is_superuser:
-                command = tmt.utils.ShellScript(
-                    f'{guest.facts.sudo_prefix} {script.to_shell_command()}'
-                )
+                command = tmt.utils.ShellScript(f'sudo -E {script.to_shell_command()}')
             else:
                 command = script
 


### PR DESCRIPTION
Instead of promising all scripts and tests would be running with `sudo`, it now states that user-provided scripts and tests would be invoked with superuser privileges. This makes the intent clearer, and gives us easier job: add `sudo` only when not already a superuser.

Pull Request Checklist

* [x] implement the feature