### PR TITLE
Handle top-level file changes more properly in `modified-ref`

### DIFF
--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -765,13 +765,14 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 cwd=self.test_dir,
             )
             if output.stdout:
-                directories = [Path(name).parent for name in output.stdout.split('\n')]
-                modified = {
-                    # ($|/): match end of test name or `/` which would be any sub-test
-                    f"^/{re.escape(str(directory))}($|/)"
-                    for directory in directories
-                    if directory
-                }
+                directories = [Path(name).parent for name in output.stdout.splitlines()]
+                modified = set()
+                for directory in directories:
+                    # Special case for the top-level, otherwise will look for literal `/\.`
+                    if directory == Path("."):
+                        modified.add("^/")
+                    else:
+                        modified.add(f"^/{re.escape(str(directory))}($|/)")
                 if not modified:
                     # Nothing was modified, do not select anything
                     return []


### PR DESCRIPTION
Previously it was trying to run the test `/\.` because the path parent was expanded as `Path('.')`.

Fixes #4610

---

Pull Request Checklist

* [x] implement the feature
* [ ] extend the test coverage
* [ ] include a release note
