### PR TITLE
Use uname -m instead of arch for architecture detection

### DIFF
--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -798,7 +798,7 @@ class GuestFacts(SerializableContainer):
         return None
 
     def _query_arch(self, guest: 'Guest') -> Optional[str]:
-        return self._query(guest, [(Command('arch'), r'(.+)')])
+        return self._query(guest, [(Command('uname', '-m'), r'(.+)')])
 
     def _query_distro(self, guest: 'Guest') -> Optional[str]:
         # Try some low-hanging fruits first. We already might have the answer,


### PR DESCRIPTION
The `arch` command is not always available because coreutils does not compile and install it by default. Use `uname -m` which is universally available.
