### PR TITLE
Let `finish` step run before `report`

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -135,8 +135,8 @@ tmt uses a 7-phase execution model:
 2. **provision**: Prepare testing environment (guests/containers)
 3. **prepare**: Install dependencies and configure environment
 4. **execute**: Run the actual tests
-5. **report**: Generate and publish test results
-6. **finish**: Cleanup and finalization tasks
+5. **finish**: Cleanup and finalization tasks
+6. **report**: Generate and publish test results
 7. **cleanup**: Remove temporary resources
 
 Each step is implemented as a plugin system supporting multiple `how` methods.

--- a/tests/login/debug.sh
+++ b/tests/login/debug.sh
@@ -7,10 +7,10 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Debug Test"
-        rlRun "tmt run --remove --until execute plans -n /plan provision -h container"
+        rlRun "tmt run --remove --until finish plans -n /plan provision -h container"
         rlRun "tmt run --last report"
         rlRun "tmt run --last login --command /bin/true"
-        rlRun "tmt run --last finish"
+        rlRun "tmt run --last cleanup"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -18,7 +18,7 @@ rlJournalStart
     rlPhaseStartTest "Last step"
         rlRun -s "$tmt login -c true"
         rlAssertGrep "interactive" "$rlRun_LOG"
-        rlRun "grep '^    finish$' -A5 '$rlRun_LOG' | grep -i interactive"
+        rlRun "grep '^    report$' -A5 '$rlRun_LOG' | grep -i interactive"
     rlPhaseEnd
 
     for step in discover provision prepare execute report finish; do

--- a/tests/login/step.sh
+++ b/tests/login/step.sh
@@ -21,7 +21,7 @@ rlJournalStart
         rlRun "grep '^    report$' -A5 '$rlRun_LOG' | grep -i interactive"
     rlPhaseEnd
 
-    for step in discover provision prepare execute report finish; do
+    for step in discover provision prepare execute finish report; do
         rlPhaseStartTest "Selected step ($step)"
             rlRun -s "$tmt login -c true -s $step"
 

--- a/tests/plan/show/test.sh
+++ b/tests/plan/show/test.sh
@@ -152,7 +152,7 @@ rlJournalStart
         rlRun "grep -Pzo '(?sm)^ *prepare ?$.*^ *report' $rlRun_LOG > $output"
         rlAssertGrep "    how shell" $output
         rlAssertGrep "    script systemctl start libvirtd" $output
-        rlRun "grep -Pzo '(?sm)^ *report ?$.*^ *finish' $rlRun_LOG > $output"
+        rlRun "grep -Pzo '(?sm)^ *report ?$.*' $rlRun_LOG > $output"
         rlAssertGrep "    how html" $output
         rlAssertGrep "    open true" $output
         rlRun "grep -A30 '^ *finish' $rlRun_LOG > $output"

--- a/tests/status/base/test.sh
+++ b/tests/status/base/test.sh
@@ -26,8 +26,8 @@ rlJournalStart
 
     rlPhaseStartTest "Very verbose"
         rlRun "tmt status -vv | tee output"
-        rlAssertGrep "(done\s+){4}todo\s+(done\s+){2}$runid\s+/plan1" "output" -E
-        rlAssertGrep "(done\s+){4}todo\s+(done\s+){2}$runid\s+/plan2" "output" -E
+        rlAssertGrep "(done\s+){5}todo\s+done\s+$runid\s+/plan1" "output" -E
+        rlAssertGrep "(done\s+){5}todo\s+done\s+$runid\s+/plan2" "output" -E
     rlPhaseEnd
 
     rlPhaseStartTest "Specify ID"

--- a/tests/steps/select/test.sh
+++ b/tests/steps/select/test.sh
@@ -50,18 +50,18 @@ rlJournalStart
         for step in discover provision prepare execute; do
             rlAssertGrep $step output
         done
-        for step in report finish; do
+        for step in finish report cleanup; do
             rlAssertNotGrep $step output
         done
         rlAssertGrep '1 test executed' output
     rlPhaseEnd
 
     rlPhaseStartTest "Since"
-        rlRun "tmt run --last --since report finish -h shell 2>&1 >/dev/null | tee output"
-        for step in discover provision prepare execute; do
+        rlRun "tmt run --last --since report 2>&1 >/dev/null | tee output"
+        for step in discover provision prepare execute finish; do
             rlAssertNotGrep $step output
         done
-        for step in report finish; do
+        for step in report cleanup; do
             rlAssertGrep $step output
         done
         rlAssertGrep '1 test passed' output
@@ -69,10 +69,10 @@ rlJournalStart
 
     rlPhaseStartTest "Before"
         rlRun "tmt run $options --before report discover -h shell 2>&1 >/dev/null | tee output"
