### PR TITLE
Fix silent package upgrades in package install

### DIFF
--- a/tests/package-managers/bootc/test.sh
+++ b/tests/package-managers/bootc/test.sh
@@ -16,7 +16,7 @@ rlJournalStart
             rlAssertGrep "package: 1 package requested" $rlRun_LOG
             rlAssertGrep "/usr/bin/flock" $rlRun_LOG
             rlAssertGrep "cmd: rpm -q --whatprovides /usr/bin/flock" $rlRun_LOG
-            rlAssertGrep "stdout: util-linux-core" $rlRun_LOG
+            rlAssertGrep "stderr: util-linux-core" $rlRun_LOG
             rlAssertNotGrep "Trying to pull quay.io/testing-farm/centos-bootc:stream10" $rlRun_LOG
             rlRun "rm -rf $run" 0 "Remove run directory"
         rlPhaseEnd

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -40,7 +40,7 @@ function assert_package_manager () {
     rlAssertGrep "package manager: $package_manager$" $rlRun_LOG
 
     if is_centos_7 "$image"; then
-        rlAssertGrep "stdout: no package provides tree-but-spelled-wrong" $rlRun_LOG
+        rlAssertGrep "stderr: no package provides tree-but-spelled-wrong" $rlRun_LOG
 
     elif is_centos "$image"; then
         rlAssertGrep "stderr: Error: Unable to find a match: tree-but-spelled-wrong" $rlRun_LOG

--- a/tests/try/basic/test.sh
+++ b/tests/try/basic/test.sh
@@ -62,7 +62,8 @@ rlJournalStart
     rlPhaseStartTest "Install"
         rlRun -s "./install.exp"
         rlAssertGrep "Let's try.*/plans/basic" $rlRun_LOG
-        rlAssertGrep "cmd: rpm -q --whatprovides tree || dnf.* install -y  tree" $rlRun_LOG
+        rlAssertGrep "cmd: rpm -q --whatprovides tree" $rlRun_LOG
+        rlAssertGrep "cmd: dnf.* install -y  tree" $rlRun_LOG
         rlAssertGrep "Run .* successfully finished. Bye for now!" $rlRun_LOG
         rlAssertGrep "container: stopped" $rlRun_LOG
         rlAssertGrep "container: removed" $rlRun_LOG

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -490,7 +490,7 @@ def _parametrize_test_assert_config_manager() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides yum-utils",
+                    r"rpm -q --whatprovides 'yum-utils' >&2 \|\| echo 'yum-utils'",
                 )
             else:
                 yield (
@@ -513,7 +513,7 @@ def _parametrize_test_assert_config_manager() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"""rpm -q --whatprovides '"'"'dnf5-command\(config-manager\)'"'"'""",
+                r"rpm -q --whatprovides 'dnf5-command\(config-manager\)' >&2 \|\| echo 'dnf5-command\(config-manager\)'",  # noqa: E501
             )
 
         elif package_manager_class in (

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -998,7 +998,7 @@ def _parametrize_test_reinstall() -> Iterator[
                     package_manager_class,
                     Package('tar'),
                     True,
-                    r"rpm -q --whatprovides tar && yum reinstall -y  tar && rpm -q --whatprovides tar",  # noqa: E501
+                    r"yum reinstall -y  tar && rpm -q --whatprovides tar",
                     'Reinstalling:\n tar',
                 )
 
@@ -1008,7 +1008,7 @@ def _parametrize_test_reinstall() -> Iterator[
                     package_manager_class,
                     Package('tar'),
                     True,
-                    r"rpm -q --whatprovides tar && yum reinstall -y  tar && rpm -q --whatprovides tar",  # noqa: E501
+                    r"yum reinstall -y  tar && rpm -q --whatprovides tar",
                     'Reinstalled:\n  tar',
                 )
 
@@ -1018,7 +1018,7 @@ def _parametrize_test_reinstall() -> Iterator[
                 package_manager_class,
                 Package('tar'),
                 True,
-                r"rpm -q --whatprovides tar && dnf reinstall -y  tar",
+                r"dnf reinstall -y  tar",
                 'Reinstalled:\n  tar',
             )
 
@@ -1028,7 +1028,7 @@ def _parametrize_test_reinstall() -> Iterator[
                 package_manager_class,
                 Package('tar'),
                 True,
-                r"rpm -q --whatprovides tar && dnf5 reinstall -y  tar",
+                r"dnf5 reinstall -y  tar",
                 'Reinstalling tar',
             )
 
@@ -1109,59 +1109,26 @@ def _generate_test_reinstall_nonexistent_matrix() -> Iterator[
     tuple[Container, PackageManagerClass, Optional[str], Optional[str], Optional[str]]
 ]:
     for container, package_manager_class in CONTAINER_BASE_MATRIX:
-        if package_manager_class is tmt.package_managers.dnf.Dnf5:
+        if (
+            package_manager_class is tmt.package_managers.dnf.Dnf5
+            or package_manager_class is tmt.package_managers.dnf.Dnf
+            or package_manager_class is tmt.package_managers.dnf.Yum
+        ):
             yield (
                 container,
                 package_manager_class,
                 True,
-                r"rpm -q --whatprovides tree-but-spelled-wrong && dnf5 reinstall -y  tree-but-spelled-wrong",  # noqa: E501
-                'no package provides tree-but-spelled-wrong',
+                r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                None,
             )
-
-        elif package_manager_class is tmt.package_managers.dnf.Dnf:
-            yield (
-                container,
-                package_manager_class,
-                True,
-                r"rpm -q --whatprovides tree-but-spelled-wrong && dnf reinstall -y  tree-but-spelled-wrong",  # noqa: E501
-                'no package provides tree-but-spelled-wrong',
-            )
-
-        elif package_manager_class is tmt.package_managers.dnf.Yum:
-            if 'fedora' in container.url:  # noqa: SIM114
-                yield (
-                    container,
-                    package_manager_class,
-                    True,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong && yum reinstall -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
-                    'no package provides tree-but-spelled-wrong',
-                )
-
-            elif 'centos' in container.url and 'centos/7' not in container.url:
-                yield (
-                    container,
-                    package_manager_class,
-                    True,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong && yum reinstall -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
-                    'no package provides tree-but-spelled-wrong',
-                )
-
-            else:
-                yield (
-                    container,
-                    package_manager_class,
-                    True,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong && yum reinstall -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
-                    'no package provides tree-but-spelled-wrong',
-                )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:
             yield (
                 container,
                 package_manager_class,
                 True,
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+dpkg-query --show \$installable_packages \\\s+&& apt reinstall -y  \$installable_packages\s+exit \$\?",  # noqa: E501
-                'dpkg-query: no packages found matching tree-but-spelled-wrong',
+                r".*?echo \"PRESENCE-TEST:tree-but-spelled-wrong:tree-but-spelled-wrong:\$\(dpkg-query --show tree-but-spelled-wrong\)\".*?",  # noqa: E501
+                None,
             )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
@@ -1172,7 +1139,7 @@ def _generate_test_reinstall_nonexistent_matrix() -> Iterator[
                 container,
                 package_manager_class,
                 True,
-                r"apk info -e tree-but-spelled-wrong && apk fix tree-but-spelled-wrong",
+                r"apk info -e tree-but-spelled-wrong",
                 None,
             )
 
@@ -1202,22 +1169,18 @@ def test_reinstall_nonexistent(
     if supported:
         assert expected_command is not None
 
-        with pytest.raises(tmt.utils.RunError) as excinfo:
-            package_manager.reinstall(Package('tree-but-spelled-wrong'))
+        # Package is not installed: check_first detects absence and skips reinstall (no-op).
+        output = package_manager.reinstall(Package('tree-but-spelled-wrong'))
+        assert output.stdout is None
+        assert output.stderr is None
 
         assert_expected_command(caplog, expected_command)
-
-        assert excinfo.type is tmt.utils.RunError
-        assert excinfo.value.returncode != 0
 
     else:
         with pytest.raises(tmt.utils.GeneralError) as excinfo:
             package_manager.reinstall(Package('tree-but-spelled-wrong'))
 
         assert excinfo.value.message == "rpm-ostree does not support reinstall operation."
-
-    if expected_output:
-        assert_output(expected_output, excinfo.value.stdout, excinfo.value.stderr)
 
 
 def _generate_test_check_presence() -> Iterator[

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1230,8 +1230,8 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('coreutils'),
                 True,
-                r"rpm -q --whatprovides coreutils >/dev/null 2>&1 \|\| echo coreutils",
-                None,
+                r"rpm -q --whatprovides 'coreutils' >&2 \|\| echo 'coreutils'",
+                r'\s+stderr:\s+coreutils-',
             )
 
             yield (
@@ -1239,7 +1239,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('tree-but-spelled-wrong'),
                 False,
-                r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                 r'\s+stdout:\s+tree-but-spelled-wrong',
             )
 
@@ -1248,8 +1248,8 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 FileSystemPath('/usr/bin/arch'),
                 True,
-                r"rpm -q --whatprovides /usr/bin/arch >/dev/null 2>&1 \|\| echo /usr/bin/arch",
-                None,
+                r"rpm -q --whatprovides '/usr/bin/arch' >&2 \|\| echo '/usr/bin/arch'",
+                r'\s+stderr:\s+coreutils-',
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf:
@@ -1259,8 +1259,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r"rpm -q --whatprovides util-linux >/dev/null 2>&1 \|\| echo util-linux",
-                    None,
+                    r"rpm -q --whatprovides 'util-linux' >&2 \|\| echo 'util-linux'",
+                    r'\s+stderr:\s+util-linux-',
                 )
 
                 yield (
@@ -1268,7 +1268,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1277,8 +1277,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
-                    None,
+                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'\s+stderr:\s+util-linux-',
                 )
 
             elif 'centos/stream9' in container.url:
@@ -1287,8 +1287,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r"rpm -q --whatprovides coreutils >/dev/null 2>&1 \|\| echo coreutils",
-                    None,
+                    r"rpm -q --whatprovides 'coreutils' >&2 \|\| echo 'coreutils'",
+                    r'\s+stderr:\s+coreutils-',
                 )
 
                 yield (
@@ -1296,7 +1296,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1305,8 +1305,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/arch >/dev/null 2>&1 \|\| echo /usr/bin/arch",
-                    None,
+                    r"rpm -q --whatprovides '/usr/bin/arch' >&2 \|\| echo '/usr/bin/arch'",
+                    r'\s+stderr:\s+coreutils-',
                 )
 
             else:
@@ -1315,8 +1315,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r"rpm -q --whatprovides util-linux-core >/dev/null 2>&1 \|\| echo util-linux-core",  # noqa: E501
-                    None,
+                    r"rpm -q --whatprovides 'util-linux-core' >&2 \|\| echo 'util-linux-core'",
+                    r'\s+stderr:\s+util-linux-core-',
                 )
 
                 yield (
@@ -1324,7 +1324,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1333,8 +1333,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
-                    None,
+                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'\s+stderr:\s+util-linux-core-',
                 )
 
         elif package_manager_class is tmt.package_managers.dnf.Yum:
@@ -1344,8 +1344,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r"rpm -q --whatprovides util-linux >/dev/null 2>&1 \|\| echo util-linux",
-                    None,
+                    r"rpm -q --whatprovides 'util-linux' >&2 \|\| echo 'util-linux'",
+                    r'\s+stderr:\s+util-linux-',
                 )
 
                 yield (
@@ -1353,7 +1353,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1362,8 +1362,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
-                    None,
+                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'\s+stderr:\s+util-linux-',
                 )
 
             elif 'centos/stream9' in container.url:
