### PR TITLE
Normalize relative paths in artifact provides to user tree

### DIFF
--- a/tests/unit/artifact/conftest.py
+++ b/tests/unit/artifact/conftest.py
@@ -60,10 +60,15 @@ def mock_copr_build_session():
 
 @pytest.fixture
 def artifact_provider(root_logger, _load_plugins):
+    mock_prepare_artifact = MagicMock()
+
     def get_provider(provider_id: str, repository_priority: int = 50):
         provider_class = get_artifact_provider(provider_id)
         return provider_class(
-            provider_id, repository_priority=repository_priority, logger=root_logger
+            provider_id,
+            repository_priority=repository_priority,
+            logger=root_logger,
+            parent=mock_prepare_artifact,
         )
 
     return get_provider

--- a/tests/unit/artifact/test_base.py
+++ b/tests/unit/artifact/test_base.py
@@ -37,7 +37,13 @@ class MockProvider(ArtifactProvider):
 
 @pytest.fixture
 def mock_provider(root_logger):
-    return MockProvider("mock:123", repository_priority=50, logger=root_logger)
+    mock_prepare_artifact = MagicMock()
+    return MockProvider(
+        "mock:123",
+        repository_priority=50,
+        logger=root_logger,
+        parent=mock_prepare_artifact,
+    )
 
 
 def test_filter_artifacts(mock_provider):
@@ -93,8 +99,19 @@ def test_persist_artifact_metadata(tmp_path, mock_provider):
 
 def test_duplicate_nvra_detection(tmp_path, root_logger):
     # Two providers with the same NVRA
-    provider1 = MockProvider("mock:provider1", repository_priority=50, logger=root_logger)
-    provider2 = MockProvider("mock:provider2", repository_priority=50, logger=root_logger)
+    mock_prepare_artifact = MagicMock()
+    provider1 = MockProvider(
+        "mock:provider1",
+        repository_priority=50,
+        logger=root_logger,
+        parent=mock_prepare_artifact,
+    )
+    provider2 = MockProvider(
+        "mock:provider2",
+        repository_priority=50,
+        logger=root_logger,
+        parent=mock_prepare_artifact,
+    )
 
     prepare = MagicMock()
     prepare.plan_workdir = tmp_path

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -246,6 +246,7 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
                     raw_id,
                     repository_priority=self.data.default_repository_priority,
                     logger=provider_logger,
+                    parent=self,
                 )
 
                 self._detect_duplicate_nvras(provider, seen_nvras)

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator, Sequence
 from functools import cached_property
 from re import Pattern
 from shlex import quote
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import tmt.log
 import tmt.utils
@@ -19,6 +19,9 @@ from tmt.guest import DownloadError, Guest
 from tmt.package_managers import Repository, Version
 from tmt.plugins import PluginRegistry
 from tmt.utils import Path, ShellScript
