### PR TITLE
Include traceback when reporting import errors

### DIFF
--- a/tmt/__main__.py
+++ b/tmt/__main__.py
@@ -1,4 +1,6 @@
 import sys
+import traceback
+from typing import NoReturn, Optional
 
 
 def import_cli_commands() -> None:
@@ -12,6 +14,40 @@ def import_cli_commands() -> None:
     import tmt.cli.lint  # noqa: F401,I001,RUF100 # type: ignore[reportUnusedImport]
     import tmt.cli.status  # noqa: F401,I001,RUF100 # type: ignore[reportUnusedImport]
     import tmt.cli.trying  # noqa: F401,I001,RUF100 # type: ignore[reportUnusedImport]
+
+
+def report_exception(
+    exception: Exception, exit_code: int = 2, message: Optional[str] = None
+) -> NoReturn:
+    # `tmt` may be unbound. In theory, `import tmt.utils` might have
+    # raised an exception, and we might end up touching `tmt.utils`
+    # that's not fully imported.
+    #
+    # Yet the reporting tools we have available are very nice, it would
+    # be a shame to not use them if we can. Let's try using our tools,
+    # and fall back to the very basic tools if anything goes wrong.
+
+    if message:
+        print(message, file=sys.stderr)
+
+    try:
+        # If we already succeeded importing `tmt.utils`, this will proceed
+        # safely, pretty much a no-op. If we failed to import `tmt.utils`,
+        # this will fail, but that's fine, we are ready for double fault.
+        from tmt.utils import show_exception
+
+        show_exception(exception)
+
+        raise SystemExit(exit_code) from exception
+
+    except Exception:
+        # No need to capture the exception in a variable: we are still
+        # inside an `except` clause, Python will chain exceptions for
+        # us. Reporting "the current" exception will include the nested
+        # one as well.
+        traceback.print_exc()
+
+        raise SystemExit(exit_code) from exception
 
 
 def run_cli() -> None:
@@ -39,32 +75,12 @@ def run_cli() -> None:
         tmt.cli._root.main()
 
     except ImportError as error:
-        print("Error: tmt package does not seem to be installed")
-        raise SystemExit(1) from error
+        report_exception(
+            error, exit_code=1, message="Error: tmt package does not seem to be installed"
+        )
+
     except Exception as error:
-        # ignore[reportUnboundVariable]: linter is right here, `tmt` may be
-        # unbound. In theory, `import tmt.utils` might have raised an exception
-        # that is not `ImportError`, and we might end up touching `tmt.utils`
-        # that's not fully imported. And we cannot `except tmt.utils` either,
-        # as the module does not exist in the global scope yet.
-        #
-        # Silence the linter, but be careful and make sure to report the
-        # possible - although very unlikely - secondary exception. Sounds
-        # pointless, but let's make investigation easier for us.
-        #
-        # ignore[unused-ignore]: mypy does not recognize this issue, and therefore
-        # the waiver seems pointless to it...
-        try:
-            tmt.utils.show_exception(error)  # type: ignore[reportUnboundVariable,unused-ignore]
-            raise SystemExit(2) from error
-
-        except Exception as nested_error:
-            import traceback
-
-            print(f"Error: failed while reporting exception: {nested_error}", file=sys.stderr)
-            traceback.print_exc()
-
-            raise SystemExit(2) from nested_error
+        report_exception(error)
 
 
 if __name__ == "__main__":

--- a/tmt/__main__.py
+++ b/tmt/__main__.py
@@ -1,6 +1,4 @@
-import sys
 import traceback
-from typing import NoReturn, Optional
 
 
 def import_cli_commands() -> None:
@@ -14,40 +12,6 @@ def import_cli_commands() -> None:
     import tmt.cli.lint  # noqa: F401,I001,RUF100 # type: ignore[reportUnusedImport]
     import tmt.cli.status  # noqa: F401,I001,RUF100 # type: ignore[reportUnusedImport]
     import tmt.cli.trying  # noqa: F401,I001,RUF100 # type: ignore[reportUnusedImport]
-
-
-def report_exception(
-    exception: Exception, exit_code: int = 2, message: Optional[str] = None
-) -> NoReturn:
-    # `tmt` may be unbound. In theory, `import tmt.utils` might have
-    # raised an exception, and we might end up touching `tmt.utils`
-    # that's not fully imported.
-    #
-    # Yet the reporting tools we have available are very nice, it would
-    # be a shame to not use them if we can. Let's try using our tools,
-    # and fall back to the very basic tools if anything goes wrong.
-
-    if message:
-        print(message, file=sys.stderr)
-
-    try:
-        # If we already succeeded importing `tmt.utils`, this will proceed
-        # safely, pretty much a no-op. If we failed to import `tmt.utils`,
-        # this will fail, but that's fine, we are ready for double fault.
-        from tmt.utils import show_exception
-
-        show_exception(exception)
-
-        raise SystemExit(exit_code) from exception
-
-    except Exception:
-        # No need to capture the exception in a variable: we are still
-        # inside an `except` clause, Python will chain exceptions for
-        # us. Reporting "the current" exception will include the nested
-        # one as well.
-        traceback.print_exc()
-
-        raise SystemExit(exit_code) from exception
 
 
 def run_cli() -> None:
@@ -74,13 +38,33 @@ def run_cli() -> None:
 
         tmt.cli._root.main()
 
-    except ImportError as error:
-        report_exception(
-            error, exit_code=1, message="Error: tmt package does not seem to be installed"
-        )
-
     except Exception as error:
-        report_exception(error)
+        # `tmt` may be unbound. In theory, `import tmt.utils` might have
+        # raised an exception, and we might end up touching `tmt.utils`
+        # that's not fully imported.
+        #
+        # Yet the reporting tools we have available are very nice, it would
+        # be a shame to not use them if we can. Let's try using our tools,
+        # and fall back to the very basic tools if anything goes wrong.
+
+        try:
+            # If we already succeeded importing `tmt.utils`, this will proceed
+            # safely, pretty much a no-op. If we failed to import `tmt.utils`,
+            # this will fail, but that's fine, we are ready for double fault.
+            from tmt.utils import show_exception
+
+            show_exception(error)
+
+            raise SystemExit(2) from error
+
+        except Exception:
+            # No need to capture the exception in a variable: we are still
+            # inside an `except` clause, Python will chain exceptions for
+            # us. Reporting "the original" exception will include "the
+            # current" one as well.
+            traceback.print_exc()
+
+            raise SystemExit(2) from error
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
"tmt package does not seem to be installed" alone does not seem to be very helpful. Patch changes import error reporting to use the same code as "regular" errors. We can try and use our nice error reporting, if that's broken, we can always fall back to much less prettier, verbose, uncontrolled, but very useful tracebacks.

Note that the "ugly" mode triggers when we break things in a really bad way. In a way that should have been captured by a test, a broken import deep somewhere in tmt code. It's not how tmt wishes to present itself to users, it's simply the best we can do to get useful info in such a weird state of things.

Pull Request Checklist

* [x] implement the feature