### PR TITLE
Make color and other logging method params keyword-only

### DIFF
--- a/examples/plugins/example/provision.py
+++ b/examples/plugins/example/provision.py
@@ -104,7 +104,7 @@ class ProvisionExample(tmt.steps.provision.ProvisionPlugin):
             val = self.get(opt)
             # You can hide some not important information about provisioning.
             if opt != 'switch':
-                self.info(opt, val, 'green')
+                self.info(opt, val, color='green')
             data[opt] = val
 
         self._guest = GuestExample(data, name=self.name, parent=self.step)
@@ -212,7 +212,7 @@ class GuestExample(tmt.Guest):
         if self.is_dry_run:
             return
 
-        self.verbose('what', self.what, 'green')
+        self.verbose('what', self.what, color='green')
 
         if self._some_your_internal_stuff():
             return
@@ -265,6 +265,6 @@ class GuestExample(tmt.Guest):
         """
 
         if self.what:
-            self.info('guest', 'removed', 'green')
+            self.info('guest', 'removed', color='green')
             self.delete()
             self.what = None

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -1253,7 +1253,7 @@ class Plan(
         self.info('')
         self.info(self.name, color='red')
         if self.summary:
-            self.verbose('summary', self.summary, 'green')
+            self.verbose('summary', self.summary, color='green')
 
     def go(self) -> None:
         """
