### PR TITLE
Create the `Logging and Output` guidelines

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -743,6 +743,49 @@ internals* when choosing the right level:
     normalization
 
 
+Debug Topics
+------------------------------------------------------------------
+
+In addition to levels, debug messages can be tagged with a
+**topic** to group related diagnostics across the codebase. Users
+can selectively enable topics with the ``--log-topic`` option
+without raising the overall debug level:
+
+.. code-block:: shell
+
+    tmt run --log-topic=key-normalization
+    tmt run --log-topic=adjust-decisions --log-topic=command-events
+
+Messages tagged with a topic are hidden by default and only shown
+when the topic is explicitly enabled. The following topics are
+available:
+
+``key-normalization``
+    Metadata key normalization.
+
+``cli-invocations``
+    CLI command invocations and option processing.
+
+``command-events``
+    Command execution events (start, finish, errors).
+
+``adjust-decisions``
+    Decisions made during the context ``adjust`` rule evaluation.
+
+``help-rendering``
+    reStructuredText parsing and rendering for help output.
+
+``policy``
+    Policy rule evaluation and application.
+
+When adding new debug messages that belong to a specific
+subsystem, use the ``topic`` parameter:
+
+.. code-block:: python
+
+    self.debug('key', value, level=3, topic=tmt.log.Topic.KEY_NORMALIZATION)
+
+
 .. _issues:
 
 Issues

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -637,6 +637,96 @@ export
 __ https://github.com/teemtee/tmt/issues/4443
 
 
+.. _logging:
+
+Logging and Output
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+tmt distinguishes between two types of terminal communication:
+**logging** and **output**. Understanding the difference is
+essential for consistent and user-friendly behavior.
+
+
+Output Types
+------------------------------------------------------------------
+
+**Logging** goes to ``stderr`` and is handled by methods such as
+``info()``, ``debug()``, ``warning()`` and ``fail()``. Logging
+communicates progress, diagnostics and status information during
+command execution. It is the primary form of communication for
+commands that do not produce structured data, such as:
+
+* ``tmt run``
+* ``tmt try``
+* ``tmt lint``
+* ``tmt clean``
+
+**Output** goes to ``stdout`` and is produced by the ``print()``
+method. Output represents the actual data result of a command —
+a list of names, exported metadata, or formatted details meant
+for further processing or inspection:
+
+* ``tmt test ls``
+* ``tmt plan show``
+* ``tmt story export``
+* ``tmt run provision --how minute --list-images``
+
+
+Logging Methods
+------------------------------------------------------------------
+
+All logging methods send their output to ``stderr``:
+
+info()
+    Communicate progress and status to the user. Supports
+    verbosity levels via the ``level`` parameter (see below).
+
+debug()
+    Provide diagnostics for tmt developers. Supports debug
+    levels via the ``level`` parameter (see below).
+
+warning()
+    Signal a potential problem that does not prevent execution
+    but deserves user attention, such as a deprecated feature
+    or a missing optional dependency.
+
+fail()
+    Report an error that caused a test, step or operation to
+    fail.
+
+
+Verbosity Levels
+------------------------------------------------------------------
+
+Verbosity levels control user-facing logging and are incremented
+with ``-v`` on the command line. Focus on **user scenarios** when
+choosing the right level:
+
+* ``info()`` / level 0 — key output: plan names, step names,
+  phase summary, overall summaries
+* ``info(level=1)`` — specific info: individual test names in
+  ``discover`` and ``execute``
+* ``info(level=2)`` — extra context: test log paths in ``report``,
+  console log path, guest facts
+* ``info(level=3)`` — full details: complete output of prepare
+  commands and test execution
+
+
+Debug Levels
+------------------------------------------------------------------
+
+Debug levels control developer-facing diagnostics and are
+incremented with ``-d`` on the command line. Focus on **tmt
+internals** when choosing the right level:
+
+* ``debug(level=1)`` — high-level info: framework choice, policy
+  application, reboot
+* ``debug(level=2)`` — detailed operations: step load, wake up,
+  guest pull/push, playbook path
+* ``debug(level=3)`` — internal plumbing: workdir handling,
+  process termination, key normalization
+
+
 .. _issues:
 
 Issues

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -736,6 +736,20 @@ choosing the right level:
     full details: complete output of prepare commands and test
     execution
 
