### PR TITLE
Adjust and document the `dry` mode implementation

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -577,62 +577,14 @@ Dry Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Dry mode, activated by the option ``--dry``, lets users preview
-"what would tmt do" without actually performing the actions. For
-example the ``tmt clean --dry`` command shows which files would be
-removed and ``tmt run --dry`` shows the test execution plan: which
-steps, phases and plugins would run, with what configuration
-without provisioning guests.
+"what would tmt do" without actually performing the actions. See
+the :ref:`dry-mode-guide` section in the guide for the full
+description of the expected behavior per step and command.
 
-When implementing new features or modifying existing code, follow
-these rules to determine what is allowed and what must be skipped
-when :py:attr:`tmt.utils.Common.is_dry_run` is true. See `#4443`__
-for background.
-
-**In scope** (allowed during dry run):
-
-* Reading, parsing and validating metadata
-* Creating and modifying the local :term:`run workdir`
-* Showing what steps and phases would be executed
-
-**Out of scope** (skipped during dry run):
-
-* Creating or modifying resources (guests, containers, images)
-* Network access (git clone, fetching remote plans or images)
-* Executing commands on guests (e.g. for provision connect)
-* Submitting tasks or tests results to external services
-* Removing provisioned guests, run workdirs or images
-
-For individual steps and commands the following behavior is
-expected:
-
-discover
-    skip git clone and remote repository operations, just show
-    what would be discovered
-
-provision
-    no pulling images, no image creation, no starting guests
-
-prepare
-    skip package installation and guest commands, just show which
-    prepare phases would run
-
-execute
-    skip test execution, show the execute method
-
-report
-    skip submission to external services, just show which report
-    steps would be run
-
-finish
-    skip executing finishing tasks, just show which finish phases
-    would run
-
-cleanup
-    skip guest removal, just show which cleanup phases would run
-
-export
-    skip writes to Nitrate and Polarion, compute and show what
-    would be changed
+When implementing new features or modifying existing code, use
+:py:attr:`tmt.utils.Common.is_dry_run` to check whether dry mode
+is active and skip actions which should not be done in dry mode.
+See `#4443`__ for background.
 
 __ https://github.com/teemtee/tmt/issues/4443
 

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -571,14 +571,14 @@ __ https://github.com/tldr-pages/tldr/blob/main/CONTRIBUTING.md
    not be reflected in the tldr pages collection.
 
 
-.. _dry-mode:
+.. _dry-mode-implementation:
 
 Dry Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Dry mode, activated by the option ``--dry``, lets users preview
 "what would tmt do" without actually performing the actions. See
-the :ref:`dry-mode-guide` section in the guide for the full
+the :ref:`dry-mode` section in the guide for the full
 description of the expected behavior per step and command.
 
 When implementing new features or modifying existing code, use

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1251,7 +1251,7 @@ __ https://github.com/teemtee/tmt/issues/2047
 
 
 
-.. _dry-mode-guide:
+.. _dry-mode:
 
 Dry Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1268,6 +1268,9 @@ phases would run without triggering any side effects.
 * Reading, parsing, and validating metadata
 * Creating and modifying the local :term:`run workdir`
 * Showing which steps, phases, and plugins would be executed
+* Read-only network queries during ``tmt tests import`` and
+  ``tmt tests export`` for nitrate and polarion, to produce
+  meaningful dry-run output
 
 **What dry mode skips:**
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1325,14 +1325,10 @@ Several other commands also support ``--dry``:
     files.
 
 ``tmt tests export``
-    Behavior depends on the export format:
-
-    * For remote service exporters (``nitrate``, ``polarion``),
-      all write operations are skipped. The exporters still
-      report what would be done.
-    * For stdout-only formats (``yaml``, ``json``, ``rst``,
-      etc.), dry mode has no effect — output is always printed
-      to the terminal since there are no side effects to skip.
+    Prints the exported item when the output targets local stdout
+    (``yaml``, ``json``, ``rst``, etc.), or prints the request
+    that would be sent when the output targets an external
+    service (``nitrate``, ``polarion``).
 
 
 .. include:: guide/test-runner.inc.rst

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1250,5 +1250,94 @@ __ https://github.com/teemtee/tmt/labels/multihost
 __ https://github.com/teemtee/tmt/issues/2047
 
 
+
+.. _dry-mode-guide:
+
+Dry Mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the ``-n`` / ``--dry`` flag to enable dry mode. In this mode
+tmt reads and validates metadata, resolves configurations, and
+reports what it would do, but skips every action that modifies
+state: no guests are provisioned, no guest commands are executed,
+no results are submitted. It is a safe way to validate a plan
+or check which tests would be selected without triggering any
+side effects.
+
+**What dry mode allows:**
+
+* Reading, parsing, and validating metadata
+* Creating and modifying the local :term:`run workdir`
+* Showing which steps, phases, and plugins would be executed
+
+**What dry mode skips:**
+
+* Creating or modifying resources (guests, containers, images)
+* Network access (git clones, fetching remote images or sources)
+* Executing any commands on guests
+* Submitting results or tasks to external services (nitrate,
+  polarion, reportportal, etc.)
+* Removing provisioned guests, run workdirs, or images
+
+The following sections describe the behavior of each step in
+dry mode:
+
+discover
+    Tests from the local repository are discovered normally.
+    If a remote repository or ``dist-git-source`` is specified,
+    the test discovery is skipped and no tests will be discovered.
+    For the :ref:`/plugins/discover/shell` plugin, tests defined
+    in the plan are always discovered, but no remote data is fetched.
+
+provision
+    No images are pulled or built. No guests are provisioned.
+    No connections to remote providers are made. The step
+    reports which provision phases would run.
+
+prepare
+    No commands are executed and no packages are installed
+    on guests. The step reports which prepare phases would run.
+
+execute
+    Tests are not executed. The step reports the execution
+    method and returns empty results.
+
+report
+    Plugins that require an external service (e.g. submitting
+    results to Polarion or ReportPortal) are skipped. Plugins
+    that only write local files (e.g. ``junit``, ``html``) still
+    produce their output. The step reports which report phases
+    would run.
+
+finish
+    No finishing tasks are executed on guests. The step reports
+    which finish phases would run.
+
+cleanup
+    Provisioned guests are not removed. The step reports which
+    cleanup phases would run.
+
+Several other commands also support ``--dry``:
+
+``tmt tests create``, ``tmt plans create``, ``tmt stories create``
+    No directories or metadata files are written. No links to
+    external issue trackers are created.
+
+``tmt tests id``, ``tmt plans id``, ``tmt stories id``
+    New UUIDs are generated and displayed but not written to disk.
+    Nodes that already have an id show their existing value.
+
+``tmt tests import``
+    Metadata is read and converted but not written to any ``.fmf``
+    files.
+
+``tmt tests export``, ``tmt plans export``, ``tmt stories export``
+    Read-only operations against external services are performed
+    so that tmt can show what *would* change. Write operations
+    (creating or updating test cases in Nitrate or Polarion) are
+    skipped. Exporters that only write local files still produce
+    their output.
+
+
 .. include:: guide/test-runner.inc.rst
 .. include:: guide/guest-preparation.inc.rst

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1324,12 +1324,15 @@ Several other commands also support ``--dry``:
     Metadata is read and converted but not written to any ``.fmf``
     files.
 