@@ -1264,8 +1264,8 @@ class Plan(
         # Additional debug info like plan environment
         self.debug('info', color='cyan', shift=0, level=3)
         # TODO: something better than str()?
-        self.debug('environment', self.environment, 'magenta', level=3)
-        self.debug('context', self.fmf_context, 'magenta', level=3)
+        self.debug('environment', self.environment, color='magenta', level=3)
+        self.debug('context', self.fmf_context, color='magenta', level=3)
 
         # Wake up all steps
         self.wake()

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2236,7 +2236,7 @@ class Guest(
             matched = re.search(rf'^.*\s:\s.*{key}=(\d+).*$', output, re.MULTILINE)
             if matched and int(matched.group(1)) > 0:
                 tasks = fmf.utils.listed(matched.group(1), 'task')
-                self.verbose(key, tasks, 'green')
+                self.verbose(key, tasks, color='green')
 
     def _sanitize_ansible_playbook_path(
         self, playbook: AnsibleApplicable, playbook_root: Optional[Path]

--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -422,7 +422,7 @@ class BeakerLibFromUrl(BeakerLib):
         self.parent.verbose(
             'commit-hash',
             tmt.utils.git.git_hash(directory=clone_dir, logger=self._logger),
-            'green',
+            color='green',
         )
 
         # Copy only the required library
@@ -437,7 +437,7 @@ class BeakerLibFromUrl(BeakerLib):
         self.parent.verbose(
             'using remote git library',
             cast(dict[str, str], self.identifier.to_minimal_dict()),
-            'green',
+            color='green',
             level=3,
         )
 

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -599,6 +599,7 @@ class VerboseLoggingFunction(Protocol):
         self,
         key: str,
         value: Optional[str] = None,
+        *,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         level: VerbosityLevel = 1,
@@ -612,6 +613,7 @@ class Print(Protocol):
     def __call__(
         self,
         text: Optional[str] = None,
+        *,
         color: 'tmt.utils.themes.Style' = None,
         file: Optional[TextIO] = None,
         nl: bool = True,
@@ -984,6 +986,7 @@ class Logger:
     def print_format(
         self,
         text: str,
+        *,
         color: 'tmt.utils.themes.Style' = None,
     ) -> str:
         """
@@ -1004,6 +1007,7 @@ class Logger:
     def print(
         self,
         text: Optional[str] = None,
+        *,
         color: 'tmt.utils.themes.Style' = None,
         file: Optional[TextIO] = None,
         nl: bool = True,
@@ -1018,6 +1022,7 @@ class Logger:
         self,
         key: str,
         value: Optional[LoggableValue] = None,
+        *,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         topic: Optional[Topic] = None,
@@ -1033,6 +1038,7 @@ class Logger:
         self,
         key: str,
         value: Optional[LoggableValue] = None,
+        *,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         level: VerbosityLevel = 1,
@@ -1056,6 +1062,7 @@ class Logger:
         self,
         key: str,
         value: Optional[LoggableValue] = None,
+        *,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         level: DebugLevel = 1,
@@ -1078,6 +1085,7 @@ class Logger:
     def warning(
         self,
         message: str,
+        *,
         shift: int = 0,
         stacklevel: int = 1,
         source: Optional[str] = None,
@@ -1100,14 +1108,16 @@ class Logger:
     def warn(
         self,
         message: str,
+        *,
         shift: int,
         stacklevel: int = 1,
     ) -> None:
-        return self.warning(message, shift, stacklevel=stacklevel + 1)
+        return self.warning(message, shift=shift, stacklevel=stacklevel + 1)
 
     def fail(
         self,
         message: str,
+        *,
         shift: int = 0,
         stacklevel: int = 1,
     ) -> None:

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -763,7 +763,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
 
         self.assert_config_manager()
 
-        self.verbose('enable repo', fmf.utils.listed(repo_ids), 'green')
+        self.verbose('enable repo', fmf.utils.listed(repo_ids), color='green')
         self.guest.execute(self.engine.enable_repo(*repo_ids))
 
     def disable_repo(self, *repo_ids: str) -> None:
@@ -777,7 +777,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
 
         self.assert_config_manager()
 
-        self.verbose('disable repo', fmf.utils.listed(repo_ids), 'green')
+        self.verbose('disable repo', fmf.utils.listed(repo_ids), color='green')
         self.guest.execute(self.engine.disable_repo(*repo_ids))
 
     def enable_copr(self, *repositories: str) -> None:

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -276,7 +276,7 @@ class Bootc(PackageManager[BootcEngine]):
 
                 self.debug(f"containerfile content: {containerfile}")
                 # Build the container image
-                self.info("package", "building container image with dependencies", "green")
+                self.info("package", "building container image with dependencies", color="green")
 
                 assert self.guest.parent is not None
 
@@ -289,14 +289,14 @@ class Bootc(PackageManager[BootcEngine]):
                 )
 
                 # Switch to the new image for next boot
-                self.info("package", f"switching to new image {image_tag}", "green")
+                self.info("package", f"switching to new image {image_tag}", color="green")
 
                 bootc_command, _ = self.engine.prepare_command()
                 bootc_command += Command('switch', '--transport', 'containers-storage', image_tag)
                 self.guest.execute(bootc_command)
 
                 # Reboot into the new image
-                self.info("package", "rebooting to apply new image", "green")
+                self.info("package", "rebooting to apply new image", color="green")
                 self.guest.reboot()
 
                 return build_output
@@ -373,7 +373,7 @@ class Bootc(PackageManager[BootcEngine]):
             return
 
         self.assert_config_manager()
-        self.verbose('enable repo', fmf.utils.listed(repo_ids), 'green')
+        self.verbose('enable repo', fmf.utils.listed(repo_ids), color='green')
         self.engine.enable_repo(*repo_ids)
 
     def disable_repo(self, *repo_ids: str) -> None:
@@ -381,7 +381,7 @@ class Bootc(PackageManager[BootcEngine]):
             return
 
         self.assert_config_manager()
-        self.verbose('disable repo', fmf.utils.listed(repo_ids), 'green')
+        self.verbose('disable repo', fmf.utils.listed(repo_ids), color='green')
         self.engine.disable_repo(*repo_ids)
 
     def finalize_installation(self) -> CommandOutput:

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -347,7 +347,7 @@ class Dnf(PackageManager[DnfEngine]):
         self.debug('Make sure the copr plugin is available.')
         self.install(Package(self.copr_plugin))
         for repository in repositories:
-            self.info('copr', repository, 'green')
+            self.info('copr', repository, color='green')
             self.guest.execute(
                 ShellScript(
                     f"{self.engine.command.to_script()} copr "

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -228,7 +228,7 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
 
         if options.skip_missing:
             for package in missing:
-                self.info('package', str(package), 'green')
+                self.info('package', str(package), color='green')
                 try:
                     super().install(package, options=no_check_options)
                 except RunError as error:

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -1547,7 +1547,7 @@ class Step(
         self.info(self.name, color='blue')
         # Show workdir in verbose mode
         if self.workdir:
-            self.debug('workdir', self.workdir, 'magenta')
+            self.debug('workdir', self.workdir, color='magenta')
 
     def prune(self, logger: tmt.log.Logger) -> None:
         """
@@ -2398,15 +2398,15 @@ class BasePlugin(
         logger = logger or self._logger
 
         # Show the method
-        logger.info('how', self.get('how'), 'magenta')
+        logger.info('how', self.get('how'), color='magenta')
         # Give summary if provided
         if self.get('summary'):
-            logger.info('summary', self.get('summary'), 'magenta')
+            logger.info('summary', self.get('summary'), color='magenta')
         # Show name only if it's not the default one
         if not self.name.startswith(tmt.utils.DEFAULT_NAME):
-            logger.info('name', self.name, 'magenta')
+            logger.info('name', self.name, color='magenta')
         # Include order in verbose mode
-        logger.verbose('order', self.order, 'magenta', level=3)
+        logger.verbose('order', self.order, color='magenta', level=3)
 
     def essential_requires(self) -> list['tmt.base.core.Dependency']:
         """

--- a/tmt/steps/cleanup/__init__.py
+++ b/tmt/steps/cleanup/__init__.py
@@ -116,7 +116,7 @@ class Cleanup(tmt.steps.StepWithQueue[CleanupStepData, PluginOutcome]):
 
         # TODO Provide a number of stopped guests
         tasks = fmf.utils.listed(self.phases(), 'task')
-        self.info('summary', f'{tasks} completed', 'green', shift=1)
+        self.info('summary', f'{tasks} completed', color='green', shift=1)
 
     def go(self, force: bool = False) -> None:
         """
@@ -127,7 +127,7 @@ class Cleanup(tmt.steps.StepWithQueue[CleanupStepData, PluginOutcome]):
 
         # Nothing more to do if already done
         if self.status() == 'done':
-            self.info('status', 'done', 'green', shift=1)
+            self.info('status', 'done', color='green', shift=1)
             self.summary()
             self.actions()
             return

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -268,7 +268,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT, None]):
                 # Note the missing Optional for values - to_minimal_dict() would
                 # not include unset keys, therefore all values should be valid.
                 for key, value in cast(dict[str, str], remote_plan_id.to_minimal_spec()).items():
-                    self.verbose(f'import {key}', value, 'green')
+                    self.verbose(f'import {key}', value, color='green')
 
     def post_dist_git(self, created_content: list[Path]) -> None:
         """
@@ -282,7 +282,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT, None]):
         :param url: URL of the remote source.
         :returns: Potential path to the metadata tree root within the fetched source.
         """
-        self.info('url', url, 'green')
+        self.info('url', url, color='green')
         if self.data.url_content_type == "git":
             self.debug(f"Clone '{url}' to '{self.test_dir}'.")
 
@@ -328,7 +328,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT, None]):
 
         if path is None or path.resolve() == Path.cwd().resolve():
             return Path('')
-        self.info('path', path, 'green')
+        self.info('path', path, color='green')
         return path
 
     def checkout_ref(self) -> None:
@@ -356,7 +356,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT, None]):
             raise tmt.utils.DiscoverError("Could not resolve dynamic reference") from error
 
         if ref:
-            self.info('ref', ref, 'green')
+            self.info('ref', ref, color='green')
             self.debug(f"Checkout ref '{ref}'.")
             self.run(Command('git', 'checkout', '-f', ref), cwd=self.test_dir)
 
@@ -366,7 +366,7 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT, None]):
                 self.verbose(
                     'commit-hash',
                     tmt.utils.git.git_hash(directory=self.test_dir, logger=self._logger),
-                    'green',
+                    color='green',
                 )
 
     def prune_tree(
@@ -886,7 +886,7 @@ class Discover(tmt.steps.Step):
 
         # Summary of selected tests
         text = listed(len(self.tests(enabled=True)), 'test') + ' selected'
-        self.info('summary', text, 'green', shift=1)
+        self.info('summary', text, color='green', shift=1)
         # Test list in verbose mode
         for test_origin in self.tests(enabled=True):
             self.verbose(test_origin.test.name, color='red', shift=2)
@@ -902,7 +902,7 @@ class Discover(tmt.steps.Step):
 
         # Nothing more to do if already done
         if self.status() == 'done':
-            self.info('status', 'done', 'green', shift=1)
+            self.info('status', 'done', color='green', shift=1)
             self.summary()
             self.actions()
             return

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -625,7 +625,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
         else:
             assert fmf_root is not None  # narrow type
             directory = fmf_root
-        self.info('directory', directory, 'green')
+        self.info('directory', directory, color='green')
         self.debug(f"Copy '{directory}' to '{self.test_dir}'.")
         tmt.utils.filesystem.copy_tree(directory, self.test_dir, self._logger)
         return path
@@ -710,10 +710,12 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
         # Check the 'test --filter' option first, then from discover
         filters = list(tmt.base.core.Test._opt('filters') or self.get('filter', []))
         for filter_ in filters:
-            self.info('filter', filter_, 'green')
+            self.info('filter', filter_, color='green')
         # Names of tests selected by --test option
         if self.data.test:
-            self.info('tests', fmf.utils.listed([test.name for test in self.data.test]), 'green')
+            self.info(
+                'tests', fmf.utils.listed([test.name for test in self.data.test]), color='green'
+            )
 
         # Check the 'test --link' option first, then from discover
         # FIXME: cast() - typeless "dispatcher" method
@@ -723,7 +725,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
         ]
 
         for link_needle in link_needles:
-            self.info('link', str(link_needle), 'green')
+            self.info('link', str(link_needle), color='green')
 
         excludes = list(tmt.base.core.Test._opt('exclude') or self.data.exclude)
         includes = list(tmt.base.core.Test._opt('include') or self.data.include)
@@ -734,7 +736,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
         if modified_url:
             previous = modified_url
             modified_url = tmt.utils.git.clonable_git_url(modified_url)
-            self.info('modified-url', modified_url, 'green')
+            self.info('modified-url', modified_url, color='green')
             if previous != modified_url:
                 self.debug(f"Original url was '{previous}'.")
             self.debug(f"Fetch also '{modified_url}' as 'reference'.")
@@ -751,13 +753,13 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 'modified-ref',
                 tmt.utils.git.default_branch(repository=self.test_dir, logger=self._logger),
             )
-            self.info('modified-ref', modified_ref, 'green')
+            self.info('modified-ref', modified_ref, color='green')
             ref_commit = self.run(
                 Command('git', 'rev-parse', '--short', str(modified_ref)),
                 cwd=self.test_dir,
             )
             assert ref_commit.stdout is not None
