### PR TITLE
Enforce artifact repo origin via NEVRA substitution and reinstall phase

### DIFF
--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -292,7 +292,7 @@ rlJournalStart
             rlAssertGrep "package manager: $package_manager$" $rlRun_LOG
 
             if is_centos_7 "$image"; then
-                rlAssertGrep "stdout: no package provides tree-but-spelled-wrong" $rlRun_LOG
+                rlAssertGrep "stderr: no package provides tree-but-spelled-wrong" $rlRun_LOG
 
             elif is_image_mode "$image"; then
                 if is_fedora "$image"; then
@@ -340,7 +340,7 @@ rlJournalStart
             rlAssertGrep "package manager: $package_manager$" $rlRun_LOG
 
             if is_centos_7 "$image"; then
-                rlAssertGrep "stdout: no package provides tree-but-spelled-wrong" $rlRun_LOG
+                rlAssertGrep "stderr: no package provides tree-but-spelled-wrong" $rlRun_LOG
 
             elif is_image_mode "$image"; then
                 if is_fedora "$image"; then
@@ -388,7 +388,7 @@ rlJournalStart
             rlAssertGrep "package manager: $package_manager$" $rlRun_LOG
 
             if is_centos_7 "$image"; then
-                rlAssertGrep "stdout: no package provides tree-but-spelled-wrong" $rlRun_LOG
+                rlAssertGrep "stderr: no package provides tree-but-spelled-wrong" $rlRun_LOG
 
             elif is_image_mode "$image"; then
                 if is_fedora "$image"; then

--- a/tests/try/basic/test.sh
+++ b/tests/try/basic/test.sh
@@ -62,7 +62,8 @@ rlJournalStart
     rlPhaseStartTest "Install"
         rlRun -s "./install.exp"
         rlAssertGrep "Let's try.*/plans/basic" $rlRun_LOG
-        rlAssertGrep "cmd: rpm -q --whatprovides tree || dnf.* install -y  tree" $rlRun_LOG
+        rlAssertGrep "cmd: rpm -q --whatprovides tree" $rlRun_LOG
+        rlAssertGrep "cmd: dnf.* install -y  tree" $rlRun_LOG
         rlAssertGrep "Run .* successfully finished. Bye for now!" $rlRun_LOG
         rlAssertGrep "container: stopped" $rlRun_LOG
         rlAssertGrep "container: removed" $rlRun_LOG

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -490,7 +490,7 @@ def _parametrize_test_assert_config_manager() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides yum-utils",
+                    r"rpm -q --whatprovides 'yum-utils' >&2 \|\| echo 'yum-utils'",
                 )
             else:
                 yield (
@@ -513,7 +513,7 @@ def _parametrize_test_assert_config_manager() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"""rpm -q --whatprovides '"'"'dnf5-command\(config-manager\)'"'"'""",
+                r"rpm -q --whatprovides 'dnf5-command\(config-manager\)' >&2 \|\| echo 'dnf5-command\(config-manager\)'",  # noqa: E501
             )
 
         elif package_manager_class in (

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -998,7 +998,7 @@ def _parametrize_test_reinstall() -> Iterator[
                     package_manager_class,
                     Package('tar'),
                     True,
-                    r"rpm -q --whatprovides tar && yum reinstall -y  tar && rpm -q --whatprovides tar",  # noqa: E501
+                    r"yum reinstall -y  tar && rpm -q --whatprovides tar",
                     'Reinstalling:\n tar',
                 )
 
@@ -1008,7 +1008,7 @@ def _parametrize_test_reinstall() -> Iterator[
                     package_manager_class,
                     Package('tar'),
                     True,
-                    r"rpm -q --whatprovides tar && yum reinstall -y  tar && rpm -q --whatprovides tar",  # noqa: E501
+                    r"yum reinstall -y  tar && rpm -q --whatprovides tar",
                     'Reinstalled:\n  tar',
                 )
 
@@ -1018,7 +1018,7 @@ def _parametrize_test_reinstall() -> Iterator[
                 package_manager_class,
                 Package('tar'),
                 True,
-                r"rpm -q --whatprovides tar && dnf reinstall -y  tar",
+                r"dnf reinstall -y  tar",
                 'Reinstalled:\n  tar',
             )
 
@@ -1028,7 +1028,7 @@ def _parametrize_test_reinstall() -> Iterator[
                 package_manager_class,
                 Package('tar'),
                 True,
-                r"rpm -q --whatprovides tar && dnf5 reinstall -y  tar",
+                r"dnf5 reinstall -y  tar",
                 'Reinstalling tar',
             )
 
@@ -1109,59 +1109,26 @@ def _generate_test_reinstall_nonexistent_matrix() -> Iterator[
     tuple[Container, PackageManagerClass, Optional[str], Optional[str], Optional[str]]
 ]:
     for container, package_manager_class in CONTAINER_BASE_MATRIX:
-        if package_manager_class is tmt.package_managers.dnf.Dnf5:
+        if (
+            package_manager_class is tmt.package_managers.dnf.Dnf5
+            or package_manager_class is tmt.package_managers.dnf.Dnf
+            or package_manager_class is tmt.package_managers.dnf.Yum
+        ):
             yield (
                 container,
                 package_manager_class,
                 True,
-                r"rpm -q --whatprovides tree-but-spelled-wrong && dnf5 reinstall -y  tree-but-spelled-wrong",  # noqa: E501
-                'no package provides tree-but-spelled-wrong',
+                r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                None,
             )
-
-        elif package_manager_class is tmt.package_managers.dnf.Dnf:
-            yield (
-                container,
-                package_manager_class,
-                True,
-                r"rpm -q --whatprovides tree-but-spelled-wrong && dnf reinstall -y  tree-but-spelled-wrong",  # noqa: E501
-                'no package provides tree-but-spelled-wrong',
-            )
-
-        elif package_manager_class is tmt.package_managers.dnf.Yum:
-            if 'fedora' in container.url:  # noqa: SIM114
-                yield (
-                    container,
-                    package_manager_class,
-                    True,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong && yum reinstall -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
-                    'no package provides tree-but-spelled-wrong',
-                )
-
-            elif 'centos' in container.url and 'centos/7' not in container.url:
-                yield (
-                    container,
-                    package_manager_class,
-                    True,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong && yum reinstall -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
-                    'no package provides tree-but-spelled-wrong',
-                )
-
-            else:
-                yield (
-                    container,
-                    package_manager_class,
-                    True,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong && yum reinstall -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
-                    'no package provides tree-but-spelled-wrong',
-                )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:
             yield (
                 container,
                 package_manager_class,
                 True,
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+dpkg-query --show \$installable_packages \\\s+&& apt reinstall -y  \$installable_packages\s+exit \$\?",  # noqa: E501
-                'dpkg-query: no packages found matching tree-but-spelled-wrong',
+                r".*?echo \"PRESENCE-TEST:tree-but-spelled-wrong:tree-but-spelled-wrong:\$\(dpkg-query --show tree-but-spelled-wrong\)\".*?",  # noqa: E501
+                None,
             )
 
         elif package_manager_class is tmt.package_managers.rpm_ostree.RpmOstree:
@@ -1172,7 +1139,7 @@ def _generate_test_reinstall_nonexistent_matrix() -> Iterator[
                 container,
                 package_manager_class,
                 True,
-                r"apk info -e tree-but-spelled-wrong && apk fix tree-but-spelled-wrong",
+                r"apk info -e tree-but-spelled-wrong",
                 None,
             )
 
@@ -1202,22 +1169,18 @@ def test_reinstall_nonexistent(
     if supported:
         assert expected_command is not None
 
-        with pytest.raises(tmt.utils.RunError) as excinfo:
-            package_manager.reinstall(Package('tree-but-spelled-wrong'))
+        # Package is not installed: check_first detects absence and skips reinstall (no-op).
+        output = package_manager.reinstall(Package('tree-but-spelled-wrong'))
+        assert output.stdout is None
+        assert output.stderr is None
 
         assert_expected_command(caplog, expected_command)
-
-        assert excinfo.type is tmt.utils.RunError
-        assert excinfo.value.returncode != 0
 
     else:
         with pytest.raises(tmt.utils.GeneralError) as excinfo:
             package_manager.reinstall(Package('tree-but-spelled-wrong'))
 
         assert excinfo.value.message == "rpm-ostree does not support reinstall operation."
-
-    if expected_output:
-        assert_output(expected_output, excinfo.value.stdout, excinfo.value.stderr)
 
 
 def _generate_test_check_presence() -> Iterator[

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1230,8 +1230,8 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('coreutils'),
                 True,
-                r"rpm -q --whatprovides coreutils >/dev/null 2>&1 \|\| echo coreutils",
-                None,
+                r"rpm -q --whatprovides 'coreutils' >&2 \|\| echo 'coreutils'",
+                r'\s+stderr:\s+coreutils-',
             )
 
             yield (
@@ -1239,7 +1239,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('tree-but-spelled-wrong'),
                 False,
-                r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                 r'\s+stdout:\s+tree-but-spelled-wrong',
             )
 
@@ -1248,8 +1248,8 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 FileSystemPath('/usr/bin/arch'),
                 True,
-                r"rpm -q --whatprovides /usr/bin/arch >/dev/null 2>&1 \|\| echo /usr/bin/arch",
-                None,
+                r"rpm -q --whatprovides '/usr/bin/arch' >&2 \|\| echo '/usr/bin/arch'",
+                r'\s+stderr:\s+coreutils-',
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf:
@@ -1259,8 +1259,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r"rpm -q --whatprovides util-linux >/dev/null 2>&1 \|\| echo util-linux",
-                    None,
+                    r"rpm -q --whatprovides 'util-linux' >&2 \|\| echo 'util-linux'",
+                    r'\s+stderr:\s+util-linux-',
                 )
 
                 yield (
@@ -1268,7 +1268,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1277,8 +1277,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
-                    None,
+                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'\s+stderr:\s+util-linux-',
                 )
 
             elif 'centos/stream9' in container.url:
@@ -1287,8 +1287,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r"rpm -q --whatprovides coreutils >/dev/null 2>&1 \|\| echo coreutils",
-                    None,
+                    r"rpm -q --whatprovides 'coreutils' >&2 \|\| echo 'coreutils'",
+                    r'\s+stderr:\s+coreutils-',
                 )
 
                 yield (
@@ -1296,7 +1296,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1305,8 +1305,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/arch >/dev/null 2>&1 \|\| echo /usr/bin/arch",
-                    None,
+                    r"rpm -q --whatprovides '/usr/bin/arch' >&2 \|\| echo '/usr/bin/arch'",
+                    r'\s+stderr:\s+coreutils-',
                 )
 
             else:
@@ -1315,8 +1315,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r"rpm -q --whatprovides util-linux-core >/dev/null 2>&1 \|\| echo util-linux-core",  # noqa: E501
-                    None,
+                    r"rpm -q --whatprovides 'util-linux-core' >&2 \|\| echo 'util-linux-core'",
+                    r'\s+stderr:\s+util-linux-core-',
                 )
 
                 yield (
@@ -1324,7 +1324,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1333,8 +1333,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
-                    None,
+                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'\s+stderr:\s+util-linux-core-',
                 )
 
         elif package_manager_class is tmt.package_managers.dnf.Yum:
@@ -1344,8 +1344,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r"rpm -q --whatprovides util-linux >/dev/null 2>&1 \|\| echo util-linux",
-                    None,
+                    r"rpm -q --whatprovides 'util-linux' >&2 \|\| echo 'util-linux'",
+                    r'\s+stderr:\s+util-linux-',
                 )
 
                 yield (
@@ -1353,7 +1353,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1362,8 +1362,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
-                    None,
+                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'\s+stderr:\s+util-linux-',
                 )
 
             elif 'centos/stream9' in container.url:
@@ -1372,8 +1372,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r"rpm -q --whatprovides coreutils >/dev/null 2>&1 \|\| echo coreutils",
-                    None,
+                    r"rpm -q --whatprovides 'coreutils' >&2 \|\| echo 'coreutils'",
+                    r'\s+stderr:\s+coreutils-',
                 )
 
                 yield (
@@ -1381,7 +1381,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1390,8 +1390,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/arch >/dev/null 2>&1 \|\| echo /usr/bin/arch",
-                    None,
+                    r"rpm -q --whatprovides '/usr/bin/arch' >&2 \|\| echo '/usr/bin/arch'",
+                    r'\s+stderr:\s+coreutils-',
                 )
 
             else:
@@ -1400,8 +1400,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r"rpm -q --whatprovides util-linux-core >/dev/null 2>&1 \|\| echo util-linux-core",  # noqa: E501
-                    None,
+                    r"rpm -q --whatprovides 'util-linux-core' >&2 \|\| echo 'util-linux-core'",
+                    r'\s+stderr:\s+util-linux-core-',
                 )
 
                 yield (
@@ -1409,7 +1409,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1418,8 +1418,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
-                    None,
+                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'\s+stderr:\s+util-linux-core-',
                 )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1230,8 +1230,8 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('coreutils'),
                 True,