-        for step in discover provision prepare execute; do
+        for step in discover provision prepare execute finish; do
             rlAssertGrep $step output
         done
-        for step in report finish; do
+        for step in report cleanup; do
             rlAssertNotGrep $step output
         done
         rlAssertGrep '1 test executed' output
@@ -83,7 +83,7 @@ rlJournalStart
         for step in discover provision prepare execute; do
             rlAssertNotGrep $step output
         done
-        for step in report finish; do
+        for step in finish report cleanup; do
             rlAssertGrep $step output
         done
         rlAssertGrep '1 test passed' output

--- a/tests/steps/select/test.sh
+++ b/tests/steps/select/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
-steps='discover provision prepare execute report finish'
+steps='discover provision prepare execute finish report cleanup'
 
 rlJournalStart
     rlPhaseStartSetup

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -121,7 +121,7 @@ PHASE_ORDER_PREPARE_VERIFY_INSTALLATION = 79
 TRY_PHASE_ORDER_PREPARE_FEATURE_FIPS = PHASE_ORDER_PREPARE_INSTALL_RECOMMENDS + 10
 
 # Supported steps and actions
-StepName = Literal['discover', 'provision', 'prepare', 'execute', 'report', 'finish', 'cleanup']
+StepName = Literal['discover', 'provision', 'prepare', 'execute', 'finish', 'report', 'cleanup']
 STEPS: list[StepName] = list(typing.get_args(StepName))
 ActionName = Literal['login', 'reboot']
 ACTIONS: list[ActionName] = list(typing.get_args(ActionName))

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -120,7 +120,7 @@ PHASE_ORDER_PREPARE_VERIFY_INSTALLATION = 79
 TRY_PHASE_ORDER_PREPARE_FEATURE_FIPS = PHASE_ORDER_PREPARE_INSTALL_RECOMMENDS + 10
 
 # Supported steps and actions
-StepName = Literal['discover', 'provision', 'prepare', 'execute', 'report', 'finish', 'cleanup']
+StepName = Literal['discover', 'provision', 'prepare', 'execute', 'finish', 'report', 'cleanup']
 STEPS: list[StepName] = list(typing.get_args(StepName))
 ActionName = Literal['login', 'reboot']
 ACTIONS: list[ActionName] = list(typing.get_args(ActionName))

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -2982,7 +2982,7 @@ class Action(Phase, tmt.utils.MultiInvokableCommon):
             # Default to the last enabled step if no completed step found
             # (skip the cleanup step as no actions are expected there)
             if login_during is None:
-                login_during = list(step.plan.steps(skip=["cleanup"]))[-1]
+                login_during = list(step.plan.steps(skip=["report", "cleanup"]))[-1]
             # Only login if the error occurred after provision
             if login_during != step.plan.discover:
                 phases[login_during.name] = [PHASE_END]

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -2982,7 +2982,7 @@ class Action(Phase, tmt.utils.MultiInvokableCommon):
             # Default to the last enabled step if no completed step found
             # (skip the cleanup step as no actions are expected there)
             if login_during is None:
-                login_during = list(step.plan.steps(skip=["report", "cleanup"]))[-1]
+                login_during = list(step.plan.steps(skip=["cleanup"]))[-1]
             # Only login if the error occurred after provision
             if login_during != step.plan.discover:
                 phases[login_during.name] = [PHASE_END]

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -2959,7 +2959,7 @@ class Action(Phase, tmt.utils.MultiInvokableCommon):
             # Default to the last enabled step if no completed step found
             # (skip the cleanup step as no actions are expected there)
             if login_during is None:
-                login_during = list(step.plan.steps(skip=["report", "cleanup"]))[-1]
+                login_during = list(step.plan.steps(skip=["cleanup"]))[-1]
             # Only login if the error occurred after provision
             if login_during != step.plan.discover:
                 phases[login_during.name] = [PHASE_END]

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -2959,7 +2959,7 @@ class Action(Phase, tmt.utils.MultiInvokableCommon):
             # Default to the last enabled step if no completed step found
             # (skip the cleanup step as no actions are expected there)
             if login_during is None:
-                login_during = list(step.plan.steps(skip=["cleanup"]))[-1]
+                login_during = list(step.plan.steps(skip=["report", "cleanup"]))[-1]
             # Only login if the error occurred after provision
             if login_during != step.plan.discover:
                 phases[login_during.name] = [PHASE_END]


### PR DESCRIPTION
Probably a remnant of old days, days when `cleanup` did not exist yet. But `finish` should be paired with `prepare`, wrapping `execute`, and when all three are done, `report`, hm, reports the results.

Pull Request Checklist

* [x] implement the feature