+
+if TYPE_CHECKING:
+    from tmt.steps.prepare.artifact import PrepareArtifact
 
 NEVRA_PATTERN = re.compile(
     r'^(?P<name>.+)-(?:(?P<epoch>\d+):)?(?P<version>.+)-(?P<release>.+)\.(?P<arch>.+)$'
@@ -108,6 +111,9 @@ class ArtifactProvider(ABC):
     #: All artifacts known to this provider. Populated by
     #: :py:meth:`_download_artifact` and/or :py:meth:`enumerate_artifacts`.
     _artifacts: list[ArtifactInfo] = simple_field(init=False, default_factory=list)
+
+    #: The PrepareArtifact phase that owns this provider.
+    parent: "PrepareArtifact"
 
     def __post_init__(self) -> None:
         self.id = self._extract_provider_id(self.raw_id)

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -7,7 +7,7 @@ from typing import ClassVar, Optional
 
 import tmt.utils
 from tmt.container import container, simple_field
-from tmt.guest import Guest
+from tmt.guest import Guest, TransferOptions
 from tmt.package_managers._rpm import RpmVersion
 from tmt.steps.prepare.artifact.providers import (
     ArtifactInfo,
@@ -115,6 +115,13 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
                 guest.push(
                     self.parent.step.plan.user_tree / artifact.location,
                     destination,
+                    # Override the flags from DEFAULT_PUSH_OPTIONS, we mainly care about
+                    # - recursive=False: is individual file
+                    # - links=False: we really need the file
+                    # - compress=True: try to make it fast
+                    options=TransferOptions(
+                        compress=True,
+                    ),
                 )
             self.logger.info(f"Successfully downloaded: '{artifact.id}'.")
         except Exception as error:

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -111,9 +111,9 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
             if self._is_url:  # Remote file, download it
                 guest.download(artifact.location, destination)
             else:  # Local file, push it to the guest
-                # Relative paths are normalized to be relative to user_tree
+                # Relative paths are normalized to be relative to user_anchor_path
                 guest.push(
-                    self.parent.step.plan.user_tree / artifact.location,
+                    self.parent.step.plan.user_anchor_path / artifact.location,
                     destination,
                     # Override the flags from DEFAULT_PUSH_OPTIONS, we mainly care about
                     # - recursive=False: is individual file

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -7,7 +7,7 @@ from typing import ClassVar, Optional
 
 import tmt.utils
 from tmt.container import container, simple_field
-from tmt.guest import Guest, TransferOptions
+from tmt.guest import Guest
 from tmt.package_managers._rpm import RpmVersion
 from tmt.steps.prepare.artifact.providers import (
     ArtifactInfo,
@@ -111,13 +111,10 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
             if self._is_url:  # Remote file, download it
                 guest.download(artifact.location, destination)
             else:  # Local file, push it to the guest
-                # When pushing a single file, use recursive=False. The default recursive=True
-                # treats the source as a directory (appending "/."), which only works for
-                # directories and fails when pushing individual files.
+                # Relative paths are normalized to be relative to user_tree
                 guest.push(
-                    tmt.utils.Path(artifact.location),
+                    self.parent.step.plan.user_tree / artifact.location,
                     destination,
-                    options=TransferOptions(recursive=False),
                 )
             self.logger.info(f"Successfully downloaded: '{artifact.id}'.")
         except Exception as error:

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -160,6 +160,7 @@ class KojiArtifactProvider(ArtifactProvider):
             f"{prefix}:{self.build_id}",
             repository_priority=self.repository_priority,
             logger=self.logger,
+            parent=self.parent,
         )
 
     @cached_property

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -78,11 +78,9 @@ class RepositoryFileProvider(ArtifactProvider):
         parsed = urlparse(self.id)
         parsed_path = Path(parsed.path)
         if parsed.scheme == 'file':
-            # Read .repo file from the local (controller) filesystem.
-            self.logger.info(f"Reading repository file from local path: {parsed_path}")
-            self.logger.debug(f"Absolute path of the repository file: '{parsed_path.resolve()}'")
             # Normalize relative paths to be relative to user_tree
             parsed_path = self.parent.step.plan.user_tree / parsed_path
+            self.logger.info(f"Reading repository file from local path: {parsed_path}")
             self.repository = Repository.from_file_path(file_path=parsed_path, logger=self.logger)
         else:
             repo_filename = parsed_path.name

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -81,6 +81,8 @@ class RepositoryFileProvider(ArtifactProvider):
             # Read .repo file from the local (controller) filesystem.
             self.logger.info(f"Reading repository file from local path: {parsed_path}")
             self.logger.debug(f"Absolute path of the repository file: '{parsed_path.resolve()}'")
+            # Normalize relative paths to be relative to user_tree
+            parsed_path = self.parent.step.plan.user_tree / parsed_path
             self.repository = Repository.from_file_path(file_path=parsed_path, logger=self.logger)
         else:
             repo_filename = parsed_path.name

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -79,8 +79,8 @@ class RepositoryFileProvider(ArtifactProvider):
         # If the file is a relative path, we need the netloc part also
         parsed_path = Path(f"{parsed.netloc}{parsed.path}")
         if parsed.scheme == 'file':
-            # Normalize relative paths to be relative to user_tree
-            parsed_path = self.parent.step.plan.user_tree / parsed_path
+            # Normalize relative paths to be relative to user_anchor_path
+            parsed_path = self.parent.step.plan.user_anchor_path / parsed_path
             self.logger.info(f"Reading repository file from local path: {parsed_path}")
             self.repository = Repository.from_file_path(file_path=parsed_path, logger=self.logger)
         else:

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -76,7 +76,8 @@ class RepositoryFileProvider(ArtifactProvider):
         self.logger.info(f"Initializing repository provider with URL: {self.id}")
 
         parsed = urlparse(self.id)
-        parsed_path = Path(parsed.path)
+        # If the file is a relative path, we need the netloc part also
+        parsed_path = Path(f"{parsed.netloc}{parsed.path}")
         if parsed.scheme == 'file':
             # Normalize relative paths to be relative to user_tree
             parsed_path = self.parent.step.plan.user_tree / parsed_path


### PR DESCRIPTION
This is needed because `guest.push` on `container` is run in the guest's provision workdir. So the user paths used there would not resolve to anything meaningful.

Testing will be covered by #4930