-                r"rpm -q --whatprovides coreutils",
-                r'\s+stdout:\s+coreutils-',
+                r"rpm -q --whatprovides coreutils >/dev/null 2>&1 \|\| echo coreutils",
+                None,
             )
 
             yield (
@@ -1239,8 +1239,8 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('tree-but-spelled-wrong'),
                 False,
-                r"rpm -q --whatprovides tree-but-spelled-wrong",
-                r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                r'\s+stdout:\s+tree-but-spelled-wrong',
             )
 
             yield (
@@ -1248,8 +1248,8 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 FileSystemPath('/usr/bin/arch'),
                 True,
-                r"rpm -q --whatprovides /usr/bin/arch",
-                r'\s+stdout:\s+coreutils-',
+                r"rpm -q --whatprovides /usr/bin/arch >/dev/null 2>&1 \|\| echo /usr/bin/arch",
+                None,
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf:
@@ -1259,8 +1259,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r"rpm -q --whatprovides util-linux",
-                    r'\s+stdout:\s+util-linux-',
+                    r"rpm -q --whatprovides util-linux >/dev/null 2>&1 \|\| echo util-linux",
+                    None,
                 )
 
                 yield (
@@ -1268,8 +1268,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong",
-                    r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
                 yield (
@@ -1277,8 +1277,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock",
-                    r'\s+stdout:\s+util-linux-',
+                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
+                    None,
                 )
 
             elif 'centos/stream9' in container.url:
@@ -1287,8 +1287,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r"rpm -q --whatprovides coreutils",
-                    r'\s+stdout:\s+coreutils-',
+                    r"rpm -q --whatprovides coreutils >/dev/null 2>&1 \|\| echo coreutils",
+                    None,
                 )
 
                 yield (
@@ -1296,8 +1296,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong",
-                    r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
                 yield (
@@ -1305,8 +1305,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/arch",
-                    r'\s+stdout:\s+coreutils-',
+                    r"rpm -q --whatprovides /usr/bin/arch >/dev/null 2>&1 \|\| echo /usr/bin/arch",
+                    None,
                 )
 
             else:
@@ -1315,8 +1315,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r"rpm -q --whatprovides util-linux-core",
-                    r'\s+stdout:\s+util-linux-core-',
+                    r"rpm -q --whatprovides util-linux-core >/dev/null 2>&1 \|\| echo util-linux-core",  # noqa: E501
+                    None,
                 )
 
                 yield (
@@ -1324,8 +1324,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong",
-                    r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
                 yield (
@@ -1333,8 +1333,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock",
-                    r'\s+stdout:\s+util-linux-core-',
+                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
+                    None,
                 )
 
         elif package_manager_class is tmt.package_managers.dnf.Yum:
@@ -1344,8 +1344,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r"rpm -q --whatprovides util-linux",
-                    r'\s+stdout:\s+util-linux-',
+                    r"rpm -q --whatprovides util-linux >/dev/null 2>&1 \|\| echo util-linux",
+                    None,
                 )
 
                 yield (
@@ -1353,8 +1353,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong",
-                    r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
                 yield (
@@ -1362,8 +1362,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock",
-                    r'\s+stdout:\s+util-linux-',
+                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
+                    None,
                 )
 
             elif 'centos/stream9' in container.url:
@@ -1372,8 +1372,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r"rpm -q --whatprovides coreutils",
-                    r'\s+stdout:\s+coreutils-',
+                    r"rpm -q --whatprovides coreutils >/dev/null 2>&1 \|\| echo coreutils",
+                    None,
                 )
 
                 yield (
@@ -1381,8 +1381,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong",
-                    r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
                 yield (
@@ -1390,8 +1390,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/arch",
-                    r'\s+stdout:\s+coreutils-',
+                    r"rpm -q --whatprovides /usr/bin/arch >/dev/null 2>&1 \|\| echo /usr/bin/arch",
+                    None,
                 )
 
             else:
@@ -1400,8 +1400,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r"rpm -q --whatprovides util-linux-core",
-                    r'\s+stdout:\s+util-linux-core-',
+                    r"rpm -q --whatprovides util-linux-core >/dev/null 2>&1 \|\| echo util-linux-core",  # noqa: E501
+                    None,
                 )
 
                 yield (
@@ -1409,8 +1409,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong",
-                    r'\s+stdout:\s+no package provides tree-but-spelled-wrong',
+                    r"rpm -q --whatprovides tree-but-spelled-wrong >/dev/null 2>&1 \|\| echo tree-but-spelled-wrong",  # noqa: E501
+                    r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
                 yield (
@@ -1418,8 +1418,8 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides /usr/bin/flock",
-                    r'\s+stdout:\s+util-linux-core-',
+                    r"rpm -q --whatprovides /usr/bin/flock >/dev/null 2>&1 \|\| echo /usr/bin/flock",  # noqa: E501
+                    None,
                 )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -343,7 +343,7 @@ def _parametrize_test_install() -> Iterator[
                 container,
                 package_manager_class,
                 Package('tree'),
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'Setting up tree',
             )
 
@@ -352,7 +352,7 @@ def _parametrize_test_install() -> Iterator[
                 container,
                 package_manager_class,
                 Package('tree'),
-                r"rpm -q --whatprovides tree \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree",  # noqa: E501
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree",
                 'Installing: tree',
             )
 
@@ -361,7 +361,7 @@ def _parametrize_test_install() -> Iterator[
                 container,
                 package_manager_class,
                 Package('tree'),
-                r"apk info -e tree \|\| apk add tree",
+                r"apk add tree",
                 'Installing tree',
             )
 
@@ -703,7 +703,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'E: Unable to locate package tree-but-spelled-wrong',
             )
 
@@ -711,7 +711,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree-but-spelled-wrong",  # noqa: E501
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree-but-spelled-wrong",  # noqa: E501
                 'no package provides tree-but-spelled-wrong',
             )
 
@@ -719,7 +719,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"apk info -e tree-but-spelled-wrong \|\| apk add tree-but-spelled-wrong",
+                r"apk add tree-but-spelled-wrong",
                 'ERROR: unable to select packages:\n  tree-but-spelled-wrong (no such package):\n    required by: world[tree-but-spelled-wrong]',  # noqa: E501
             )
 
@@ -815,7 +815,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y --ignore-missing \$installable_packages\s+exit 0",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree-but-spelled-wrong\"\s+apt install -y --ignore-missing \$installable_packages\s+exit 0",  # noqa: E501
                 'E: Unable to locate package tree-but-spelled-wrong',
             )
 
@@ -823,7 +823,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
                 'no package provides tree-but-spelled-wrong',
             )
 
@@ -831,7 +831,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"apk info -e tree-but-spelled-wrong \|\| apk add tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
+                r"apk add tree-but-spelled-wrong \|\| /bin/true",
                 'ERROR: unable to select packages:\n  tree-but-spelled-wrong (no such package):\n    required by: world[tree-but-spelled-wrong]',  # noqa: E501
             )
 
@@ -1592,7 +1592,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                 container,
                 package_manager_class,
                 FileSystemPath('/usr/bin/dos2unix'),
-                r".*?set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"\"\s+fs_path_package=\"\$\(apt-file search --package-only /usr/bin/dos2unix\)\"\s+\[ -z \"\$fs_path_package\" \] && echo \"No package found for path /usr/bin/dos2unix\" && exit 1\s+installable_packages=\"\$installable_packages \$fs_path_package\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y\s+\$installable_packages\s+exit \$\?",  # noqa: E501
+                r".*?set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"\"\s+fs_path_package=\"\$\(apt-file search --package-only /usr/bin/dos2unix\)\"\s+\[ -z \"\$fs_path_package\" \] && echo \"No package found for path /usr/bin/dos2unix\" && exit 1\s+installable_packages=\"\$installable_packages \$fs_path_package\"\s+apt install -y\s+\$installable_packages\s+exit \$\?",  # noqa: E501
                 "Setting up dos2unix",
             )
 
@@ -1601,7 +1601,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                 container,
                 package_manager_class,
                 FileSystemPath('/usr/bin/dos2unix'),
-                r"rpm -qf /usr/bin/dos2unix \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  /usr/bin/dos2unix",  # noqa: E501
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  /usr/bin/dos2unix",  # noqa: E501
                 "Installing 1 packages:\n  dos2unix-",
             )
 
@@ -1610,7 +1610,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                 container,
                 package_manager_class,
                 FileSystemPath('/usr/bin/dos2unix'),
-                r"apk info -e dos2unix \|\| apk add dos2unix",
+                r"apk add dos2unix",
                 'Installing dos2unix',
             )
 
@@ -1726,7 +1726,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('tree'), Package('nano')),
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree nano\"\s+dpkg-query --show \$installable_packages \\\s+\|\| apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree nano\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'Setting up tree',
             )
 
@@ -1735,7 +1735,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('tree'), Package('nano')),
-                r"rpm -q --whatprovides tree nano \|\| rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree nano",  # noqa: E501
+                r"rpm-ostree install --apply-live --idempotent --allow-inactive --assumeyes  tree nano",  # noqa: E501
                 'Installing: tree',
             )
 
@@ -1744,7 +1744,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('tree'), Package('diffutils')),
-                r"apk info -e tree diffutils \|\| apk add tree diffutils",
+                r"apk add tree diffutils",
                 'Installing tree',
             )
 
@@ -1896,7 +1896,7 @@ def _parametrize_test_install_downloaded() -> Iterator[
                 package_manager_class,
                 (Package('tree'), Package('nano')),
                 ('tree*.x86_64.rpm', 'nano*.x86_64.rpm'),
-                r".*?dpkg-query --show \$installable_packages \\\n^\|\| apt install -y  \$installable_packages.*",  # noqa: E501
+                r".*?apt install -y  \$installable_packages.*",
                 'Setting up tree',
                 marks=pytest.mark.skip(reason="not supported yet"),
             )
@@ -1907,7 +1907,7 @@ def _parametrize_test_install_downloaded() -> Iterator[
                 package_manager_class,
                 (Package('tree'), Package('nano')),
                 ('tree*.x86_64.rpm', 'nano*.x86_64.rpm'),
-                r"apk info -e tree nano \|\| apk add tree nano",
+                r"apk add tree nano",
                 'Installing tree',
                 marks=pytest.mark.skip(reason="not supported yet"),
             )

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -915,7 +915,7 @@ def _parametrize_test_install_dont_check_first() -> Iterator[
                 container,
                 package_manager_class,
                 Package('tree'),
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree\"\s+/bin/false \\\s+\|\| apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'Setting up tree',
             )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -490,7 +490,7 @@ def _parametrize_test_assert_config_manager() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r'rpm -q --whatprovides "yum-utils" >&2 \|\| echo "yum-utils"',
+                    r'rpm -q --whatprovides yum-utils >&2 \|\| echo yum-utils',
                 )
             else:
                 yield (
@@ -513,7 +513,7 @@ def _parametrize_test_assert_config_manager() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r'rpm -q --whatprovides "dnf5-command\(config-manager\)" >&2 \|\| echo "dnf5-command\(config-manager\)"',  # noqa: E501
+                r"""rpm -q --whatprovides '"'"'dnf5-command\(config-manager\)'"'"' >&2 \|\| echo '"'"'dnf5-command\(config-manager\)'"'"'""",  # noqa: E501
             )
 
         elif package_manager_class in (
@@ -1118,7 +1118,7 @@ def _generate_test_reinstall_nonexistent_matrix() -> Iterator[
                 container,
                 package_manager_class,
                 True,
-                r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                 None,
             )
 
@@ -1193,7 +1193,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('coreutils'),
                 True,
-                r'rpm -q --whatprovides "coreutils" >&2 \|\| echo "coreutils"',
+                r'rpm -q --whatprovides coreutils >&2 \|\| echo coreutils',
                 r'\s+stderr:\s+coreutils-',
             )
 
@@ -1202,7 +1202,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('tree-but-spelled-wrong'),
                 False,
-                r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                 r'\s+stdout:\s+tree-but-spelled-wrong',
             )
 
@@ -1211,7 +1211,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 FileSystemPath('/usr/bin/arch'),
                 True,
-                r'rpm -q --whatprovides "/usr/bin/arch" >&2 \|\| echo "/usr/bin/arch"',
+                r'rpm -q --whatprovides /usr/bin/arch >&2 \|\| echo /usr/bin/arch',
                 r'\s+stderr:\s+coreutils-',
             )
 
@@ -1222,7 +1222,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r'rpm -q --whatprovides "util-linux" >&2 \|\| echo "util-linux"',
+                    r'rpm -q --whatprovides util-linux >&2 \|\| echo util-linux',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1231,7 +1231,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                    r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1240,7 +1240,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
+                    r'rpm -q --whatprovides /usr/bin/flock >&2 \|\| echo /usr/bin/flock',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1250,7 +1250,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r'rpm -q --whatprovides "coreutils" >&2 \|\| echo "coreutils"',
+                    r'rpm -q --whatprovides coreutils >&2 \|\| echo coreutils',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1259,7 +1259,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                    r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1268,7 +1268,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r'rpm -q --whatprovides "/usr/bin/arch" >&2 \|\| echo "/usr/bin/arch"',
+                    r'rpm -q --whatprovides /usr/bin/arch >&2 \|\| echo /usr/bin/arch',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1278,7 +1278,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r'rpm -q --whatprovides "util-linux-core" >&2 \|\| echo "util-linux-core"',
+                    r'rpm -q --whatprovides util-linux-core >&2 \|\| echo util-linux-core',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 
@@ -1287,7 +1287,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                    r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1296,7 +1296,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
+                    r'rpm -q --whatprovides /usr/bin/flock >&2 \|\| echo /usr/bin/flock',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 
@@ -1307,7 +1307,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r'rpm -q --whatprovides "util-linux" >&2 \|\| echo "util-linux"',
+                    r'rpm -q --whatprovides util-linux >&2 \|\| echo util-linux',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1316,7 +1316,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                    r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1325,7 +1325,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
+                    r'rpm -q --whatprovides /usr/bin/flock >&2 \|\| echo /usr/bin/flock',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1335,7 +1335,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r'rpm -q --whatprovides "coreutils" >&2 \|\| echo "coreutils"',
+                    r'rpm -q --whatprovides coreutils >&2 \|\| echo coreutils',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1344,7 +1344,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                    r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1353,7 +1353,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r'rpm -q --whatprovides "/usr/bin/arch" >&2 \|\| echo "/usr/bin/arch"',
+                    r'rpm -q --whatprovides /usr/bin/arch >&2 \|\| echo /usr/bin/arch',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1363,7 +1363,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r'rpm -q --whatprovides "util-linux-core" >&2 \|\| echo "util-linux-core"',
+                    r'rpm -q --whatprovides util-linux-core >&2 \|\| echo util-linux-core',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 
@@ -1372,7 +1372,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
+                    r'rpm -q --whatprovides tree-but-spelled-wrong >&2 \|\| echo tree-but-spelled-wrong',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1381,7 +1381,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
+                    r'rpm -q --whatprovides /usr/bin/flock >&2 \|\| echo /usr/bin/flock',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -484,11 +484,20 @@ def _parametrize_test_assert_config_manager() -> Iterator[
 ]:
     for container, package_manager_class in CONTAINER_BASE_MATRIX:
         if package_manager_class is tmt.package_managers.dnf.Yum:
-            yield (
-                container,
-                package_manager_class,
-                r"yum install -y  yum-utils && rpm -q --whatprovides yum-utils",
-            )
+            if 'centos/7' in container.url:
+                # yum-utils ships pre-installed on CentOS 7; check_presence returns
+                # True → install is skipped, only the rpm check appears in logs.
+                yield (
+                    container,
+                    package_manager_class,
+                    r"rpm -q --whatprovides yum-utils",
+                )
+            else:
+                yield (
+                    container,
+                    package_manager_class,
+                    r"yum install -y  yum-utils && rpm -q --whatprovides yum-utils",
+                )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf:
             yield (
@@ -498,10 +507,13 @@ def _parametrize_test_assert_config_manager() -> Iterator[
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf5:
+            # dnf5-command(config-manager) ships pre-installed on modern Fedora
+            # via dnf5-plugins; check_presence returns True → install is skipped,
+            # only the rpm presence-check command appears in the logs.
             yield (
                 container,
                 package_manager_class,
-                r"""dnf5 install -y  '"'"'dnf5-command\(config-manager\)'"'"'""",
+                r"""rpm -q --whatprovides '"'"'dnf5-command\(config-manager\)'"'"'""",
             )
 
         elif package_manager_class in (
@@ -1722,11 +1734,13 @@ def _parametrize_test_install_multiple() -> Iterator[
             )
 
         elif package_manager_class is tmt.package_managers.apt.Apt:
+            # nano is pre-installed on Ubuntu/Debian base images; use nmap instead
+            # so that check_presence finds both packages absent and installs both.
             yield (
                 container,
                 package_manager_class,
-                (Package('tree'), Package('nano')),
-                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree nano\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
+                (Package('tree'), Package('nmap')),
+                r"set -x\s+export DEBIAN_FRONTEND=noninteractive\s+installable_packages=\"tree nmap\"\s+apt install -y  \$installable_packages\s+exit \$\?",  # noqa: E501
                 'Setting up tree',
             )
 
@@ -2120,11 +2134,14 @@ def _parametrize_test_install_debuginfo_nonexistent() -> Iterator[
 ]:
     for container, package_manager_class in CONTAINER_BASE_MATRIX:
         if package_manager_class is tmt.package_managers.dnf.Dnf5:
+            # Dnf5Engine._base_debuginfo_command = Command('dnf5', 'debuginfo-install'),
+            # so install_debuginfo goes straight to the built-in subcommand without a
+            # separate install-tool step.
             yield (
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                r"dnf5 install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                r"dnf5 debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
                 None,
             )
 
@@ -2138,11 +2155,12 @@ def _parametrize_test_install_debuginfo_nonexistent() -> Iterator[
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Yum:
+            # YumEngine.install() always appends a post-install rpm-q presence check.
             yield (
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                r"yum install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                r"yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
                 None,
             )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -490,7 +490,7 @@ def _parametrize_test_assert_config_manager() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides 'yum-utils' >&2 \|\| echo 'yum-utils'",
+                    r'rpm -q --whatprovides "yum-utils" >&2 \|\| echo "yum-utils"',
                 )
             else:
                 yield (
@@ -513,7 +513,7 @@ def _parametrize_test_assert_config_manager() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides 'dnf5-command\(config-manager\)' >&2 \|\| echo 'dnf5-command\(config-manager\)'",  # noqa: E501
+                r'rpm -q --whatprovides "dnf5-command\(config-manager\)" >&2 \|\| echo "dnf5-command\(config-manager\)"',  # noqa: E501
             )
 
         elif package_manager_class in (
@@ -1118,7 +1118,7 @@ def _generate_test_reinstall_nonexistent_matrix() -> Iterator[
                 container,
                 package_manager_class,
                 True,
-                r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                 None,
             )
 
@@ -1193,7 +1193,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('coreutils'),
                 True,
-                r"rpm -q --whatprovides 'coreutils' >&2 \|\| echo 'coreutils'",
+                r'rpm -q --whatprovides "coreutils" >&2 \|\| echo "coreutils"',
                 r'\s+stderr:\s+coreutils-',
             )
 
@@ -1202,7 +1202,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 Package('tree-but-spelled-wrong'),
                 False,
-                r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                 r'\s+stdout:\s+tree-but-spelled-wrong',
             )
 
@@ -1211,7 +1211,7 @@ def _generate_test_check_presence() -> Iterator[
                 package_manager_class,
                 FileSystemPath('/usr/bin/arch'),
                 True,
-                r"rpm -q --whatprovides '/usr/bin/arch' >&2 \|\| echo '/usr/bin/arch'",
+                r'rpm -q --whatprovides "/usr/bin/arch" >&2 \|\| echo "/usr/bin/arch"',
                 r'\s+stderr:\s+coreutils-',
             )
 
@@ -1222,7 +1222,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r"rpm -q --whatprovides 'util-linux' >&2 \|\| echo 'util-linux'",
+                    r'rpm -q --whatprovides "util-linux" >&2 \|\| echo "util-linux"',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1231,7 +1231,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1240,7 +1240,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1250,7 +1250,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r"rpm -q --whatprovides 'coreutils' >&2 \|\| echo 'coreutils'",
+                    r'rpm -q --whatprovides "coreutils" >&2 \|\| echo "coreutils"',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1259,7 +1259,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1268,7 +1268,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r"rpm -q --whatprovides '/usr/bin/arch' >&2 \|\| echo '/usr/bin/arch'",
+                    r'rpm -q --whatprovides "/usr/bin/arch" >&2 \|\| echo "/usr/bin/arch"',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1278,7 +1278,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r"rpm -q --whatprovides 'util-linux-core' >&2 \|\| echo 'util-linux-core'",
+                    r'rpm -q --whatprovides "util-linux-core" >&2 \|\| echo "util-linux-core"',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 
@@ -1287,7 +1287,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1296,7 +1296,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 
@@ -1307,7 +1307,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux'),
                     True,
-                    r"rpm -q --whatprovides 'util-linux' >&2 \|\| echo 'util-linux'",
+                    r'rpm -q --whatprovides "util-linux" >&2 \|\| echo "util-linux"',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1316,7 +1316,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1325,7 +1325,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
                     r'\s+stderr:\s+util-linux-',
                 )
 
@@ -1335,7 +1335,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('coreutils'),
                     True,
-                    r"rpm -q --whatprovides 'coreutils' >&2 \|\| echo 'coreutils'",
+                    r'rpm -q --whatprovides "coreutils" >&2 \|\| echo "coreutils"',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1344,7 +1344,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1353,7 +1353,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/arch'),
                     True,
-                    r"rpm -q --whatprovides '/usr/bin/arch' >&2 \|\| echo '/usr/bin/arch'",
+                    r'rpm -q --whatprovides "/usr/bin/arch" >&2 \|\| echo "/usr/bin/arch"',
                     r'\s+stderr:\s+coreutils-',
                 )
 
@@ -1363,7 +1363,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('util-linux-core'),
                     True,
-                    r"rpm -q --whatprovides 'util-linux-core' >&2 \|\| echo 'util-linux-core'",
+                    r'rpm -q --whatprovides "util-linux-core" >&2 \|\| echo "util-linux-core"',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 
@@ -1372,7 +1372,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     Package('tree-but-spelled-wrong'),
                     False,
-                    r"rpm -q --whatprovides 'tree-but-spelled-wrong' >&2 \|\| echo 'tree-but-spelled-wrong'",  # noqa: E501
+                    r'rpm -q --whatprovides "tree-but-spelled-wrong" >&2 \|\| echo "tree-but-spelled-wrong"',  # noqa: E501
                     r'\s+stdout:\s+tree-but-spelled-wrong',
                 )
 
@@ -1381,7 +1381,7 @@ def _generate_test_check_presence() -> Iterator[
                     package_manager_class,
                     FileSystemPath('/usr/bin/flock'),
                     True,
-                    r"rpm -q --whatprovides '/usr/bin/flock' >&2 \|\| echo '/usr/bin/flock'",
+                    r'rpm -q --whatprovides "/usr/bin/flock" >&2 \|\| echo "/usr/bin/flock"',
                     r'\s+stderr:\s+util-linux-core-',
                 )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -279,7 +279,7 @@ def _parametrize_test_install() -> Iterator[
                     container,
                     package_manager_class,
                     Package('tree'),
-                    r"rpm -q --whatprovides tree \|\| yum install -y  tree && rpm -q --whatprovides tree",  # noqa: E501
+                    r"yum install -y  tree && rpm -q --whatprovides tree",
                     'Installing:',
                 )
 
@@ -288,7 +288,7 @@ def _parametrize_test_install() -> Iterator[
                     container,
                     package_manager_class,
                     Package('dconf'),
-                    r"rpm -q --whatprovides dconf \|\| yum install -y  dconf && rpm -q --whatprovides dconf",  # noqa: E501
+                    r"yum install -y  dconf && rpm -q --whatprovides dconf",
                     'Installed:\n  dconf',
                 )
 
@@ -297,7 +297,7 @@ def _parametrize_test_install() -> Iterator[
                     container,
                     package_manager_class,
                     Package('tree'),
-                    r"rpm -q --whatprovides tree \|\| yum install -y  tree && rpm -q --whatprovides tree",  # noqa: E501
+                    r"yum install -y  tree && rpm -q --whatprovides tree",
                     'Installed:\n  tree',
                 )
 
@@ -307,7 +307,7 @@ def _parametrize_test_install() -> Iterator[
                     container,
                     package_manager_class,
                     Package('tree'),
-                    r"rpm -q --whatprovides tree \|\| dnf install -y  tree",
+                    r"dnf install -y  tree",
                     'Installing:',
                 )
 
@@ -316,7 +316,7 @@ def _parametrize_test_install() -> Iterator[
                     container,
                     package_manager_class,
                     Package('dconf'),
-                    r"rpm -q --whatprovides dconf \|\| dnf install -y  dconf",
+                    r"dnf install -y  dconf",
                     'Installed:\n  dconf',
                 )
 
@@ -325,7 +325,7 @@ def _parametrize_test_install() -> Iterator[
                     container,
                     package_manager_class,
                     Package('tree'),
-                    r"rpm -q --whatprovides tree \|\| dnf install -y  tree",
+                    r"dnf install -y  tree",
                     'Installed:\n  tree',
                 )
 
@@ -334,7 +334,7 @@ def _parametrize_test_install() -> Iterator[
                 container,
                 package_manager_class,
                 Package('tree'),
-                r"rpm -q --whatprovides tree \|\| dnf5 install -y  tree",
+                r"dnf5 install -y  tree",
                 'Installing:',
             )
 
@@ -487,21 +487,21 @@ def _parametrize_test_assert_config_manager() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides yum-utils \|\| yum install -y  yum-utils && rpm -q --whatprovides yum-utils",  # noqa: E501
+                r"yum install -y  yum-utils && rpm -q --whatprovides yum-utils",
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf:
             yield (
                 container,
                 package_manager_class,
-                r"""rpm -q --whatprovides '"'"'dnf-command\(config-manager\)'"'"' \|\| dnf install -y  '"'"'dnf-command\(config-manager\)'"'"'""",  # noqa: E501
+                r"""dnf install -y  '"'"'dnf-command\(config-manager\)'"'"'""",
             )
 
         elif package_manager_class is tmt.package_managers.dnf.Dnf5:
             yield (
                 container,
                 package_manager_class,
-                r"""rpm -q --whatprovides '"'"'dnf5-command\(config-manager\)'"'"' \|\| dnf5 install -y  '"'"'dnf5-command\(config-manager\)'"'"'""",  # noqa: E501
+                r"""dnf5 install -y  '"'"'dnf5-command\(config-manager\)'"'"'""",
             )
 
         elif package_manager_class in (
@@ -643,7 +643,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf5 install -y  tree-but-spelled-wrong",  # noqa: E501
+                r"dnf5 install -y  tree-but-spelled-wrong",
                 'No match for argument: tree-but-spelled-wrong',
             )
 
@@ -652,7 +652,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf install -y  tree-but-spelled-wrong",  # noqa: E501
+                    r"dnf install -y  tree-but-spelled-wrong",
                     'No match for argument: tree-but-spelled-wrong',
                 )
 
@@ -660,7 +660,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf install -y  tree-but-spelled-wrong",  # noqa: E501
+                    r"dnf install -y  tree-but-spelled-wrong",
                     'Error: Unable to find a match: tree-but-spelled-wrong',
                 )
 