-            self.verbose('modified-ref hash', ref_commit.stdout.strip(), 'green')
+            self.verbose('modified-ref hash', ref_commit.stdout.strip(), color='green')
             output = self.run(
                 Command(
                     'git', 'log', '--format=', '--stat', '--name-only', f"{modified_ref}..HEAD"
@@ -937,7 +939,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
         if fmf_root is None or fmf_root.resolve() == Path.cwd().resolve():
             fmf_root = Path('')
         else:
-            self.info('path', fmf_root, 'green')
+            self.info('path', fmf_root, color='green')
 
         # Discover tests
         self._tests = self.do_the_discovery(fmf_root)

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -702,8 +702,8 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
         logger: tmt.log.Logger,
     ) -> None:
         self.go_prolog(logger)
-        logger.verbose('ignore-duration', self.data.ignore_duration, 'green', level=2)
-        logger.verbose('exit-first', self.data.exit_first, 'green', level=2)
+        logger.verbose('ignore-duration', self.data.ignore_duration, color='green', level=2)
+        logger.verbose('exit-first', self.data.exit_first, color='green', level=2)
 
     @property
     def discover(self) -> Union[Discover, 'DiscoverFmf']:
@@ -1168,7 +1168,7 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
         if pending_tests:
             message.append(fmf.utils.listed(pending_tests, 'test') + ' pending')
 
-        self.info('summary', ', '.join(message), 'green', shift=1)
+        self.info('summary', ', '.join(message), color='green', shift=1)
 
     def update_results(self, results: list['Result']) -> None:
         """
@@ -1258,7 +1258,7 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
 
         # Nothing more to do if already done
         if self.status() == 'done':
-            self.info('status', 'done', 'green', shift=1)
+            self.info('status', 'done', color='green', shift=1)
             self.summary()
             self.actions()
             return

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -298,7 +298,7 @@ class ExecuteUpgrade(ExecuteInternal):
             value = self.get(key)
             if value:
                 if key == "test":
-                    self.info('test', fmf.utils.listed(value), 'green')
+                    self.info('test', fmf.utils.listed(value), color='green')
                 else:
                     self.info(key, value, color='green')
 

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -111,7 +111,7 @@ class Finish(tmt.steps.StepWithQueue[FinishStepData, PluginOutcome]):
         """
 
         tasks = fmf.utils.listed(self.phases(), 'task')
-        self.info('summary', f'{tasks} completed', 'green', shift=1)
+        self.info('summary', f'{tasks} completed', color='green', shift=1)
 
     def go(self, force: bool = False) -> None:
         """
@@ -122,7 +122,7 @@ class Finish(tmt.steps.StepWithQueue[FinishStepData, PluginOutcome]):
 
         # Nothing more to do if already done
         if self.status() == 'done':
-            self.info('status', 'done', 'green', shift=1)
+            self.info('status', 'done', color='green', shift=1)
             self.summary()
             self.actions()
             return

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -64,11 +64,11 @@ class PreparePlugin(tmt.steps.Plugin[PrepareStepDataT, PluginOutcome]):
 
         # Show guest name first in multihost scenarios
         if self.step.plan.provision.is_multihost:
-            logger.info('guest', guest.name, 'green')
+            logger.info('guest', guest.name, color='green')
 
         # Show requested role if defined
         if self.data.where:
-            logger.info('where', fmf.utils.listed(self.data.where), 'green')
+            logger.info('where', fmf.utils.listed(self.data.where), color='green')
 
         return PluginOutcome()
 
@@ -188,7 +188,7 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
         """
 
         preparations = fmf.utils.listed(self.preparations_applied, 'preparation')
-        self.info('summary', f'{preparations} applied', 'green', shift=1)
+        self.info('summary', f'{preparations} applied', color='green', shift=1)
 
     def go(self, force: bool = False) -> None:
         """
@@ -199,7 +199,7 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
 
         # Nothing more to do if already done
         if self.status() == 'done':
-            self.info('status', 'done', 'green', shift=1)
+            self.info('status', 'done', color='green', shift=1)
             self.summary()
             self.actions()
             return

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -192,7 +192,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
 
         # Apply each playbook on the guest
         for playbook_index, _playbook in enumerate(self.data.playbook):
-            logger.info('playbook', _playbook, 'green')
+            logger.info('playbook', _playbook, color='green')
 
             playbook_name = f'{self.name} / {_playbook}'
             lowercased_playbook = _playbook.lower()

--- a/tmt/steps/prepare/feature/__init__.py
+++ b/tmt/steps/prepare/feature/__init__.py
@@ -197,7 +197,7 @@ class FeatureBase(tmt.utils.Common):
         if filepath.exists():
             return filepath
 
-        logger.warning(f"Cannot find any suitable playbook for '{filename}'.", 0)
+        logger.warning(f"Cannot find any suitable playbook for '{filename}'.")
         return None
 
     @classmethod

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -221,7 +221,7 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
 
         # Check rpm packages in local directories
         for directory in directories:
-            self.info('directory', directory, 'green')
+            self.info('directory', directory, color='green')
             if not directory.is_dir():
                 raise tmt.utils.PrepareError(f"Packages directory '{directory}' not found.")
             for filepath in directory.iterdir():
@@ -255,11 +255,11 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
         # Show a brief summary by default
         if not self.verbosity_level:
             summary = fmf.utils.listed(installables, max=3)
-            self.info(title, summary, 'green')
+            self.info(title, summary, color='green')
         # Provide a full list of packages in verbose mode
         else:
             summary = fmf.utils.listed(installables, 'package')
-            self.info(title, summary + ' requested', 'green')
+            self.info(title, summary + ' requested', color='green')
             for package in sorted(installables):
                 self.verbose(str(package), shift=1)
 
@@ -288,7 +288,7 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
                 )
             )
             summary = fmf.utils.listed([str(p) for p in self.local_packages], 'local package')
-            self.info('total', f"{summary} installed", 'green')
+            self.info('total', f"{summary} installed", color='green')
 
         if self.remote_packages:
             install_outputs.append(

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -160,7 +160,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
 
         # Give a short summary
         overview = fmf.utils.listed(self.data.script, 'script')
-        logger.info('overview', f'{overview} found', 'green')
+        logger.info('overview', f'{overview} found', color='green')
 
         worktree = self.step.plan.worktree
         assert worktree is not None  # narrow type
@@ -185,7 +185,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
                     )
 
                     if self.data.ref:
-                        self.info('ref', self.data.ref, 'green')
+                        self.info('ref', self.data.ref, color='green')
                         self.run(Command('git', 'checkout', '-f', self.data.ref), cwd=repo_path)
 
             guest.push(
@@ -258,7 +258,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             script_index = script_count - len(script_queue)
             script = original_script = script_queue.pop(0)
 
-            logger.verbose('script', script, 'green')
+            logger.verbose('script', script, color='green')
 
             script_name = f'{self.name} / script #{script_index}'
 

--- a/tmt/steps/provision/__init__.py
+++ b/tmt/steps/provision/__init__.py
@@ -489,7 +489,7 @@ class Provision(tmt.steps.Step):
 
         # Summary of provisioned guests
         guests = fmf.utils.listed(self.ready_guests, 'guest')
-        self.info('summary', f'{guests} provisioned', 'green', shift=1)
+        self.info('summary', f'{guests} provisioned', color='green', shift=1)
         # Guest list in verbose mode
         for guest in self.ready_guests:
             if not guest.name.startswith(tmt.utils.DEFAULT_NAME):
@@ -504,7 +504,7 @@ class Provision(tmt.steps.Step):
 
         # Nothing more to do if already done
         if self.status() == 'done':
-            self.info('status', 'done', 'green', shift=1)
+            self.info('status', 'done', color='green', shift=1)
             self.summary()
             self.actions()
             return

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -591,10 +591,10 @@ class GuestArtemis(tmt.GuestSsh):
                     'Failed to create', response=response, request_data=data
                 )
 
-            self.info('guest', 'has been requested', 'green')
+            self.info('guest', 'has been requested', color='green')
             self.guestname = response.json()['guestname']
 
-        self.info('guestname', self.guestname, 'green')
+        self.info('guestname', self.guestname, color='green')
 
         # Track the previous state to only log when it changes
         previous_state = None
@@ -660,8 +660,8 @@ class GuestArtemis(tmt.GuestSsh):
         if self.guestname is None or self.primary_address is None:
             self._create()
 
-        self.verbose('primary address', self.primary_address, 'green')
-        self.verbose('topology address', self.topology_address, 'green')
+        self.verbose('primary address', self.primary_address, color='green')
+        self.verbose('topology address', self.topology_address, color='green')
 
         self.assert_reachable()
 
@@ -676,10 +676,10 @@ class GuestArtemis(tmt.GuestSsh):
         response = self.api.delete(f'/guests/{self.guestname}')
 
         if response.status_code == 404:
-            self.info('guest', 'no longer exists', 'red')
+            self.info('guest', 'no longer exists', color='red')
 
         elif response.ok:
-            self.info('guest', 'has been removed', 'green')
+            self.info('guest', 'has been removed', color='green')
 
         else:
             self.info(
@@ -703,7 +703,7 @@ class GuestArtemis(tmt.GuestSsh):
             def trigger_reboot() -> None:
                 response = self.api.query(f'/guests/{self.guestname}/reboot', method='post')
                 if response.status_code == 202:
-                    self.info('guest', 'reboot requested', 'green')
+                    self.info('guest', 'reboot requested', color='green')
                 else:
                     raise ArtemisProvisionError('Failed to reboot guest', response=response)
 
@@ -857,7 +857,7 @@ class GuestLogArtemis(tmt.guest.GuestLog):
                 f"Failed to initialize, API responded with HTTP {response.status_code} code.", self
             )
 
-        logger.info(f'{self.name} log', 'requested', 'green')
+        logger.info(f'{self.name} log', 'requested', color='green')
 
     def update(self, *, logger: tmt.log.Logger) -> None:
         if self.guest.guestname is None:

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -218,8 +218,8 @@ class GuestConnect(tmt.guest.GuestSsh):
 
         self.debug(f"Doing nothing to start guest '{self.primary_address}'.")
 
-        self.verbose('primary address', self.primary_address, 'green')
-        self.verbose('topology address', self.topology_address, 'green')
+        self.verbose('primary address', self.primary_address, color='green')
+        self.verbose('topology address', self.topology_address, color='green')
 
         self.assert_reachable()
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -209,8 +209,8 @@ class GuestLocal(tmt.Guest):
 
         self.debug(f"Doing nothing to start guest '{self.primary_address}'.")
 
-        self.verbose('primary address', self.primary_address, 'green')
-        self.verbose('topology address', self.topology_address, 'green')
+        self.verbose('primary address', self.primary_address, color='green')
+        self.verbose('topology address', self.topology_address, color='green')
 
         self.assert_reachable()
 

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -287,7 +287,7 @@ class MockShell:
             for fileno, _ in events:
                 if fileno == self.mock_shell_stderr_fd:
                     for line in self.mock_shell.stderr.readlines():
-                        self.parent._logger.debug('stderr', line.rstrip(), 'yellow')
+                        self.parent._logger.debug('stderr', line.rstrip(), color='yellow')
 
         if mock_shell_result is not None:
             raise tmt.utils.ProvisionError(
@@ -415,10 +415,10 @@ class MockShell:
             )
 
             stream_out = _DecodingStream(
-                lambda text: output_logger('stdout', text, 'yellow', level=3)
+                lambda text: output_logger('stdout', text, color='yellow', level=3)
             )
             stream_err = _DecodingStream(
-                lambda text: output_logger('stderr', text, 'yellow', level=3)
+                lambda text: output_logger('stderr', text, color='yellow', level=3)
             )
             returncode = None
 

--- a/tmt/steps/provision/mrack.py
+++ b/tmt/steps/provision/mrack.py
@@ -1098,7 +1098,7 @@ EOF
 
             logger.debug('mrack request', req, level=3)
 
-            logger.info('whiteboard', host.whiteboard, 'green')
+            logger.info('whiteboard', host.whiteboard, color='green')
 
             return req
 
@@ -1633,10 +1633,10 @@ class GuestBeaker(tmt.guest.GuestSsh):
             if not response:
                 raise ProvisionError(f"Failed to create, response: '{response}'.")
 
-            self.info('guest', 'has been requested', 'green')
+            self.info('guest', 'has been requested', color='green')
             self.job_id = f'J:{response["id"]}'
 
-        self.info('job id', self.job_id, 'green')
+        self.info('job id', self.job_id, color='green')
 
         # Track the previous state to only log when it changes
         previous_state = None
@@ -1688,8 +1688,8 @@ class GuestBeaker(tmt.guest.GuestSsh):
 
         self.primary_address = self.topology_address = guest_info['system']
 
-        self.verbose('primary address', self.primary_address, 'green')
-        self.verbose('topology address', self.topology_address, 'green')
+        self.verbose('primary address', self.primary_address, color='green')
+        self.verbose('topology address', self.topology_address, color='green')
 
         self.assert_reachable()
 

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -293,14 +293,14 @@ class GuestContainer(tmt.Guest):
         if self.container:
             self.primary_address = self.topology_address = self.container
 
-            self.verbose('primary address', self.primary_address, 'green')
-            self.verbose('topology address', self.topology_address, 'green')
+            self.verbose('primary address', self.primary_address, color='green')
+            self.verbose('topology address', self.topology_address, color='green')
 
             return
 
         self.container = self.primary_address = self.topology_address = self._tmt_name()
-        self.verbose('primary address', self.primary_address, 'green')
-        self.verbose('topology address', self.topology_address, 'green')
+        self.verbose('primary address', self.primary_address, color='green')
+        self.verbose('topology address', self.topology_address, color='green')
 
         # Check if the image is available
         assert self.image is not None
@@ -325,7 +325,7 @@ class GuestContainer(tmt.Guest):
                 self._logger,
             )
 
-        self.verbose('name', self.container, 'green')
+        self.verbose('name', self.container, color='green')
 
         additional_args = []
 
@@ -660,7 +660,7 @@ class GuestContainer(tmt.Guest):
             self.podman(
                 Command('container', 'stop', '--time', str(self.stop_time), self.container)
             )
-            self.info('container', 'stopped', 'green')
+            self.info('container', 'stopped', color='green')
 
     def remove(self) -> None:
         """
@@ -669,7 +669,7 @@ class GuestContainer(tmt.Guest):
 
         if self.container:
             self.podman(Command('container', 'rm', '-f', self.container))
-            self.info('container', 'removed', 'green')
+            self.info('container', 'removed', color='green')
 
         if self.network:
             # Will remove the network if there are no more containers attached to it.
@@ -678,7 +678,7 @@ class GuestContainer(tmt.Guest):
                     Command('network', 'rm', self.network),
                     message=f"Remove network '{self.network}'.",
                 )