@@ -1372,8 +1372,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r"rpm -q --whatprovides coreutils >/dev/null 2>&1 \|\| echo coreutils",
-                    None,
+                    r"rpm -q --whatprovides 'coreutils' >&2 \|\| echo 'coreutils'",
+                    r'\s+stderr:\s+coreutils-',
                 )
 
                 yield (
@@ -1381,7 +1381,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1390,8 +1390,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/arch >/dev/null 2>&1 \|\| echo /usr/bin/arch",
-                    None,
+                    r"rpm -q --whatprovides '/usr/bin/arch' >&2 \|\| echo '/usr/bin/arch'",
+                    r'\s+stderr:\s+coreutils-',
                 )
 
             else:
@@ -1400,8 +1400,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r"rpm -q --whatprovides util-linux-core >/dev/null 2>&1 \|\| echo util-linux-core",  # noqa: E501
-                    None,
+                    r"rpm -q --whatprovides 'util-linux-core' >&2 \|\| echo 'util-linux-core'",
+                    r'\s+stderr:\s+util-linux-core-',
                 )
 
                 yield (
@@ -1409,7 +1409,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1418,8 +1418,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
-                    None,
+                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'\s+stderr:\s+util-linux-core-',
                 )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1230,8 +1230,8 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('coreutils'),
                 True,
-                r"rpm -q --whatprovides coreutils",
-                r'\s+stdout:\s+coreutils-',
+                r"rpm -q --whatprovides coreutils >/dev/null 2>&1 \|\| echo coreutils",
+                None,
             )
 
             yield (
@@ -1239,8 +1239,8 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('tree-but-spelled-wrong'),
                 False,
-                r"rpm -q --whatprovides tree-but-spelled-wrong",
-                r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                r'\s+stdout:\s+tree-but-spelled-wrong',
             )
 
             yield (
@@ -1248,8 +1248,8 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 FileSystemPath('/usr/bin/arch'),
                 True,
-                r"rpm -q --whatprovides /usr/bin/arch",
-                r'\s+stdout:\s+coreutils-',
+                r"rpm -q --whatprovides /usr/bin/arch >/dev/null 2>&1 \|\| echo /usr/bin/arch",
+                None,
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf:
@@ -1259,8 +1259,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r"rpm -q --whatprovides util-linux",
-                    r'\s+stdout:\s+util-linux-',
+                    r"rpm -q --whatprovides util-linux >/dev/null 2>&1 \|\| echo util-linux",
+                    None,
                 )
 
                 yield (
@@ -1268,8 +1268,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong",
-                    r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
                 yield (
@@ -1277,8 +1277,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock",
-                    r'\s+stdout:\s+util-linux-',
+                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
+                    None,
                 )
 
             elif 'centos/stream9' in container.url:
@@ -1287,8 +1287,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r"rpm -q --whatprovides coreutils",
-                    r'\s+stdout:\s+coreutils-',
+                    r"rpm -q --whatprovides coreutils >/dev/null 2>&1 \|\| echo coreutils",
+                    None,
                 )
 
                 yield (
@@ -1296,8 +1296,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong",
-                    r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
                 yield (
@@ -1305,8 +1305,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/arch",
-                    r'\s+stdout:\s+coreutils-',
+                    r"rpm -q --whatprovides /usr/bin/arch >/dev/null 2>&1 \|\| echo /usr/bin/arch",
+                    None,
                 )
 
             else:
@@ -1315,8 +1315,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r"rpm -q --whatprovides util-linux-core",
-                    r'\s+stdout:\s+util-linux-core-',
+                    r"rpm -q --whatprovides util-linux-core >/dev/null 2>&1 \|\| echo util-linux-core",  # noqa: E501
+                    None,
                 )
 
                 yield (
@@ -1324,8 +1324,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong",
-                    r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
                 yield (
@@ -1333,8 +1333,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock",
-                    r'\s+stdout:\s+util-linux-core-',
+                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
+                    None,
                 )
 
         elif package_manager_class is tmt.package_managers.dnf.Yum:
@@ -1344,8 +1344,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r"rpm -q --whatprovides util-linux",
-                    r'\s+stdout:\s+util-linux-',
+                    r"rpm -q --whatprovides util-linux >/dev/null 2>&1 \|\| echo util-linux",
+                    None,
                 )
 
                 yield (
@@ -1353,8 +1353,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong",
-                    r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
                 yield (
@@ -1362,8 +1362,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock",
-                    r'\s+stdout:\s+util-linux-',
+                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
+                    None,
                 )
 
             elif 'centos/stream9' in container.url:
@@ -1372,8 +1372,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r"rpm -q --whatprovides coreutils",
-                    r'\s+stdout:\s+coreutils-',
+                    r"rpm -q --whatprovides coreutils >/dev/null 2>&1 \|\| echo coreutils",
+                    None,
                 )
 
                 yield (
@@ -1381,8 +1381,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong",
-                    r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
                 yield (
@@ -1390,8 +1390,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/arch",
-                    r'\s+stdout:\s+coreutils-',
+                    r"rpm -q --whatprovides /usr/bin/arch >/dev/null 2>&1 \|\| echo /usr/bin/arch",
+                    None,
                 )
 
             else:
@@ -1400,8 +1400,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r"rpm -q --whatprovides util-linux-core",
-                    r'\s+stdout:\s+util-linux-core-',
+                    r"rpm -q --whatprovides util-linux-core >/dev/null 2>&1 \|\| echo util-linux-core",  # noqa: E501
+                    None,
                 )
 
                 yield (
@@ -1409,8 +1409,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong",
-                    r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
                 yield (
@@ -1418,8 +1418,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock",
-                    r'\s+stdout:\s+util-linux-core-',
+                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
+                    None,
                 )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -343,7 +343,7 @@ def _parametrize_test_install() -> Iterator[
                 container,
                 package_manager_class,
                 Package('tree'),
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'Setting up tree',
             )
 
@@ -352,7 +352,7 @@ def _parametrize_test_install() -> Iterator[
                 container,
                 package_manager_class,
                 Package('tree'),
-                r"rpm -q --whatprovides tree \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree",  # noqa: E501
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree",
                 'Installing: tree',
             )
 
@@ -361,7 +361,7 @@ def _parametrize_test_install() -> Iterator[
                 container,
                 package_manager_class,
                 Package('tree'),
-                r"apk info -e tree \|\| apk add tree",
+                r"apk add tree",
                 'Installing tree',
             )
 
@@ -703,7 +703,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'E: Unable to locate package tree-but-spelled-wrong',
             )
 
@@ -711,7 +711,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree-but-spelled-wrong",  # noqa: E501
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree-but-spelled-wrong",  # noqa: E501
                 'no package provides tree-but-spelled-wrong',
             )
 
@@ -719,7 +719,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"apk info -e tree-but-spelled-wrong \|\| apk add tree-but-spelled-wrong",
+                r"apk add tree-but-spelled-wrong",
                 'ERROR: unable to select packages:\n  tree-but-spelled-wrong (no such package):\n    required by: world[tree-but-spelled-wrong]',  # noqa: E501
             )
 
@@ -815,7 +815,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y --ignore-missing \$installable_packages\s+exit 0",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+apt install -y --ignore-missing \$installable_packages\s+exit 0",  # noqa: E501
                 'E: Unable to locate package tree-but-spelled-wrong',
             )
 
@@ -823,7 +823,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
                 'no package provides tree-but-spelled-wrong',
             )
 
@@ -831,7 +831,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"apk info -e tree-but-spelled-wrong \|\| apk add tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
+                r"apk add tree-but-spelled-wrong \|\| /bin/true",
                 'ERROR: unable to select packages:\n  tree-but-spelled-wrong (no such package):\n    required by: world[tree-but-spelled-wrong]',  # noqa: E501
             )
 
@@ -1592,7 +1592,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                 container,
                 package_manager_class,
                 FileSystemPath('/usr/bin/dos2unix'),
-                r".*?set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"\"\s+fs_path_package=\"\$\(apt-file search --package-only /usr/bin/dos2unix\)\"\s+\[ -z \"\$fs_path_package\" \] && echo \"No package found for path /usr/bin/dos2unix\" && exit 1\s+installable_packages=\"\$installable_packages \$fs_path_package\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y\s+\$installable_packages\s+exit \$\?",  # noqa: E501
+                r".*?set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"\"\s+fs_path_package=\"\$\(apt-file search --package-only /usr/bin/dos2unix\)\"\s+\[ -z \"\$fs_path_package\" \] && echo \"No package found for path /usr/bin/dos2unix\" && exit 1\s+installable_packages=\"\$installable_packages \$fs_path_package\"\s+apt install -y\s+\$installable_packages\s+exit \$\?",  # noqa: E501
                 "Setting up dos2unix",
             )
 
@@ -1601,7 +1601,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                 container,
                 package_manager_class,
                 FileSystemPath('/usr/bin/dos2unix'),
-                r"rpm -qf /usr/bin/dos2unix \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  /usr/bin/dos2unix",  # noqa: E501
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  /usr/bin/dos2unix",  # noqa: E501
                 "Installing 1 packages:\n  dos2unix-",
             )
 
@@ -1610,7 +1610,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                 container,
                 package_manager_class,
                 FileSystemPath('/usr/bin/dos2unix'),
-                r"apk info -e dos2unix \|\| apk add dos2unix",
+                r"apk add dos2unix",
                 'Installing dos2unix',
             )
 
@@ -1726,7 +1726,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('tree'), Package('nano')),
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree nano\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree nano\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'Setting up tree',
             )
 
@@ -1735,7 +1735,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('tree'), Package('nano')),
-                r"rpm -q --whatprovides tree nano \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree nano",  # noqa: E501
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree nano",  # noqa: E501
                 'Installing: tree',
             )
 
@@ -1744,7 +1744,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('tree'), Package('diffutils')),
-                r"apk info -e tree diffutils \|\| apk add tree diffutils",
+                r"apk add tree diffutils",
                 'Installing tree',
             )
 
@@ -1896,7 +1896,7 @@ def _parametrize_test_install_downloaded() -> Iterator[
                 package_manager_class,
                 (Package('tree'), Package('nano')),
                 ('tree*.x86_64.rpm', 'nano*.x86_64.rpm'),
-                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y  \$installable_packages.*",  # noqa: E501
+                r".*?apt install -y  \$installable_packages.*",
                 'Setting up tree',
                 marks=pytest.mark.skip(reason="not supported yet"),
             )
@@ -1907,7 +1907,7 @@ def _parametrize_test_install_downloaded() -> Iterator[
                 package_manager_class,
                 (Package('tree'), Package('nano')),
                 ('tree*.x86_64.rpm', 'nano*.x86_64.rpm'),
-                r"apk info -e tree nano \|\| apk add tree nano",
+                r"apk add tree nano",
                 'Installing tree',
                 marks=pytest.mark.skip(reason="not supported yet"),
             )

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -915,7 +915,7 @@ def _parametrize_test_install_dont_check_first() -> Iterator[
                 container,
                 package_manager_class,
                 Package('tree'),
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree\"\s+/bin/false \\\s+\|\| apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'Setting up tree',
             )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -490,7 +490,7 @@ def _parametrize_test_assert_config_manager() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r'rpm -q --whatprovides "yum-utils" >&2 \|\| echo "yum-utils"',