@@ -669,7 +669,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
+                    r"yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
                     'No match for argument: tree-but-spelled-wrong',
                 )
 
@@ -677,7 +677,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
+                    r"yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
                     'Error: Unable to find a match: tree-but-spelled-wrong',
                 )
 
@@ -687,7 +687,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
+                    r"yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
                     'No match for argument: tree-but-spelled-wrong',
                 )
 
@@ -695,7 +695,7 @@ def _parametrize_test_install_nonexistent() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
+                    r"yum install -y  tree-but-spelled-wrong && rpm -q --whatprovides tree-but-spelled-wrong",  # noqa: E501
                     'No package tree-but-spelled-wrong available.',
                 )
 
@@ -764,7 +764,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf5 install -y --skip-unavailable tree-but-spelled-wrong",  # noqa: E501
+                r"dnf5 install -y --skip-unavailable tree-but-spelled-wrong",
                 None,
             )
 
@@ -772,7 +772,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
             yield (
                 container,
                 package_manager_class,
-                r"rpm -q --whatprovides tree-but-spelled-wrong \|\| dnf install -y --skip-broken tree-but-spelled-wrong",  # noqa: E501
+                r"dnf install -y --skip-broken tree-but-spelled-wrong",
                 'No match for argument: tree-but-spelled-wrong',
             )
 
@@ -781,7 +781,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
+                    r"yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",
                     'No match for argument: tree-but-spelled-wrong',
                 )
 
@@ -789,7 +789,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
+                    r"yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",
                     'No match for argument: tree-but-spelled-wrong',
                 )
 
@@ -799,7 +799,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
+                    r"yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",
                     'No match for argument: tree-but-spelled-wrong',
                 )
 
@@ -807,7 +807,7 @@ def _parametrize_test_install_nonexistent_skip() -> Iterator[
                 yield (
                     container,
                     package_manager_class,
-                    r"rpm -q --whatprovides tree-but-spelled-wrong \|\| yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",  # noqa: E501
+                    r"yum install -y --skip-broken tree-but-spelled-wrong \|\| /bin/true",
                     'No package tree-but-spelled-wrong available.',
                 )
 
@@ -1555,7 +1555,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                 container,
                 package_manager_class,
                 FileSystemPath('/usr/bin/dos2unix'),
-                r"rpm -q --whatprovides /usr/bin/dos2unix \|\| dnf5 install -y  /usr/bin/dos2unix",
+                r"dnf5 install -y  /usr/bin/dos2unix",
                 '[1/1] dos2unix',
             )
 
@@ -1564,7 +1564,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                 container,
                 package_manager_class,
                 FileSystemPath('/usr/bin/dos2unix'),
-                r"rpm -q --whatprovides /usr/bin/dos2unix \|\| dnf install -y  /usr/bin/dos2unix",
+                r"dnf install -y  /usr/bin/dos2unix",
                 'Installed:\n  dos2unix-',
             )
 
@@ -1574,7 +1574,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                     container,
                     package_manager_class,
                     FileSystemPath('/usr/bin/dos2unix'),
-                    r"rpm -q --whatprovides /usr/bin/dos2unix \|\| yum install -y  /usr/bin/dos2unix && rpm -q --whatprovides /usr/bin/dos2unix",  # noqa: E501
+                    r"yum install -y  /usr/bin/dos2unix && rpm -q --whatprovides /usr/bin/dos2unix",  # noqa: E501
                     'Installed:\n  dos2unix.',
                 )
 
@@ -1583,7 +1583,7 @@ def _parametrize_test_install_filesystempath() -> Iterator[
                     container,
                     package_manager_class,
                     FileSystemPath('/usr/bin/dos2unix'),
-                    r"rpm -q --whatprovides /usr/bin/dos2unix \|\| yum install -y  /usr/bin/dos2unix && rpm -q --whatprovides /usr/bin/dos2unix",  # noqa: E501
+                    r"yum install -y  /usr/bin/dos2unix && rpm -q --whatprovides /usr/bin/dos2unix",  # noqa: E501
                     'Installed:\n  dos2unix-',
                 )
 
@@ -1662,7 +1662,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dconf'), Package('libpng')),
-                    r"rpm -q --whatprovides dconf libpng \|\| yum install -y  dconf libpng && rpm -q --whatprovides dconf libpng",  # noqa: E501
+                    r"yum install -y  dconf libpng && rpm -q --whatprovides dconf libpng",
                     'Complete!',
                 )
 
@@ -1671,7 +1671,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('tree'), Package('diffutils')),
-                    r"rpm -q --whatprovides tree diffutils \|\| yum install -y  tree diffutils && rpm -q --whatprovides tree diffutils",  # noqa: E501
+                    r"yum install -y  tree diffutils && rpm -q --whatprovides tree diffutils",
                     'Complete!',
                 )
 
@@ -1680,7 +1680,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('tree'), Package('nano')),
-                    r"rpm -q --whatprovides tree nano \|\| yum install -y  tree nano && rpm -q --whatprovides tree nano",  # noqa: E501
+                    r"yum install -y  tree nano && rpm -q --whatprovides tree nano",
                     'Complete!',
                 )
 
@@ -1690,7 +1690,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dconf'), Package('libpng')),
-                    r"rpm -q --whatprovides dconf libpng \|\| dnf install -y  dconf libpng",
+                    r"dnf install -y  dconf libpng",
                     'Complete!',
                 )
 
@@ -1699,7 +1699,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('tree'), Package('diffutils')),
-                    r"rpm -q --whatprovides tree diffutils \|\| dnf install -y  tree diffutils",
+                    r"dnf install -y  tree diffutils",
                     'Complete!',
                 )
 
@@ -1708,7 +1708,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('tree'), Package('nano')),
-                    r"rpm -q --whatprovides tree nano \|\| dnf install -y  tree nano",
+                    r"dnf install -y  tree nano",
                     'Complete!',
                 )
 
@@ -1717,7 +1717,7 @@ def _parametrize_test_install_multiple() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('tree'), Package('nano')),
-                r"rpm -q --whatprovides tree nano \|\| dnf5 install -y  tree nano",
+                r"dnf5 install -y  tree nano",
                 None,
             )
 
@@ -2019,7 +2019,7 @@ def _parametrize_test_install_debuginfo() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dconf'), Package('libpng')),
-                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dconf libpng && rpm -q dconf-debuginfo libpng-debuginfo",  # noqa: E501
+                    r"dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dconf libpng && rpm -q dconf-debuginfo libpng-debuginfo",  # noqa: E501
                     None,
                 )
 
@@ -2028,7 +2028,7 @@ def _parametrize_test_install_debuginfo() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dos2unix'), Package('tree')),
-                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",  # noqa: E501
+                    r"dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",  # noqa: E501
                     None,
                 )
 
@@ -2050,7 +2050,7 @@ def _parametrize_test_install_debuginfo() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dconf'), Package('libpng')),
-                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y  dconf libpng && rpm -q dconf-debuginfo libpng-debuginfo",  # noqa: E501
+                    r"yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y  dconf libpng && rpm -q dconf-debuginfo libpng-debuginfo",  # noqa: E501
                     None,
                 )
 
@@ -2059,7 +2059,7 @@ def _parametrize_test_install_debuginfo() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dos2unix'), Package('tree')),
-                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",  # noqa: E501
+                    r"yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree && rpm -q dos2unix-debuginfo tree-debuginfo",  # noqa: E501
                     None,
                 )
 
@@ -2124,7 +2124,7 @@ def _parametrize_test_install_debuginfo_nonexistent() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                r"rpm -q --whatprovides /usr/bin/debuginfo-install || dnf5 install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                r"dnf5 install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
                 None,
             )
 
@@ -2133,7 +2133,7 @@ def _parametrize_test_install_debuginfo_nonexistent() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                r"rpm -q --whatprovides /usr/bin/debuginfo-install || dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                r"dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
                 None,
             )
 
@@ -2142,7 +2142,7 @@ def _parametrize_test_install_debuginfo_nonexistent() -> Iterator[
                 container,
                 package_manager_class,
                 (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                r"rpm -q --whatprovides /usr/bin/debuginfo-install || yum install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
+                r"yum install -y  /usr/bin/debuginfo-install && debuginfo-install -y  dos2unix tree-but-spelled-wrong && rpm -q dos2unix-debuginfo tree-but-spelled-wrong-debuginfo",  # noqa: E501
                 None,
             )
 
@@ -2244,7 +2244,7 @@ def _parametrize_test_install_debuginfo_nonexistent_skip() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                    r"rpm -q --whatprovides /usr/bin/debuginfo-install \|\| dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",  # noqa: E501
+                    r"dnf install -y  /usr/bin/debuginfo-install && debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",  # noqa: E501
                     None,
                 )
 
@@ -2266,7 +2266,7 @@ def _parametrize_test_install_debuginfo_nonexistent_skip() -> Iterator[
                     container,
                     package_manager_class,
                     (Package('dos2unix'), Package('tree-but-spelled-wrong')),
-                    r"rpm -q --whatprovides /usr/bin/debuginfo-install || yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",  # noqa: E501
+                    r"yum install -y  /usr/bin/debuginfo-install && rpm -q --whatprovides /usr/bin/debuginfo-install && debuginfo-install -y --skip-broken dos2unix tree-but-spelled-wrong",  # noqa: E501
                     None,
                 )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1679,11 +1679,13 @@ def _parametrize_test_install_multiple() -> Iterator[
                 )
 
             elif 'centos' in container.url:
+                # diffutils is pre-installed on centos/7 and centos/stream10;
+                # nano is absent from any CentOS minimal image.
                 yield (
                     container,
                     package_manager_class,
-                    (Package('tree'), Package('diffutils')),
-                    r"yum install -y  tree diffutils && rpm -q --whatprovides tree diffutils",
+                    (Package('tree'), Package('nano')),
+                    r"yum install -y  tree nano && rpm -q --whatprovides tree nano",
                     'Complete!',
                 )
 
@@ -1707,11 +1709,13 @@ def _parametrize_test_install_multiple() -> Iterator[
                 )
 
             elif 'centos' in container.url:
+                # diffutils is pre-installed on centos/7 and centos/stream10;
+                # nano is absent from any CentOS minimal image.
                 yield (
                     container,
                     package_manager_class,
-                    (Package('tree'), Package('diffutils')),
-                    r"dnf install -y  tree diffutils",
+                    (Package('tree'), Package('nano')),
+                    r"dnf install -y  tree nano",
                     'Complete!',
                 )
 