-                self.info('container', 'network removed', 'green')
+                self.info('container', 'network removed', color='green')
             except tmt.utils.RunError as err:
                 if err.stderr and 'network is being used' in err.stderr:
                     # error string:

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -932,7 +932,7 @@ class GuestTestcloud(tmt.GuestSsh):
             if key_type is not None:
                 command += Command("-t", key_type)
             self._run_guest_command(command, silent=True)
-            self.verbose('key', self.key[0], 'green')
+            self.verbose('key', self.key[0], color='green')
             public_key = (self.guest_workdir / f'{key_name}.pub').read_text()
 
         return public_key
@@ -1146,9 +1146,9 @@ class GuestTestcloud(tmt.GuestSsh):
         # error later. Validate the image after download and retry if needed.
         def prepare_image() -> None:
             self._image = testcloud.image.Image(self.image_url)
-            self.verbose('qcow', self._image.name, 'green')
+            self.verbose('qcow', self._image.name, color='green')
             if not Path(self._image.local_path).exists():
-                self.info('progress', 'downloading...', 'cyan')
+                self.info('progress', 'downloading...', color='cyan')
             try:
                 self._image.prepare()
             except FileNotFoundError as error:
@@ -1224,12 +1224,12 @@ class GuestTestcloud(tmt.GuestSsh):
         self.info(
             'memory',
             f'{int(tmt.hardware.UNITS(f"{self._domain.memory_size} kB").to("MB").magnitude)} MB',
-            'green',
+            color='green',
         )
         self.info(
             'disk',
             f'{tmt.hardware.UNITS(f"{self._domain.storage_devices[0].size} GB").to("GB")}',
-            'green',
+            color='green',
         )
 
         for i, device in enumerate(self._domain.storage_devices):
