### PR TITLE
Improve test log and report guidance in the guide

### DIFF
--- a/docs/guide/execute-tests.inc.rst
+++ b/docs/guide/execute-tests.inc.rst
@@ -67,8 +67,8 @@ If you do need to investigate test logs after running tests, use
 the ``-vv`` option to display full paths to log files, or ``-vvv``
 to show the complete test output directly in the terminal.
 
-During the run, use ``-vv`` or ``-vvv`` on the ``tmt run``
-command to see log paths or full output as tests are executed:
+To see log paths or full output during the run,  use ``-vv`` or
+``-vvv`` on the ``tmt run`` command:
 
 .. code-block:: shell
 

--- a/docs/guide/execute-tests.inc.rst
+++ b/docs/guide/execute-tests.inc.rst
@@ -60,6 +60,36 @@ the execution is finished:
     tmt run -r
 
 
+Access Test Logs
+------------------------------------------------------------------
+
+If you do need to investigate test logs after running tests, use
+the ``-vv`` option to display full paths to log files, or ``-vvv``
+to show the complete test output directly in the terminal.
+
+During the run, use ``-vv`` or ``-vvv`` on the ``tmt run``
+command to see log paths or full output as tests are executed:
+
+.. code-block:: shell
+
+    # Show paths to test log files during the run
+    $ tmt run -vv
+
+    # Show complete test output directly during the run
+    $ tmt run -vvv
+
+After the run is finished, use ``--last`` to access results from
+the most recent run without re-executing it:
+
+.. code-block:: shell
+
+    # Show paths to test log files from the last run
+    $ tmt run --last report -vv
+
+    # Show complete test output from the last run
+    $ tmt run --last report -vvv
+
+
 Select Plans
 ------------------------------------------------------------------
 

--- a/docs/guide/execute-tests.inc.rst
+++ b/docs/guide/execute-tests.inc.rst
@@ -59,35 +59,17 @@ the execution is finished:
     tmt run --rm
     tmt run -r
 
-
-Access Test Logs
-------------------------------------------------------------------
-
-If you do need to investigate test logs after running tests, use
-the ``-vv`` option to display full paths to log files, or ``-vvv``
-to show the complete test output directly in the terminal.
-
-To see log paths or full output during the run,  use ``-vv`` or
-``-vvv`` on the ``tmt run`` command:
+To investigate test logs during the run, use ``tmt run -vvv`` to
+see test progress and results (see :ref:`execute-progress` for
+details on verbosity levels). After the run is finished, review
+logs from the most recent run using the ``report`` step:
 
 .. code-block:: shell
 
-    # Show paths to test log files during the run
-    $ tmt run -vv
-
-    # Show complete test output directly during the run
-    $ tmt run -vvv
-
-After the run is finished, use ``--last`` to access results from
-the most recent run without re-executing it:
-
-.. code-block:: shell
-
-    # Show paths to test log files from the last run
     $ tmt run --last report -vv
 
-    # Show complete test output from the last run
-    $ tmt run --last report -vvv
+See :ref:`check-report` for more options including ``html``
+reports.
 
 
 Select Plans
@@ -238,6 +220,8 @@ some of them it is possible to use the ``--all`` option:
     tmt run --all provision --how=local
 
 
+.. _execute-progress:
+
 Execute Progress
 ------------------------------------------------------------------
 
@@ -258,7 +242,7 @@ are printed:
 
 .. code-block:: shell
 
-    $ tmt run --all execute -v
+    $ tmt run -v
 
         execute
             how: tmt
@@ -268,7 +252,7 @@ More verbose mode prints summary of the test being executed first:
 
 .. code-block:: shell
 
-    $ tmt run --all execute -vv
+    $ tmt run -vv
 
         execute
             how: tmt
@@ -280,7 +264,7 @@ The most verbose mode prints also the test output:
 
 .. code-block:: shell
 
-    $ tmt run --all execute -vvv
+    $ tmt run -vvv
 
         execute
             how: tmt
@@ -297,26 +281,17 @@ The most verbose mode prints also the test output:
                     00:00:04 pass /tests/core/adjust [1/16]
 
 
+.. _check-report:
+
 Check Report
 ------------------------------------------------------------------
 
-When a particular step is ``done``, it won't be executed
-repeatedly unless ``--force`` is used:
+To review results of your most recent run, use ``--last`` to
+access the ``report`` step without re-executing the whole run:
 
 .. code-block:: shell
 
-    $ tmt run -l report --verbose
-    /plans/features/core
-        report
-            status: done
-            summary: 10 tests passed
-
-If you need additional information about your already ``done``
-run use ``--force`` together with the ``--verbose`` option:
-
-.. code-block:: shell
-
-    $ tmt run -l report -v --force
+    $ tmt run --last report --verbose
     /plans/features/core
         report
             how: display
@@ -336,7 +311,7 @@ In order to investigate test logs raise verbosity even more:
 
 .. code-block:: shell
 
-    $ tmt run -l report -vv --force
+    $ tmt run -l report -vv
     /plans/features/core
         report
             how: display
@@ -358,8 +333,8 @@ it in your favorite web browser:
 
 .. code-block:: shell
 
-    $ tmt run --last report --how html --open --force
-    $ tmt run -l report -h html -of
+    $ tmt run --last report --how html --open
+    $ tmt run -l report -h html -o
 
 
 Provision Options


### PR DESCRIPTION
Improve the guide to make it easier for users to find test logs
and reports. Add cross-references to the "Execute Progress" and
"Check Report" sections, simplify command examples and add
a short paragraph at the top pointing users to the right place for
investigating test output.

Fixes https://github.com/teemtee/tmt/issues/4876