+                    r'rpm -q --whatprovides yum-utils >&2 \|\| echo yum-utils',
                 )
             else:
                 yield (
@@ -513,7 +513,7 @@ def _parametrize_test_assert_config_manager() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r'rpm -q --whatprovides "dnf5-command\(config-manager\)" >&2 \|\| echo "dnf5-command\(config-manager\)"',  # noqa: E501
+                r"""rpm -q --whatprovides '"'"'dnf5-command\(config-manager\)'"'"' >&2 \|\| echo '"'"'dnf5-command\(config-manager\)'"'"'""",  # noqa: E501
             )
 
         elif package_manager_class in (
@@ -1118,7 +1118,7 @@ def _generate_test_reinstall_nonexistent_matrix() -> Iterator[
                 container,
                 package_manager_class,
                 True,
-                r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                 None,
             )
 
@@ -1193,7 +1193,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('coreutils'),
                 True,
-                r'rpm -q --whatprovides "coreutils" >&2 \|\| echo "coreutils"',
+                r'rpm -q --whatprovides coreutils >&2 \|\| echo coreutils',
                 r'\s+stderr:\s+coreutils-',
             )
 
@@ -1202,7 +1202,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('tree-but-spelled-wrong'),
                 False,
-                r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                 r'\s+stdout:\s+tree-but-spelled-wrong',
             )
 
@@ -1211,7 +1211,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 FileSystemPath('/usr/bin/arch'),
                 True,
-                r'rpm -q --whatprovides "/usr/bin/arch" >&2 \|\| echo "/usr/bin/arch"',
+                r'rpm -q --whatprovides /usr/bin/arch >&2 \|\| echo /usr/bin/arch',
                 r'\s+stderr:\s+coreutils-',
             )
 
@@ -1222,7 +1222,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r'rpm -q --whatprovides "util-linux" >&2 \|\| echo "util-linux"',
+                    r'rpm -q --whatprovides util-linux >&2 \|\| echo util-linux',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1231,7 +1231,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                    r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1240,7 +1240,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
+                    r'rpm -q --whatprovides /usr/bin/flock >&2 \|\| echo /usr/bin/flock',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1250,7 +1250,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r'rpm -q --whatprovides "coreutils" >&2 \|\| echo "coreutils"',
+                    r'rpm -q --whatprovides coreutils >&2 \|\| echo coreutils',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1259,7 +1259,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                    r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1268,7 +1268,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r'rpm -q --whatprovides "/usr/bin/arch" >&2 \|\| echo "/usr/bin/arch"',
+                    r'rpm -q --whatprovides /usr/bin/arch >&2 \|\| echo /usr/bin/arch',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1278,7 +1278,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r'rpm -q --whatprovides "util-linux-core" >&2 \|\| echo "util-linux-core"',
+                    r'rpm -q --whatprovides util-linux-core >&2 \|\| echo util-linux-core',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 
@@ -1287,7 +1287,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                    r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1296,7 +1296,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
+                    r'rpm -q --whatprovides /usr/bin/flock >&2 \|\| echo /usr/bin/flock',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 
@@ -1307,7 +1307,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r'rpm -q --whatprovides "util-linux" >&2 \|\| echo "util-linux"',
+                    r'rpm -q --whatprovides util-linux >&2 \|\| echo util-linux',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1316,7 +1316,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                    r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1325,7 +1325,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
+                    r'rpm -q --whatprovides /usr/bin/flock >&2 \|\| echo /usr/bin/flock',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1335,7 +1335,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r'rpm -q --whatprovides "coreutils" >&2 \|\| echo "coreutils"',
+                    r'rpm -q --whatprovides coreutils >&2 \|\| echo coreutils',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1344,7 +1344,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                    r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1353,7 +1353,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r'rpm -q --whatprovides "/usr/bin/arch" >&2 \|\| echo "/usr/bin/arch"',
+                    r'rpm -q --whatprovides /usr/bin/arch >&2 \|\| echo /usr/bin/arch',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1363,7 +1363,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r'rpm -q --whatprovides "util-linux-core" >&2 \|\| echo "util-linux-core"',
+                    r'rpm -q --whatprovides util-linux-core >&2 \|\| echo util-linux-core',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 
@@ -1372,7 +1372,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                    r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1381,7 +1381,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
+                    r'rpm -q --whatprovides /usr/bin/flock >&2 \|\| echo /usr/bin/flock',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -484,11 +484,20 @@ def _parametrize_test_assert_config_manager() -> Iterator[
 ]:
     for container, package_manager_class in CONTAINER_BASE_MATRIX:
         if package_manager_class is tmt.package_managers.dnf.Yum:
-            yield (
-                container,
-                package_manager_class,
-                r"yum install -y  yum-utils && rpm -q --whatprovides yum-utils",
-            )
+            if 'centos/7' in container.url:
+                # yum-utils ships pre-installed on CentOS 7; check_presence returns
+                # True → install is skipped, only the rpm check appears in logs.
+                yield (
+                    container,
+                    package_manager_class,
+                    r"rpm -q --whatprovides yum-utils",
+                )
+            else:
+                yield (
+                    container,
+                    package_manager_class,
+                    r"yum install -y  yum-utils && rpm -q --whatprovides yum-utils",
+                )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf:
             yield (
@@ -498,10 +507,13 @@ def _parametrize_test_assert_config_manager() -> Iterator[
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf5:
+            # dnf5-command(config-manager) ships pre-installed on modern Fedora
+            # via dnf5-plugins; check_presence returns True → install is skipped,
+            # only the rpm presence-check command appears in the logs.
             yield (
                 container,
                 package_manager_class,
-                r"""dnf5 install -y  '"'"'dnf5-command\(config-manager\)'"'"'""",
+                r"""rpm -q --whatprovides '"'"'dnf5-command\(config-manager\)'"'"'""",
             )
 
         elif package_manager_class in (
@@ -1722,11 +1734,13 @@ def _parametrize_test_install_multiple() -> Iterator[
             )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:
+            # nano is pre-installed on Ubuntu/Debian base images; use nmap instead
+            # so that check_presence finds both packages absent and installs both.
             yield (
                 container,
                 package_manager_class,
-                (Package('tree'), Package('nano')),
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree nano\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
+                (Package('tree'), Package('nmap')),
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree nmap\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'Setting up tree',
             )
 
@@ -2120,11 +2134,14 @@ def _parametrize_test_install_debuginfo_nonexistent() -> Iterator[
 ]:
     for container, package_manager_class in CONTAINER_BASE_MATRIX:
         if package_manager_class is tmt.package_managers.dnf.Dnf5:
+            # Dnf5Engine._base_debuginfo_command = Command('dnf5', 'debuginfo-install'),
+            # so install_debuginfo goes straight to the built-in subcommand without a
+            # separate install-tool step.
             yield (
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                r"dnf5 install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                r"dnf5 debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
                 None,
             )
 
@@ -2138,11 +2155,12 @@ def _parametrize_test_install_debuginfo_nonexistent() -> Iterator[
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Yum:
+            # YumEngine.install() always appends a post-install rpm-q presence check.
             yield (
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                r"yum install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                r"yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
                 None,
             )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -490,7 +490,7 @@ def _parametrize_test_assert_config_manager() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides 'yum-utils' >&2 \|\| echo 'yum-utils'",
+                    r'rpm -q --whatprovides "yum-utils" >&2 \|\| echo "yum-utils"',
                 )
             else:
                 yield (
@@ -513,7 +513,7 @@ def _parametrize_test_assert_config_manager() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides 'dnf5-command\(config-manager\)' >&2 \|\| echo 'dnf5-command\(config-manager\)'",  # noqa: E501
+                r'rpm -q --whatprovides "dnf5-command\(config-manager\)" >&2 \|\| echo "dnf5-command\(config-manager\)"',  # noqa: E501
             )
 
         elif package_manager_class in (
@@ -1118,7 +1118,7 @@ def _generate_test_reinstall_nonexistent_matrix() -> Iterator[
                 container,
                 package_manager_class,
                 True,
-                r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                 None,
             )
 
@@ -1193,7 +1193,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('coreutils'),
                 True,
-                r"rpm -q --whatprovides 'coreutils' >&2 \|\| echo 'coreutils'",
+                r'rpm -q --whatprovides "coreutils" >&2 \|\| echo "coreutils"',
                 r'\s+stderr:\s+coreutils-',
             )
 
@@ -1202,7 +1202,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('tree-but-spelled-wrong'),
                 False,
-                r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                 r'\s+stdout:\s+tree-but-spelled-wrong',
             )
 
@@ -1211,7 +1211,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 FileSystemPath('/usr/bin/arch'),
                 True,
-                r"rpm -q --whatprovides '/usr/bin/arch' >&2 \|\| echo '/usr/bin/arch'",
+                r'rpm -q --whatprovides "/usr/bin/arch" >&2 \|\| echo "/usr/bin/arch"',
                 r'\s+stderr:\s+coreutils-',
             )
 
@@ -1222,7 +1222,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r"rpm -q --whatprovides 'util-linux' >&2 \|\| echo 'util-linux'",
+                    r'rpm -q --whatprovides "util-linux" >&2 \|\| echo "util-linux"',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1231,7 +1231,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1240,7 +1240,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1250,7 +1250,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r"rpm -q --whatprovides 'coreutils' >&2 \|\| echo 'coreutils'",
+                    r'rpm -q --whatprovides "coreutils" >&2 \|\| echo "coreutils"',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1259,7 +1259,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1268,7 +1268,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r"rpm -q --whatprovides '/usr/bin/arch' >&2 \|\| echo '/usr/bin/arch'",
+                    r'rpm -q --whatprovides "/usr/bin/arch" >&2 \|\| echo "/usr/bin/arch"',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1278,7 +1278,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r"rpm -q --whatprovides 'util-linux-core' >&2 \|\| echo 'util-linux-core'",
+                    r'rpm -q --whatprovides "util-linux-core" >&2 \|\| echo "util-linux-core"',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 
@@ -1287,7 +1287,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1296,7 +1296,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 
@@ -1307,7 +1307,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r"rpm -q --whatprovides 'util-linux' >&2 \|\| echo 'util-linux'",
+                    r'rpm -q --whatprovides "util-linux" >&2 \|\| echo "util-linux"',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1316,7 +1316,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1325,7 +1325,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1335,7 +1335,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r"rpm -q --whatprovides 'coreutils' >&2 \|\| echo 'coreutils'",
+                    r'rpm -q --whatprovides "coreutils" >&2 \|\| echo "coreutils"',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1344,7 +1344,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1353,7 +1353,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r"rpm -q --whatprovides '/usr/bin/arch' >&2 \|\| echo '/usr/bin/arch'",
+                    r'rpm -q --whatprovides "/usr/bin/arch" >&2 \|\| echo "/usr/bin/arch"',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1363,7 +1363,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r"rpm -q --whatprovides 'util-linux-core' >&2 \|\| echo 'util-linux-core'",
+                    r'rpm -q --whatprovides "util-linux-core" >&2 \|\| echo "util-linux-core"',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 
@@ -1372,7 +1372,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1381,7 +1381,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -279,7 +279,7 @@ def _parametrize_test_install() -> Iterator[
                     container,
                     package_manager_class,
                     Package('tree'),
-                    r"rpm -q --whatprovides tree \|\| yum install -y  tree && rpm -q --whatprovides tree",  # noqa: E501
+                    r"yum install -y  tree && rpm -q --whatprovides tree",
                     'Installing:',
                 )
 
@@ -288,7 +288,7 @@ def _parametrize_test_install() -> Iterator[
                     container,
                     package_manager_class,
                     Package('dconf'),
-                    r"rpm -q --whatprovides dconf \|\| yum install -y  dconf && rpm -q --whatprovides dconf",  # noqa: E501
+                    r"yum install -y  dconf && rpm -q --whatprovides dconf",
                     'Installed:\n  dconf',
                 )
 
@@ -297,7 +297,7 @@ def _parametrize_test_install() -> Iterator[
                     container,
                     package_manager_class,
                     Package('tree'),
-                    r"rpm -q --whatprovides tree \|\| yum install -y  tree && rpm -q --whatprovides tree",  # noqa: E501
+                    r"yum install -y  tree && rpm -q --whatprovides tree",
                     'Installed:\n  tree',
                 )
 
@@ -307,7 +307,7 @@ def _parametrize_test_install() -> Iterator[
                     container,
                     package_manager_class,
                     Package('tree'),
-                    r"rpm -q --whatprovides tree \|\| dnf install -y  tree",
+                    r"dnf install -y  tree",
                     'Installing:',
                 )
 
@@ -316,7 +316,7 @@ def _parametrize_test_install() -> Iterator[
                     container,
                     package_manager_class,
                     Package('dconf'),
-                    r"rpm -q --whatprovides dconf \|\| dnf install -y  dconf",
+                    r"dnf install -y  dconf",
                     'Installed:\n  dconf',
                 )
 
@@ -325,7 +325,7 @@ def _parametrize_test_install() -> Iterator[
                     container,
                     package_manager_class,
                     Package('tree'),
-                    r"rpm -q --whatprovides tree \|\| dnf install -y  tree",
+                    r"dnf install -y  tree",
                     'Installed:\n  tree',
                 )
 
@@ -334,7 +334,7 @@ def _parametrize_test_install() -> Iterator[
                 container,
                 package_manager_class,
                 Package('tree'),
-                r"rpm -q --whatprovides tree \|\| dnf5 install -y  tree",
+                r"dnf5 install -y  tree",
                 'Installing:',
             )
 
@@ -487,21 +487,21 @@ def _parametrize_test_assert_config_manager() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides yum-utils \|\| yum install -y  yum-utils && rpm -q --whatprovides yum-utils",  # noqa: E501
+                r"yum install -y  yum-utils && rpm -q --whatprovides yum-utils",
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf:
             yield (
                 container,
                 package_manager_class,
-                r"""rpm -q --whatprovides '"'"'dnf-command\(config-manager\)'"'"' \|\| dnf install -y  '"'"'dnf-command\(config-manager\)'"'"'""",  # noqa: E501
+                r"""dnf install -y  '"'"'dnf-command\(config-manager\)'"'"'""",
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf5:
             yield (
                 container,
                 package_manager_class,
-                r"""rpm -q --whatprovides '"'"'dnf5-command\(config-manager\)'"'"' \|\| dnf5 install -y  '"'"'dnf5-command\(config-manager\)'"'"'""",  # noqa: E501
+                r"""dnf5 install -y  '"'"'dnf5-command\(config-manager\)'"'"'""",
             )
 
         elif package_manager_class in (
@@ -643,7 +643,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf5 install -y  tree-but-spelled-wrong",  # noqa: E501
+                r"dnf5 install -y  tree-but-spelled-wrong",
                 'No match for argument: tree-but-spelled-wrong',
             )
 
@@ -652,7 +652,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf install -y  tree-but-spelled-wrong",  # noqa: E501
+                    r"dnf install -y  tree-but-spelled-wrong",
                     'No match for argument: tree-but-spelled-wrong',
                 )
 
@@ -660,7 +660,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf install -y  tree-but-spelled-wrong",  # noqa: E501
+                    r"dnf install -y  tree-but-spelled-wrong",
                     'Error: Unable to find a match: tree-but-spelled-wrong',
                 )
 