+When deciding where to place a new message, ask from the user's
+perspective:
+
+* Would a user running plain ``tmt run`` need this information to
+  understand what is happening? ... ``info()`` (level 0)
+* Is the message useful when the user wants details about
+  individual items such as tests, guests, packages and plugins?
+  ...  ``info(level=1)``
+* Does it help investigating results after the run, for example
+  log paths or guest facts?  ... ``info(level=2)``
+* Is it providing the full command or test output? ...
+  ``info(level=3)``
+* Would only a tmt developer care? ... ``debug()``
+
 
 Debug Levels
 ------------------------------------------------------------------

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -667,7 +667,6 @@ a list of names, exported metadata, or formatted details meant
 for further processing or inspection:
 
 * ``tmt test ls``
-* ``tmt plan show``
 * ``tmt story export``
 * ``tmt run provision --how minute --list-images``
 

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -655,18 +655,13 @@ commands it is also stored in the ``log.txt`` file under the
 :term:`run workdir`. It is handled by methods such as ``info()``,
 ``debug()``, ``warning()`` and ``fail()``. Logging communicates
 progress, diagnostics and status information during command
-execution. It is the primary form of communication for commands
-that do not produce structured data, such as:
-
-* ``tmt run``
-* ``tmt try``
-* ``tmt lint``
-* ``tmt clean``
+execution. This is the main mode of communication you should use
+throughout the code.
 
 **Output** goes to ``stdout`` and is produced by the ``print()``
-method. Output represents the actual data result of a command —
-a list of names, exported metadata, or formatted details meant
-for further processing or inspection:
+method. Output represents the actual data result of a command,
+such as a list of names, exported metadata, or formatted details
+meant for further processing or inspection:
 
 * ``tmt test ls``
 * ``tmt story export``
@@ -761,7 +756,7 @@ internals* when choosing the right level:
     normalization
 
 
-Debug Topics
+Log Topics
 ------------------------------------------------------------------
 
 In addition to levels, debug messages can be tagged with a
@@ -775,33 +770,16 @@ without raising the overall debug level:
     tmt run --log-topic=adjust-decisions --log-topic=command-events
 
 Messages tagged with a topic are hidden by default and only shown
-when the topic is explicitly enabled. The following topics are
-available:
-
-``key-normalization``
-    Metadata key normalization.
-
-``cli-invocations``
-    CLI command invocations and option processing.
-
-``command-events``
-    Command execution events (start, finish, errors).
-
-``adjust-decisions``
-    Decisions made during the context ``adjust`` rule evaluation.
-
-``help-rendering``
-    reStructuredText parsing and rendering for help output.
-
-``policy``
-    Policy rule evaluation and application.
-
-When adding new debug messages that belong to a specific
-subsystem, use the ``topic`` parameter:
+when the topic is explicitly enabled. When adding new debug
+messages that belong to a specific subsystem, use the ``topic``
+parameter:
 
 .. code-block:: python
 
     self.debug('key', value, level=3, topic=tmt.log.Topic.KEY_NORMALIZATION)
+
+See the :py:class:`tmt.log.Topic` class for the list of available
+topics.
 
 
 .. _issues:

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -701,6 +701,22 @@ All logging methods send their output to ``stderr``:
     Report an error that caused a test, step or operation to
     fail.
 
+The ``info()``, ``verbose()`` and ``debug()`` methods accept a
+``key`` and an optional ``value`` parameter. The ``key`` is a
+short label (e.g. step name, action) and ``value`` provides the
+detail, optional ``color`` parameter can be used for choosing the
+desired color:
+
+.. code-block:: python
+
+    self.info(key='status', value='done', color='green')
+    self.info('status', 'done', 'green')
+
+They are formatted as ``key: value`` in the output.  The
+``warning()`` and ``fail()`` methods take a single ``message``
+parameter and automatically set the ``key`` to ``warn`` or
+``fail``.
+
 
 Verbosity Levels
 ------------------------------------------------------------------

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -650,11 +650,13 @@ essential for consistent and user-friendly behavior.
 Output Types
 ------------------------------------------------------------------
 
-**Logging** goes to ``stderr`` and is handled by methods such as
-``info()``, ``debug()``, ``warning()`` and ``fail()``. Logging
-communicates progress, diagnostics and status information during
-command execution. It is the primary form of communication for
-commands that do not produce structured data, such as:
+**Logging** goes to ``stderr``, for ``tmt run`` and ``tmt try``
+commands it is also stored in the ``log.txt`` file under the
+:term:`run workdir`. It is handled by methods such as ``info()``,
+``debug()``, ``warning()`` and ``fail()``. Logging communicates
+progress, diagnostics and status information during command
+execution. It is the primary form of communication for commands
+that do not produce structured data, such as:
 
 * ``tmt run``
 * ``tmt try``

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -720,35 +720,25 @@ Verbosity levels control user-facing logging and are incremented
 with ``-v`` on the command line. Focus on *user scenarios* when
 choosing the right level:
 