--- a/tests/unit/test_package_managers.py
+++ b/tests/unit/test_package_managers.py
@@ -1051,7 +1051,7 @@ def _parametrize_test_reinstall() -> Iterator[
                 package_manager_class,
                 Package('bash'),
                 True,
-                r"apk info -e bash && apk fix bash",
+                r"apk fix bash",
                 'Reinstalling bash',
             )
 

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -564,7 +564,18 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-        return self.guest.execute(self.engine.reinstall(*installables, options=options))
+        options = options or Options()
+
+        if not options.check_first or not installables:
+            return self.guest.execute(self.engine.reinstall(*installables, options=options))
+
+        presence = self.check_presence(*installables)
+        present = tuple(p for p, is_present in presence.items() if is_present)
+
+        if not present:
+            return CommandOutput(stdout=None, stderr=None)
+
+        return self.guest.execute(self.engine.reinstall(*present, options=options))
 
     def install_debuginfo(
         self,

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -552,7 +552,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
             return self.guest.execute(self.engine.install(*installables, options=options))
 
         presence = self.check_presence(*installables)
-        missing = tuple(p for p, present in presence.items() if not present)
+        missing = {p for p, present in presence.items() if not present}
 
         if not missing:
             return CommandOutput(stdout=None, stderr=None)
@@ -570,7 +570,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
             return self.guest.execute(self.engine.reinstall(*installables, options=options))
 
         presence = self.check_presence(*installables)
-        present = tuple(p for p, is_present in presence.items() if is_present)
+        present = {p for p, is_present in presence.items() if is_present}
 
         if not present:
             return CommandOutput(stdout=None, stderr=None)

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -541,23 +541,34 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
             for match in pattern.finditer(output):
                 yield match.group(1)
 
+    def _check_first_filter(
+        self,
+        *installables: Installable,
+        options: Options,
+        present: bool,
+    ) -> list[Installable]:
+        """
+        Filter installables by presence when check_first is set.
+
+        Returns the full list of installables when check_first is not set.
+        Returns a subset (possibly empty) matching the desired presence state
+        when check_first is set. Order is preserved.
+        """
+        if not options.check_first:
+            return list(installables)
+        presence = self.check_presence(*installables)
+        return [p for p, is_present in presence.items() if is_present == present]
+
     def install(
         self,
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
         options = options or Options()
-
-        if not options.check_first or not installables:
-            return self.guest.execute(self.engine.install(*installables, options=options))
-
-        presence = self.check_presence(*installables)
-        missing = {p for p, present in presence.items() if not present}
-
-        if not missing:
+        to_install = self._check_first_filter(*installables, options=options, present=False)
+        if not to_install:
             return CommandOutput(stdout=None, stderr=None)
-
-        return self.guest.execute(self.engine.install(*missing, options=options))
+        return self.guest.execute(self.engine.install(*to_install, options=options))
 
     def reinstall(
         self,
@@ -565,17 +576,10 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         options: Optional[Options] = None,
     ) -> CommandOutput:
         options = options or Options()
-
-        if not options.check_first or not installables:
-            return self.guest.execute(self.engine.reinstall(*installables, options=options))
-
-        presence = self.check_presence(*installables)
-        present = {p for p, is_present in presence.items() if is_present}
-
-        if not present:
+        to_reinstall = self._check_first_filter(*installables, options=options, present=True)
+        if not to_reinstall:
             return CommandOutput(stdout=None, stderr=None)
-
-        return self.guest.execute(self.engine.reinstall(*present, options=options))
+        return self.guest.execute(self.engine.reinstall(*to_reinstall, options=options))
 
     def install_debuginfo(
         self,

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -1,6 +1,5 @@
 import abc
 import configparser
-import dataclasses
 import enum
 import re
 import shlex
@@ -558,9 +557,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         if not missing:
             return CommandOutput(stdout=None, stderr=None)
 
-        return self.guest.execute(
-            self.engine.install(*missing, options=dataclasses.replace(options, check_first=False))
-        )
+        return self.guest.execute(self.engine.install(*missing, options=options))
 
     def reinstall(
         self,

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -1,5 +1,6 @@
 import abc
 import configparser
+import dataclasses
 import enum
 import re
 import shlex
@@ -546,7 +547,20 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-        return self.guest.execute(self.engine.install(*installables, options=options))
+        options = options or Options()
+
+        if not options.check_first or not installables:
+            return self.guest.execute(self.engine.install(*installables, options=options))
+
+        presence = self.check_presence(*installables)
+        missing = tuple(p for p, present in presence.items() if not present)
+
+        if not missing:
+            return CommandOutput(stdout=None, stderr=None)
+
+        return self.guest.execute(
+            self.engine.install(*missing, options=dataclasses.replace(options, check_first=False))
+        )
 
     def reinstall(
         self,

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -329,12 +329,10 @@ class Options:
     #: If set, instruct package manager to install from untrusted sources.
     allow_untrusted: bool = False
 
-    #: If set, allow erasing conflicting or obsoleting packages (``--allowerasing``).
-    #: Supported by DNF4 and DNF5.
+    #: If set, allow erasing conflicting or obsoleting packages during install.
     allow_erasing: bool = False
 
-    #: If set, allow downgrades of transitive dependencies (``--allow-downgrade``).
-    #: DNF5 only; DNF4 handles transitive downgrades automatically.
+    #: If set, allow downgrades of transitive dependencies during install.
     allow_downgrade: bool = False
 
 

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -329,6 +329,14 @@ class Options:
     #: If set, instruct package manager to install from untrusted sources.
     allow_untrusted: bool = False
 
+    #: If set, allow erasing conflicting or obsoleting packages (``--allowerasing``).
+    #: Supported by DNF4 and DNF5.
+    allow_erasing: bool = False
+
+    #: If set, allow downgrades of transitive dependencies (``--allow-downgrade``).
+    #: DNF5 only; DNF4 handles transitive downgrades automatically.
+    allow_downgrade: bool = False
+
 
 class PackageManagerEngine(tmt.utils.Common):
     command: Command

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -141,9 +141,6 @@ class ApkEngine(PackageManagerEngine):
             f'{self.command.to_script()} fix {" ".join(escape_installables(*packages))}'
         )
 
-        if options.check_first:
-            script = self._construct_presence_script(*packages)[1] & script
-
         if options.skip_missing:
             script = script | ShellScript('/bin/true')
 

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -123,9 +123,6 @@ class ApkEngine(PackageManagerEngine):
             f'{" ".join(escape_installables(*packages))}'
         )
 
-        if options.check_first:
-            script = self._construct_presence_script(*packages)[1] | script
-
         if options.skip_missing:
             script = script | ShellScript('/bin/true')
 

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -64,12 +64,10 @@ installable_packages="$installable_packages $fs_path_package"
   {% endfor %}
 {% endif %}
 
-{% if OPTIONS.check_first %}
+{% if OPTIONS.check_first and COMMAND != 'install' -%}
 dpkg-query --show $installable_packages \\
-{% else -%}
-/bin/false \\
-{% endif -%}
-{{ '||' if COMMAND == 'install' else '&&' }} {{ ENGINE.command.to_script() }} {{ COMMAND }} {{ ENGINE.options.to_script() }} {{ EXTRA_OPTIONS }} $installable_packages
+&& {% endif -%}
+{{ ENGINE.command.to_script() }} {{ COMMAND }} {{ ENGINE.options.to_script() }} {{ EXTRA_OPTIONS }} $installable_packages
 
 {% if OPTIONS.skip_missing %}
 exit 0

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -64,7 +64,9 @@ installable_packages="$installable_packages $fs_path_package"
   {% endfor %}
 {% endif %}
 
-{{ ENGINE.command.to_script() }} {{ COMMAND }} {{ ENGINE.options.to_script() }} {{ EXTRA_OPTIONS }} $installable_packages
+{% if CHECK_FIRST %}
+dpkg-query --show $installable_packages \\
+&& {% endif %}{{ ENGINE.command.to_script() }} {{ COMMAND }} {{ ENGINE.options.to_script() }} {{ EXTRA_OPTIONS }} $installable_packages
 
 {% if OPTIONS.skip_missing %}
 exit 0
@@ -214,6 +216,7 @@ class AptEngine(PackageManagerEngine):
                     COMMAND='reinstall',
                     OPTIONS=options,
                     EXTRA_OPTIONS=extra_options,
+                    CHECK_FIRST=True,
                     REAL_PACKAGES=escape_installables(*real_packages),
                     FILESYSTEM_PATHS=escape_installables(*filesystem_paths),
                 )
@@ -226,8 +229,9 @@ class AptEngine(PackageManagerEngine):
                 COMMAND='reinstall',
                 OPTIONS=options,
                 EXTRA_OPTIONS=extra_options,
-                REAL_PACKAGES=real_packages,
-                FILESYSTEM_PATHS=filesystem_paths,
+                CHECK_FIRST=True,
+                REAL_PACKAGES=escape_installables(*real_packages),
+                FILESYSTEM_PATHS=escape_installables(*filesystem_paths),
             )
         )
 

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -181,6 +181,7 @@ class AptEngine(PackageManagerEngine):
                     COMMAND='install',
                     OPTIONS=options,
                     EXTRA_OPTIONS=extra_options,
+                    CHECK_FIRST=False,
                     REAL_PACKAGES=escape_installables(*real_packages),
                     FILESYSTEM_PATHS=escape_installables(*filesystem_paths),
                 )
@@ -193,6 +194,7 @@ class AptEngine(PackageManagerEngine):
                 COMMAND='install',
                 OPTIONS=options,
                 EXTRA_OPTIONS=extra_options,
+                CHECK_FIRST=False,
                 REAL_PACKAGES=escape_installables(*real_packages),
                 FILESYSTEM_PATHS=escape_installables(*filesystem_paths),
             )

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -64,9 +64,6 @@ installable_packages="$installable_packages $fs_path_package"
   {% endfor %}
 {% endif %}
 
-{% if OPTIONS.check_first and COMMAND != 'install' -%}
-dpkg-query --show $installable_packages \\
-&& {% endif -%}
 {{ ENGINE.command.to_script() }} {{ COMMAND }} {{ ENGINE.options.to_script() }} {{ EXTRA_OPTIONS }} $installable_packages
 
 {% if OPTIONS.skip_missing %}

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -1,4 +1,3 @@
-import re
 import uuid
 from collections.abc import Iterator
 from typing import Any, Optional
@@ -15,7 +14,7 @@ from tmt.package_managers import (
     PackageManagerEngine,
     provides_package_manager,
 )
-from tmt.utils import Command, CommandOutput, GeneralError, Path, RunError, ShellScript
+from tmt.utils import Command, CommandOutput, Path, ShellScript
 
 LOCALHOST_BOOTC_IMAGE_PREFIX = "localhost/tmt"
 
@@ -210,32 +209,18 @@ class Bootc(PackageManager[BootcEngine]):
         return self.guest.bootc_builder.extract_package_name_from_package_manager_output(output)
 
     def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
+        if not installables:
+            return {}
+
         script = self.engine.check_presence(*installables)
+        output = self.guest.execute(script)
 
-        try:
-            output = self.guest.execute(script)
-            stdout = output.stdout
+        results: dict[Installable, bool] = dict.fromkeys(installables, True)
+        missing = {line.strip() for line in (output.stdout or '').splitlines() if line.strip()}
 
-        except RunError as exc:
-            stdout = exc.stdout
-
-        if stdout is None:
-            raise GeneralError("rpm presence check provided no output")
-
-        results: dict[Installable, bool] = {}
-
-        for line, installable in zip(stdout.strip().splitlines(), installables):
-            match = re.match(rf'package {re.escape(str(installable))} is not installed', line)
-            if match is not None:
+        for installable in installables:
+            if str(installable) in missing:
                 results[installable] = False
-                continue
-
-            match = re.match(rf'no package provides {re.escape(str(installable))}', line)
-            if match is not None:
-                results[installable] = False
-                continue
-
-            results[installable] = True
 
         return results
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -81,16 +81,22 @@ class DnfEngine(PackageManagerEngine):
 
         extra_options = self._extra_dnf_options(options)
 