@@ -669,7 +669,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
+                    r"yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
                     'No match for argument: tree-but-spelled-wrong',
                 )
 
@@ -677,7 +677,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
+                    r"yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
                     'Error: Unable to find a match: tree-but-spelled-wrong',
                 )
 
@@ -687,7 +687,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
+                    r"yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
                     'No match for argument: tree-but-spelled-wrong',
                 )
 
@@ -695,7 +695,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
+                    r"yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
                     'No package tree-but-spelled-wrong available.',
                 )
 
@@ -764,7 +764,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf5 install -y --skip-unavailable tree-but-spelled-wrong",  # noqa: E501
+                r"dnf5 install -y --skip-unavailable tree-but-spelled-wrong",
                 None,
             )
 
@@ -772,7 +772,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf install -y --skip-broken tree-but-spelled-wrong",  # noqa: E501
+                r"dnf install -y --skip-broken tree-but-spelled-wrong",
                 'No match for argument: tree-but-spelled-wrong',
             )
 
@@ -781,7 +781,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
+                    r"yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",
                     'No match for argument: tree-but-spelled-wrong',
                 )
 
@@ -789,7 +789,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
+                    r"yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",
                     'No match for argument: tree-but-spelled-wrong',
                 )
 
@@ -799,7 +799,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
+                    r"yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",
                     'No match for argument: tree-but-spelled-wrong',
                 )
 
@@ -807,7 +807,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
+                    r"yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",
                     'No package tree-but-spelled-wrong available.',
                 )
 
@@ -1555,7 +1555,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                 container,
                 package_manager_class,
                 FileSystemPath('/usr/bin/dos2unix'),
-                r"rpm -q --whatprovides /usr/bin/dos2unix \|\| dnf5 install -y  /usr/bin/dos2unix",
+                r"dnf5 install -y  /usr/bin/dos2unix",
                 '[1/1] dos2unix',
             )
 
@@ -1564,7 +1564,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                 container,
                 package_manager_class,
                 FileSystemPath('/usr/bin/dos2unix'),
-                r"rpm -q --whatprovides /usr/bin/dos2unix \|\| dnf install -y  /usr/bin/dos2unix",
+                r"dnf install -y  /usr/bin/dos2unix",
                 'Installed:\n  dos2unix-',
             )
 
@@ -1574,7 +1574,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                     container,
                     package_manager_class,
                     FileSystemPath('/usr/bin/dos2unix'),
-                    r"rpm -q --whatprovides /usr/bin/dos2unix \|\| yum install -y  /usr/bin/dos2unix && rpm -q --whatprovides /usr/bin/dos2unix",  # noqa: E501
+                    r"yum install -y  /usr/bin/dos2unix && rpm -q --whatprovides /usr/bin/dos2unix",  # noqa: E501
                     'Installed:\n  dos2unix.',
                 )
 
@@ -1583,7 +1583,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                     container,
                     package_manager_class,
                     FileSystemPath('/usr/bin/dos2unix'),
-                    r"rpm -q --whatprovides /usr/bin/dos2unix \|\| yum install -y  /usr/bin/dos2unix && rpm -q --whatprovides /usr/bin/dos2unix",  # noqa: E501
+                    r"yum install -y  /usr/bin/dos2unix && rpm -q --whatprovides /usr/bin/dos2unix",  # noqa: E501
                     'Installed:\n  dos2unix-',
                 )
 
@@ -1662,7 +1662,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dconf'), Package('libpng')),
-                    r"rpm -q --whatprovides dconf libpng \|\| yum install -y  dconf libpng && rpm -q --whatprovides dconf libpng",  # noqa: E501
+                    r"yum install -y  dconf libpng && rpm -q --whatprovides dconf libpng",
                     'Complete!',
                 )
 
@@ -1671,7 +1671,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('tree'), Package('diffutils')),
-                    r"rpm -q --whatprovides tree diffutils \|\| yum install -y  tree diffutils && rpm -q --whatprovides tree diffutils",  # noqa: E501
+                    r"yum install -y  tree diffutils && rpm -q --whatprovides tree diffutils",
                     'Complete!',
                 )
 
@@ -1680,7 +1680,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('tree'), Package('nano')),
-                    r"rpm -q --whatprovides tree nano \|\| yum install -y  tree nano && rpm -q --whatprovides tree nano",  # noqa: E501
+                    r"yum install -y  tree nano && rpm -q --whatprovides tree nano",
                     'Complete!',
                 )
 
@@ -1690,7 +1690,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dconf'), Package('libpng')),
-                    r"rpm -q --whatprovides dconf libpng \|\| dnf install -y  dconf libpng",
+                    r"dnf install -y  dconf libpng",
                     'Complete!',
                 )
 
@@ -1699,7 +1699,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('tree'), Package('diffutils')),
-                    r"rpm -q --whatprovides tree diffutils \|\| dnf install -y  tree diffutils",
+                    r"dnf install -y  tree diffutils",
                     'Complete!',
                 )
 
@@ -1708,7 +1708,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('tree'), Package('nano')),
-                    r"rpm -q --whatprovides tree nano \|\| dnf install -y  tree nano",
+                    r"dnf install -y  tree nano",
                     'Complete!',
                 )
 
@@ -1717,7 +1717,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('tree'), Package('nano')),
-                r"rpm -q --whatprovides tree nano \|\| dnf5 install -y  tree nano",
+                r"dnf5 install -y  tree nano",
                 None,
             )
 
@@ -2019,7 +2019,7 @@ def _parametrize_test_install_debuginfo() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dconf'), Package('libpng')),
-                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dconf libpng && rpm -q dconf-debuginfo libpng-debuginfo",  # noqa: E501
+                    r"dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dconf libpng && rpm -q dconf-debuginfo libpng-debuginfo",  # noqa: E501
                     None,
                 )
 
@@ -2028,7 +2028,7 @@ def _parametrize_test_install_debuginfo() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dos2unix'), Package('tree')),
-                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",  # noqa: E501
+                    r"dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",  # noqa: E501
                     None,
                 )
 
@@ -2050,7 +2050,7 @@ def _parametrize_test_install_debuginfo() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dconf'), Package('libpng')),
-                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y  dconf libpng && rpm -q dconf-debuginfo libpng-debuginfo",  # noqa: E501
+                    r"yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y  dconf libpng && rpm -q dconf-debuginfo libpng-debuginfo",  # noqa: E501
                     None,
                 )
 
@@ -2059,7 +2059,7 @@ def _parametrize_test_install_debuginfo() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dos2unix'), Package('tree')),
-                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",  # noqa: E501
+                    r"yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",  # noqa: E501
                     None,
                 )
 
@@ -2124,7 +2124,7 @@ def _parametrize_test_install_debuginfo_nonexistent() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                r"rpm -q --whatprovides /usr/bin/debuginfo-install || dnf5 install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                r"dnf5 install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
                 None,
             )
 
@@ -2133,7 +2133,7 @@ def _parametrize_test_install_debuginfo_nonexistent() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                r"rpm -q --whatprovides /usr/bin/debuginfo-install || dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                r"dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
                 None,
             )
 
@@ -2142,7 +2142,7 @@ def _parametrize_test_install_debuginfo_nonexistent() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                r"rpm -q --whatprovides /usr/bin/debuginfo-install || yum install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                r"yum install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
                 None,
             )
 
@@ -2244,7 +2244,7 @@ def _parametrize_test_install_debuginfo_nonexistent_skip() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",  # noqa: E501
+                    r"dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",  # noqa: E501
                     None,
                 )
 
@@ -2266,7 +2266,7 @@ def _parametrize_test_install_debuginfo_nonexistent_skip() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                    r"rpm -q --whatprovides /usr/bin/debuginfo-install || yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",  # noqa: E501
+                    r"yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",  # noqa: E501
                     None,
                 )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1679,11 +1679,13 @@ def _parametrize_test_install_multiple() -> Iterator[
                 )
 
             elif 'centos' in container.url:
+                # diffutils is pre-installed on centos/7 and centos/stream10;
+                # nano is absent from any CentOS minimal image.
                 yield (
                     container,
                     package_manager_class,
-                    (Package('tree'), Package('diffutils')),
-                    r"yum install -y  tree diffutils && rpm -q --whatprovides tree diffutils",
+                    (Package('tree'), Package('nano')),
+                    r"yum install -y  tree nano && rpm -q --whatprovides tree nano",
                     'Complete!',
                 )
 