-``info(level=0)`` == ``info()``
-    key output: plan names, step names, phase summary, overall
+level 0: progress and summaries
+    use ``info(level=0)`` or short ``info()`` for the current
+    state of steps and phases, their names, ``how`` methods and
     summaries
 
-``info(level=1)``
-    specific info: individual test names in ``discover`` and
-    ``execute``
+level 1: phase inputs and outputs
+    ``info(level=1)`` is dedicated for the essential phase input
+    and output such as discovered test names, required packages or
+    individual test results
 
-``info(level=2)``
-    extra context: test log paths in ``report``, console log path,
-    guest facts
+level 2: investigation details
+    details needed when investigating what went wrong such as log
+    paths, remote links, external sources, guest facts, duration
+    deadlines or executed commands should go to ``info(level=2)``
 
-``info(level=3)``
-    full details: complete output of prepare commands and test
-    execution
-
-When deciding where to place a new message, ask from the user's
-perspective:
-
-* Would a user running plain ``tmt run`` need this information to
-  understand what is happening? ... ``info()`` (level 0)
-* Is the message useful when the user wants details about
-  individual items such as tests, guests, packages and plugins?
-  ...  ``info(level=1)``
-* Does it help investigating results after the run, for example
-  log paths or guest facts?  ... ``info(level=2)``
-* Is it providing the full command or test output? ...
-  ``info(level=3)``
-* Would only a tmt developer care? ... ``debug()``
+level 3: full output
+    use ``info(level=3)`` for command outputs, full test output,
+    rendered script, other constructed input, queued/executed
+    tasks
 
 
 Debug Levels
@@ -758,16 +748,18 @@ Debug levels control developer-facing diagnostics and are
 incremented with ``-d`` on the command line. Focus on *tmt
 internals* when choosing the right level:
 
-``debug(level=1)``
-    high-level info: framework choice, policy application, reboot
+level 1: high-level info
+    use ``debug(level=1)`` for the high-level stuff like framework
+    choice, policy application or reboot actions
 
-``debug(level=2)``
-    detailed operations: step load, wake up, guest pull/push,
-    playbook path
+level 2: detailed operations
+    detailed operations such as step load, wake up, guest
+    pull/push or playbook paths should go to ``debug(level=2)``
 
-``debug(level=3)``
-    internal plumbing: workdir handling, process termination, key
-    normalization
+level 3: internal plumbing
+    use ``debug(level=3)`` for the low-level implementation
+    details such as workdir handling, process termination, key
+    normalization and similar
 
 
 Log Topics

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -676,7 +676,7 @@ Logging Methods
 
 All logging methods send their output to ``stderr``:
 
-info()
+``info()``
     Communicate progress and status to the user. Supports
     verbosity levels via the ``level`` parameter (see below).
 
@@ -686,16 +686,16 @@ info()
         target state. Currently, use the ``verbose()`` method for
         logging with specific verbosity levels.
 
-debug()
+``debug()``
     Provide diagnostics for tmt developers. Supports debug
     levels via the ``level`` parameter (see below).
 
-warning()
+``warning()``
     Signal a potential problem that does not prevent execution
     but deserves user attention, such as a deprecated feature
     or a missing optional dependency.
 
-fail()
+``fail()``
     Report an error that caused a test, step or operation to
     fail.
 
@@ -704,32 +704,43 @@ Verbosity Levels
 ------------------------------------------------------------------
 
 Verbosity levels control user-facing logging and are incremented
-with ``-v`` on the command line. Focus on _user scenarios_ when
+with ``-v`` on the command line. Focus on *user scenarios* when
 choosing the right level:
 
-* ``info()`` / level 0 — key output: plan names, step names,
-  phase summary, overall summaries
-* ``info(level=1)`` — specific info: individual test names in
-  ``discover`` and ``execute``
-* ``info(level=2)`` — extra context: test log paths in ``report``,
-  console log path, guest facts
-* ``info(level=3)`` — full details: complete output of prepare
-  commands and test execution
+``info(level=0)`` == ``info()``
+    key output: plan names, step names, phase summary, overall
+    summaries
+
+``info(level=1)``
+    specific info: individual test names in ``discover`` and
+    ``execute``
+
+``info(level=2)``
+    extra context: test log paths in ``report``, console log path,
+    guest facts
+
+``info(level=3)``
+    full details: complete output of prepare commands and test
+    execution
 
 
 Debug Levels
 ------------------------------------------------------------------
 
 Debug levels control developer-facing diagnostics and are
-incremented with ``-d`` on the command line. Focus on **tmt
-internals** when choosing the right level:
+incremented with ``-d`` on the command line. Focus on *tmt
+internals* when choosing the right level:
 
