### PR TITLE
Refine koji artifact error handling

### DIFF
--- a/packaging/rpm/tmt.spec
+++ b/packaging/rpm/tmt.spec
@@ -49,7 +49,6 @@ metadata specification (L1 and L2) and allows easy test execution.
 %pyproject_extras_subpkg -n tmt report-junit
 %pyproject_extras_subpkg -n tmt report-polarion
 %pyproject_extras_subpkg -n tmt link-jira
-%pyproject_extras_subpkg -n tmt prepare-artifact
 
 %package -n     tmt+test-convert
 Summary:        Dependencies required for tmt test import and export
@@ -134,6 +133,14 @@ Requires:       tmt == %{version}-%{release}
 Requires:       mock
 
 %description -n tmt+provision-mock %_metapackage_description
+
+%package -n     tmt+prepare-artifact
+Summary:        Dependencies required for tmt prepare artifact
+Requires:       tmt == %{version}-%{release}
+Requires:       koji
+Requires:       python3-copr
+
+%description -n tmt+prepare-artifact %_metapackage_description
 
 # Replace with pyproject_extras_subpkg at some point
 %package -n     tmt+all

--- a/packaging/rpm/tmt.spec
+++ b/packaging/rpm/tmt.spec
@@ -202,6 +202,7 @@ install -pm 644 %{name}/steps/provision/mrack/mrack* %{buildroot}/etc/%{name}/
 %{_mandir}/man1/tmt.1.gz
 %{_datadir}/bash-completion/completions/%{name}
 
+%files -n tmt+prepare-artifact -f %{_pyproject_ghost_distinfo}
 %files -n tmt+provision-container -f %{_pyproject_ghost_distinfo}
 %files -n tmt+provision-virtual -f %{_pyproject_ghost_distinfo}
 %files -n tmt+provision-bootc -f %{_pyproject_ghost_distinfo}

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -125,11 +125,11 @@ class KojiArtifactProvider(ArtifactProvider):
         Also :py:attr:`_top_url` and :py:attr:`_api_url` being the base URL for the Koji instance.
         """
         import_koji(self.logger)
+        config = koji.read_config("koji")  # type: ignore[union-attr]
+        self._api_url = api_url or config.get("server")
+        self._top_url = top_url or config.get("topurl")
 
         try:
-            config = koji.read_config("koji")  # type: ignore[union-attr]
-            self._api_url = api_url or config.get("server")
-            self._top_url = top_url or config.get("topurl")
             return ClientSession(self._api_url)
         except Exception as error:
             raise tmt.utils.GeneralError(


### PR DESCRIPTION
- The try except was too eager and it would fail during the raising of the exception
- The `/etc/koji` is part of `koji` package, `python3-koji` is insufficient. Seems testing-farm was hiding this issue because of injected dependencies

Fixes #4929