### PR TITLE
Send `SIGHUP` to podman-executed tests

### DIFF
--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -646,6 +646,12 @@ class GuestContainer(tmt.Guest):
         """
 
         if self.container:
+            try:
+                self.podman(Command('exec', self.container, 'kill', '-HUP', '-1'))
+            except tmt.utils.RunError as exc:
+                # this is expected when there are no leftover processes to kill
+                self._logger.debug(f"Failed sending SIGHUP on container .stop(): {exc}")
+
             self.podman(
                 Command('container', 'stop', '--time', str(self.stop_time), self.container)
             )

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -650,6 +650,7 @@ class GuestContainer(tmt.Guest):
                 self.podman(Command('exec', self.container, 'kill', '-HUP', '-1'))
             except tmt.utils.RunError as exc:
                 # this is expected when there are no leftover processes to kill
+                # TODO: needs a helper similar to show_exception_as_warning()
                 self._logger.debug(f"Failed sending SIGHUP on container .stop(): {exc}")
 
             self.podman(


### PR DESCRIPTION
The original `container stop --time` doesn't actually do anything useful, podman signals and waits only for the PID 1 to stop (an interactive bash session typically for a container's CMD), not the exec'd test.

The SIGHUP is useful for tests that set up external state that needs to be shut down safely, and even for (most) use cases where the container is thrown away, the extra `kill` doesn't add much delay.

Note that this is only a partial fix to the problem, as `podman stop --time N` always waits the full duration, because the interactive bash has `SIG_IGN` for `SIGTERM` (and even if it hadn't, it's running as PID 1 with kernel protection), so it sticks around.\
A proper fix would probably be to re-engineer the whole stopping logic, and perhaps overriding container CMD / ENTRYPOINT and maybe not closing the test output immediately.

For now, this small fix keeps backwards compatibility for people who rely on the (public API) `stop-time` to continue working as it now does, while allowing tests to trap HUP.

Note that I chose `SIGHUP` because sending `SIGTERM` to a hierarchy of processes (test wrapper, etc.) causes all of them to die at the same time, triggering `SIGHUP` anyway in the child processes (because `tmt` always allocates a TTY).\
Also, arguably, it's the more appropriate signal here, but opinions might vary on that.
<details>
<summary>SIGTERM version</summary>

Sending `SIGTERM` would be a lot more involved without much benefit over `SIGHUP` (both can be trapped, and typically are, along with `SIGINT`, as any of the 3 can legitimately appear on a clean termination).
```python
    Command('exec', self.container, '/bin/bash', '-c', 'read pid _ < /var/tmp/tmt-test.pid && kill -TERM $pid')
```
(probably with less path hardcoding)
</details>

Thanks!

Related issue: https://github.com/teemtee/tmt/issues/1362

---

I've tested it on this main.fmf:

```
/plan:
  provision:
    how: container
    stop-time: 30
  discover:
    how: fmf
  execute:
    how: tmt

/test:
  test: |
    trap 'echo "trap fired" > $TMT_TEST_DATA/trap-proof; exit 0' HUP
    echo "waiting for signal..."
    sleep 300 &
    wait $!
    echo "sleep finished normally"
```

---

Pull Request Checklist

* [ ] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
