### PR TITLE
Rename enable_repo/disable_repo package manager methods

### DIFF
--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -563,7 +563,7 @@ def test_assert_config_manager(
             package_manager.assert_config_manager()
 
 
-def _parametrize_test_enable_disable_repo() -> Iterator[
+def _parametrize_test_enable_disable_repository() -> Iterator[
     tuple[Container, PackageManagerClass, str, Union[str, Exception]]
 ]:
     for container, package_manager_class in CONTAINER_BASE_MATRIX:
@@ -614,10 +614,10 @@ def _parametrize_test_enable_disable_repo() -> Iterator[
 @pytest.mark.containers
 @pytest.mark.parametrize(
     ('container_per_test', 'package_manager_class', 'action', 'expected_command_or_exception'),
-    list(_parametrize_test_enable_disable_repo()),
+    list(_parametrize_test_enable_disable_repository()),
     indirect=["container_per_test"],
 )
-def test_enable_disable_repo(
+def test_enable_disable_repository(
     container_per_test: ContainerData,
     guest_per_test: GuestContainer,
     package_manager_class: PackageManagerClass,
@@ -630,7 +630,11 @@ def test_enable_disable_repo(
         container_per_test, guest_per_test, package_manager_class, root_logger
     )
 
-    method = package_manager.enable_repo if action == 'enable' else package_manager.disable_repo
+    method = (
+        package_manager.enable_repository
+        if action == 'enable'
+        else package_manager.disable_repository
+    )
 
     if isinstance(expected_command_or_exception, str):
         # The command will fail because 'test-repo' does not exist in the

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -728,7 +728,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         self.verbose('enable repo', fmf.utils.listed(repo_ids), 'green')
         self.guest.execute(self.engine.enable_repository(*repo_ids))
 
-    def disable_repo(self, *repo_ids: str) -> None:
+    def disable_repository(self, *repo_ids: str) -> None:
         """
         Disable specified repositories.
 

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -714,7 +714,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         """
         raise PrepareError(f"Package manager '{self.NAME}' does not support config-manager.")
 
-    def enable_repo(self, *repo_ids: str) -> None:
+    def enable_repository(self, *repo_ids: str) -> None:
         """
         Enable specified repositories.
 

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -393,7 +393,7 @@ class PackageManagerEngine(tmt.utils.Common):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def enable_repo(self, *repo_ids: str) -> ShellScript:
+    def enable_repository(self, *repo_ids: str) -> ShellScript:
         """
         Enable specified repositories.
 
@@ -403,7 +403,7 @@ class PackageManagerEngine(tmt.utils.Common):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def disable_repo(self, *repo_ids: str) -> ShellScript:
+    def disable_repository(self, *repo_ids: str) -> ShellScript:
         """
         Disable specified repositories.
 
@@ -726,7 +726,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         self.assert_config_manager()
 
         self.verbose('enable repo', fmf.utils.listed(repo_ids), 'green')
-        self.guest.execute(self.engine.enable_repo(*repo_ids))
+        self.guest.execute(self.engine.enable_repository(*repo_ids))
 
     def disable_repo(self, *repo_ids: str) -> None:
         """
@@ -740,7 +740,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         self.assert_config_manager()
 
         self.verbose('disable repo', fmf.utils.listed(repo_ids), 'green')
-        self.guest.execute(self.engine.disable_repo(*repo_ids))
+        self.guest.execute(self.engine.disable_repository(*repo_ids))
 
     def enable_copr(self, *repositories: str) -> None:
         """

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -752,7 +752,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         """
         raise PrepareError(f"Package manager '{self.NAME}' does not support config-manager.")
 
-    def enable_repo(self, *repo_ids: str) -> None:
+    def enable_repository(self, *repo_ids: str) -> None:
         """
         Enable specified repositories.
 

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -766,7 +766,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         self.verbose('enable repo', fmf.utils.listed(repo_ids), 'green')
         self.guest.execute(self.engine.enable_repository(*repo_ids))
 
-    def disable_repo(self, *repo_ids: str) -> None:
+    def disable_repository(self, *repo_ids: str) -> None:
         """
         Disable specified repositories.
 

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -406,7 +406,7 @@ class PackageManagerEngine(tmt.utils.Common):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def enable_repo(self, *repo_ids: str) -> ShellScript:
+    def enable_repository(self, *repo_ids: str) -> ShellScript:
         """
         Enable specified repositories.
 
@@ -416,7 +416,7 @@ class PackageManagerEngine(tmt.utils.Common):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def disable_repo(self, *repo_ids: str) -> ShellScript:
+    def disable_repository(self, *repo_ids: str) -> ShellScript:
         """
         Disable specified repositories.
 
@@ -764,7 +764,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         self.assert_config_manager()
 
         self.verbose('enable repo', fmf.utils.listed(repo_ids), 'green')
-        self.guest.execute(self.engine.enable_repo(*repo_ids))
+        self.guest.execute(self.engine.enable_repository(*repo_ids))
 
     def disable_repo(self, *repo_ids: str) -> None:
         """
@@ -778,7 +778,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         self.assert_config_manager()
 
         self.verbose('disable repo', fmf.utils.listed(repo_ids), 'green')
-        self.guest.execute(self.engine.disable_repo(*repo_ids))
+        self.guest.execute(self.engine.disable_repository(*repo_ids))
 
     def enable_copr(self, *repositories: str) -> None:
         """

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -98,12 +98,12 @@ class ApkEngine(PackageManagerEngine):
     def refresh_metadata(self) -> ShellScript:
         return ShellScript(f'{self.command.to_script()} update')
 
-    def enable_repo(self, *repo_ids: str) -> ShellScript:
+    def enable_repository(self, *repo_ids: str) -> ShellScript:
         raise tmt.utils.PrepareError(
             "Package manager 'apk' does not support enabling repositories."
         )
 
-    def disable_repo(self, *repo_ids: str) -> ShellScript:
+    def disable_repository(self, *repo_ids: str) -> ShellScript:
         raise tmt.utils.PrepareError(
             "Package manager 'apk' does not support disabling repositories."
         )

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -153,12 +153,12 @@ class AptEngine(PackageManagerEngine):
             f'export DEBIAN_FRONTEND=noninteractive; {self.command.to_script()} update'
         )
 
-    def enable_repo(self, *repo_ids: str) -> ShellScript:
+    def enable_repository(self, *repo_ids: str) -> ShellScript:
         raise tmt.utils.PrepareError(
             "Package manager 'apt' does not support enabling repositories."
         )
 
-    def disable_repo(self, *repo_ids: str) -> ShellScript:
+    def disable_repository(self, *repo_ids: str) -> ShellScript:
         raise tmt.utils.PrepareError(
             "Package manager 'apt' does not support disabling repositories."
         )

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -176,17 +176,17 @@ class BootcEngine(PackageManagerEngine):
         self.containerfile_directives.append(f'RUN {script}')
         return script
 
-    def enable_repo(self, *repo_ids: str) -> ShellScript:
+    def enable_repository(self, *repo_ids: str) -> ShellScript:
         self.open_containerfile_directives()
 
-        script = self.aux_engine.enable_repo(*repo_ids)
+        script = self.aux_engine.enable_repository(*repo_ids)
         self.containerfile_directives.append(f'RUN {script}')
         return script
 
-    def disable_repo(self, *repo_ids: str) -> ShellScript:
+    def disable_repository(self, *repo_ids: str) -> ShellScript:
         self.open_containerfile_directives()
 
-        script = self.aux_engine.disable_repo(*repo_ids)
+        script = self.aux_engine.disable_repository(*repo_ids)
         self.containerfile_directives.append(f'RUN {script}')
         return script
 
@@ -364,7 +364,7 @@ class Bootc(PackageManager[BootcEngine]):
 
         self.assert_config_manager()
         self.verbose('enable repo', fmf.utils.listed(repo_ids), 'green')
-        self.engine.enable_repo(*repo_ids)
+        self.engine.enable_repository(*repo_ids)
 
     def disable_repo(self, *repo_ids: str) -> None:
         if not repo_ids:
@@ -372,7 +372,7 @@ class Bootc(PackageManager[BootcEngine]):
 
         self.assert_config_manager()
         self.verbose('disable repo', fmf.utils.listed(repo_ids), 'green')
-        self.engine.disable_repo(*repo_ids)
+        self.engine.disable_repository(*repo_ids)
 
     def finalize_installation(self) -> CommandOutput:
         """

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -358,7 +358,7 @@ class Bootc(PackageManager[BootcEngine]):
     def assert_config_manager(self) -> None:
         self.guest.bootc_builder.assert_config_manager()
 
-    def enable_repo(self, *repo_ids: str) -> None:
+    def enable_repository(self, *repo_ids: str) -> None:
         if not repo_ids:
             return
 

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -366,7 +366,7 @@ class Bootc(PackageManager[BootcEngine]):
         self.verbose('enable repo', fmf.utils.listed(repo_ids), 'green')
         self.engine.enable_repository(*repo_ids)
 
-    def disable_repo(self, *repo_ids: str) -> None:
+    def disable_repository(self, *repo_ids: str) -> None:
         if not repo_ids:
             return
 

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -177,17 +177,17 @@ class BootcEngine(PackageManagerEngine):
         self.containerfile_directives.append(f'RUN {script}')
         return script
 
-    def enable_repo(self, *repo_ids: str) -> ShellScript:
+    def enable_repository(self, *repo_ids: str) -> ShellScript:
         self.open_containerfile_directives()
 
-        script = self.aux_engine.enable_repo(*repo_ids)
+        script = self.aux_engine.enable_repository(*repo_ids)
         self.containerfile_directives.append(f'RUN {script}')
         return script
 
-    def disable_repo(self, *repo_ids: str) -> ShellScript:
+    def disable_repository(self, *repo_ids: str) -> ShellScript:
         self.open_containerfile_directives()
 
-        script = self.aux_engine.disable_repo(*repo_ids)
+        script = self.aux_engine.disable_repository(*repo_ids)
         self.containerfile_directives.append(f'RUN {script}')
         return script
 
@@ -374,7 +374,7 @@ class Bootc(PackageManager[BootcEngine]):
 
         self.assert_config_manager()
         self.verbose('enable repo', fmf.utils.listed(repo_ids), 'green')
-        self.engine.enable_repo(*repo_ids)
+        self.engine.enable_repository(*repo_ids)
 
     def disable_repo(self, *repo_ids: str) -> None:
         if not repo_ids:
@@ -382,7 +382,7 @@ class Bootc(PackageManager[BootcEngine]):
 
         self.assert_config_manager()
         self.verbose('disable repo', fmf.utils.listed(repo_ids), 'green')
-        self.engine.disable_repo(*repo_ids)
+        self.engine.disable_repository(*repo_ids)
 
     def finalize_installation(self) -> CommandOutput:
         """

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -376,7 +376,7 @@ class Bootc(PackageManager[BootcEngine]):
         self.verbose('enable repo', fmf.utils.listed(repo_ids), 'green')
         self.engine.enable_repository(*repo_ids)
 
-    def disable_repo(self, *repo_ids: str) -> None:
+    def disable_repository(self, *repo_ids: str) -> None:
         if not repo_ids:
             return
 

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -368,7 +368,7 @@ class Bootc(PackageManager[BootcEngine]):
     def assert_config_manager(self) -> None:
         self.guest.bootc_builder.assert_config_manager()
 
-    def enable_repo(self, *repo_ids: str) -> None:
+    def enable_repository(self, *repo_ids: str) -> None:
         if not repo_ids:
             return
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -129,10 +129,10 @@ class DnfEngine(PackageManagerEngine):
             f'{self.command.to_script()} makecache {self.options.to_script()} --refresh'
         )
 
-    def enable_repo(self, *repo_ids: str) -> ShellScript:
+    def enable_repository(self, *repo_ids: str) -> ShellScript:
         return (self.command + Command('config-manager', '--enable', *repo_ids)).to_script()
 
-    def disable_repo(self, *repo_ids: str) -> ShellScript:
+    def disable_repository(self, *repo_ids: str) -> ShellScript:
         return (self.command + Command('config-manager', '--disable', *repo_ids)).to_script()
 
     def install(
@@ -421,10 +421,10 @@ class YumEngine(DnfEngine):
 
         return command
 
-    def enable_repo(self, *repo_ids: str) -> ShellScript:
+    def enable_repository(self, *repo_ids: str) -> ShellScript:
         return (self._yum_config_manager_command() + Command('--enable', *repo_ids)).to_script()
 
-    def disable_repo(self, *repo_ids: str) -> ShellScript:
+    def disable_repository(self, *repo_ids: str) -> ShellScript:
         return (self._yum_config_manager_command() + Command('--disable', *repo_ids)).to_script()
 
     def resolve_provides(

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -165,10 +165,10 @@ class DnfEngine(PackageManagerEngine):
             f'{self.command.to_script()} makecache {self.options.to_script()} --refresh'
         )
 
-    def enable_repo(self, *repo_ids: str) -> ShellScript:
+    def enable_repository(self, *repo_ids: str) -> ShellScript:
         return (self.command + Command('config-manager', '--enable', *repo_ids)).to_script()
 
-    def disable_repo(self, *repo_ids: str) -> ShellScript:
+    def disable_repository(self, *repo_ids: str) -> ShellScript:
         return (self.command + Command('config-manager', '--disable', *repo_ids)).to_script()
 
     def install(
@@ -498,10 +498,10 @@ class YumEngine(DnfEngine):
             )
         ).to_script()
 
-    def enable_repo(self, *repo_ids: str) -> ShellScript:
+    def enable_repository(self, *repo_ids: str) -> ShellScript:
         return (self._yum_config_manager_command() + Command('--enable', *repo_ids)).to_script()
 
-    def disable_repo(self, *repo_ids: str) -> ShellScript:
+    def disable_repository(self, *repo_ids: str) -> ShellScript:
         return (self._yum_config_manager_command() + Command('--disable', *repo_ids)).to_script()
 
     def _sanitize_rpm_whatprovides(self, original_installable: Installable) -> Installable:

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -86,10 +86,10 @@ class MockEngine(PackageManagerEngine):
     def refresh_metadata(self) -> ShellScript:
         return self._prepare_mock_command_script('makecache --refresh')
 
-    def enable_repo(self, *repo_ids: str) -> ShellScript:
+    def enable_repository(self, *repo_ids: str) -> ShellScript:
         raise PrepareError("Package manager 'mock' does not support enabling repositories.")
 
-    def disable_repo(self, *repo_ids: str) -> ShellScript:
+    def disable_repository(self, *repo_ids: str) -> ShellScript:
         raise PrepareError("Package manager 'mock' does not support disabling repositories.")
 
 

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -77,10 +77,10 @@ class RpmOstreeEngine(PackageManagerEngine):
         # script = ShellScript(f'{self.command.to_script()} refresh-md --force')
         # return self.guest.execute(script)
 
-    def enable_repo(self, *repo_ids: str) -> ShellScript:
+    def enable_repository(self, *repo_ids: str) -> ShellScript:
         raise PrepareError("Package manager 'rpm-ostree' does not support enabling repositories.")
 
-    def disable_repo(self, *repo_ids: str) -> ShellScript:
+    def disable_repository(self, *repo_ids: str) -> ShellScript:
         raise PrepareError("Package manager 'rpm-ostree' does not support disabling repositories.")
 
     def install(

--- a/tmt/steps/prepare/feature/crb.py
+++ b/tmt/steps/prepare/feature/crb.py
@@ -85,7 +85,7 @@ class Crb(ToggleableFeature):
             return
 
         if action == 'enable':
-            guest.package_manager.enable_repo(*repo_ids)
+            guest.package_manager.enable_repository(*repo_ids)
         else:
             guest.package_manager.disable_repo(*repo_ids)
 

--- a/tmt/steps/prepare/feature/crb.py
+++ b/tmt/steps/prepare/feature/crb.py
@@ -87,7 +87,7 @@ class Crb(ToggleableFeature):
         if action == 'enable':
             guest.package_manager.enable_repository(*repo_ids)
         else:
-            guest.package_manager.disable_repo(*repo_ids)
+            guest.package_manager.disable_repository(*repo_ids)
 
     @classmethod
     def enable(cls, guest: Guest, logger: tmt.log.Logger) -> None:

--- a/tmt/steps/prepare/feature/epel.py
+++ b/tmt/steps/prepare/feature/epel.py
@@ -102,11 +102,11 @@ class Epel(ToggleableFeature):
                 guest.package_manager.install(Package("epel-next-release"))
 
         logger.verbose('Enable EPEL')
-        guest.package_manager.enable_repo('epel', 'epel-debuginfo', 'epel-source')
+        guest.package_manager.enable_repository('epel', 'epel-debuginfo', 'epel-source')
 
         # EPEL Next is only available for CentOS Stream 9
         if distro == 'centos' and version == 9:
-            guest.package_manager.enable_repo(
+            guest.package_manager.enable_repository(
                 'epel-next', 'epel-next-debuginfo', 'epel-next-source'
             )
 

--- a/tmt/steps/prepare/feature/epel.py
+++ b/tmt/steps/prepare/feature/epel.py
@@ -128,12 +128,12 @@ class Epel(ToggleableFeature):
         logger.verbose('Disable EPEL')
         epel_package = Package("epel-release")
         if guest.package_manager.check_presence(epel_package).get(epel_package):
-            guest.package_manager.disable_repo('epel', 'epel-debuginfo', 'epel-source')
+            guest.package_manager.disable_repository('epel', 'epel-debuginfo', 'epel-source')
 
         # EPEL Next is only available for CentOS Stream 9
         if distro == 'centos' and version == 9:
             epel_next_package = Package("epel-next-release")
             if guest.package_manager.check_presence(epel_next_package).get(epel_next_package):
-                guest.package_manager.disable_repo(
+                guest.package_manager.disable_repository(
                     'epel-next', 'epel-next-debuginfo', 'epel-next-source'
                 )


### PR DESCRIPTION
We already have `install_repository`, `create_repository`, let's follow the full-name suite.

Pull Request Checklist

* [x] implement the feature