-* ``debug(level=1)`` — high-level info: framework choice, policy
-  application, reboot
-* ``debug(level=2)`` — detailed operations: step load, wake up,
-  guest pull/push, playbook path
-* ``debug(level=3)`` — internal plumbing: workdir handling,
-  process termination, key normalization
+``debug(level=1)``
+    high-level info: framework choice, policy application, reboot
+
+``debug(level=2)``
+    detailed operations: step load, wake up, guest pull/push,
+    playbook path
+
+``debug(level=3)``
+    internal plumbing: workdir handling, process termination, key
+    normalization
 
 
 .. _issues:

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -681,6 +681,12 @@ info()
     Communicate progress and status to the user. Supports
     verbosity levels via the ``level`` parameter (see below).
 
+    .. note::
+
+        Using the ``level`` parameter with ``info()`` is a planned
+        target state. Currently, use the ``verbose()`` method for
+        logging with specific verbosity levels.
+
 debug()
     Provide diagnostics for tmt developers. Supports debug
     levels via the ``level`` parameter (see below).
@@ -699,7 +705,7 @@ Verbosity Levels
 ------------------------------------------------------------------
 
 Verbosity levels control user-facing logging and are incremented
-with ``-v`` on the command line. Focus on **user scenarios** when
+with ``-v`` on the command line. Focus on _user scenarios_ when
 choosing the right level:
 
 * ``info()`` / level 0 — key output: plan names, step names,

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -721,24 +721,21 @@ with ``-v`` on the command line. Focus on *user scenarios* when
 choosing the right level:
 
 level 0: progress and summaries
-    use ``info(level=0)`` or short ``info()`` for the current
-    state of steps and phases, their names, ``how`` methods and
-    summaries
+    the current state of steps and phases, their names, ``how``
+    methods and summaries
 
 level 1: phase inputs and outputs
-    ``info(level=1)`` is dedicated for the essential phase input
-    and output such as discovered test names, required packages or
-    individual test results
+    the essential phase input and output such as discovered test
+    names, required packages or individual test results
 
 level 2: investigation details
     details needed when investigating what went wrong such as log
     paths, remote links, external sources, guest facts, duration
-    deadlines or executed commands should go to ``info(level=2)``
+    deadlines or executed commands
 
 level 3: full output
-    use ``info(level=3)`` for command outputs, full test output,
-    rendered script, other constructed input, queued/executed
-    tasks
+    command outputs, full test output, rendered script, other
+    constructed input, queued/executed tasks
 
 
 Debug Levels
@@ -749,17 +746,16 @@ incremented with ``-d`` on the command line. Focus on *tmt
 internals* when choosing the right level:
 
 level 1: high-level info
-    use ``debug(level=1)`` for the high-level stuff like framework
-    choice, policy application or reboot actions
+    the high-level stuff like framework choice, policy application
+    or reboot actions
 
 level 2: detailed operations
-    detailed operations such as step load, wake up, guest
-    pull/push or playbook paths should go to ``debug(level=2)``
+    more detailed actions such as step load, wake up, guest
+    pull/push or playbook paths
 
 level 3: internal plumbing
-    use ``debug(level=3)`` for the low-level implementation
-    details such as workdir handling, process termination, key
-    normalization and similar
+    the low-level implementation details such as workdir handling,
+    process termination, key normalization and similar
 
 
 Log Topics

--- a/docs/releases/pending/4814.fmf
+++ b/docs/releases/pending/4814.fmf
@@ -1,0 +1,4 @@
+description: |
+    The :ref:`contribute` guide now includes a :ref:`logging`
+    section with guidelines for verbosity levels, debug levels and
+    debug topics.

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -65,11 +65,22 @@ DEFAULT_DEBUG_LEVEL = 0
 
 
 class Topic(enum.Enum):
+    #: Metadata key normalization.
     KEY_NORMALIZATION = 'key-normalization'
+
+    #: CLI command invocations and option processing.
     CLI_INVOCATIONS = 'cli-invocations'
+
+    #: Command execution events (start, finish, errors).
     COMMAND_EVENTS = 'command-events'
+
+    #: Decisions made during the context ``adjust`` rule evaluation.
     ADJUST_DECISIONS = 'adjust-decisions'
+
+    #: reStructuredText parsing and rendering for help output.
     HELP_RENDERING = 'help-rendering'
+
+    #: Policy rule evaluation and application.
     POLICY = 'policy'
 
 


### PR DESCRIPTION
Add a new section defining the individual output types and individual verbosity levels. Describes the target state to which we want to get.

Fix #4814.

Pull Request Checklist

* [x] write the documentation
* [x] include a release note