-``tmt tests export``, ``tmt plans export``, ``tmt stories export``
-    Read-only operations against external services are performed
-    so that tmt can show what *would* change. Write operations
-    (creating or updating test cases in Nitrate or Polarion) are
-    skipped. Exporters that only write local files still produce
-    their output.
+``tmt tests export``
+    Behavior depends on the export format:
+
+    * For remote service exporters (``nitrate``, ``polarion``),
+      all write operations are skipped. The exporters still
+      report what would be done.
+    * For stdout-only formats (``yaml``, ``json``, ``rst``,
+      etc.), dry mode has no effect — output is always printed
+      to the terminal since there are no side effects to skip.
 
 
 .. include:: guide/test-runner.inc.rst

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1310,6 +1310,9 @@ cleanup
     Provisioned guests are not removed. The step reports which
     cleanup phases would run.
 
+login
+    Login to the guest is skipped.
+
 Several other commands also support ``--dry``:
 
 ``tmt tests create``, ``tmt plans create``, ``tmt stories create``
@@ -1329,6 +1332,15 @@ Several other commands also support ``--dry``:
     (``yaml``, ``json``, ``rst``, etc.), or prints the request
     that would be sent when the output targets an external
     service (``nitrate``, ``polarion``).
+
+``tmt clean``, ``tmt clean runs``, ``tmt clean guests``, ``tmt clean images``
+    No workdirs, guests or images are removed. The commands report
+    what would be cleaned instead.
+
+``tmt try``
+    The interactive session starts but all steps behave as in dry
+    mode: no guests are provisioned, no commands are executed on
+    guests, and no tests are run.
 
 
 .. include:: guide/test-runner.inc.rst

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1283,7 +1283,7 @@ dry mode:
 
 discover
     No tests are discovered. No remote data is fetched.
-    The step reports which provision phases would run.
+    The step reports which discover phases would run.
 
 provision
     No images are pulled or built. No guests are provisioned.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1260,9 +1260,8 @@ Use the ``-n`` / ``--dry`` flag to enable dry mode. In this mode
 tmt reads and validates metadata, resolves configurations, and
 reports what it would do, but skips every action that modifies
 state: no guests are provisioned, no guest commands are executed,
-no results are submitted. It is a safe way to validate a plan
-or check which tests would be selected without triggering any
-side effects.
+no results are submitted. It is a safe way to see which steps and
+phases would run without triggering any side effects.
 
 **What dry mode allows:**
 
@@ -1283,11 +1282,8 @@ The following sections describe the behavior of each step in
 dry mode:
 
 discover
-    Tests from the local repository are discovered normally.
-    If a remote repository or ``dist-git-source`` is specified,
-    the test discovery is skipped and no tests will be discovered.
-    For the :ref:`/plugins/discover/shell` plugin, tests defined
-    in the plan are always discovered, but no remote data is fetched.
+    No tests are discovered. No remote data is fetched.
+    The step reports which provision phases would run.
 
 provision
     No images are pulled or built. No guests are provisioned.

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1272,7 +1272,8 @@ phases would run without triggering any side effects.
 **What dry mode skips:**
 
 * Creating or modifying resources (guests, containers, images)
-* Network access (git clones, fetching remote images or sources)
+* Network access (git clones, fetching remote images or sources,
+  importing remote plans)
 * Executing any commands on guests
 * Submitting results or tasks to external services (nitrate,
   polarion, reportportal, etc.)

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1299,11 +1299,8 @@ execute
     method and returns empty results.
 
 report
-    Plugins that require an external service (e.g. submitting
-    results to Polarion or ReportPortal) are skipped. Plugins
-    that only write local files (e.g. ``junit``, ``html``) still
-    produce their output. The step reports which report phases
-    would run.
+    No external services are used. No local files are created.
+    The step reports which report phases would run.
 
 finish
     No finishing tasks are executed on guests. The step reports

--- a/docs/releases/1.75.0/4443.fmf
+++ b/docs/releases/1.75.0/4443.fmf
@@ -1,5 +1,5 @@
 description: |
-    The :ref:`contribute` guide now includes a :ref:`dry-mode`
+    The :ref:`contribute` guide now includes a :ref:`dry-mode-implementation`
     section defining what ``--dry`` should and should not skip,
     with clear in-scope and out-of-scope rules and per-step
     behavior guidelines for developers.

--- a/docs/releases/pending/4982.fmf
+++ b/docs/releases/pending/4982.fmf
@@ -1,5 +1,5 @@
 description: |
-    A new :ref:`dry-mode-guide` section has been added to the guide
+    A new :ref:`dry-mode` section has been added to the guide
     documenting the expected behavior of each step and command
     in dry mode. The implementation has been updated to match
     the documentation.

--- a/docs/releases/pending/4982.fmf
+++ b/docs/releases/pending/4982.fmf
@@ -1,0 +1,5 @@
+description: |
+    A new :ref:`dry-mode-guide` section has been added to the guide
+    documenting the expected behavior of each step and command
+    in dry mode. The implementation has been updated to match
+    the documentation.

--- a/examples/plugins/example/provision.py
+++ b/examples/plugins/example/provision.py
@@ -82,7 +82,7 @@ class ProvisionExample(tmt.steps.provision.ProvisionPlugin):
         print("wake() called")
 
         # Don't schedule anything if ve are in dry mode
-        if self.opt('dry'):
+        if self.is_dry_run:
             return
 
         if data:
@@ -209,7 +209,7 @@ class GuestExample(tmt.Guest):
 
         print("start() called")
 
-        if self.opt('dry'):
+        if self.is_dry_run:
             return
 
         self.verbose('what', self.what, 'green')

--- a/stories/cli/common.fmf
+++ b/stories/cli/common.fmf
@@ -73,10 +73,10 @@ story:
       - verified-by: /tests/core/dry
 
 /dry:
-    summary: Run in dry mode without performing any side effects
+    summary: Run in dry mode without causing any side effects
     story:
         As a user I want to run commands in dry mode so that I
-        can safely inspect what would happen without triggering
+        can safely inspect what would happen without causing
         any side effects.
     description: |
         When dry mode is enabled, tmt reads and validates metadata,