@@ -1707,11 +1709,13 @@ def _parametrize_test_install_multiple() -> Iterator[
                 )
 
             elif 'centos' in container.url:
+                # diffutils is pre-installed on centos/7 and centos/stream10;
+                # nano is absent from any CentOS minimal image.
                 yield (
                     container,
                     package_manager_class,
-                    (Package('tree'), Package('diffutils')),
-                    r"dnf install -y  tree diffutils",
+                    (Package('tree'), Package('nano')),
+                    r"dnf install -y  tree nano",
                     'Complete!',
                 )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1051,7 +1051,7 @@ def _parametrize_test_reinstall() -> Iterator[
                 package_manager_class,
                 Package('bash'),
                 True,
-                r"apk info -e bash && apk fix bash",
+                r"apk fix bash",
                 'Reinstalling bash',
             )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -31,7 +31,7 @@ from tmt.package_managers import (
 from tmt.steps.provision.podman import GuestContainer
 from tmt.utils import ShellScript
 
-from . import MATCH, assert_log
+from . import MATCH, SEARCH, assert_log
 
 # We will need a logger...
 logger = tmt.Logger.create()
@@ -983,6 +983,158 @@ def test_install_dont_check_first(
     output = package_manager.install(package, options=Options(check_first=False))
 
     assert_expected_command(caplog, expected_command)
+
+    assert_output(expected_output, output.stdout, output.stderr)
+
+
+def _parametrize_test_install_check_first_skips_present() -> Iterator[
+    tuple[Container, PackageManagerClass, Package, Package, str, str, Optional[str]]
+]:
+    for container, package_manager_class in CONTAINER_BASE_MATRIX:
+        if package_manager_class is tmt.package_managers.dnf.Dnf5:
+            # tar is pre-installed in all Fedora containers; tree is absent.
+            yield (
+                container,
+                package_manager_class,
+                Package('tar'),
+                Package('tree'),
+                r"rpm -q --whatprovides tar >&2 \|\| echo tar",
+                r"dnf5 install -y  tree",
+                None,
+            )
+
+        elif package_manager_class is tmt.package_managers.dnf.Dnf:
+            if 'ubi/8' in container.url:
+                # tree is not available in UBI 8 default repos; use dconf.
+                yield (
+                    container,
+                    package_manager_class,
+                    Package('tar'),
+                    Package('dconf'),
+                    r"rpm -q --whatprovides tar >&2 \|\| echo tar",
+                    r"dnf install -y  dconf",
+                    'Installed:\n  dconf',
+                )
+            else:
+                yield (
+                    container,
+                    package_manager_class,
+                    Package('tar'),
+                    Package('tree'),
+                    r"rpm -q --whatprovides tar >&2 \|\| echo tar",
+                    r"dnf install -y  tree",
+                    'Installed:\n  tree',
+                )
+
+        elif package_manager_class is tmt.package_managers.dnf.Yum:
+            if 'ubi/8' in container.url:
+                yield (
+                    container,
+                    package_manager_class,
+                    Package('tar'),
+                    Package('dconf'),
+                    r"rpm -q --whatprovides tar >&2 \|\| echo tar",
+                    r"yum install -y  dconf && rpm -q --whatprovides dconf",
+                    'Installed:\n  dconf',
+                )
+            else:
+                yield (
+                    container,
+                    package_manager_class,
+                    Package('tar'),
+                    Package('tree'),
+                    r"rpm -q --whatprovides tar >&2 \|\| echo tar",
+                    r"yum install -y  tree && rpm -q --whatprovides tree",
+                    'Installed:\n  tree',
+                )
+
+        elif package_manager_class is tmt.package_managers.apt.Apt:
+            # tar is pre-installed in Ubuntu and Debian; tree is absent.
+            yield (
+                container,
+                package_manager_class,
+                Package('tar'),
+                Package('tree'),
+                r'PRESENCE-TEST:tar:tar:',
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
+                'Setting up tree',
+            )
+
+        elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
+            # tar is pre-installed in rpm-ostree images; tree is absent.
+            yield (
+                container,
+                package_manager_class,
+                Package('tar'),
+                Package('tree'),
+                r"rpm -q --whatprovides tar >&2 \|\| echo tar",
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree",
+                'Installing: tree',
+            )
+
+        elif package_manager_class is tmt.package_managers.apk.Apk:
+            # busybox is pre-installed in Alpine; tree is absent.
+            yield (
+                container,
+                package_manager_class,
+                Package('busybox'),
+                Package('tree'),
+                r"apk info -e busybox tree",
+                r"apk add tree",
+                'Installing tree',
+            )
+
+        else:
+            pytest.fail(f"Unhandled package manager class '{package_manager_class}'.")
+
+
+@pytest.mark.containers
+@pytest.mark.parametrize(
+    (
+        'container_per_test',
+        'package_manager_class',
+        'present_package',
+        'absent_package',
+        'expected_check_command',
+        'expected_install_command',
+        'expected_output',
+    ),
+    list(_parametrize_test_install_check_first_skips_present()),
+    indirect=["container_per_test"],
+    ids=CONTAINER_MATRIX_IDS,
+)
+def test_install_check_first_skips_present(
+    container_per_test: ContainerData,
+    guest_per_test: GuestContainer,
+    package_manager_class: PackageManagerClass,
+    present_package: Package,
+    absent_package: Package,
+    expected_check_command: str,
+    expected_install_command: str,
+    expected_output: Optional[str],
+    root_logger: tmt.log.Logger,
+    caplog: _pytest.logging.LogCaptureFixture,
+) -> None:
+    """
+    Regression test: with check_first=True and a mixed set [present, absent],
+    only the absent package should reach the install command. The present package
+    should not be forwarded to the package manager and should not be silently upgraded.
+    """
+    package_manager = create_package_manager(
+        container_per_test, guest_per_test, package_manager_class, root_logger
+    )
+
+    output = package_manager.install(
+        present_package,
+        absent_package,
+        options=Options(check_first=True),
+    )
+
+    # The presence check should have run and covered the pre-installed package.
+    assert_log(caplog, message=SEARCH(expected_check_command))
+
+    # Only the absent package should have been passed to the install command
+    assert_expected_command(caplog, expected_install_command)
 
     assert_output(expected_output, output.stdout, output.stderr)
 

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -1,5 +1,6 @@
 import abc
 import configparser
+import dataclasses
 import enum
 import re
 import shlex
@@ -575,7 +576,8 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         to_install = self._check_first_filter(*installables, options=options, present=False)
         if not to_install:
             return CommandOutput(stdout=None, stderr=None)
-        return self.guest.execute(self.engine.install(*to_install, options=options))
+        no_check_options = dataclasses.replace(options, check_first=False)
+        return self.guest.execute(self.engine.install(*to_install, options=no_check_options))
 
     def reinstall(
         self,
@@ -586,7 +588,8 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         to_reinstall = self._check_first_filter(*installables, options=options, present=True)
         if not to_reinstall:
             return CommandOutput(stdout=None, stderr=None)
-        return self.guest.execute(self.engine.reinstall(*to_reinstall, options=options))
+        no_check_options = dataclasses.replace(options, check_first=False)
+        return self.guest.execute(self.engine.reinstall(*to_reinstall, options=no_check_options))
 
     def install_debuginfo(
         self,

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -1,6 +1,5 @@
 import abc
 import configparser
-import dataclasses
 import enum
 import re
 import shlex
@@ -564,9 +563,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         if not missing:
             return CommandOutput(stdout=None, stderr=None)
 
-        return self.guest.execute(
-            self.engine.install(*missing, options=dataclasses.replace(options, check_first=False))
-        )
+        return self.guest.execute(self.engine.install(*missing, options=options))
 
     def reinstall(
         self,

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -1,5 +1,6 @@
 import abc
 import configparser
+import dataclasses
 import enum
 import re
 import shlex
@@ -552,7 +553,20 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-        return self.guest.execute(self.engine.install(*installables, options=options))
+        options = options or Options()
+
+        if not options.check_first or not installables:
+            return self.guest.execute(self.engine.install(*installables, options=options))
+
+        presence = self.check_presence(*installables)
+        missing = tuple(p for p, present in presence.items() if not present)
+
+        if not missing:
+            return CommandOutput(stdout=None, stderr=None)
+
+        return self.guest.execute(
+            self.engine.install(*missing, options=dataclasses.replace(options, check_first=False))
+        )
 
     def reinstall(
         self,

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -570,7 +570,18 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-        return self.guest.execute(self.engine.reinstall(*installables, options=options))
+        options = options or Options()
+
+        if not options.check_first or not installables:
+            return self.guest.execute(self.engine.reinstall(*installables, options=options))
+
+        presence = self.check_presence(*installables)
+        present = tuple(p for p, is_present in presence.items() if is_present)
+
+        if not present:
+            return CommandOutput(stdout=None, stderr=None)
+
+        return self.guest.execute(self.engine.reinstall(*present, options=options))
 
     def install_debuginfo(
         self,

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -547,23 +547,34 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
             for match in pattern.finditer(output):
                 yield match.group(1)
 
+    def _check_first_filter(
+        self,
+        *installables: Installable,
+        options: Options,
+        present: bool,
+    ) -> list[Installable]:
+        """
+        Filter installables by presence when check_first is set.
+
+        Returns the full list of installables when check_first is not set.
+        Returns a subset (possibly empty) matching the desired presence state
+        when check_first is set. Order is preserved.
+        """
+        if not options.check_first:
+            return list(installables)
+        presence = self.check_presence(*installables)
+        return [p for p, is_present in presence.items() if is_present == present]
+
     def install(
         self,
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
         options = options or Options()
-
-        if not options.check_first or not installables:
-            return self.guest.execute(self.engine.install(*installables, options=options))
-
-        presence = self.check_presence(*installables)
-        missing = {p for p, present in presence.items() if not present}
-
-        if not missing:
+        to_install = self._check_first_filter(*installables, options=options, present=False)
+        if not to_install:
             return CommandOutput(stdout=None, stderr=None)
-
-        return self.guest.execute(self.engine.install(*missing, options=options))
+        return self.guest.execute(self.engine.install(*to_install, options=options))
 
     def reinstall(
         self,
@@ -571,17 +582,10 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         options: Optional[Options] = None,
     ) -> CommandOutput:
         options = options or Options()
-
-        if not options.check_first or not installables:
-            return self.guest.execute(self.engine.reinstall(*installables, options=options))
-
-        presence = self.check_presence(*installables)
-        present = {p for p, is_present in presence.items() if is_present}
-
-        if not present:
+        to_reinstall = self._check_first_filter(*installables, options=options, present=True)
+        if not to_reinstall:
             return CommandOutput(stdout=None, stderr=None)
-
-        return self.guest.execute(self.engine.reinstall(*present, options=options))
+        return self.guest.execute(self.engine.reinstall(*to_reinstall, options=options))
 
     def install_debuginfo(
         self,

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -554,11 +554,12 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         present: bool,
     ) -> list[Installable]:
         """
-        Filter installables by presence when check_first is set.
+        Filter installables by their presence when "check first" is enabled.
 
-        Returns the full list of installables when check_first is not set.
-        Returns a subset (possibly empty) matching the desired presence state
-        when check_first is set. Order is preserved.
+        :returns: full list of installables when :py:attr:`Options.check_first`
+            of ``options`` is not set, a subset of installables whose presence
+            matches ``present`` otherwise. The returned list can be empty. Order
+            of installables is preserved.
         """
         if not options.check_first:
             return list(installables)

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -558,7 +558,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
             return self.guest.execute(self.engine.install(*installables, options=options))
 
         presence = self.check_presence(*installables)
-        missing = tuple(p for p, present in presence.items() if not present)
+        missing = {p for p, present in presence.items() if not present}
 
         if not missing:
             return CommandOutput(stdout=None, stderr=None)
@@ -576,7 +576,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
             return self.guest.execute(self.engine.reinstall(*installables, options=options))
 
         presence = self.check_presence(*installables)
-        present = tuple(p for p, is_present in presence.items() if is_present)
+        present = {p for p, is_present in presence.items() if is_present}
 
         if not present:
             return CommandOutput(stdout=None, stderr=None)

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -141,9 +141,6 @@ class ApkEngine(PackageManagerEngine):
             f'{self.command.to_script()} fix {" ".join(escape_installables(*packages))}'
         )
 
-        if options.check_first:
-            script = self._construct_presence_script(*packages)[1] & script
-
         if options.skip_missing:
             script = script | ShellScript('/bin/true')
 

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -123,9 +123,6 @@ class ApkEngine(PackageManagerEngine):
             f'{" ".join(escape_installables(*packages))}'
         )
 
-        if options.check_first:
-            script = self._construct_presence_script(*packages)[1] | script
-
         if options.skip_missing:
             script = script | ShellScript('/bin/true')
 

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -64,12 +64,10 @@ installable_packages="$installable_packages $fs_path_package"
   {% endfor %}
 {% endif %}
 
-{% if OPTIONS.check_first %}
+{% if OPTIONS.check_first and COMMAND != 'install' -%}
 dpkg-query --show $installable_packages \\
-{% else -%}
-/bin/false \\
-{% endif -%}
-{{ '||' if COMMAND == 'install' else '&&' }} {{ ENGINE.command.to_script() }} {{ COMMAND }} {{ ENGINE.options.to_script() }} {{ EXTRA_OPTIONS }} $installable_packages
+&& {% endif -%}
+{{ ENGINE.command.to_script() }} {{ COMMAND }} {{ ENGINE.options.to_script() }} {{ EXTRA_OPTIONS }} $installable_packages
 
 {% if OPTIONS.skip_missing %}
 exit 0

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -64,7 +64,9 @@ installable_packages="$installable_packages $fs_path_package"
   {% endfor %}
 {% endif %}
 
-{{ ENGINE.command.to_script() }} {{ COMMAND }} {{ ENGINE.options.to_script() }} {{ EXTRA_OPTIONS }} $installable_packages
+{% if CHECK_FIRST %}
+dpkg-query --show $installable_packages \\
+&& {% endif %}{{ ENGINE.command.to_script() }} {{ COMMAND }} {{ ENGINE.options.to_script() }} {{ EXTRA_OPTIONS }} $installable_packages
 
 {% if OPTIONS.skip_missing %}
 exit 0
@@ -214,6 +216,7 @@ class AptEngine(PackageManagerEngine):
                     COMMAND='reinstall',
                     OPTIONS=options,
                     EXTRA_OPTIONS=extra_options,
+                    CHECK_FIRST=True,
                     REAL_PACKAGES=escape_installables(*real_packages),
                     FILESYSTEM_PATHS=escape_installables(*filesystem_paths),
                 )
@@ -226,8 +229,9 @@ class AptEngine(PackageManagerEngine):
                 COMMAND='reinstall',
                 OPTIONS=options,
                 EXTRA_OPTIONS=extra_options,
-                REAL_PACKAGES=real_packages,
-                FILESYSTEM_PATHS=filesystem_paths,
+                CHECK_FIRST=True,
+                REAL_PACKAGES=escape_installables(*real_packages),
+                FILESYSTEM_PATHS=escape_installables(*filesystem_paths),
             )
         )
 

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -181,6 +181,7 @@ class AptEngine(PackageManagerEngine):
                     COMMAND='install',
                     OPTIONS=options,
                     EXTRA_OPTIONS=extra_options,
+                    CHECK_FIRST=False,
                     REAL_PACKAGES=escape_installables(*real_packages),
                     FILESYSTEM_PATHS=escape_installables(*filesystem_paths),
                 )
@@ -193,6 +194,7 @@ class AptEngine(PackageManagerEngine):
                 COMMAND='install',
                 OPTIONS=options,
                 EXTRA_OPTIONS=extra_options,
+                CHECK_FIRST=False,
                 REAL_PACKAGES=escape_installables(*real_packages),
                 FILESYSTEM_PATHS=escape_installables(*filesystem_paths),
             )

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -64,9 +64,6 @@ installable_packages="$installable_packages $fs_path_package"
   {% endfor %}
 {% endif %}
 
-{% if OPTIONS.check_first and COMMAND != 'install' -%}
-dpkg-query --show $installable_packages \\
-&& {% endif -%}
 {{ ENGINE.command.to_script() }} {{ COMMAND }} {{ ENGINE.options.to_script() }} {{ EXTRA_OPTIONS }} $installable_packages
 
 {% if OPTIONS.skip_missing %}

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -1,4 +1,3 @@
-import re
 import uuid
 from collections.abc import Iterator
 from typing import Any, Optional
@@ -15,7 +14,7 @@ from tmt.package_managers import (
     PackageManagerEngine,
     provides_package_manager,
 )
-from tmt.utils import Command, CommandOutput, GeneralError, Path, RunError, ShellScript
+from tmt.utils import Command, CommandOutput, Path, ShellScript
 
 LOCALHOST_BOOTC_IMAGE_PREFIX = "localhost/tmt"
 
@@ -210,32 +209,18 @@ class Bootc(PackageManager[BootcEngine]):
         return self.guest.bootc_builder.extract_package_name_from_package_manager_output(output)
 
     def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
+        if not installables:
+            return {}
+
         script = self.engine.check_presence(*installables)
+        output = self.guest.execute(script)
 
-        try:
-            output = self.guest.execute(script)
-            stdout = output.stdout
+        results: dict[Installable, bool] = dict.fromkeys(installables, True)
+        missing = {line.strip() for line in (output.stdout or '').splitlines() if line.strip()}
 
-        except RunError as exc:
-            stdout = exc.stdout
-
-        if stdout is None:
-            raise GeneralError("rpm presence check provided no output")
-
-        results: dict[Installable, bool] = {}
-
-        for line, installable in zip(stdout.strip().splitlines(), installables):
-            match = re.match(rf'package {re.escape(str(installable))} is not installed', line)
-            if match is not None:
+        for installable in installables:
+            if str(installable) in missing:
                 results[installable] = False
-                continue
-
-            match = re.match(rf'no package provides {re.escape(str(installable))}', line)
-            if match is not None:
-                results[installable] = False
-                continue
-
-            results[installable] = True
 
         return results
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -77,7 +77,7 @@ class DnfEngine(PackageManagerEngine):
 
     def check_presence(self, *installables: Installable) -> ShellScript:
         parts = [
-            f"rpm -q --whatprovides '{installable}' >&2 || echo '{installable}'"
+            f'rpm -q --whatprovides "{installable}" >&2 || echo "{installable}"'
             for installable in installables
         ]
         return ShellScript('\n'.join(parts))

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -76,10 +76,10 @@ class DnfEngine(PackageManagerEngine):
         return ShellScript(f'rpm -q {" ".join(escape_installables(*installables))}')
 
     def check_presence(self, *installables: Installable) -> ShellScript:
-        parts = [
-            f'rpm -q --whatprovides "{installable}" >&2 || echo "{installable}"'
-            for installable in installables
-        ]
+        parts: list[str] = []
+        for installable in installables:
+            e = next(escape_installables(installable))
+            parts.append(f'rpm -q --whatprovides {e} >&2 || echo {e}')
         return ShellScript('\n'.join(parts))
 
     def _construct_install_script(

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -313,9 +313,9 @@ class Dnf(PackageManager[DnfEngine]):
             # rpm exits non-zero when any installable is missing. When checking
             # multiple installables in one command, stdout only contains lines for
             # found packages (so zip-based parsing silently drops missing ones).
-            # Error messages for missing packages always go to stderr parse that
-            # to correctly identify each absent installable.
-            stderr = exc.stderr or ''
+            # "no package provides X" messages go to stdout; some errors (e.g.
+            # file-not-found) go to stderr. Search both to be safe.
+            output = (exc.stdout or '') + '\n' + (exc.stderr or '')
 
             for installable in installables:
                 installable_str = re.escape(str(installable))
@@ -327,7 +327,7 @@ class Dnf(PackageManager[DnfEngine]):
                     # rpm -q --whatprovides /path
                     rf'|error: file {installable_str}: No such file or directory'
                 )
-                if pattern.search(stderr):
+                if pattern.search(output):
                     results[installable] = False
 
             # rpm exited non-zero but no missing packages were identified

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -77,7 +77,7 @@ class DnfEngine(PackageManagerEngine):
 
     def check_presence(self, *installables: Installable) -> ShellScript:
         parts = [
-            f'rpm -q --whatprovides {escaped} >/dev/null 2>&1 || echo {escaped}'
+            f"rpm -q --whatprovides '{escaped}' >&2 || echo '{escaped}'"
             for escaped in escape_installables(*installables)
         ]
         return ShellScript('\n'.join(parts))

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -76,11 +76,12 @@ class DnfEngine(PackageManagerEngine):
         return ShellScript(f'rpm -q {" ".join(escape_installables(*installables))}')
 
     def check_presence(self, *installables: Installable) -> ShellScript:
-        parts: list[str] = []
-        for installable in installables:
-            e = next(escape_installables(installable))
-            parts.append(f'rpm -q --whatprovides {e} >&2 || echo {e}')
-        return ShellScript('\n'.join(parts))
+        return ShellScript(
+            '\n'.join(
+                f'rpm -q --whatprovides {escaped} >&2 || echo {escaped}'
+                for escaped in escape_installables(*installables)
+            )
+        )
 
     def _construct_install_script(
         self, *installables: Installable, options: Optional[Options] = None

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -102,16 +102,11 @@ class DnfEngine(PackageManagerEngine):
 
         extra_options = self._extra_dnf_options(options)
 
-        script = ShellScript(
+        return ShellScript(
             f'{self.command.to_script()} reinstall '
             f'{self.options.to_script()} {extra_options} '
             f'{" ".join(escape_installables(*installables))}'
         )
-
-        if options.check_first:
-            script = self._construct_presence_script(*installables) & script
-
-        return script
 
     def _construct_install_debuginfo_script(
         self, *installables: Installable, options: Optional[Options] = None

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -300,41 +300,40 @@ class Dnf(PackageManager[DnfEngine]):
         return result
 
     def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
+        if not installables:
+            return {}
+
+        # Assume all present; mark missing ones identified from rpm error output.
+        results: dict[Installable, bool] = dict.fromkeys(installables, True)
+
         try:
-            output = self.guest.execute(self.engine.check_presence(*installables))
-            stdout = output.stdout
+            self.guest.execute(self.engine.check_presence(*installables))
 
         except RunError as exc:
-            stdout = exc.stdout
+            # rpm exits non-zero when any installable is missing. When checking
+            # multiple installables in one command, stdout only contains lines for
+            # found packages (so zip-based parsing silently drops missing ones).
+            # Error messages for missing packages always go to stderr parse that
+            # to correctly identify each absent installable.
+            stderr = exc.stderr or ''
 
-        if stdout is None:
-            raise GeneralError("rpm presence check provided no output")
+            for installable in installables:
+                installable_str = re.escape(str(installable))
+                pattern = re.compile(
+                    # rpm -q PACKAGE
+                    rf'package {installable_str} is not installed'
+                    # rpm -q --whatprovides CAPABILITY
+                    rf'|no package provides {installable_str}'
+                    # rpm -q --whatprovides /path
+                    rf'|error: file {installable_str}: No such file or directory'
+                )
+                if pattern.search(stderr):
+                    results[installable] = False
 
-        results: dict[Installable, bool] = {}
-
-        for line, installable in zip(stdout.strip().splitlines(), installables):
-            # Match for packages not installed, when "rpm -q PACKAGE" used
-            match = re.match(rf'package {re.escape(str(installable))} is not installed', line)
-            if match is not None:
-                results[installable] = False
-                continue
-
-            # Match for provided rpm capabilities (packages, commands, etc.),
-            # when "rpm -q --whatprovides CAPABILITY" used
-            match = re.match(rf'no package provides {re.escape(str(installable))}', line)
-            if match is not None:
-                results[installable] = False
-                continue
-
-            # Match for filesystem paths, when "rpm -q --whatprovides PATH" used
-            match = re.match(
-                rf'error: file {re.escape(str(installable))}: No such file or directory', line
-            )
-            if match is not None:
-                results[installable] = False
-                continue
-
-            results[installable] = True
+            # rpm exited non-zero but no missing packages were identified
+            # this signals an unexpected failure (db corruption, permission error, etc.)
+            if all(results.values()):
+                raise
 
         return results
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -85,21 +85,10 @@ class DnfEngine(PackageManagerEngine):
 
         extra_options = self._extra_dnf_options(options)
 
-        install_cmd = (
-            f'{self.command.to_script()} install {self.options.to_script()} {extra_options}'
-        )
-
-        if not options.check_first:
-            return ShellScript(f'{install_cmd} {" ".join(escape_installables(*installables))}')
-
-        # Avoid best=True upgrades: set-level || check sends present packages to DNF.
-        pkgs = ' '.join(escape_installables(*installables))
         return ShellScript(
-            f'_tmt_missing=(); '
-            f'for _tmt_pkg in {pkgs}; do '
-            f'rpm -q --whatprovides "$_tmt_pkg" &>/dev/null || _tmt_missing+=("$_tmt_pkg"); '
-            f'done; '
-            f'[[ ${{#_tmt_missing[@]}} -eq 0 ]] || {install_cmd} "${{_tmt_missing[@]}}"'
+            f'{self.command.to_script()} install '
+            f'{self.options.to_script()} {extra_options} '
+            f'{" ".join(escape_installables(*installables))}'
         )
 
     def _construct_reinstall_script(
@@ -293,7 +282,6 @@ class Dnf(PackageManager[DnfEngine]):
     probe_priority = 50
 
     def list_packages(self, repository: Repository) -> list[Version]:
-
         script = self.engine.list_packages(repository)
         output = self.guest.execute(script)
         stdout = output.stdout
@@ -349,6 +337,25 @@ class Dnf(PackageManager[DnfEngine]):
 
         return results
 
+    def install(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> CommandOutput:
+        options = options or Options()
+
+        if not options.check_first or not installables:
+            return super().install(*installables, options=options)
+
+        presence = self.check_presence(*installables)
+        missing = tuple(p for p, present in presence.items() if not present)
+
+        if not missing:
+            return CommandOutput(stdout=None, stderr=None)
+
+        options.check_first = False
+        return super().install(*missing, options=options)
+
     def assert_config_manager(self) -> None:
         self.debug('Make sure the config-manager plugin is available.')
         self.install(Package(self.config_manager_plugin))
@@ -378,7 +385,6 @@ class Dnf(PackageManager[DnfEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-
         options = options or Options()
         options.check_first = False
         # Use both install/reinstall to get all packages refreshed
@@ -392,7 +398,6 @@ class Dnf(PackageManager[DnfEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-
         output = super().install_debuginfo(*installables, options=options)
 
         # Check the packages are installed because 'debuginfo-install'

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -77,8 +77,8 @@ class DnfEngine(PackageManagerEngine):
 
     def check_presence(self, *installables: Installable) -> ShellScript:
         parts = [
-            f"rpm -q --whatprovides '{escaped}' >&2 || echo '{escaped}'"
-            for escaped in escape_installables(*installables)
+            f"rpm -q --whatprovides '{installable}' >&2 || echo '{installable}'"
+            for installable in installables
         ]
         return ShellScript('\n'.join(parts))
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -282,6 +282,7 @@ class Dnf(PackageManager[DnfEngine]):
     probe_priority = 50
 
     def list_packages(self, repository: Repository) -> list[Version]:
+
         script = self.engine.list_packages(repository)
         output = self.guest.execute(script)
         stdout = output.stdout
@@ -337,25 +338,6 @@ class Dnf(PackageManager[DnfEngine]):
 
         return results
 
-    def install(
-        self,
-        *installables: Installable,
-        options: Optional[Options] = None,
-    ) -> CommandOutput:
-        options = options or Options()
-
-        if not options.check_first or not installables:
-            return super().install(*installables, options=options)
-
-        presence = self.check_presence(*installables)
-        missing = tuple(p for p, present in presence.items() if not present)
-
-        if not missing:
-            return CommandOutput(stdout=None, stderr=None)
-
-        options.check_first = False
-        return super().install(*missing, options=options)
-
     def assert_config_manager(self) -> None:
         self.debug('Make sure the config-manager plugin is available.')
         self.install(Package(self.config_manager_plugin))
@@ -385,6 +367,7 @@ class Dnf(PackageManager[DnfEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
+
         options = options or Options()
         options.check_first = False
         # Use both install/reinstall to get all packages refreshed
@@ -398,6 +381,7 @@ class Dnf(PackageManager[DnfEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
+
         output = super().install_debuginfo(*installables, options=options)
 
         # Check the packages are installed because 'debuginfo-install'

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -17,7 +17,7 @@ from tmt.package_managers import (
     provides_package_manager,
 )
 from tmt.package_managers._rpm import RpmVersion
-from tmt.utils import Command, CommandOutput, GeneralError, PrepareError, RunError, ShellScript
+from tmt.utils import Command, CommandOutput, GeneralError, PrepareError, ShellScript
 
 
 class DnfEngine(PackageManagerEngine):
@@ -76,7 +76,11 @@ class DnfEngine(PackageManagerEngine):
         return ShellScript(f'rpm -q {" ".join(escape_installables(*installables))}')
 
     def check_presence(self, *installables: Installable) -> ShellScript:
-        return self._construct_presence_script(*installables)
+        parts = [
+            f'rpm -q --whatprovides {escaped} >/dev/null 2>&1 || echo {escaped}'
+            for escaped in escape_installables(*installables)
+        ]
+        return ShellScript('\n'.join(parts))
 
     def _construct_install_script(
         self, *installables: Installable, options: Optional[Options] = None
@@ -303,37 +307,15 @@ class Dnf(PackageManager[DnfEngine]):
         if not installables:
             return {}
 
-        # Assume all present; mark missing ones identified from rpm error output.
         results: dict[Installable, bool] = dict.fromkeys(installables, True)
 
-        try:
-            self.guest.execute(self.engine.check_presence(*installables))
+        # Script always exits 0; stdout contains one line per missing package.
+        output = self.guest.execute(self.engine.check_presence(*installables))
+        missing = {line.strip() for line in (output.stdout or '').splitlines() if line.strip()}
 
-        except RunError as exc:
-            # rpm exits non-zero when any installable is missing. When checking
-            # multiple installables in one command, stdout only contains lines for
-            # found packages (so zip-based parsing silently drops missing ones).
-            # "no package provides X" messages go to stdout; some errors (e.g.
-            # file-not-found) go to stderr. Search both to be safe.
-            output = (exc.stdout or '') + '\n' + (exc.stderr or '')
-
-            for installable in installables:
-                installable_str = re.escape(str(installable))
-                pattern = re.compile(
-                    # rpm -q PACKAGE
-                    rf'package {installable_str} is not installed'
-                    # rpm -q --whatprovides CAPABILITY
-                    rf'|no package provides {installable_str}'
-                    # rpm -q --whatprovides /path
-                    rf'|error: file {installable_str}: No such file or directory'
-                )
-                if pattern.search(output):
-                    results[installable] = False
-
-            # rpm exited non-zero but no missing packages were identified
-            # this signals an unexpected failure (db corruption, permission error, etc.)
-            if all(results.values()):
-                raise
+        for installable in installables:
+            if str(installable) in missing:
+                results[installable] = False
 
         return results
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -85,16 +85,22 @@ class DnfEngine(PackageManagerEngine):
 
         extra_options = self._extra_dnf_options(options)
 
-        script = ShellScript(
-            f'{self.command.to_script()} install '
-            f'{self.options.to_script()} {extra_options} '
-            f'{" ".join(escape_installables(*installables))}'
+        install_cmd = (
+            f'{self.command.to_script()} install {self.options.to_script()} {extra_options}'
         )
 
-        if options.check_first:
-            script = self._construct_presence_script(*installables) | script
+        if not options.check_first:
+            return ShellScript(f'{install_cmd} {" ".join(escape_installables(*installables))}')
 
-        return script
+        # Avoid best=True upgrades: set-level || check sends present packages to DNF.
+        pkgs = ' '.join(escape_installables(*installables))
+        return ShellScript(
+            f'_tmt_missing=(); '
+            f'for _tmt_pkg in {pkgs}; do '
+            f'rpm -q --whatprovides "$_tmt_pkg" &>/dev/null || _tmt_missing+=("$_tmt_pkg"); '
+            f'done; '
+            f'[[ ${{#_tmt_missing[@]}} -eq 0 ]] || {install_cmd} "${{_tmt_missing[@]}}"'
+        )
 
     def _construct_reinstall_script(
         self, *installables: Installable, options: Optional[Options] = None

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -53,11 +53,12 @@ class MockEngine(PackageManagerEngine):
         return (Command('mock'), options)
 
     def check_presence(self, *installables: Installable) -> ShellScript:
-        parts = [
-            f'rpm -q --whatprovides "{installable}" >&2 || echo "{installable}"'
-            for installable in installables
-        ]
-        return ShellScript('\n'.join(parts))
+        return ShellScript(
+            '\n'.join(
+                f'rpm -q --whatprovides {escaped} >&2 || echo {escaped}'
+                for escaped in escape_installables(*installables)
+            )
+        )
 
     def install(
         self,

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -54,8 +54,8 @@ class MockEngine(PackageManagerEngine):
 
     def check_presence(self, *installables: Installable) -> ShellScript:
         parts = [
-            f"rpm -q --whatprovides '{escaped}' >&2 || echo '{escaped}'"
-            for escaped in escape_installables(*installables)
+            f"rpm -q --whatprovides '{installable}' >&2 || echo '{installable}'"
+            for installable in installables
         ]
         return ShellScript('\n'.join(parts))
 

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -133,7 +133,7 @@ class _MockPackageManager(PackageManager[MockEngine]):
             )
 
         presence = self.check_presence(*installables)
-        missing = tuple(p for p, present in presence.items() if not present)
+        missing = {p for p, present in presence.items() if not present}
 
         if not missing:
             return CommandOutput(stdout=None, stderr=None)
@@ -153,7 +153,7 @@ class _MockPackageManager(PackageManager[MockEngine]):
             )
 
         presence = self.check_presence(*installables)
-        present = tuple(p for p, is_present in presence.items() if is_present)
+        present = {p for p, is_present in presence.items() if is_present}
 
         if not present:
             return CommandOutput(stdout=None, stderr=None)

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -1,4 +1,3 @@
-import re
 from typing import (
     Optional,
 )
@@ -13,7 +12,7 @@ from tmt.package_managers import (
     provides_package_manager,
 )
 from tmt.steps.provision.mock import GuestMock
-from tmt.utils import Command, CommandOutput, GeneralError, PrepareError, RunError, ShellScript
+from tmt.utils import Command, CommandOutput, PrepareError, ShellScript
 
 
 class MockEngine(PackageManagerEngine):
@@ -54,7 +53,11 @@ class MockEngine(PackageManagerEngine):
         return (Command('mock'), options)
 
     def check_presence(self, *installables: Installable) -> ShellScript:
-        return ShellScript(f'rpm -q --whatprovides {" ".join(escape_installables(*installables))}')
+        parts = [
+            f"rpm -q --whatprovides '{escaped}' >&2 || echo '{escaped}'"
+            for escaped in escape_installables(*installables)
+        ]
+        return ShellScript('\n'.join(parts))
 
     def install(
         self,
@@ -101,44 +104,19 @@ class _MockPackageManager(PackageManager[MockEngine]):
     probe_priority = 130
     _engine_class = MockEngine
 
-    # Implementation "stolen" from the dnf package manager family. It should
-    # be good enough for mock, at least for now.
     def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
-        try:
-            output = self.guest.execute(self.engine.check_presence(*installables))
-            stdout = output.stdout
+        if not installables:
+            return {}
 
-        except RunError as exc:
-            stdout = exc.stdout
+        results: dict[Installable, bool] = dict.fromkeys(installables, True)
 
-        if stdout is None:
-            raise GeneralError("rpm presence check provided no output")
+        # Script always exits 0; stdout contains one line per missing package.
+        output = self.guest.execute(self.engine.check_presence(*installables))
+        missing = {line.strip() for line in (output.stdout or '').splitlines() if line.strip()}
 
-        results: dict[Installable, bool] = {}
-
-        for line, installable in zip(stdout.strip().splitlines(), installables):
-            # Match for packages not installed, when "rpm -q PACKAGE" used
-            match = re.match(rf'package {re.escape(str(installable))} is not installed', line)
-            if match is not None:
+        for installable in installables:
+            if str(installable) in missing:
                 results[installable] = False
-                continue
-
-            # Match for provided rpm capabilities (packages, commands, etc.),
-            # when "rpm -q --whatprovides CAPABILITY" used
-            match = re.match(rf'no package provides {re.escape(str(installable))}', line)
-            if match is not None:
-                results[installable] = False
-                continue
-
-            # Match for filesystem paths, when "rpm -q --whatprovides PATH" used
-            match = re.match(
-                rf'error: file {re.escape(str(installable))}: No such file or directory', line
-            )
-            if match is not None:
-                results[installable] = False
-                continue
-
-            results[installable] = True
 
         return results
 
@@ -167,16 +145,20 @@ class _MockPackageManager(PackageManager[MockEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-        if options is not None and options.check_first:
-            # TODO implement a more robust check that the package is not installed
-            # other than catching RunError.
-            try:
-                self.guest.execute(self.engine.check_presence(*installables))
-            except RunError as err:
-                return err.output
-        return self.guest.run(
-            self.engine.reinstall(*installables, options=options).to_shell_command()
-        )
+        options = options or Options()
+
+        if not options.check_first or not installables:
+            return self.guest.run(
+                self.engine.reinstall(*installables, options=options).to_shell_command()
+            )
+
+        presence = self.check_presence(*installables)
+        present = tuple(p for p, is_present in presence.items() if is_present)
+
+        if not present:
+            return CommandOutput(stdout=None, stderr=None)
+
+        return self.guest.run(self.engine.reinstall(*present, options=options).to_shell_command())
 
     def install_debuginfo(
         self,

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -147,14 +147,20 @@ class _MockPackageManager(PackageManager[MockEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-        if options is not None and options.check_first:
-            try:
-                return self.guest.execute(self.engine.check_presence(*installables))
-            except RunError:
-                pass
-        return self.guest.run(
-            self.engine.install(*installables, options=options).to_shell_command()
-        )
+        options = options or Options()
+
+        if not options.check_first or not installables:
+            return self.guest.run(
+                self.engine.install(*installables, options=options).to_shell_command()
+            )
+
+        presence = self.check_presence(*installables)
+        missing = tuple(p for p, present in presence.items() if not present)
+
+        if not missing:
+            return CommandOutput(stdout=None, stderr=None)
+
+        return self.guest.run(self.engine.install(*missing, options=options).to_shell_command())
 
     def reinstall(
         self,

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -54,7 +54,7 @@ class MockEngine(PackageManagerEngine):
 
     def check_presence(self, *installables: Installable) -> ShellScript:
         parts = [
-            f"rpm -q --whatprovides '{installable}' >&2 || echo '{installable}'"
+            f'rpm -q --whatprovides "{installable}" >&2 || echo "{installable}"'
             for installable in installables
         ]
         return ShellScript('\n'.join(parts))
@@ -126,19 +126,10 @@ class _MockPackageManager(PackageManager[MockEngine]):
         options: Optional[Options] = None,
     ) -> CommandOutput:
         options = options or Options()
-
-        if not options.check_first or not installables:
-            return self.guest.run(
-                self.engine.install(*installables, options=options).to_shell_command()
-            )
-
-        presence = self.check_presence(*installables)
-        missing = {p for p, present in presence.items() if not present}
-
-        if not missing:
+        to_install = self._check_first_filter(*installables, options=options, present=False)
+        if not to_install:
             return CommandOutput(stdout=None, stderr=None)
-
-        return self.guest.run(self.engine.install(*missing, options=options).to_shell_command())
+        return self.guest.run(self.engine.install(*to_install, options=options).to_shell_command())
 
     def reinstall(
         self,
@@ -146,19 +137,12 @@ class _MockPackageManager(PackageManager[MockEngine]):
         options: Optional[Options] = None,
     ) -> CommandOutput:
         options = options or Options()
-
-        if not options.check_first or not installables:
-            return self.guest.run(
-                self.engine.reinstall(*installables, options=options).to_shell_command()
-            )
-
-        presence = self.check_presence(*installables)
-        present = {p for p, is_present in presence.items() if is_present}
-
-        if not present:
+        to_reinstall = self._check_first_filter(*installables, options=options, present=True)
+        if not to_reinstall:
             return CommandOutput(stdout=None, stderr=None)
-
-        return self.guest.run(self.engine.reinstall(*present, options=options).to_shell_command())
+        return self.guest.run(
+            self.engine.reinstall(*to_reinstall, options=options).to_shell_command()
+        )
 
     def install_debuginfo(
         self,

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -243,18 +243,18 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
         required, recommended = self.sort_packages(*installables, options=options)
 
         # sort_packages already checked presence; skip the check in super().install.
-        no_check = dataclasses.replace(options, check_first=False)
+        no_check_options = dataclasses.replace(options, check_first=False)
 
         for package in recommended:
             self.info('package', str(package), 'green')
             try:
-                super().install(package, options=no_check)
+                super().install(package, options=no_check_options)
             except RunError as error:
                 self.debug(f"Package installation failed: {error}")
                 self.warn(f"Unable to install recommended package '{package}'.")
 
         if required:
-            return super().install(*required, options=no_check)
+            return super().install(*required, options=no_check_options)
 
         return CommandOutput(stdout=None, stderr=None)
 

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -1,3 +1,4 @@
+import dataclasses
 import re
 from typing import Optional
 
@@ -241,16 +242,19 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
         options = options or Options()
         required, recommended = self.sort_packages(*installables, options=options)
 
+        # sort_packages already checked presence; skip the check in super().install.
+        no_check = dataclasses.replace(options, check_first=False)
+
         for package in recommended:
             self.info('package', str(package), 'green')
             try:
-                super().install(package, options=options)
+                super().install(package, options=no_check)
             except RunError as error:
                 self.debug(f"Package installation failed: {error}")
                 self.warn(f"Unable to install recommended package '{package}'.")
 
         if required:
-            return super().install(*required, options=options)
+            return super().install(*required, options=no_check)
 
         return CommandOutput(stdout=None, stderr=None)
 

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -213,50 +213,27 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
 
         Dnf5(guest=self.guest, logger=self._logger).enable_copr(*repositories)
 
-    def sort_packages(
-        self,
-        *installables: Installable,
-        options: Options,
-    ) -> tuple[list[Installable], list[Installable]]:
-        """Sort packages into required and recommended based on presence and skip_missing."""
-        required: list[Installable] = []
-        recommended: list[Installable] = []
-
-        presence = self.check_presence(*installables)
-
-        for installable, present in presence.items():
-            if present:
-                continue
-            if options.skip_missing:
-                recommended.append(installable)
-            else:
-                required.append(installable)
-
-        return required, recommended
-
     def install(
         self,
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
         options = options or Options()
-        required, recommended = self.sort_packages(*installables, options=options)
 
-        # sort_packages already checked presence; skip the check in super().install.
+        missing = [p for p, present in self.check_presence(*installables).items() if not present]
         no_check_options = dataclasses.replace(options, check_first=False)
 
-        for package in recommended:
-            self.info('package', str(package), 'green')
-            try:
-                super().install(package, options=no_check_options)
-            except RunError as error:
-                self.debug(f"Package installation failed: {error}")
-                self.warn(f"Unable to install recommended package '{package}'.")
+        if options.skip_missing:
+            for package in missing:
+                self.info('package', str(package), 'green')
+                try:
+                    super().install(package, options=no_check_options)
+                except RunError as error:
+                    self.debug(f"Package installation failed: {error}")
+                    self.warn(f"Unable to install recommended package '{package}'.")
+            return CommandOutput(stdout=None, stderr=None)
 
-        if required:
-            return super().install(*required, options=no_check_options)
-
-        return CommandOutput(stdout=None, stderr=None)
+        return super().install(*missing, options=no_check_options)
 
     def install_local(
         self,

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -97,9 +97,6 @@ class RpmOstreeEngine(PackageManagerEngine):
             f'{" ".join(escape_installables(*installables))}'
         )
 
-        if options.check_first:
-            script = self._construct_presence_script(*installables) | script
-
         if options.skip_missing:
             script = script | ShellScript('/bin/true')
 

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -220,6 +220,9 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
     ) -> CommandOutput:
         options = options or Options()
 
+        if not options.check_first:
+            return super().install(*installables, options=options)
+
         missing = [p for p, present in self.check_presence(*installables).items() if not present]
         no_check_options = dataclasses.replace(options, check_first=False)
 


### PR DESCRIPTION
On RHEL and CentOS Stream, DNF ships with `best=True` by default. When tmt installed a set of packages and any one was missing, it sent the entire set to DNF via a shell-level presence check:

```bash
rpm -q --whatprovides pkg-a pkg-b pkg-c || dnf install -y pkg-a pkg-b pkg-c
```

If `pkg-c` was missing, the `||` fired and DNF received all three packages. With `best=True`, DNF silently upgraded `pkg-a` and `pkg-b` even though they were already installed. An unintended side effect that could break test environments.

### Fix

Replace the shell-level `check || install` one-liner with a Python 2-stage process in `PackageManager.install()`:

1. `check_presence()` — determine which packages are actually missing (per-package, Python level)
2. `install()` — pass **only the missing subset** to the package manager

This is now the single, consistent implementation for all package managers. No engine needs to handle `check_first` in its install script.

Previously, installing a set `[A (installed, old), B (missing)]` would inadvertently upgrade A (via `best=True`). 
Now only B is passed to the package manager : A is untouched. This is intentional: `check_first` means *"skip if present"*, not *"upgrade if outdated"*. 
Callers that need a guaranteed upgrade can pass `check_first=False`.

@bajertom  edit: fixes https://github.com/teemtee/tmt/issues/4909