@@ -1274,7 +1274,7 @@ class GuestTestcloud(tmt.GuestSsh):
             workarounds=self._workarounds,
         )
 
-        self.verbose('name', self.instance_name, 'green')
+        self.verbose('name', self.instance_name, color='green')
 
         # Decide if we want to multiply timeouts when emulating an architecture
         time_coeff = NON_KVM_TIMEOUT_COEF if not self.is_kvm else 1
@@ -1295,7 +1295,7 @@ class GuestTestcloud(tmt.GuestSsh):
             )
 
         # Boot the virtual machine
-        self.info('progress', 'booting...', 'cyan')
+        self.info('progress', 'booting...', color='cyan')
         self.verbose("console log", self.logdir / CONSOLE_LOG_FILE, level=2, color="cyan")
         assert libvirt is not None
 
@@ -1307,9 +1307,9 @@ class GuestTestcloud(tmt.GuestSsh):
             raise ProvisionError("Failed to boot testcloud instance.") from error
         self.primary_address = self.topology_address = self._instance.get_ip()
         self.port = int(self._instance.get_instance_port())
-        self.verbose('primary address', self.primary_address, 'green')
-        self.verbose('topology address', self.topology_address, 'green')
-        self.verbose('port', self.port, 'green')
+        self.verbose('primary address', self.primary_address, color='green')
+        self.verbose('topology address', self.topology_address, color='green')
+        self.verbose('port', self.port, color='green')
         self._instance.create_ip_file(self.primary_address)
 
         # Wait a bit until the box is up