--- a/stories/cli/common.fmf
+++ b/stories/cli/common.fmf
@@ -73,11 +73,21 @@ story:
       - verified-by: /tests/core/dry
 
 /dry:
-    summary: Run in dry mode, just let me know what would be done
+    summary: Run in dry mode without performing any side effects
     story:
-        As a user I want to run commands in dry mode so that I can
-        see what would happen if I run the command but no actions
-        are performed or changes saved to disk.
+        As a user I want to run commands in dry mode so that I
+        can safely inspect what would happen without triggering
+        any side effects.
+    description: |
+        When dry mode is enabled, tmt reads and validates metadata,
+        resolves configurations, and reports what it would do, but
+        skips every action that modifies state: no guests are
+        provisioned, no guest commands are executed, no results are
+        submitted.
+
+        See the :ref:`dry-mode-guide` section of the guide for a
+        detailed description of the behavior of each step and
+        command.
     example:
         - tmt run -n
         - tmt run --dry

--- a/stories/cli/common.fmf
+++ b/stories/cli/common.fmf
@@ -85,7 +85,7 @@ story:
         provisioned, no guest commands are executed, no results are
         submitted.
 
-        See the :ref:`dry-mode-guide` section of the guide for a
+        See the :ref:`dry-mode` section of the guide for a
         detailed description of the behavior of each step and
         command.
     example:

--- a/tests/plan/import/basic.sh
+++ b/tests/plan/import/basic.sh
@@ -127,7 +127,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Run Tests"
-        rlRun -s "tmt run -v --remove --dry plan --name /plans/minimal" 0 "Run tests (dry mode)"
+        rlRun -s "tmt run -v --remove --dry plan --name /plans/minimal" 2 "Expect error (dry mode)"
         rlRun -s "tmt run -v --remove       plan --name /plans/minimal" 0 "Run tests"
         rlAssertGrep "pass /tests/one" $rlRun_LOG
         rlAssertGrep "pass /tests/two" $rlRun_LOG
@@ -140,19 +140,19 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Imported plan's adjust should be respected"
-        rlRun -s "tmt run --remove --dry plan --name /plans/full/tmt" 2 "Expect error (dry mode)"
-        rlRun -s "tmt -c how=full run -r --dry plan -n /plans/full/tmt" 0 "Run plan (dry mode)"
+        rlRun -s "tmt run --remove discover plan --name /plans/full/tmt" 2 "Expect error"
+        rlRun -s "tmt -c how=full run -r discover plan -n /plans/full/tmt" 0 "Discover plan"
     rlPhaseEnd
 
     rlPhaseStartTest "Remote plan should not be fetched if disabled by adjust"
         cleanup
-        rlRun -s "tmt -ddd -c distro=rhel-10 run --remove --dry plan --name /plans/importing/disabled-by-adjust" 0 "Run enabled plan"
+        rlRun -s "tmt -ddd -c distro=rhel-10 run --remove discover plan --name /plans/importing/disabled-by-adjust" 0 "Run enabled plan"
         rlAssertGrep "Plan '/plans/importing/disabled-by-adjust' importing" $rlRun_LOG
         rlAssertNotGrep "Plan '/plans/importing/disabled-by-adjust' is not enabled, skipping imports resolution" $rlRun_LOG
         rlAssertNotGrep "No plans found." $rlRun_LOG
 
         cleanup
-        rlRun -s "tmt -ddd -c distro=fedora-rawhide run --remove --dry plan --name /plans/importing/disabled-by-adjust" 2 "Expect no plans to be found"
+        rlRun -s "tmt -ddd -c distro=fedora-rawhide run --remove discover plan --name /plans/importing/disabled-by-adjust" 2 "Expect no plans to be found"
         rlAssertNotGrep "Plan '/plans/importing/disabled-by-adjust' importing" $rlRun_LOG
         rlAssertGrep "Plan '/plans/importing/disabled-by-adjust' is not enabled, skipping imports resolution" $rlRun_LOG
         rlAssertGrep "No plans found." $rlRun_LOG
@@ -175,13 +175,13 @@ rlJournalStart
 
     rlPhaseStartTest "Disabled remote plan should be fetched if enabled by adjust"
         cleanup
-        rlRun -s "tmt -ddd -c distro=fedora-rawhide run --remove --dry plan --name /plans/importing/enabled-by-adjust" 0 "Run enabled plan"
+        rlRun -s "tmt -ddd -c distro=fedora-rawhide run --remove discover plan --name /plans/importing/enabled-by-adjust" 0 "Run enabled plan"
         rlAssertGrep "Plan '/plans/importing/enabled-by-adjust' importing" $rlRun_LOG
         rlAssertNotGrep "Plan '/plans/importing/enabled-by-adjust' is not enabled, skipping imports resolution" $rlRun_LOG
         rlAssertNotGrep "No plans found." $rlRun_LOG
 
         cleanup
-        rlRun -s "tmt -ddd -c distro=rhel-10 run --remove --dry plan --name /plans/importing/enabled-by-adjust" 2 "Expect no plans to be found"
+        rlRun -s "tmt -ddd -c distro=rhel-10 run --remove discover plan --name /plans/importing/enabled-by-adjust" 2 "Expect no plans to be found"
         rlAssertNotGrep "Plan '/plans/importing/enabled-by-adjust' importing" $rlRun_LOG
         rlAssertGrep "Plan '/plans/importing/enabled-by-adjust' is not enabled, skipping imports resolution" $rlRun_LOG
         rlAssertGrep "No plans found." $rlRun_LOG

--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -149,7 +149,9 @@ def test_multihost_name(root_logger: Logger) -> None:
 def test_execute_no_connection_closed(
     root_logger: Logger, stdout: str, expected: str, monkeypatch: Any
 ) -> None:
-    step = Provision(plan=MagicMock(name='mock<plan>'), raw_data=[{}], logger=root_logger)
+    step = Provision(
+        plan=MagicMock(name='mock<plan>', is_dry_run=False), raw_data=[{}], logger=root_logger
+    )
     guest = GuestSsh(
         logger=root_logger, parent=step, name='foo', data=GuestSshData(primary_address='bar')
     )

--- a/tests/unit/test_report_junit.py
+++ b/tests/unit/test_report_junit.py
@@ -12,7 +12,7 @@ from tmt.utils import Path
 @pytest.fixture
 def report_fix(tmppath: Path, root_logger):
     # need to provide genuine workdir paths - mock would break os.path.* calls
