### PR TITLE
Define what ``--dry`` should and should not skip

### DIFF
--- a/agents/release-notes.md
+++ b/agents/release-notes.md
@@ -18,6 +18,7 @@ When creating release notes for tmt, use the milestone name as input (e.g., "1.6
    - Be concise but descriptive
    - Skip PRs that already have release notes added
    - Focus on user-facing changes and improvements
+   - Include notable contributor-facing documentation (e.g. new guidelines in the contributor guide)
 
 4. **Content guidelines**:
    - Include new features and enhancements

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -605,21 +605,34 @@ for background.
 For individual steps and commands the following behavior is
 expected:
 
-* ``discover`` — skip git clone and remote repository operations,
-  just show what would be discovered
-* ``provision`` — no pulling images, no image creation, no
-  starting guests
-* ``prepare`` — skip package installation and guest commands,
-  just show which prepare phases would run
-* ``execute`` — skip test execution, show the execute method
-* ``report`` — skip submission to external services, just show
-  which report steps would be run
-* ``finish`` — skip executing finishing tasks, just show which
-  finish phases would run
-* ``cleanup`` — skip guest removal, just show which cleanup
-  phases would run
-* ``export`` — skip writes to Nitrate and Polarion, compute and
-  show what would be changed
+discover
+    skip git clone and remote repository operations, just show
+    what would be discovered
+
+provision
+    no pulling images, no image creation, no starting guests
+
+prepare
+    skip package installation and guest commands, just show which
+    prepare phases would run
+
+execute
+    skip test execution, show the execute method
+
+report
+    skip submission to external services, just show which report
+    steps would be run
+
+finish
+    skip executing finishing tasks, just show which finish phases
+    would run
+
+cleanup
+    skip guest removal, just show which cleanup phases would run
+
+export
+    skip writes to Nitrate and Polarion, compute and show what
+    would be changed
 
 __ https://github.com/teemtee/tmt/issues/4443
 

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -607,13 +607,13 @@ expected:
 
 * ``discover`` — skip git clone and remote repository operations,
   just show what would be discovered
-* ``provision`` — no pulling images, no images creation, no
+* ``provision`` — no pulling images, no image creation, no
   starting guests
 * ``prepare`` — skip package installation and guest commands,
   just show which prepare phases would run
 * ``execute`` — skip test execution, show the execute method
 * ``report`` — skip submission to external services, just show
-  which reports steps would be run
+  which report steps would be run
 * ``finish`` — skip executing finishing tasks, just show which
   finish phases would run
 * ``cleanup`` — skip guest removal, just show which cleanup

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -571,6 +571,60 @@ __ https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
    not be reflected in the tldr pages collection.
 
 
+.. _dry-mode:
+
+Dry Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Dry mode, activated by the option ``--dry``, lets users preview
+the test execution plan — which steps, phases and plugins would
+run, with what configuration — without provisioning any resources
+or making any changes outside the local workdir. It answers "what
+would tmt do?" before committing time and infrastructure to an
+actual run.
+
+When implementing new features or modifying existing code, follow
+these rules to determine what is allowed and what must be skipped
+when ``is_dry_run`` is true. See `#4443`__ for background.
+
+**In scope** (allowed during dry run):
+
+* Reading and modifying the local workdir
+* Parsing and validating metadata
+* Showing what steps and phases would be executed
+* Importing local plans and files
+
+**Out of scope** (skipped during dry run):
+
+* Creating or modifying external resources (guests, containers,
+  images)
+* Executing commands on guests
+* Submitting tasks or tests results to external services
+* Network access (git clone, fetching remote plans or images)
+* Removing provisioned guests, cleaning up run workdirs, images
+
+For individual steps and commands the following behavior is
+expected:
+
+* ``discover`` — skip git clone and remote repository operations,
+  just show what would be discovered
+* ``provision`` — no pulling images, no images creation, no
+  starting guests
+* ``prepare`` — skip package installation and guest commands,
+  just show which prepare phases would run
+* ``execute`` — skip test execution, show the execute method
+* ``report`` — skip submission to external services, just show
+  which reports steps would be run
+* ``finish`` — skip executing finishing tasks, just show which
+  finish phases would run
+* ``cleanup`` — skip guest removal, just show which cleanup
+  phases would run
+* ``export`` — skip writes to Nitrate and Polarion, compute and
+  show what would be changed
+
+__ https://github.com/teemtee/tmt/issues/4443
+
+
 .. _issues:
 
 Issues

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -577,31 +577,30 @@ Dry Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Dry mode, activated by the option ``--dry``, lets users preview
-the test execution plan — which steps, phases and plugins would
-run, with what configuration — without provisioning any resources
-or making any changes outside the local workdir. It answers "what
-would tmt do?" before committing time and infrastructure to an
-actual run.
+"what would tmt do" without actually performing the actions. For
+example the ``tmt clean --dry`` command shows which files would be
+removed and ``tmt run --dry`` shows the test execution plan: which
+steps, phases and plugins would run, with what configuration
+without provisioning guests.
 
 When implementing new features or modifying existing code, follow
 these rules to determine what is allowed and what must be skipped
-when ``is_dry_run`` is true. See `#4443`__ for background.
+when :py:attr:`tmt.utils.Common.is_dry_run` is true. See `#4443`__
+for background.
 
 **In scope** (allowed during dry run):
 
-* Reading and modifying the local workdir
-* Parsing and validating metadata
+* Reading, parsing and validating metadata
+* Creating and modifying the local :term:`run workdir`
 * Showing what steps and phases would be executed
-* Importing local plans and files
 
 **Out of scope** (skipped during dry run):
 
-* Creating or modifying external resources (guests, containers,
-  images)
-* Executing commands on guests
-* Submitting tasks or tests results to external services
+* Creating or modifying resources (guests, containers, images)
 * Network access (git clone, fetching remote plans or images)
-* Removing provisioned guests, cleaning up run workdirs, images
+* Executing commands on guests (e.g. for provision connect)
+* Submitting tasks or tests results to external services
+* Removing provisioned guests, run workdirs or images
 
 For individual steps and commands the following behavior is
 expected:

--- a/docs/releases/pending/4443.fmf
+++ b/docs/releases/pending/4443.fmf
@@ -1,0 +1,5 @@
+description: |
+    The :ref:`contribute` guide now includes a :ref:`dry-mode`
+    section defining what ``--dry`` should and should not skip,
+    with clear in-scope and out-of-scope rules and per-step
+    behavior guidelines for developers.


### PR DESCRIPTION
Added a new 'Dry Mode' section to the contributor docs describing the purpose of ``--dry`` and defining clear rules for what is in scope and out of scope.

Includes per-step behavior guidelines for developers implementing new features or modifying existing code.

I went with the stricter approach, that is no network access which should ensure that the command executed in dry mode will never take long time, e.g. when pulling large images or repositories.

Fix: #4443

Pull Request Checklist

* [x] write the documentation
* [x] include a release note