@@ -1332,7 +1332,7 @@ class GuestTestcloud(tmt.GuestSsh):
             except testcloud.exceptions.TestcloudInstanceError as error:
                 raise tmt.utils.ProvisionError("Failed to stop testcloud instance.") from error
 
-            self.info('guest', 'stopped', 'green')
+            self.info('guest', 'stopped', color='green')
 
     def remove(self) -> None:
         """
@@ -1346,7 +1346,7 @@ class GuestTestcloud(tmt.GuestSsh):
             except FileNotFoundError as error:
                 raise tmt.utils.ProvisionError("Failed to remove testcloud instance.") from error
 
-            self.info('guest', 'removed', 'green')
+            self.info('guest', 'removed', color='green')
 
     def reboot(
         self,

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -80,7 +80,7 @@ class Report(tmt.steps.Step):
         """
 
         summary = tmt.result.Result.summary(self.plan.execute.results())
-        self.info('summary', summary, 'green', shift=1)
+        self.info('summary', summary, color='green', shift=1)
 
     def go(self, force: bool = False) -> None:
         """
@@ -91,7 +91,7 @@ class Report(tmt.steps.Step):
 
         # Nothing more to do if already done
         if self.status() == 'done':
-            self.info('status', 'done', 'green', shift=1)
+            self.info('status', 'done', color='green', shift=1)
             self.summary()
             self.actions()
             return

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -425,7 +425,7 @@ def make_junit_xml(
         try:
             tree_root = etree.fromstring(xml_data, xml_parser)
         except etree.XMLSyntaxError as error:
-            phase.verbose('rendered XML', xml_data, 'red')
+            phase.verbose('rendered XML', xml_data, color='red')
             raise tmt.utils.ReportError(
                 'The generated XML output is not a valid XML file. Use `--verbose` argument '
                 'to show the output.'
@@ -589,6 +589,6 @@ class ReportJUnit(tmt.steps.report.ReportPlugin[ReportJUnitData]):
         )
         try:
             f_path.write_text(xml_data)
-            self.info('output', f_path, 'yellow')
+            self.info('output', f_path, color='yellow')
         except Exception as error:
             raise tmt.utils.ReportError(f"Failed to write the output '{f_path}'.") from error

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -475,4 +475,4 @@ class ReportPolarion(tmt.steps.report.ReportPlugin[ReportPolarionData]):
                 'curl -k -u <USER>:<PASSWORD> -X POST -F file=@<XUNIT_XML_FILE_PATH> '
                 '<POLARION_URL>/polarion/import/xunit'
             )
-        self.info('xUnit file saved at', f_path, 'yellow')
+        self.info('xUnit file saved at', f_path, color='yellow')

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -906,10 +906,10 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
             if not create_launch:
                 launch_name = yaml_to_dict(response.text).get("name") or ""
                 self.verbose("launch", launch_name, color="green")
-                self.verbose("id", launch_id, "yellow", shift=1)
+                self.verbose("id", launch_id, color="yellow", shift=1)
 
             assert launch_uuid is not None
-            self.verbose("uuid", launch_uuid, "yellow", shift=1)
+            self.verbose("uuid", launch_uuid, color="yellow", shift=1)
             self.data.launch_uuid = launch_uuid
 
             launch_url = f"{self.data.url}/ui/#{self.data.project}/launches/all/{launch_id}"
@@ -935,10 +935,10 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
 
             elif suite_name:
                 self.info("suite", suite_name, color="green")
-                self.verbose("id", suite_id, "yellow", shift=1)
+                self.verbose("id", suite_id, color="yellow", shift=1)
 
             if suite_uuid:
-                self.verbose("uuid", suite_uuid, "yellow", shift=1)
+                self.verbose("uuid", suite_uuid, color="yellow", shift=1)
                 self.data.suite_uuid = suite_uuid
 
             # The first test starts with the launch (at the worst case)
@@ -1015,7 +1015,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
 
                     item_uuid = yaml_to_dict(response.text).get("id")
                     assert item_uuid is not None
-                    self.verbose("uuid", item_uuid, "yellow", shift=1)
+                    self.verbose("uuid", item_uuid, color="yellow", shift=1)
                     self.data.test_uuids.setdefault(serial_number, {})[guest_name] = item_uuid
                 else:
                     item_uuid = self.data.test_uuids[serial_number][guest_name]
@@ -1090,7 +1090,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
                                 },
                             )
 
-                            self.verbose("uuid", child_item_uuid, "yellow", shift=2)
+                            self.verbose("uuid", child_item_uuid, color="yellow", shift=2)
 
                 # Finish the parent test item
                 response = self.rp_api_put(
@@ -1131,7 +1131,7 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
                 launch_url = str(yaml_to_dict(response.text).get("link"))
 
             assert launch_url is not None
-            self.info("url", launch_url, "magenta")
+            self.info("url", launch_url, color="magenta")
             self.data.launch_url = launch_url
 
     def go(self, *, logger: Optional[tmt.log.Logger] = None) -> None:

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -492,7 +492,7 @@ class StreamLogger(Thread):
         for _line in self.stream:
             line = _line.decode('utf-8', errors='replace')
             if self.stream_output and line != '':
-                self.logger(self.log_header, line.rstrip('\n'), 'yellow', level=3)
+                self.logger(self.log_header, line.rstrip('\n'), color='yellow', level=3)
             self.output.append(line)
 
     def get_output(self) -> Optional[str]:
@@ -1679,6 +1679,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
     def print(
         self,
         text: str,
+        *,
         color: 'tmt.utils.themes.Style' = None,
     ) -> None:
         """