-        script = ShellScript(
-            f'{self.command.to_script()} install '
-            f'{self.options.to_script()} {extra_options} '
-            f'{" ".join(escape_installables(*installables))}'
+        install_cmd = (
+            f'{self.command.to_script()} install {self.options.to_script()} {extra_options}'
         )
 
-        if options.check_first:
-            script = self._construct_presence_script(*installables) | script
+        if not options.check_first:
+            return ShellScript(f'{install_cmd} {" ".join(escape_installables(*installables))}')
 
-        return script
+        # Avoid best=True upgrades: set-level || check sends present packages to DNF.
+        pkgs = ' '.join(escape_installables(*installables))
+        return ShellScript(
+            f'_tmt_missing=(); '
+            f'for _tmt_pkg in {pkgs}; do '
+            f'rpm -q --whatprovides "$_tmt_pkg" &>/dev/null || _tmt_missing+=("$_tmt_pkg"); '
+            f'done; '
+            f'[[ ${{#_tmt_missing[@]}} -eq 0 ]] || {install_cmd} "${{_tmt_missing[@]}}"'
+        )
 
     def _construct_reinstall_script(
         self, *installables: Installable, options: Optional[Options] = None

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -59,6 +59,9 @@ class DnfEngine(PackageManagerEngine):
             else:
                 raise GeneralError(f"Unhandled package manager command '{command}'.")
 
+        if options.allow_erasing:
+            extra_options += Command('--allowerasing')
+
         return extra_options
 
     def _construct_presence_script(
@@ -397,6 +400,18 @@ class Dnf5Engine(DnfEngine):
     _base_debuginfo_command = Command('dnf5', 'debuginfo-install')
     skip_missing_packages_option = '--skip-unavailable'
     skip_missing_debuginfo_option = skip_missing_packages_option
+
+    def _extra_dnf_options(self, options: Options, command: Optional[Command] = None) -> Command:
+        """
+        Collect additional options for ``dnf5`` based on given options.
+        """
+
+        extra_options = super()._extra_dnf_options(options, command)
+
+        if options.allow_downgrade:
+            extra_options += Command('--allow-downgrade')
+
+        return extra_options
 
 
 @provides_package_manager('dnf5')

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -296,41 +296,40 @@ class Dnf(PackageManager[DnfEngine]):
         return result
 
     def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
+        if not installables:
+            return {}
+
+        # Assume all present; mark missing ones identified from rpm error output.
+        results: dict[Installable, bool] = dict.fromkeys(installables, True)
+
         try:
-            output = self.guest.execute(self.engine.check_presence(*installables))
-            stdout = output.stdout
+            self.guest.execute(self.engine.check_presence(*installables))
 
         except RunError as exc:
-            stdout = exc.stdout
+            # rpm exits non-zero when any installable is missing. When checking
+            # multiple installables in one command, stdout only contains lines for
+            # found packages (so zip-based parsing silently drops missing ones).
+            # Error messages for missing packages always go to stderr parse that
+            # to correctly identify each absent installable.
+            stderr = exc.stderr or ''
 
-        if stdout is None:
-            raise GeneralError("rpm presence check provided no output")
+            for installable in installables:
+                installable_str = re.escape(str(installable))
+                pattern = re.compile(
+                    # rpm -q PACKAGE
+                    rf'package {installable_str} is not installed'
+                    # rpm -q --whatprovides CAPABILITY
+                    rf'|no package provides {installable_str}'
+                    # rpm -q --whatprovides /path
+                    rf'|error: file {installable_str}: No such file or directory'
+                )
+                if pattern.search(stderr):
+                    results[installable] = False
 
-        results: dict[Installable, bool] = {}
-
-        for line, installable in zip(stdout.strip().splitlines(), installables):
-            # Match for packages not installed, when "rpm -q PACKAGE" used
-            match = re.match(rf'package {re.escape(str(installable))} is not installed', line)
-            if match is not None:
-                results[installable] = False
-                continue
-
-            # Match for provided rpm capabilities (packages, commands, etc.),
-            # when "rpm -q --whatprovides CAPABILITY" used
-            match = re.match(rf'no package provides {re.escape(str(installable))}', line)
-            if match is not None:
-                results[installable] = False
-                continue
-
-            # Match for filesystem paths, when "rpm -q --whatprovides PATH" used
-            match = re.match(
-                rf'error: file {re.escape(str(installable))}: No such file or directory', line
-            )
-            if match is not None:
-                results[installable] = False
-                continue
-
-            results[installable] = True
+            # rpm exited non-zero but no missing packages were identified
+            # this signals an unexpected failure (db corruption, permission error, etc.)
+            if all(results.values()):
+                raise
 
         return results
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -430,6 +430,11 @@ class Dnf5(Dnf):
 class YumEngine(DnfEngine):
     _base_command = Command('yum')
 
+    def _extra_dnf_options(self, options: Options, command: Optional[Command] = None) -> Command:
+        if options.allow_erasing:
+            raise PrepareError("Package manager 'yum' does not support '--allowerasing'.")
+        return super()._extra_dnf_options(options, command)
+
     def _yum_config_manager_command(self) -> Command:
         command = Command('yum-config-manager')
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -73,7 +73,7 @@ class DnfEngine(PackageManagerEngine):
 
     def check_presence(self, *installables: Installable) -> ShellScript:
         parts = [
-            f"rpm -q --whatprovides '{installable}' >&2 || echo '{installable}'"
+            f'rpm -q --whatprovides "{installable}" >&2 || echo "{installable}"'
             for installable in installables
         ]
         return ShellScript('\n'.join(parts))

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -278,6 +278,7 @@ class Dnf(PackageManager[DnfEngine]):
     probe_priority = 50
 
     def list_packages(self, repository: Repository) -> list[Version]:
+
         script = self.engine.list_packages(repository)
         output = self.guest.execute(script)
         stdout = output.stdout
@@ -333,25 +334,6 @@ class Dnf(PackageManager[DnfEngine]):
 
         return results
 
-    def install(
-        self,
-        *installables: Installable,
-        options: Optional[Options] = None,
-    ) -> CommandOutput:
-        options = options or Options()
-
-        if not options.check_first or not installables:
-            return super().install(*installables, options=options)
-
-        presence = self.check_presence(*installables)
-        missing = tuple(p for p, present in presence.items() if not present)
-
-        if not missing:
-            return CommandOutput(stdout=None, stderr=None)
-
-        options.check_first = False
-        return super().install(*missing, options=options)
-
     def assert_config_manager(self) -> None:
         self.debug('Make sure the config-manager plugin is available.')
         self.install(Package(self.config_manager_plugin))
@@ -381,6 +363,7 @@ class Dnf(PackageManager[DnfEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
+
         options = options or Options()
         options.check_first = False
         # Use both install/reinstall to get all packages refreshed
@@ -394,6 +377,7 @@ class Dnf(PackageManager[DnfEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
+
         output = super().install_debuginfo(*installables, options=options)
 
         # Check the packages are installed because 'debuginfo-install'

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -73,7 +73,7 @@ class DnfEngine(PackageManagerEngine):
 
     def check_presence(self, *installables: Installable) -> ShellScript:
         parts = [
-            f'rpm -q --whatprovides {escaped} >/dev/null 2>&1 || echo {escaped}'
+            f"rpm -q --whatprovides '{escaped}' >&2 || echo '{escaped}'"
             for escaped in escape_installables(*installables)
         ]
         return ShellScript('\n'.join(parts))

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -309,9 +309,9 @@ class Dnf(PackageManager[DnfEngine]):
             # rpm exits non-zero when any installable is missing. When checking
             # multiple installables in one command, stdout only contains lines for
             # found packages (so zip-based parsing silently drops missing ones).
-            # Error messages for missing packages always go to stderr parse that
-            # to correctly identify each absent installable.
-            stderr = exc.stderr or ''
+            # "no package provides X" messages go to stdout; some errors (e.g.
+            # file-not-found) go to stderr. Search both to be safe.
+            output = (exc.stdout or '') + '\n' + (exc.stderr or '')
 
             for installable in installables:
                 installable_str = re.escape(str(installable))
@@ -323,7 +323,7 @@ class Dnf(PackageManager[DnfEngine]):
                     # rpm -q --whatprovides /path
                     rf'|error: file {installable_str}: No such file or directory'
                 )
-                if pattern.search(stderr):
+                if pattern.search(output):
                     results[installable] = False
 
             # rpm exited non-zero but no missing packages were identified

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -72,11 +72,12 @@ class DnfEngine(PackageManagerEngine):
         return ShellScript(f'rpm -q {" ".join(escape_installables(*installables))}')
 
     def check_presence(self, *installables: Installable) -> ShellScript:
-        parts: list[str] = []
-        for installable in installables:
-            e = next(escape_installables(installable))
-            parts.append(f'rpm -q --whatprovides {e} >&2 || echo {e}')
-        return ShellScript('\n'.join(parts))
+        return ShellScript(
+            '\n'.join(
+                f'rpm -q --whatprovides {escaped} >&2 || echo {escaped}'
+                for escaped in escape_installables(*installables)
+            )
+        )
 
     def _construct_install_script(
         self, *installables: Installable, options: Optional[Options] = None

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -17,7 +17,7 @@ from tmt.package_managers import (
     provides_package_manager,
 )
 from tmt.package_managers._rpm import RpmVersion
-from tmt.utils import Command, CommandOutput, GeneralError, PrepareError, RunError, ShellScript
+from tmt.utils import Command, CommandOutput, GeneralError, PrepareError, ShellScript
 
 
 class DnfEngine(PackageManagerEngine):
@@ -72,7 +72,11 @@ class DnfEngine(PackageManagerEngine):
         return ShellScript(f'rpm -q {" ".join(escape_installables(*installables))}')
 
     def check_presence(self, *installables: Installable) -> ShellScript:
-        return self._construct_presence_script(*installables)
+        parts = [
+            f'rpm -q --whatprovides {escaped} >/dev/null 2>&1 || echo {escaped}'
+            for escaped in escape_installables(*installables)
+        ]
+        return ShellScript('\n'.join(parts))
 
     def _construct_install_script(
         self, *installables: Installable, options: Optional[Options] = None
@@ -299,37 +303,15 @@ class Dnf(PackageManager[DnfEngine]):
         if not installables:
             return {}
 
-        # Assume all present; mark missing ones identified from rpm error output.
         results: dict[Installable, bool] = dict.fromkeys(installables, True)
 
-        try:
-            self.guest.execute(self.engine.check_presence(*installables))
+        # Script always exits 0; stdout contains one line per missing package.
+        output = self.guest.execute(self.engine.check_presence(*installables))
+        missing = {line.strip() for line in (output.stdout or '').splitlines() if line.strip()}
 
-        except RunError as exc:
-            # rpm exits non-zero when any installable is missing. When checking
-            # multiple installables in one command, stdout only contains lines for
-            # found packages (so zip-based parsing silently drops missing ones).
-            # "no package provides X" messages go to stdout; some errors (e.g.
-            # file-not-found) go to stderr. Search both to be safe.
-            output = (exc.stdout or '') + '\n' + (exc.stderr or '')
-
-            for installable in installables:
-                installable_str = re.escape(str(installable))
-                pattern = re.compile(
-                    # rpm -q PACKAGE
-                    rf'package {installable_str} is not installed'
-                    # rpm -q --whatprovides CAPABILITY
-                    rf'|no package provides {installable_str}'
-                    # rpm -q --whatprovides /path
-                    rf'|error: file {installable_str}: No such file or directory'
-                )
-                if pattern.search(output):
-                    results[installable] = False
-
-            # rpm exited non-zero but no missing packages were identified
-            # this signals an unexpected failure (db corruption, permission error, etc.)
-            if all(results.values()):
-                raise
+        for installable in installables:
+            if str(installable) in missing:
+                results[installable] = False
 
         return results
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -73,8 +73,8 @@ class DnfEngine(PackageManagerEngine):
 
     def check_presence(self, *installables: Installable) -> ShellScript:
         parts = [
-            f"rpm -q --whatprovides '{escaped}' >&2 || echo '{escaped}'"
-            for escaped in escape_installables(*installables)
+            f"rpm -q --whatprovides '{installable}' >&2 || echo '{installable}'"
+            for installable in installables
         ]
         return ShellScript('\n'.join(parts))
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -81,21 +81,10 @@ class DnfEngine(PackageManagerEngine):
 
         extra_options = self._extra_dnf_options(options)
 
-        install_cmd = (
-            f'{self.command.to_script()} install {self.options.to_script()} {extra_options}'
-        )
-
-        if not options.check_first:
-            return ShellScript(f'{install_cmd} {" ".join(escape_installables(*installables))}')
-
-        # Avoid best=True upgrades: set-level || check sends present packages to DNF.
-        pkgs = ' '.join(escape_installables(*installables))
         return ShellScript(
-            f'_tmt_missing=(); '
-            f'for _tmt_pkg in {pkgs}; do '
-            f'rpm -q --whatprovides "$_tmt_pkg" &>/dev/null || _tmt_missing+=("$_tmt_pkg"); '
-            f'done; '
-            f'[[ ${{#_tmt_missing[@]}} -eq 0 ]] || {install_cmd} "${{_tmt_missing[@]}}"'
+            f'{self.command.to_script()} install '
+            f'{self.options.to_script()} {extra_options} '
+            f'{" ".join(escape_installables(*installables))}'
         )
 
     def _construct_reinstall_script(
@@ -289,7 +278,6 @@ class Dnf(PackageManager[DnfEngine]):
     probe_priority = 50
 
     def list_packages(self, repository: Repository) -> list[Version]:
-
         script = self.engine.list_packages(repository)
         output = self.guest.execute(script)
         stdout = output.stdout
@@ -345,6 +333,25 @@ class Dnf(PackageManager[DnfEngine]):
 
         return results
 
+    def install(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> CommandOutput:
+        options = options or Options()
+
+        if not options.check_first or not installables:
+            return super().install(*installables, options=options)
+
+        presence = self.check_presence(*installables)
+        missing = tuple(p for p, present in presence.items() if not present)
+
+        if not missing:
+            return CommandOutput(stdout=None, stderr=None)
+
+        options.check_first = False
+        return super().install(*missing, options=options)
+
     def assert_config_manager(self) -> None:
         self.debug('Make sure the config-manager plugin is available.')
         self.install(Package(self.config_manager_plugin))
@@ -374,7 +381,6 @@ class Dnf(PackageManager[DnfEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-
         options = options or Options()
         options.check_first = False
         # Use both install/reinstall to get all packages refreshed
@@ -388,7 +394,6 @@ class Dnf(PackageManager[DnfEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-
         output = super().install_debuginfo(*installables, options=options)
 
         # Check the packages are installed because 'debuginfo-install'

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -98,16 +98,11 @@ class DnfEngine(PackageManagerEngine):
 
         extra_options = self._extra_dnf_options(options)
 
-        script = ShellScript(
+        return ShellScript(
             f'{self.command.to_script()} reinstall '
             f'{self.options.to_script()} {extra_options} '
             f'{" ".join(escape_installables(*installables))}'
         )
-
-        if options.check_first:
-            script = self._construct_presence_script(*installables) & script
-
-        return script
 
     def _construct_install_debuginfo_script(
         self, *installables: Installable, options: Optional[Options] = None

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -72,10 +72,10 @@ class DnfEngine(PackageManagerEngine):
         return ShellScript(f'rpm -q {" ".join(escape_installables(*installables))}')
 
     def check_presence(self, *installables: Installable) -> ShellScript:
-        parts = [
-            f'rpm -q --whatprovides "{installable}" >&2 || echo "{installable}"'
-            for installable in installables
-        ]
+        parts: list[str] = []
+        for installable in installables:
+            e = next(escape_installables(installable))
+            parts.append(f'rpm -q --whatprovides {e} >&2 || echo {e}')
         return ShellScript('\n'.join(parts))
 
     def _construct_install_script(

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -60,6 +60,7 @@ class DnfEngine(PackageManagerEngine):
                 raise GeneralError(f"Unhandled package manager command '{command}'.")
 
         if options.allow_erasing:
+            # Supported by DNF4 and DNF5; YumEngine raises PrepareError for this flag.
             extra_options += Command('--allowerasing')
 
         return extra_options
@@ -409,6 +410,7 @@ class Dnf5Engine(DnfEngine):
         extra_options = super()._extra_dnf_options(options, command)
 
         if options.allow_downgrade:
+            # DNF4 allows transitive downgrades automatically; this flag is DNF5-specific.
             extra_options += Command('--allow-downgrade')
 
         return extra_options

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -53,11 +53,12 @@ class MockEngine(PackageManagerEngine):
         return (Command('mock'), options)
 
     def check_presence(self, *installables: Installable) -> ShellScript:
-        parts = [
-            f'rpm -q --whatprovides "{installable}" >&2 || echo "{installable}"'
-            for installable in installables
-        ]
-        return ShellScript('\n'.join(parts))
+        return ShellScript(
+            '\n'.join(
+                f'rpm -q --whatprovides {escaped} >&2 || echo {escaped}'
+                for escaped in escape_installables(*installables)
+            )
+        )
 
     def install(
         self,

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -54,8 +54,8 @@ class MockEngine(PackageManagerEngine):
 
     def check_presence(self, *installables: Installable) -> ShellScript:
         parts = [
-            f"rpm -q --whatprovides '{escaped}' >&2 || echo '{escaped}'"
-            for escaped in escape_installables(*installables)
+            f"rpm -q --whatprovides '{installable}' >&2 || echo '{installable}'"
+            for installable in installables
         ]
         return ShellScript('\n'.join(parts))
 

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -133,7 +133,7 @@ class _MockPackageManager(PackageManager[MockEngine]):
             )
 
         presence = self.check_presence(*installables)
-        missing = tuple(p for p, present in presence.items() if not present)
+        missing = {p for p, present in presence.items() if not present}
 
         if not missing:
             return CommandOutput(stdout=None, stderr=None)
@@ -153,7 +153,7 @@ class _MockPackageManager(PackageManager[MockEngine]):
             )
 
         presence = self.check_presence(*installables)
-        present = tuple(p for p, is_present in presence.items() if is_present)
+        present = {p for p, is_present in presence.items() if is_present}
 
         if not present:
             return CommandOutput(stdout=None, stderr=None)

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -1,4 +1,3 @@
-import re
 from typing import (
     Optional,
 )
@@ -13,7 +12,7 @@ from tmt.package_managers import (
     provides_package_manager,
 )
 from tmt.steps.provision.mock import GuestMock
-from tmt.utils import Command, CommandOutput, GeneralError, PrepareError, RunError, ShellScript
+from tmt.utils import Command, CommandOutput, PrepareError, ShellScript
 
 
 class MockEngine(PackageManagerEngine):
@@ -54,7 +53,11 @@ class MockEngine(PackageManagerEngine):
         return (Command('mock'), options)
 
     def check_presence(self, *installables: Installable) -> ShellScript:
-        return ShellScript(f'rpm -q --whatprovides {" ".join(escape_installables(*installables))}')
+        parts = [
+            f"rpm -q --whatprovides '{escaped}' >&2 || echo '{escaped}'"
+            for escaped in escape_installables(*installables)
+        ]
+        return ShellScript('\n'.join(parts))
 
     def install(
         self,
@@ -101,44 +104,19 @@ class _MockPackageManager(PackageManager[MockEngine]):
     probe_priority = 130
     _engine_class = MockEngine
 
-    # Implementation "stolen" from the dnf package manager family. It should
-    # be good enough for mock, at least for now.
     def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
-        try:
-            output = self.guest.execute(self.engine.check_presence(*installables))
-            stdout = output.stdout
+        if not installables:
+            return {}
 
-        except RunError as exc:
-            stdout = exc.stdout
+        results: dict[Installable, bool] = dict.fromkeys(installables, True)
 
-        if stdout is None:
-            raise GeneralError("rpm presence check provided no output")
+        # Script always exits 0; stdout contains one line per missing package.
+        output = self.guest.execute(self.engine.check_presence(*installables))
+        missing = {line.strip() for line in (output.stdout or '').splitlines() if line.strip()}
 
-        results: dict[Installable, bool] = {}
-
-        for line, installable in zip(stdout.strip().splitlines(), installables):
-            # Match for packages not installed, when "rpm -q PACKAGE" used
-            match = re.match(rf'package {re.escape(str(installable))} is not installed', line)
-            if match is not None:
+        for installable in installables:
+            if str(installable) in missing:
                 results[installable] = False
-                continue
-
-            # Match for provided rpm capabilities (packages, commands, etc.),
-            # when "rpm -q --whatprovides CAPABILITY" used
-            match = re.match(rf'no package provides {re.escape(str(installable))}', line)
-            if match is not None:
-                results[installable] = False
-                continue
-
-            # Match for filesystem paths, when "rpm -q --whatprovides PATH" used
-            match = re.match(
-                rf'error: file {re.escape(str(installable))}: No such file or directory', line
-            )
-            if match is not None:
-                results[installable] = False
-                continue
-
-            results[installable] = True
 
         return results
 
@@ -167,16 +145,20 @@ class _MockPackageManager(PackageManager[MockEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-        if options is not None and options.check_first:
-            # TODO implement a more robust check that the package is not installed
-            # other than catching RunError.
-            try:
-                self.guest.execute(self.engine.check_presence(*installables))
-            except RunError as err:
-                return err.output
-        return self.guest.run(
-            self.engine.reinstall(*installables, options=options).to_shell_command()
-        )
+        options = options or Options()
+
+        if not options.check_first or not installables:
+            return self.guest.run(
+                self.engine.reinstall(*installables, options=options).to_shell_command()
+            )
+
+        presence = self.check_presence(*installables)
+        present = tuple(p for p, is_present in presence.items() if is_present)
+
+        if not present:
+            return CommandOutput(stdout=None, stderr=None)
+
+        return self.guest.run(self.engine.reinstall(*present, options=options).to_shell_command())
 
     def install_debuginfo(
         self,

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -147,14 +147,20 @@ class _MockPackageManager(PackageManager[MockEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-        if options is not None and options.check_first:
-            try:
-                return self.guest.execute(self.engine.check_presence(*installables))
-            except RunError:
-                pass
-        return self.guest.run(
-            self.engine.install(*installables, options=options).to_shell_command()
-        )
+        options = options or Options()
+
+        if not options.check_first or not installables:
+            return self.guest.run(
+                self.engine.install(*installables, options=options).to_shell_command()
+            )
+
+        presence = self.check_presence(*installables)
+        missing = tuple(p for p, present in presence.items() if not present)
+
+        if not missing:
+            return CommandOutput(stdout=None, stderr=None)
+
+        return self.guest.run(self.engine.install(*missing, options=options).to_shell_command())
 
     def reinstall(
         self,

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -54,7 +54,7 @@ class MockEngine(PackageManagerEngine):
 
     def check_presence(self, *installables: Installable) -> ShellScript:
         parts = [
-            f"rpm -q --whatprovides '{installable}' >&2 || echo '{installable}'"
+            f'rpm -q --whatprovides "{installable}" >&2 || echo "{installable}"'
             for installable in installables
         ]
         return ShellScript('\n'.join(parts))
@@ -126,19 +126,10 @@ class _MockPackageManager(PackageManager[MockEngine]):
         options: Optional[Options] = None,
     ) -> CommandOutput:
         options = options or Options()
-
-        if not options.check_first or not installables:
-            return self.guest.run(
-                self.engine.install(*installables, options=options).to_shell_command()
-            )
-
-        presence = self.check_presence(*installables)
-        missing = {p for p, present in presence.items() if not present}
-
-        if not missing:
+        to_install = self._check_first_filter(*installables, options=options, present=False)
+        if not to_install:
             return CommandOutput(stdout=None, stderr=None)
-
-        return self.guest.run(self.engine.install(*missing, options=options).to_shell_command())
+        return self.guest.run(self.engine.install(*to_install, options=options).to_shell_command())
 
     def reinstall(
         self,
@@ -146,19 +137,12 @@ class _MockPackageManager(PackageManager[MockEngine]):
         options: Optional[Options] = None,
     ) -> CommandOutput:
         options = options or Options()
-
-        if not options.check_first or not installables:
-            return self.guest.run(
-                self.engine.reinstall(*installables, options=options).to_shell_command()
-            )
-
-        presence = self.check_presence(*installables)
-        present = {p for p, is_present in presence.items() if is_present}
-
-        if not present:
+        to_reinstall = self._check_first_filter(*installables, options=options, present=True)
+        if not to_reinstall:
             return CommandOutput(stdout=None, stderr=None)
-
-        return self.guest.run(self.engine.reinstall(*present, options=options).to_shell_command())
+        return self.guest.run(
+            self.engine.reinstall(*to_reinstall, options=options).to_shell_command()
+        )
 
     def install_debuginfo(
         self,

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -243,18 +243,18 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
         required, recommended = self.sort_packages(*installables, options=options)
 
         # sort_packages already checked presence; skip the check in super().install.
-        no_check = dataclasses.replace(options, check_first=False)
+        no_check_options = dataclasses.replace(options, check_first=False)
 
         for package in recommended:
             self.info('package', str(package), 'green')
             try:
-                super().install(package, options=no_check)
+                super().install(package, options=no_check_options)
             except RunError as error:
                 self.debug(f"Package installation failed: {error}")
                 self.warn(f"Unable to install recommended package '{package}'.")
 
         if required:
-            return super().install(*required, options=no_check)
+            return super().install(*required, options=no_check_options)
 
         return CommandOutput(stdout=None, stderr=None)
 

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -1,3 +1,4 @@
+import dataclasses
 import re
 from typing import Optional
 
@@ -241,16 +242,19 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
         options = options or Options()
         required, recommended = self.sort_packages(*installables, options=options)
 
+        # sort_packages already checked presence; skip the check in super().install.
+        no_check = dataclasses.replace(options, check_first=False)
+
         for package in recommended:
             self.info('package', str(package), 'green')
             try:
-                super().install(package, options=options)
+                super().install(package, options=no_check)
             except RunError as error:
                 self.debug(f"Package installation failed: {error}")
                 self.warn(f"Unable to install recommended package '{package}'.")
 
         if required:
-            return super().install(*required, options=options)
+            return super().install(*required, options=no_check)
 
         return CommandOutput(stdout=None, stderr=None)
 

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -213,50 +213,27 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
 
         Dnf5(guest=self.guest, logger=self._logger).enable_copr(*repositories)
 
-    def sort_packages(
-        self,
-        *installables: Installable,
-        options: Options,
-    ) -> tuple[list[Installable], list[Installable]]:
-        """Sort packages into required and recommended based on presence and skip_missing."""
-        required: list[Installable] = []
-        recommended: list[Installable] = []
-
-        presence = self.check_presence(*installables)
-
-        for installable, present in presence.items():
-            if present:
-                continue
-            if options.skip_missing:
-                recommended.append(installable)
-            else:
-                required.append(installable)
-
-        return required, recommended
-
     def install(
         self,
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
         options = options or Options()
-        required, recommended = self.sort_packages(*installables, options=options)
 
-        # sort_packages already checked presence; skip the check in super().install.
+        missing = [p for p, present in self.check_presence(*installables).items() if not present]
         no_check_options = dataclasses.replace(options, check_first=False)
 
-        for package in recommended:
-            self.info('package', str(package), 'green')
-            try:
-                super().install(package, options=no_check_options)
-            except RunError as error:
-                self.debug(f"Package installation failed: {error}")
-                self.warn(f"Unable to install recommended package '{package}'.")
+        if options.skip_missing:
+            for package in missing:
+                self.info('package', str(package), 'green')
+                try:
+                    super().install(package, options=no_check_options)
+                except RunError as error:
+                    self.debug(f"Package installation failed: {error}")
+                    self.warn(f"Unable to install recommended package '{package}'.")
+            return CommandOutput(stdout=None, stderr=None)
 
-        if required:
-            return super().install(*required, options=no_check_options)
-
-        return CommandOutput(stdout=None, stderr=None)
+        return super().install(*missing, options=no_check_options)
 
     def install_local(
         self,

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -97,9 +97,6 @@ class RpmOstreeEngine(PackageManagerEngine):
             f'{" ".join(escape_installables(*installables))}'
         )
 
-        if options.check_first:
-            script = self._construct_presence_script(*installables) | script
-
         if options.skip_missing:
             script = script | ShellScript('/bin/true')
 

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -220,6 +220,9 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
     ) -> CommandOutput:
         options = options or Options()
 
+        if not options.check_first:
+            return super().install(*installables, options=options)
+
         missing = [p for p, present in self.check_presence(*installables).items() if not present]
         no_check_options = dataclasses.replace(options, check_first=False)
 

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -20,7 +20,10 @@ from tmt.steps.prepare.artifact.providers import (
 # ``@provides_method`` causes pyright to lose the class type, which is the
 # root cause of all ``pyright: ignore`` waivers referencing these two classes.
 # This will be fixed by https://github.com/teemtee/tmt/issues/4766.
-from tmt.steps.prepare.install import PrepareInstall  # pyright: ignore[reportUnknownVariableType]
+from tmt.steps.prepare.install import (
+    PrepareInstall,  # pyright: ignore[reportUnknownVariableType]
+    PrepareInstallData,  # pyright: ignore[reportUnknownVariableType]
+)
 from tmt.steps.prepare.verify_installation import (
     PrepareVerifyInstallation,  # pyright: ignore[reportUnknownVariableType]
     PrepareVerifyInstallationData,
@@ -201,6 +204,25 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
     SHARED_REPO_DIR_NAME: ClassVar[str] = 'artifact-shared-repo'
     ARTIFACTS_METADATA_FILENAME: ClassVar[str] = 'artifacts.yaml'
 
+    #: tmt-managed install phase names whose package lists may be rewritten with artifact NEVRAs.
+    _TMT_INSTALL_PHASE_NAMES: ClassVar[frozenset[str]] = frozenset(
+        {
+            'essential-requires',
+            'requires',
+            'recommends',
+            'requires (dist-git)',
+            'recommends (dist-git)',
+        }
+    )
+
+    #: Name of the auto-injected reinstall phase.
+    REINSTALL_PHASE_NAME: ClassVar[str] = 'fix-artifact-origins'
+
+    #: Summary of the auto-injected reinstall phase.
+    REINSTALL_PHASE_SUMMARY: ClassVar[str] = (
+        'Reinstall artifact packages by name to fix swdb origin for pre-installed packages'
+    )
+
     #: Name of the auto-injected verify-installation phase.
     VERIFY_PHASE_NAME: ClassVar[str] = 'verify-artifact-packages'
 
@@ -235,6 +257,7 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
         # Initialize all providers and have them contribute to the shared repo
         providers: list[ArtifactProvider] = []
         seen_nvras: dict[str, str] = {}
+        seen_download_pkg_names: dict[str, tuple[str, str]] = {}
 
         # --- Pass 1: Initialize all providers and validate for duplicate NVRAs ---
         for raw_id in self.data.provide:
@@ -249,7 +272,7 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
                     parent=self,
                 )
 
-                self._detect_duplicate_nvras(provider, seen_nvras)
+                self._detect_duplicate_nvras(provider, seen_nvras, seen_download_pkg_names)
 
                 providers.append(provider)
 
@@ -310,9 +333,22 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
         # Persist artifact metadata to YAML
         self._save_artifacts_metadata(providers)
 
-        # Verify phase injection
+        # Verify phase injection — three steps in order:
+        #   1. Rewrite requires/recommends package specifiers to exact NEVRAs so the install
+        #      phases pull the artifact version from the artifact repo (not whatever the package
+        #      manager would pick by default).
+        #   2. Inject a reinstall phase (order 76) that runs after the install phases to fix swdb
+        #      origin for packages that were pre-installed at the correct NEVRA and therefore
+        #      skipped by step 1 (dnf install is a no-op when the version is already present).
+        #   3. Inject the verify phase (order 79) that confirms every package came from an
+        #      expected artifact repository.
         if self.data.verify:
-            self._inject_verify_phase(providers, guest)
+            pkgs_to_verify, specifier_to_nevra = self._compute_pkgs_to_verify(providers, guest)
+            if pkgs_to_verify:
+                if specifier_to_nevra:
+                    self._substitute_artifact_nevras(specifier_to_nevra, guest)
+                self._inject_reinstall_phase(pkgs_to_verify)
+            self._inject_verify_phase(pkgs_to_verify)
 
         # Report configuration summary
         logger.info(
@@ -322,39 +358,33 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
 
         return outcome
 
-    def _inject_verify_phase(self, providers: list[ArtifactProvider], guest: Guest) -> None:
+    def _compute_pkgs_to_verify(
+        self,
+        providers: list[ArtifactProvider],
+        guest: Guest,
+    ) -> tuple[dict[str, set[str]], dict[str, str]]:
         """
-        Inject a verify-installation phase for packages from these providers.
+        Compute verification data for artifact packages found in tmt-managed install phases.
 
-        If a verify phase already exists for the same where= group, merge
-        the packages into it. Otherwise, create and add a new phase.
+        Returns ``(pkgs_to_verify, specifier_to_nevra)`` where:
+        - ``pkgs_to_verify``: pkg_name → acceptable repo_ids (empty when nothing to verify)
+        - ``specifier_to_nevra``: install-phase specifier → exact artifact NEVRA to substitute
         """
-        # Collect packages from the install phases injected by tmt on behalf of
-        # test/essential requirements. User-defined prepare/install phases are
-        # intentionally excluded.
-        #
-        # Phase name sources:
-        #   'essential-requires'    — Prepare._go() in tmt/steps/prepare/__init__.py
-        #   'requires'              — Prepare._go() in tmt/steps/prepare/__init__.py
-        #   'recommends'            — Prepare._go() in tmt/steps/prepare/__init__.py
-        #   'requires (dist-git)'   — tmt/steps/prepare/distgit.py
-        #   'recommends (dist-git)' — tmt/steps/prepare/distgit.py
-        _tmt_install_phase_names = {
-            'essential-requires',
-            'requires',
-            'recommends',
-            'requires (dist-git)',
-            'recommends (dist-git)',
-        }
         pkg_names: set[str] = set()
         _install_phases = self.step.phases(classes=PrepareInstall)  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
         for install_phase in _install_phases:  # pyright: ignore[reportUnknownVariableType]
-            if install_phase.data.name not in _tmt_install_phase_names:  # pyright: ignore[reportUnknownMemberType]
+            if install_phase.data.name not in self._TMT_INSTALL_PHASE_NAMES:  # pyright: ignore[reportUnknownMemberType]
                 continue
             if not install_phase.enabled_on_guest(guest):  # pyright: ignore[reportUnknownMemberType]
                 continue
             for pkg in install_phase.data.package:  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
                 pkg_names.add(str(pkg))  # pyright: ignore[reportUnknownArgumentType]
+
+        if not pkg_names:
+            self.debug(
+                'No packages in tmt-managed install phases, skipping artifact verification.'
+            )
+            return {}, {}
 
         provider_repo_ids = {SHARED_REPO_NAME} | {
             repo_id
@@ -363,18 +393,11 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
             for repo_id in repo.repo_ids
         }
 
-        if not pkg_names:
-            self.debug(
-                'No packages in tmt-managed install phases, skipping artifact verification.'
-            )
-            return
-
         # Resolve all requirements to canonical package names via whatprovides so
         # they can be matched against artifact.version.name below.  This handles
-        # plain names, file paths, pkgconfig(...) and package-level provides
+        # plain names, file paths, pkgconfig(...) and package-level provides.
         # Artifact repos are already configured on the guest at this
         # point even though the packages themselves are not yet installed.
-
         resolved = guest.package_manager.resolve_provides(list(pkg_names), provider_repo_ids)
 
         resolved_names = {version.name for versions in resolved.values() for version in versions}
@@ -387,6 +410,92 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
 
         if not pkgs_to_verify:
             self.verbose('No packages to be installed were found in the provided artifacts.')
+            return {}, {}
+
+        # Build canonical_name → NEVRA. Two passes: download providers (koji, copr.build, file)
+        # win unconditionally because they physically supply the RPM; repo-only providers
+        # (repository-file, copr.repository) fill in any gaps via setdefault.
+        pkg_to_nevra: dict[str, str] = {}
+        for provider in providers:
+            if not provider.get_repositories():  # download provider
+                for artifact in provider.artifacts:
+                    if artifact.version.name in pkgs_to_verify:
+                        pkg_to_nevra[artifact.version.name] = artifact.version.nvra
+        for provider in providers:
+            if provider.get_repositories():  # repo-only provider
+                for artifact in provider.artifacts:
+                    if artifact.version.name in pkgs_to_verify:
+                        pkg_to_nevra.setdefault(artifact.version.name, artifact.version.nvra)
+
+        # Map each install-phase specifier to the NEVRA it should be rewritten as.
+        # ``resolved`` maps original specifier (e.g. "pkgconfig(foo)") → list of Versions;
+        # we take the first canonical name that has a known artifact NEVRA.
+        # Specifiers that resolve to no artifact are left unchanged by _substitute_artifact_nevras.
+        specifier_to_nevra: dict[str, str] = {}
+        for specifier, versions in resolved.items():
+            for version in versions:
+                if version.name in pkg_to_nevra:
+                    specifier_to_nevra[specifier] = pkg_to_nevra[version.name]
+                    break  # one NEVRA per specifier is sufficient
+
+        return pkgs_to_verify, specifier_to_nevra
+
+    def _substitute_artifact_nevras(
+        self,
+        specifier_to_nevra: dict[str, str],
+        guest: Guest,
+    ) -> None:
+        """
+        Replace artifact package specifiers in tmt-managed install phases with exact NEVRAs.
+
+        This ensures the install phase installs precisely the artifact version rather than
+        whatever the package manager would select from the available repositories.
+        """
+        _install_phases = self.step.phases(classes=PrepareInstall)  # pyright: ignore[reportUnknownVariableType,reportUnknownArgumentType]
+        for install_phase in _install_phases:  # pyright: ignore[reportUnknownVariableType]
+            if install_phase.data.name not in self._TMT_INSTALL_PHASE_NAMES:  # pyright: ignore[reportUnknownMemberType]
+                continue
+            if not install_phase.enabled_on_guest(guest):  # pyright: ignore[reportUnknownMemberType]
+                continue
+            # Replace each specifier with its artifact NEVRA; fall back to the original
+            # string for packages that are not covered by any artifact provider.
+            install_phase.data.package = [  # pyright: ignore[reportUnknownMemberType]
+                tmt.base.core.DependencySimple(specifier_to_nevra.get(str(pkg), str(pkg)))  # pyright: ignore[reportUnknownArgumentType]
+                for pkg in install_phase.data.package  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            ]
+
+    def _inject_reinstall_phase(self, pkgs_to_verify: dict[str, set[str]]) -> None:
+        """
+        Inject a reinstall phase to fix swdb origin for pre-installed packages.
+
+        Packages already at the correct NEVRA before the install phases run are
+        skipped by those phases (check_first=True), leaving their swdb origin as
+        ``<unknown>``. This phase reinstalls them by name so DNF re-records the
+        origin from the artifact repository.
+
+        Runs at order 76 — after requires/recommends (70/75), before verify (79).
+        """
+        reinstall_data = PrepareInstallData(  # pyright: ignore[reportUnknownVariableType]
+            name=self.REINSTALL_PHASE_NAME,
+            how='install',
+            summary=self.REINSTALL_PHASE_SUMMARY,
+            order=tmt.steps.PHASE_ORDER_PREPARE_INSTALL_RECOMMENDS + 1,
+            where=list(self.data.where),
+            package=[tmt.base.core.DependencySimple(name) for name in pkgs_to_verify],
+            reinstall=True,
+            missing='skip',
+        )
+        reinstall_phase = PreparePlugin.delegate(self.step, data=reinstall_data)  # pyright: ignore[reportUnknownVariableType]
+        self.step.add_phase(reinstall_phase)  # pyright: ignore[reportUnknownArgumentType]
+
+    def _inject_verify_phase(self, pkgs_to_verify: dict[str, set[str]]) -> None:
+        """
+        Inject a verify-installation phase for packages from these providers.
+
+        If a verify phase already exists for the same where= group, merge
+        the packages into it. Otherwise, create and add a new phase.
+        """
+        if not pkgs_to_verify:
             return
 
         self.debug(f"Verifying {fmf.utils.listed(sorted(pkgs_to_verify), 'package')}.")
@@ -427,20 +536,44 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
         ]
 
     def _detect_duplicate_nvras(
-        self, provider: ArtifactProvider, seen_nvras: dict[str, str]
+        self,
+        provider: ArtifactProvider,
+        seen_nvras: dict[str, str],
+        seen_download_pkg_names: dict[str, tuple[str, str]],
     ) -> None:
         """
-        Check for duplicate NVRAs across providers.
+        Check for duplicate NVRAs and conflicting package names across providers.
         """
         raw_id = provider.raw_id
+        # Download providers have their artifacts pre-populated (via @cached_property) before
+        # fetch_contents runs, so their package names are available at Pass 1 validation time.
+        # Repo-only providers populate _artifacts lazily via enumerate_artifacts() in Pass 2,
+        # so their artifacts list is empty here no name-conflict check needed for them.
+        is_download = not provider.get_repositories()
 
-        for artifact_info in provider.artifact_metadata:
-            if (nvra := artifact_info["nvra"]) in seen_nvras:
+        for artifact in provider.artifacts:
+            nvra = artifact.version.nvra
+            if nvra in seen_nvras:
                 raise tmt.utils.PrepareError(
                     f"Artifact '{nvra}' provided by both '{seen_nvras[nvra]}' and '{raw_id}'."
                 )
-
             seen_nvras[nvra] = raw_id
+
+            # For download providers, also detect the same package name at different NEVRAs
+            # _ensure_artifacts_installed can only install one NEVRA per name, so this would
+            # silently pick one and ignore the other.
+            if is_download:
+                pkg_name = artifact.version.name
+                if pkg_name in seen_download_pkg_names:
+                    prev_nvra, prev_id = seen_download_pkg_names[pkg_name]
+                    if prev_nvra != nvra:
+                        raise tmt.utils.PrepareError(
+                            f"Download providers '{prev_id}' and '{raw_id}' both declare "
+                            f"package '{pkg_name}' at different NEVRAs "
+                            f"('{prev_nvra}' vs '{nvra}'). This conflict cannot be resolved."
+                        )
+                else:
+                    seen_download_pkg_names[pkg_name] = (nvra, raw_id)
 
     def _save_artifacts_metadata(self, providers: list[ArtifactProvider]) -> None:
         """

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -11,7 +11,7 @@ import tmt.log
 import tmt.steps
 import tmt.steps.prepare
 import tmt.utils
-from tmt.container import container, field
+from tmt.container import container, field, simple_field
 from tmt.guest import Guest
 from tmt.package_managers import (
     FileSystemPath,
@@ -79,6 +79,9 @@ class PrepareInstallData(tmt.steps.prepare.PrepareStepData):
         choices=['fail', 'skip'],
         help='Action on missing packages, fail (default) or skip.',
     )
+
+    #: Internal: call ``reinstall`` instead of ``install`` for plain package names.
+    reinstall: bool = simple_field(default=False)
 
 
 @tmt.steps.provides_method('install')
@@ -430,6 +433,19 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
 
         if not self.data.package and not self.data.directory:
             self.debug("No packages for installation found.", level=3)
+            return outcome
+
+        if self.data.reinstall:
+            # Reinstall plain package names only (no local files or URLs).
+            # skip_missing (missing='skip') means packages absent from all repos are silently
+            # ignored rather than failing — the package manager will skip the reinstall for
+            # packages that cannot be found.  We bypass _install's retry-on-metadata-refresh
+            # logic because a reinstall failure here is non-fatal by design.
+            if self.packages:
+                guest.package_manager.reinstall(
+                    *self._list_installables('package', *self.packages),
+                    options=options,
+                )
             return outcome
 
         # ... and install packages.


### PR DESCRIPTION

When `verify: true` is set on the artifact plugin, package origin enforcement now works in three ordered phases:

- **NEVRA substitution** : before the install phases run, each tmt-managed install phase (`requires`, `recommends`, `requires (dist-git)`, etc.) has its package specifiers rewritten to exact artifact NEVRAs. This forces the package manager to pull the artifact-repo version rather than whatever the default resolution would pick.

- **Reinstall phase (order 76)** : injected between the install phases and the verify phase. Packages already present at the correct NEVRA are silently skipped by `dnf install`, leaving their `swdb` origin as `<unknown>`. The reinstall phase runs `dnf reinstall` by name so DNF re-records the origin from the artifact repository.

- **Verify phase (order 79)** : unchanged; confirms every package came from an expected artifact repository.

Additionally, `_detect_duplicate_nvras` is extended to also catch the case where two download providers declare the same package name at different NEVRAs (a conflict that cannot be resolved).

On the `PrepareInstall` side, a new internal `reinstall: bool` field on `PrepareInstallData` routes the injected phase through `package_manager.reinstall` instead of `install`, with `missing=skip` so absent packages are silently ignored.

Blocked on

**PR1**:  https://github.com/teemtee/tmt/pull/4937
**PR2**:  https://github.com/teemtee/tmt/pull/4938.