-    step_mock = MagicMock(workdir=tmppath)
+    step_mock = MagicMock(workdir=tmppath, is_dry_run=False)
     plan_mock = MagicMock()
     name_property = PropertyMock(return_value='name')
 

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -1576,7 +1576,7 @@ class Plan(
 
         try:
             # Clone the whole git repository if executing tests (run is attached)
-            if self.my_run and not self.my_run.is_dry_run:
+            if self.my_run:
                 nodes = self._resolve_import_from_git(reference)
 
             # Use fmf cache for exploring plans (the whole git repo is not needed)
@@ -1598,6 +1598,11 @@ class Plan(
 
         if not self.is_remote_plan_reference:
             return [self]
+
+        # Do not fetch remote plans in dry mode
+        if self.is_dry_run:
+            self.info(f"Plan '{self.name}' was skipped - import is not allowed in dry mode.")
+            return []
 
         if not self._imported_plans:
             for reference in self._imported_plan_references:

--- a/tmt/cli/_root.py
+++ b/tmt/cli/_root.py
@@ -773,7 +773,7 @@ def tests_import(
             raise tmt.utils.GeneralError(
                 "Option --case or --plan is mandatory when using --manual."
             )
-        tmt.convert.read_manual(plan, case, disabled, with_script, context.obj.logger)
+        tmt.convert.read_manual(plan, case, disabled, with_script, dry, context.obj.logger)
         return
 
     if not paths:

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -121,18 +121,8 @@ def read_manual(
         data['test'] = 'test.md'
 
         if dry_run:
-            echo(
-                style(
-                    f"Test case would be stored into '{new_cwd / dir_name / 'test.md'}'.",
-                    fg='magenta',
-                )
-            )
-            echo(
-                style(
-                    f"Metadata would be stored into '{new_cwd / dir_name / 'main.fmf'}'.",
-                    fg='magenta',
-                )
-            )
+            log.info(f"Test case would be stored into '{new_cwd / dir_name / 'test.md'}'.")
+            log.info(f"Metadata would be stored into '{new_cwd / dir_name / 'main.fmf'}'.")
         else:
             write_markdown(Path.cwd() / 'test.md', md_content)
             write(Path.cwd() / 'main.fmf', data)
@@ -785,7 +775,7 @@ def read_nitrate(
         else:
             write_markdown(md_path, md_content)
     elif dry_run:
-        echo(style(f"Test case file '{md_path}' would be removed.", fg='magenta'))
+        log.info(f"Test case file '{md_path}' would be removed.")
     else:
         try:
             md_path.unlink()

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -58,6 +58,7 @@ def read_manual(
     case_id: int,
     disabled: bool,
     with_script: bool,
+    dry_run: bool,
     logger: tmt.log.Logger,
 ) -> None:
     """
@@ -88,8 +89,9 @@ def read_manual(
 
     # Create directory to store manual tests in
     new_cwd = Path(tree.root) / 'Manual'
-    new_cwd.mkdir(exist_ok=True)
-    os.chdir(new_cwd)
+    if not dry_run:
+        new_cwd.mkdir(exist_ok=True)
+        os.chdir(new_cwd)
 
     for cid in case_ids:
         testcase = nitrate.TestCase(cid)
@@ -104,9 +106,10 @@ def read_manual(
         dir_name = testcase.summary.replace(' ', '_')
         dir_name = dir_name.replace('/', '_')
         directory = Path(dir_name)
-        directory.mkdir(exist_ok=True)
+        if not dry_run:
+            directory.mkdir(exist_ok=True)
+            os.chdir(directory)
 
-        os.chdir(directory)
         echo(f"Importing the '{directory}' test case.")
 
         # Test case data
@@ -117,11 +120,26 @@ def read_manual(
         data['manual'] = True
         data['test'] = 'test.md'
 
-        write_markdown(Path.cwd() / 'test.md', md_content)
-        write(Path.cwd() / 'main.fmf', data)
-        os.chdir(new_cwd)
+        if dry_run:
+            echo(
+                style(
+                    f"Test case would be stored into '{new_cwd / dir_name / 'test.md'}'.",
+                    fg='magenta',
+                )
+            )
+            echo(
+                style(
+                    f"Metadata would be stored into '{new_cwd / dir_name / 'main.fmf'}'.",
+                    fg='magenta',
+                )
+            )
+        else:
+            write_markdown(Path.cwd() / 'test.md', md_content)
+            write(Path.cwd() / 'main.fmf', data)
+            os.chdir(new_cwd)
 
-    os.chdir(old_cwd)
+    if not dry_run:
+        os.chdir(old_cwd)
 
 
 def read_manual_data(testcase: 'TestCase') -> dict[str, str]:
@@ -766,6 +784,8 @@ def read_nitrate(
             echo(style(f"Test case would be stored into '{md_path}'.", fg='magenta'))
         else:
             write_markdown(md_path, md_content)
+    elif dry_run:
+        echo(style(f"Test case file '{md_path}' would be removed.", fg='magenta'))
     else:
         try:
             md_path.unlink()

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2033,6 +2033,9 @@ class Guest(
         Setup the guest after it has been started. It is called after :py:meth:`Guest.start`.
         """
 
+        if self.is_dry_run:
+            return
+
         self.install_scripts(tmt.steps.scripts.SCRIPTS)
 
     # A couple of requiremens for this field:
@@ -3503,6 +3506,9 @@ class GuestSsh(Guest, CommandCollector):
             for batch execution (when ``immediately=False`` on supported guests).
         """
 
+        if self.is_dry_run:
+            return tmt.utils.CommandOutput(stdout=None, stderr=None)
+
         sourced_files = sourced_files or []
 
         # For guests in image mode collect non testing commands with
@@ -3514,7 +3520,7 @@ class GuestSsh(Guest, CommandCollector):
             return None
 
         # Abort if guest is unavailable
-        if self.primary_address is None and not self.is_dry_run:
+        if self.primary_address is None:
             raise tmt.utils.GeneralError('The guest is not available.')
 
         ssh_command: tmt.utils.Command = self._ssh_command
@@ -3643,8 +3649,11 @@ class GuestSsh(Guest, CommandCollector):
             only privileged users are allowed to modify.
         """
 
+        if self.is_dry_run:
+            return
+
         # Abort if guest is unavailable
-        if self.primary_address is None and not self.is_dry_run:
+        if self.primary_address is None:
             raise tmt.utils.GeneralError('The guest is not available.')
 
         self._assert_rsync()
@@ -3709,8 +3718,11 @@ class GuestSsh(Guest, CommandCollector):
             :py:data:`DEFAULT_PULL_OPTIONS`.
         """
 
+        if self.is_dry_run:
+            return
+
         # Abort if guest is unavailable
-        if self.primary_address is None and not self.is_dry_run:
+        if self.primary_address is None:
             raise tmt.utils.GeneralError('The guest is not available.')
 
         self._assert_rsync()

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -3314,6 +3314,10 @@ class Login(Action):
             self.warn("Login not possible in discover step (no guests provisioned yet).")
             return
 
+        if self.is_dry_run:
+            self.info('login', 'Skipped in dry mode.', color='yellow')
+            return
+
         # Nothing to do if there are no guests ready for login
         if not self.parent.plan.provision.ready_guests:
             self.info('login', 'No guests ready for login', color='yellow')

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -282,9 +282,6 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT, None]):
         :returns: Potential path to the metadata tree root within the fetched source.
         """
         self.info('url', url, 'green')
-        if self.is_dry_run:
-            return None
-
         if self.data.url_content_type == "git":
             self.debug(f"Clone '{url}' to '{self.test_dir}'.")
 

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -282,6 +282,9 @@ class DiscoverPlugin(tmt.steps.GuestlessPlugin[DiscoverStepDataT, None]):
         :returns: Potential path to the metadata tree root within the fetched source.
         """
         self.info('url', url, 'green')
+        if self.is_dry_run:
+            return None
+
         if self.data.url_content_type == "git":
             self.debug(f"Clone '{url}' to '{self.test_dir}'.")
 

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -627,8 +627,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             directory = fmf_root
         self.info('directory', directory, 'green')
         self.debug(f"Copy '{directory}' to '{self.test_dir}'.")
-        if not self.is_dry_run:
-            tmt.utils.filesystem.copy_tree(directory, self.test_dir, self._logger)
+        tmt.utils.filesystem.copy_tree(directory, self.test_dir, self._logger)
         return path
 
     def go(self, *, path: Optional[Path] = None, logger: Optional[tmt.log.Logger] = None) -> None:
@@ -647,6 +646,8 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
 
         # Dist-git source processing during discover step
         if dist_git_source:
+            if self.is_dry_run:
+                return
             try:
                 git_root = tmt.utils.git.git_root(fmf_root=self.test_dir, logger=self._logger)
                 if not git_root:
@@ -701,7 +702,9 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
         # Prepare the whole tree path
         path = path or Path('')
         tree_path = self.test_dir / path.unrooted()
-        if not tree_path.is_dir() and not self.is_dry_run:
+        if not tree_path.is_dir():
+            if self.is_dry_run:
+                return []
             raise tmt.utils.DiscoverError(f"Metadata tree path '{path}' not found.")
 
         # Show filters and test names if provided
@@ -735,55 +738,59 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             self.info('modified-url', modified_url, 'green')
             if previous != modified_url:
                 self.debug(f"Original url was '{previous}'.")
-            self.debug(f"Fetch also '{modified_url}' as 'reference'.")
-            self.run(
-                Command('git', 'remote', 'add', 'reference', modified_url),
-                cwd=self.test_dir,
-            )
-            self.run(
-                Command('git', 'fetch', 'reference'),
-                cwd=self.test_dir,
-            )
+            if self.is_dry_run:
+                self.debug("Skipping 'modified-url' fetch in dry run.")
+            else:
+                self.debug(f"Fetch also '{modified_url}' as 'reference'.")
+                self.run(
+                    Command('git', 'remote', 'add', 'reference', modified_url),
+                    cwd=self.test_dir,
+                )
+                self.run(
+                    Command('git', 'fetch', 'reference'),
+                    cwd=self.test_dir,
+                )
         if modified_only:
-            modified_ref = self.get(
-                'modified-ref',
-                tmt.utils.git.default_branch(repository=self.test_dir, logger=self._logger),
-            )
-            self.info('modified-ref', modified_ref, 'green')
-            ref_commit = self.run(
-                Command('git', 'rev-parse', '--short', str(modified_ref)),
-                cwd=self.test_dir,
-            )
-            assert ref_commit.stdout is not None
-            self.verbose('modified-ref hash', ref_commit.stdout.strip(), 'green')
-            output = self.run(
-                Command(
-                    'git', 'log', '--format=', '--stat', '--name-only', f"{modified_ref}..HEAD"
-                ),
-                cwd=self.test_dir,
-            )
-            if output.stdout:
-                directories = [Path(name).parent for name in output.stdout.split('\n')]
-                modified = {
-                    # ($|/): match end of test name or `/` which would be any sub-test
-                    f"^/{re.escape(str(directory))}($|/)"
-                    for directory in directories
-                    if directory
-                }
-                if not modified:
+            if self.is_dry_run and self.get('modified-url'):
+                self.debug("Skipping 'modified-only' filter in dry run.")
+            else:
+                modified_ref = self.get(
+                    'modified-ref',
+                    tmt.utils.git.default_branch(repository=self.test_dir, logger=self._logger),
+                )
+                self.info('modified-ref', modified_ref, 'green')
+                ref_commit = self.run(
+                    Command('git', 'rev-parse', '--short', str(modified_ref)),
+                    cwd=self.test_dir,
+                )
+                assert ref_commit.stdout is not None
+                self.verbose('modified-ref hash', ref_commit.stdout.strip(), 'green')
+                output = self.run(
+                    Command(
+                        'git', 'log', '--format=', '--stat', '--name-only', f"{modified_ref}..HEAD"
+                    ),
+                    cwd=self.test_dir,
+                )
+                if output.stdout:
+                    directories = [Path(name).parent for name in output.stdout.split('\n')]
+                    modified = {
+                        # ($|/): match end of test name or `/` which would be any sub-test
+                        f"^/{re.escape(str(directory))}($|/)"
+                        for directory in directories
+                        if directory
+                    }
+                    if not modified:
+                        # Nothing was modified, do not select anything
+                        return []
+                    self.debug(f"Limit to modified test dirs: {modified}", level=3)
+                    self.data.test.extend(TestsWithAdjusts(name=name) for name in modified)
+                else:
+                    self.debug(f"No modified directories between '{modified_ref}..HEAD' found.")
                     # Nothing was modified, do not select anything
                     return []
-                self.debug(f"Limit to modified test dirs: {modified}", level=3)
-                self.data.test.extend(TestsWithAdjusts(name=name) for name in modified)
-            else:
-                self.debug(f"No modified directories between '{modified_ref}..HEAD' found.")
-                # Nothing was modified, do not select anything
-                return []
 
         # Initialize the metadata tree, search for available tests
         self.debug(f"Check metadata tree in '{tree_path}'.")
-        if self.is_dry_run:
-            return []
         tests = []
         tree = tmt.Tree(
             logger=self._logger,
@@ -868,7 +875,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             else:
                 location = dist_git_extract
             # User specified location or 'root' of extracted sources
-            if not (Path(location) / '.fmf').is_dir() and not self.is_dry_run:
+            if not (Path(location) / '.fmf').is_dir():
                 fmf.Tree.init(location)
         elif dist_git_remove_fmf_root:
             try:
@@ -878,8 +885,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                 )[0]
             except tmt.utils.MetadataError:
                 self.warn("No fmf root to remove, there isn't one already.")
-            if not self.is_dry_run:
-                shutil.rmtree((dist_git_extract or extracted_fmf_root) / '.fmf')
+            shutil.rmtree((dist_git_extract or extracted_fmf_root) / '.fmf')
         if not dist_git_extract:
             try:
                 # TODO: This is ill-defined in combination with path, maybe this should go away
@@ -903,8 +909,7 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                             f"Directory '{self.step.plan.node.root}' is not in a git repository."
                         ) from error
                     self.debug(f"Copy '{git_root}' to '{self.test_dir}'.")
-                    if not self.is_dry_run:
-                        tmt.utils.filesystem.copy_tree(git_root, self.test_dir, self._logger)
+                    tmt.utils.filesystem.copy_tree(git_root, self.test_dir, self._logger)
             else:
                 if not dist_git_merge:
                     if self.data.path:
@@ -916,25 +921,24 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
                     fmf_root = top_fmf_root.relative_to(self.source_dir)
 
         # Copy extracted sources into test_dir
-        if not self.is_dry_run:
-            flatten = dist_git_merge
-            if dist_git_extract == '/':
-                flatten = False
-                copy_these = created_content
-            elif dist_git_extract:
-                copy_these = [dist_git_extract.relative_to(self.source_dir)]
+        flatten = dist_git_merge
+        if dist_git_extract == '/':
+            flatten = False
+            copy_these = created_content
+        elif dist_git_extract:
+            copy_these = [dist_git_extract.relative_to(self.source_dir)]
+        else:
+            copy_these = [top_fmf_root.relative_to(self.source_dir)]
+        for to_copy in copy_these:
+            src = self.source_dir / to_copy
+            if src.is_dir():
+                tmt.utils.filesystem.copy_tree(
+                    self.source_dir / to_copy,
+                    self.test_dir if flatten else self.test_dir / to_copy,
+                    self._logger,
+                )
             else:
-                copy_these = [top_fmf_root.relative_to(self.source_dir)]
-            for to_copy in copy_these:
-                src = self.source_dir / to_copy
-                if src.is_dir():
-                    tmt.utils.filesystem.copy_tree(
-                        self.source_dir / to_copy,
-                        self.test_dir if flatten else self.test_dir / to_copy,
-                        self._logger,
-                    )
-                else:
-                    shutil.copyfile(src, self.test_dir / to_copy)
+                shutil.copyfile(src, self.test_dir / to_copy)
 
         # Adjust path and optionally show
         if fmf_root is None or fmf_root.resolve() == Path.cwd().resolve():

--- a/tmt/steps/discover/fmf.py
+++ b/tmt/steps/discover/fmf.py
@@ -637,17 +637,18 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
 
         super().go(path=path, logger=logger)
 
-        dist_git_source = self.get('dist-git-source', False)
-
         # No tests are selected in some cases
         self._tests: list[tmt.Test] = []
+
+        if self.is_dry_run:
+            return
+
+        dist_git_source = self.get('dist-git-source', False)
 
         self.log_import_plan_details()
 
         # Dist-git source processing during discover step
         if dist_git_source:
-            if self.is_dry_run:
-                return
             try:
                 git_root = tmt.utils.git.git_root(fmf_root=self.test_dir, logger=self._logger)
                 if not git_root:
@@ -703,8 +704,6 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
         path = path or Path('')
         tree_path = self.test_dir / path.unrooted()
         if not tree_path.is_dir():
-            if self.is_dry_run:
-                return []
             raise tmt.utils.DiscoverError(f"Metadata tree path '{path}' not found.")
 
         # Show filters and test names if provided
@@ -738,56 +737,50 @@ class DiscoverFmf(tmt.steps.discover.DiscoverPlugin[DiscoverFmfStepData]):
             self.info('modified-url', modified_url, 'green')
             if previous != modified_url:
                 self.debug(f"Original url was '{previous}'.")
-            if self.is_dry_run:
-                self.debug("Skipping 'modified-url' fetch in dry run.")
-            else:
-                self.debug(f"Fetch also '{modified_url}' as 'reference'.")
-                self.run(
-                    Command('git', 'remote', 'add', 'reference', modified_url),
-                    cwd=self.test_dir,
-                )
-                self.run(
-                    Command('git', 'fetch', 'reference'),
-                    cwd=self.test_dir,
-                )
+            self.debug(f"Fetch also '{modified_url}' as 'reference'.")
+            self.run(
+                Command('git', 'remote', 'add', 'reference', modified_url),
+                cwd=self.test_dir,
+            )
+            self.run(
+                Command('git', 'fetch', 'reference'),
+                cwd=self.test_dir,
+            )
         if modified_only:
-            if self.is_dry_run and self.get('modified-url'):
-                self.debug("Skipping 'modified-only' filter in dry run.")
-            else:
-                modified_ref = self.get(
-                    'modified-ref',
-                    tmt.utils.git.default_branch(repository=self.test_dir, logger=self._logger),
-                )
-                self.info('modified-ref', modified_ref, 'green')
-                ref_commit = self.run(
-                    Command('git', 'rev-parse', '--short', str(modified_ref)),
-                    cwd=self.test_dir,
-                )
-                assert ref_commit.stdout is not None
-                self.verbose('modified-ref hash', ref_commit.stdout.strip(), 'green')
-                output = self.run(
-                    Command(
-                        'git', 'log', '--format=', '--stat', '--name-only', f"{modified_ref}..HEAD"
-                    ),
-                    cwd=self.test_dir,
-                )
-                if output.stdout:
-                    directories = [Path(name).parent for name in output.stdout.split('\n')]
-                    modified = {
-                        # ($|/): match end of test name or `/` which would be any sub-test
-                        f"^/{re.escape(str(directory))}($|/)"
-                        for directory in directories
-                        if directory
-                    }
-                    if not modified:
-                        # Nothing was modified, do not select anything
-                        return []
-                    self.debug(f"Limit to modified test dirs: {modified}", level=3)
-                    self.data.test.extend(TestsWithAdjusts(name=name) for name in modified)
-                else:
-                    self.debug(f"No modified directories between '{modified_ref}..HEAD' found.")
+            modified_ref = self.get(
+                'modified-ref',
+                tmt.utils.git.default_branch(repository=self.test_dir, logger=self._logger),
+            )
+            self.info('modified-ref', modified_ref, 'green')
+            ref_commit = self.run(
+                Command('git', 'rev-parse', '--short', str(modified_ref)),
+                cwd=self.test_dir,
+            )
+            assert ref_commit.stdout is not None
+            self.verbose('modified-ref hash', ref_commit.stdout.strip(), 'green')
+            output = self.run(
+                Command(
+                    'git', 'log', '--format=', '--stat', '--name-only', f"{modified_ref}..HEAD"
+                ),
+                cwd=self.test_dir,
+            )
+            if output.stdout:
+                directories = [Path(name).parent for name in output.stdout.split('\n')]
+                modified = {
+                    # ($|/): match end of test name or `/` which would be any sub-test
+                    f"^/{re.escape(str(directory))}($|/)"
+                    for directory in directories
+                    if directory
+                }
+                if not modified:
                     # Nothing was modified, do not select anything
                     return []
+                self.debug(f"Limit to modified test dirs: {modified}", level=3)
+                self.data.test.extend(TestsWithAdjusts(name=name) for name in modified)
+            else:
+                self.debug(f"No modified directories between '{modified_ref}..HEAD' found.")
+                # Nothing was modified, do not select anything
+                return []
 
         # Initialize the metadata tree, search for available tests
         self.debug(f"Check metadata tree in '{tree_path}'.")

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -382,6 +382,10 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin[DiscoverShellData]):
         """
 
         super().go(path=path, logger=logger)
+
+        if self.is_dry_run:
+            return
+
         tests = fmf.Tree({'summary': 'tests'})
 
         self.log_import_plan_details()
@@ -418,7 +422,7 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin[DiscoverShellData]):
             }
             tests.child(data.name, test_fmf_keys)
 
-        if self.data.dist_git_source and not self.is_dry_run:
+        if self.data.dist_git_source:
             assert self.step.plan.my_run is not None  # narrow type
             assert self.step.plan.my_run.tree is not None  # narrow type
             assert self.step.plan.my_run.tree.root is not None  # narrow type

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -418,7 +418,7 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin[DiscoverShellData]):
             }
             tests.child(data.name, test_fmf_keys)
 
-        if self.data.dist_git_source:
+        if self.data.dist_git_source and not self.is_dry_run:
             assert self.step.plan.my_run is not None  # narrow type
             assert self.step.plan.my_run.tree is not None  # narrow type
             assert self.step.plan.my_run.tree.root is not None  # narrow type

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -186,6 +186,9 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
 
         outcome = super().go(guest=guest, environment=environment, logger=logger)
 
+        if self.is_dry_run:
+            return outcome
+
         # Apply each playbook on the guest
         for playbook_index, _playbook in enumerate(self.data.playbook):
             logger.info('playbook', _playbook, 'green')

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -220,6 +220,9 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
 
         outcome = super().go(guest=guest, environment=environment, logger=logger)
 
+        if self.is_dry_run:
+            return outcome
+
         # Prepare a shared directory on the guest for aggregating artifacts.
         shared_repo_dir: Path = self.plan_workdir / self.SHARED_REPO_DIR_NAME
 

--- a/tmt/steps/prepare/distgit.py
+++ b/tmt/steps/prepare/distgit.py
@@ -193,6 +193,9 @@ class PrepareDistGit(tmt.steps.prepare.PreparePlugin[DistGitData]):
 
         outcome = super().go(guest=guest, environment=environment, logger=logger)
 
+        if self.is_dry_run:
+            return outcome
+
         environment = environment or tmt.utils.Environment()
 
         # Packages required for this plugin to work and additional required packages

--- a/tmt/steps/prepare/feature/__init__.py
+++ b/tmt/steps/prepare/feature/__init__.py
@@ -358,7 +358,7 @@ class PrepareFeature(tmt.steps.prepare.PreparePlugin[PrepareFeatureData]):
         outcome = super().go(guest=guest, environment=environment, logger=logger)
 
         # Nothing to do in dry mode
-        if self.opt('dry'):
+        if self.is_dry_run:
             return outcome
 
         for plugin_id in _FEATURE_PLUGIN_REGISTRY.iter_plugin_ids():

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -129,6 +129,9 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
 
         outcome = super().go(guest=guest, environment=environment, logger=logger)
 
+        if self.is_dry_run:
+            return outcome
+
         reboot_context = tmt.steps.context.reboot.RebootContext(
             owner_label=f'{self.step.name} / {self.name}',
             guest=guest,
@@ -169,9 +172,6 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
 
             environment[self._cloned_repo_path_envvar_name] = EnvVarValue(repo_path.resolve())
 
-            if self.is_dry_run:
-                return
-
             with self._url_clone_lock:
                 if not repo_path.exists():
                     repo_path.parent.mkdir(parents=True, exist_ok=True)
@@ -211,9 +211,6 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             )
 
         def _prepare_topology() -> None:
-            if self.is_dry_run:
-                return
-
             topology = tmt.steps.Topology(self.step.plan.provision.ready_guests)
             topology.guest = tmt.steps.GuestTopology(guest)
 

--- a/tmt/steps/provision/artemis.py
+++ b/tmt/steps/provision/artemis.py
@@ -654,6 +654,9 @@ class GuestArtemis(tmt.GuestSsh):
         load() is completed so all guest data should be available.
         """
 
+        if self.is_dry_run:
+            return
+
         if self.guestname is None or self.primary_address is None:
             self._create()
 

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -565,6 +565,9 @@ class GuestMock(tmt.Guest):
         Execute the command in a running mock shell for increased speed.
         """
 
+        if self.is_dry_run:
+            return tmt.utils.CommandOutput(stdout=None, stderr=None)
+
         sourced_files = sourced_files or []
 
         if self.mock_shell.mock_shell is None:
@@ -647,6 +650,9 @@ class GuestMock(tmt.Guest):
         self.stop()
 
     def start(self) -> None:
+        if self.is_dry_run:
+            return
+
         self.mock_shell.enter_shell()
 
     def stop(self) -> None:
@@ -667,6 +673,9 @@ class GuestMock(tmt.Guest):
         Compress option is ignored, it only slows down the execution.
         Create destination option is ignored, there were problems with workdir.
         """
+        if self.is_dry_run:
+            return
+
         # TODO chmod permissions for tar
         options = options or tmt.guest.DEFAULT_PUSH_OPTIONS
         excludes = Command()
@@ -722,6 +731,9 @@ class GuestMock(tmt.Guest):
         For files we use `cp` or `install`.
         Compress option is ignored, it only slows down the execution.
         """
+        if self.is_dry_run:
+            return
+
         # TODO chmod permissions for tar
         options = options or tmt.guest.DEFAULT_PULL_OPTIONS
         excludes = Command()

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -523,9 +523,12 @@ class GuestContainer(tmt.Guest):
         Execute given commands in podman via shell
         """
 
+        if self.is_dry_run:
+            return tmt.utils.CommandOutput(stdout=None, stderr=None)
+
         sourced_files = sourced_files or []
 
-        if not self.container and not self.is_dry_run:
+        if not self.container:
             raise tmt.utils.ProvisionError('Could not execute without provisioned container.')
 
         podman_command = Command('exec')

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -148,13 +148,13 @@ class ReportHtml(tmt.steps.report.ReportPlugin[ReportHtmlData]):
         except Exception as error:
             raise tmt.utils.ReportError(f"Failed to write the output '{filepath}'.") from error
 
-        # Nothing more to do in dry mode
-        if self.is_dry_run:
-            return
-
         # Show output file path
         self.info("output", filepath, color='yellow')
         if not self.data.open:
+            return
+
+        # Nothing more to do in dry mode
+        if self.is_dry_run:
             return
 
         # Open target in webbrowser

--- a/tmt/steps/report/html.py
+++ b/tmt/steps/report/html.py
@@ -95,6 +95,9 @@ class ReportHtml(tmt.steps.report.ReportPlugin[ReportHtmlData]):
 
         super().go(logger=logger)
 
+        if self.is_dry_run:
+            return
+
         # Prepare the template
         environment = tmt.utils.templates.default_template_environment()
 
@@ -151,10 +154,6 @@ class ReportHtml(tmt.steps.report.ReportPlugin[ReportHtmlData]):
         # Show output file path
         self.info("output", filepath, color='yellow')
         if not self.data.open:
-            return
-
-        # Nothing more to do in dry mode
-        if self.is_dry_run:
             return
 
         # Open target in webbrowser

--- a/tmt/steps/report/junit.py
+++ b/tmt/steps/report/junit.py
@@ -575,6 +575,9 @@ class ReportJUnit(tmt.steps.report.ReportPlugin[ReportJUnitData]):
 
         self.check_options()
 
+        if self.is_dry_run:
+            return
+
         f_path = self.data.file or self.phase_workdir / DEFAULT_FILENAME
 
         xml_data = make_junit_xml(

--- a/tmt/steps/report/polarion.py
+++ b/tmt/steps/report/polarion.py
@@ -298,6 +298,9 @@ class ReportPolarion(tmt.steps.report.ReportPlugin[ReportPolarionData]):
 
         super().go(logger=logger)
 
+        if self.is_dry_run:
+            return
+
         from tmt.export.polarion import find_polarion_case_ids, import_polarion
 
         import_polarion()

--- a/tmt/steps/report/reportportal.py
+++ b/tmt/steps/report/reportportal.py
@@ -1166,6 +1166,9 @@ class ReportReportPortal(tmt.steps.report.ReportPlugin[ReportReportPortalData]):
                 f"instance ({self.data.url})."
             )
 
+        if self.is_dry_run:
+            return
+
         with catch_warnings_safe(
             action=warning_filter_action, category=urllib3.exceptions.InsecureRequestWarning
         ):


### PR DESCRIPTION
This PR documents how tmt behaves in dry mode and introduces some changes to the existing dry mode implementation:
- Added early returns to guest's `setup`, `execute`, `push`, and `pull` methods.
- Added early returns to all prepare plugins.
- Discover plugins will show what phases would run, but no tests will be discovered.
- All report phases will be skipped.
- Plan imports will be skipped.

Here is a full list of what dry mode covers:

> - [x] Plan import - guarded by dry mode check
> 
> CLI:
> - [x] `tmt run` - propagates dry mode to every step
> - [x] `tmt run login` - dry mode check in `tmt.step.Login._login` method
> - [x] `tmt try` - uses dry mode checks in the individual steps
> - [x] `tmt tests/plans/stories create` - file, directory and Jira link creations are guarded by dry mode checks
> - [x] `tmt tests import` - dry mode checks for fmf writes
> - [x] `tmt tests export -h nitrate` - all write operations are guarded by dry mode checks
> - [x] `tmt tests export -h polarion` - all write operations are guarded by dry mode checks
> - [x] `tmt tests export -h yaml/json/rst/template` - no dry mode, prints to stdout
> - [x] `tmt tests/plans/stories id` - fmf node write is guarded by dry mode check 
> - [x] `tmt clean runs/guests/images` - guarded by dry mode checks in `tmt.base.core.Clean`
> - [ ] `tmt link` - no dry mode
> - [ ] `tmt setup` - no dry mode
> 
> Discover step:
> - [x] DiscoverFmf - dry mode check in `go` method
> - [x] DiscoverShell - dry mode check in `go` method
> 
> Provision step:
> - [ ] ProvisionLocal - no dry mode
> - [x] ProvisionConnect - dry mode checks in guest methods
> - [x] ProvisionPodman - dry mode checks in guest methods
> - [x] ProvisionBootc - dry mode checks for building and renaming the image, and in guest methods
> - [x] ProvisionArtemis - dry mode checks in guest methods
> - [x] ProvisionTestcloud - dry mode checks in guest methods
> - [x] ProvisionMrack - dry mode checks in guest methods
> - [x] ProvisionMock - dry mode checks in guest methods
> 
> Prepare step:
> - [x] PrepareInstall - dry mode check in `go` method
> - [x] PrepareAnsible - dry mode check in `go` method
> - [x] PrepareShell - dry mode check in `go` method
> - [x] PrepareDistGit - dry mode check in `go` method
> - [x] PrepareArtifact - dry mode check in `go` method
> - [x] PrepareFeature - dry mode check in `go` method
> - [x] PrepareVerifyInstallation - dry mode check in `go` method
> 
> Execute step:
> - [x] ExecuteInternal - dry mode check in `go` method
> - [x] ExecuteUpgrade - dry mode check in `go` method
> 
> Report step:
> - [ ] ReportDisplay - no dry mode, prints to `stdout`
> - [x] ReportHtml - dry mode check in `go` method
> - [x] ReportJUnit - dry mode check in `go` method
> - [x] ReportPolarion - dry mode check in `go` method
> - [x] ReportReportPortal - dry mode check in `go` method
> 
> Finish step:
> - [x] FinishAnsible - dry mode check via PrepareAnsible
> - [x] FinishShell - dry mode check via PrepareShell
> 
> Cleanup step:
> - [x] CleanupInternal - dry mode check in `go` method
> 
> Guests:
> - [x] Guest - `setup` method has a dry run check, `start` is no-op
> - [x] GuestSsh - `setup`, `push`, `pull` and `execute` methods have dry run checks, `start` is no-op
> - [ ] GuestLocal - no dry mode
> - [x] GuestConnect - `setup`, `push`, `pull` and `execute` methods have dry run checks
> - [x] GuestContainer - `start`, `setup` and `execute` methods have dry run checks
> - [x] GuestBootc - `start`, `setup`, `push`, `pull` and `execute` methods have dry run checks
> - [x] GuestArtemis - `start`, `setup`, `push`, `pull` and `execute` methods have dry run checks
> - [x] GuestTestcloud - `start`, `setup`, `push`, `pull` and `execute` methods have dry run checks
> - [x] GuestBeaker - `start`, `setup`, `push`, `pull` and `execute` methods have dry run checks
> - [x] GuestMock - `start`, `setup`, `push`, `pull` and `execute` methods have dry run checks


Resolves #4951 
Resolves #4851 

Assisted-by: Cursor

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [x] include a release note