@@ -1698,6 +1699,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         self,
         key: str,
         value: Optional[LoggableValue] = None,
+        *,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         topic: Optional[tmt.log.Topic] = None,
@@ -1720,6 +1722,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         self,
         key: str,
         value: Optional[LoggableValue] = None,
+        *,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         level: 'VerbosityLevel' = 1,
@@ -1746,6 +1749,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         self,
         key: str,
         value: Optional[LoggableValue] = None,
+        *,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 0,
         level: 'DebugLevel' = 1,
@@ -1768,14 +1772,14 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             stacklevel=stacklevel + 1,
         )
 
-    def warn(self, message: str, shift: int = 0, stacklevel: int = 1) -> None:
+    def warn(self, message: str, *, shift: int = 0, stacklevel: int = 1) -> None:
         """
         Show a yellow warning message on info level, send to stderr
         """
 
         self._logger.warning(message, shift=shift, stacklevel=stacklevel + 1)
 
-    def fail(self, message: str, shift: int = 0, stacklevel: int = 1) -> None:
+    def fail(self, message: str, *, shift: int = 0, stacklevel: int = 1) -> None:
         """
         Show a red failure message on info level, send to stderr
         """
@@ -1786,6 +1790,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         self,
         key: str,
         value: Optional[str] = None,
+        *,
         color: 'tmt.utils.themes.Style' = None,
         shift: int = 1,
         level: VerbosityLevel = 3,


### PR DESCRIPTION
It is very easy to log a message plus color name because when value is omitted, color name becomes the `value` argument. Prevent any doubt by making color & everything but the message - or key & value - keyword-only arguments.

Pull Request Checklist

* [x] implement the feature