### PR TITLE
Move logger helpers to dedicated class

### DIFF
--- a/tmt/log.py
+++ b/tmt/log.py
@@ -1034,3 +1034,145 @@ class Logger:
             cls._bootstrap_logger.add_console_handler()
 
         return cls._bootstrap_logger
+
+
+class Loggable:
+    """
+    Logging helper class.
+
+    Provides helper functions to interact with the :py:class:`Logger` and
+    some sensible defaults for the formatting.
+    """
+
+    #: Actual logger object
+    _logger: Logger
+
+    def inject_logger(self, logger: Logger) -> None:
+        self._logger = logger
+
+    def __init__(
+        self,
+        *,
+        logger: Logger,
+        **kwargs: Any,
+    ) -> None:
+        self.inject_logger(logger)
+
+    def print(
+        self,
+        text: str,
+        color: 'tmt.utils.themes.Style' = None,
+    ) -> None:
+        """
+        Print out an output.
+
+        This method is supposed to be used for emitting a command output. Not
+        to be mistaken with logging - errors, warnings, general command progress,
+        and so on.
+
+        ``print()`` emits even when ``--quiet`` is used, as the option suppresses
+        **logging** but not the actual command output.
+        """
+
+        self._logger.print(text, color=color)
+
+    def info(
+        self,
+        key: str,
+        value: Optional[LoggableValue] = None,
+        color: 'tmt.utils.themes.Style' = None,
+        shift: int = 0,
+        topic: Optional[Topic] = None,
+        stacklevel: int = 1,
+    ) -> None:
+        """
+        Show a message unless in quiet mode
+        """
+
+        self._logger.info(
+            key,
+            value=value,
+            color=color,
+            shift=shift,
+            topic=topic,
+            stacklevel=stacklevel + 1,
+        )
+
+    def verbose(
+        self,
+        key: str,
+        value: Optional[LoggableValue] = None,
+        color: 'tmt.utils.themes.Style' = None,
+        shift: int = 0,
+        level: int = 1,
+        topic: Optional[Topic] = None,
+        stacklevel: int = 1,
+    ) -> None:
+        """
+        Show message if in requested verbose mode level
+
+        In quiet mode verbose messages are not displayed.
+        """
+
+        self._logger.verbose(
+            key,
+            value=value,
+            color=color,
+            shift=shift,
+            level=level,
+            topic=topic,
+            stacklevel=stacklevel + 1,
+        )
+
+    def debug(
+        self,
+        key: str,
+        value: Optional[LoggableValue] = None,
+        color: 'tmt.utils.themes.Style' = None,
+        shift: int = 0,
+        level: int = 1,
+        topic: Optional[Topic] = None,
+        stacklevel: int = 1,
+    ) -> None:
+        """
+        Show message if in requested debug mode level
+
+        In quiet mode debug messages are not displayed.
+        """
+
+        self._logger.debug(
+            key,
+            value=value,
+            color=color,
+            shift=shift,
+            level=level,
+            topic=topic,
+            stacklevel=stacklevel + 1,
+        )
+
+    def warn(
+        self,
+        message: str,
+        shift: int = 0,
+        stacklevel: int = 1,
+        source: Optional[str] = None,
+        reason: Optional[str] = None,
+    ) -> None:
+        """
+        Show a yellow warning message on info level, send to stderr
+        """
+
+        self._logger.warning(
+            message,
+            shift=shift,
+            stacklevel=stacklevel + 1,
+            source=source,
+            reason=reason,
+        )
+
+    def fail(self, message: str, shift: int = 0, stacklevel: int = 1) -> None:
+        """
+        Show a red failure message on info level, send to stderr
+        """
+
+        self._logger.fail(message, shift=shift, stacklevel=stacklevel + 1)

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -1047,6 +1047,9 @@ class Loggable:
     #: Actual logger object
     _logger: Logger
 
+    #: Relative log indent level shift against the parent
+    _relative_indent: int
+
     def inject_logger(self, logger: Logger) -> None:
         self._logger = logger
 
@@ -1054,9 +1057,11 @@ class Loggable:
         self,
         *,
         logger: Logger,
+        relative_indent: int = 1,
         **kwargs: Any,
     ) -> None:
         self.inject_logger(logger)
+        self._relative_indent = relative_indent
 
     def print(
         self,
@@ -1176,3 +1181,67 @@ class Loggable:
         """
 
         self._logger.fail(message, shift=shift, stacklevel=stacklevel + 1)
+
+    def _level(self) -> int:
+        """
+        Hierarchy level
+        """
+        parent = getattr(self, "parent", None)
+
+        if parent is None or not isinstance(parent, Loggable):
+            return -1
+        assert isinstance(parent, Loggable)  # narrow type
+        return parent._level() + self._relative_indent
+
+    def _indent(
+        self,
+        key: str,
+        value: Optional[str] = None,
+        color: 'tmt.utils.themes.Style' = None,
+        shift: int = 0,
+    ) -> str:
+        """
+        Indent message according to the object hierarchy
+        """
+
+        return indent(key, value=value, color=color, level=self._level() + shift)
+
+    @property
+    def debug_level(self) -> int:
+        """
+        The current debug level applied to this object
+        """
+
+        return self._logger.debug_level
+
+    @debug_level.setter
+    def debug_level(self, level: int) -> None:
+        """
+        Update the debug level attached to this object
+        """
+
+        self._logger.debug_level = level
+
+    @property
+    def verbosity_level(self) -> int:
+        """
+        The current verbosity level applied to this object
+        """
+
+        return self._logger.verbosity_level
+
+    @verbosity_level.setter
+    def verbosity_level(self, level: int) -> None:
+        """
+        Update the verbosity level attached to this object
+        """
+
+        self._logger.verbosity_level = level
+
+    @property
+    def quietness(self) -> bool:
+        """
+        The current quietness level applied to this object
+        """
+
+        return self._logger.quiet

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -2335,12 +2335,25 @@ class Common(_CommonBase, metaclass=_CommonMeta):
             stacklevel=stacklevel + 1,
         )
 
-    def warn(self, message: str, shift: int = 0, stacklevel: int = 1) -> None:
+    def warn(
+        self,
+        message: str,
+        shift: int = 0,
+        stacklevel: int = 1,
+        source: Optional[str] = None,
+        reason: Optional[str] = None,
+    ) -> None:
         """
         Show a yellow warning message on info level, send to stderr
         """
 
-        self._logger.warning(message, shift=shift, stacklevel=stacklevel + 1)
+        self._logger.warning(
+            message,
+            shift=shift,
+            stacklevel=stacklevel + 1,
+            source=source,
+            reason=reason,
+        )
 
     def fail(self, message: str, shift: int = 0, stacklevel: int = 1) -> None:
         """

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -74,7 +74,6 @@ from tmt._compat.importlib.readers import MultiplexedPath
 from tmt._compat.pathlib import Path
 from tmt._compat.typing import ParamSpec, Self
 from tmt.container import container
-from tmt.log import LoggableValue
 from tmt.utils.themes import style
 
 if TYPE_CHECKING:
@@ -1758,7 +1757,7 @@ class _CommonMeta(abc.ABCMeta):
         cls.cli_invocation: Optional[tmt.cli.CliInvocation] = None
 
 
-class Common(_CommonBase, metaclass=_CommonMeta):
+class Common(_CommonBase, tmt.log.Loggable, metaclass=_CommonMeta):
     """
     Common shared stuff
 
@@ -1791,9 +1790,6 @@ class Common(_CommonBase, metaclass=_CommonMeta):
     # `safe_name` accordingly. Direct access not encouraged, use `name` and
     # `safe_name` attributes.
     _name: str
-
-    def inject_logger(self, logger: tmt.log.Logger) -> None:
-        self._logger = logger
 
     def __init__(
         self,
@@ -1831,8 +1827,6 @@ class Common(_CommonBase, metaclass=_CommonMeta):
 
         self._workdir_root = workdir_root
         self.cli_invocation = cli_invocation
-
-        self.inject_logger(logger)
 
         # Relative log indent level shift against the parent
         self._relative_indent = relative_indent
@@ -2242,125 +2236,6 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         """
 
         return tmt.log.indent(key, value=value, color=color, level=self._level() + shift)
-
-    def print(
-        self,
-        text: str,
-        color: 'tmt.utils.themes.Style' = None,
-    ) -> None:
-        """
-        Print out an output.
-
-        This method is supposed to be used for emitting a command output. Not
-        to be mistaken with logging - errors, warnings, general command progress,
-        and so on.
-
-        ``print()`` emits even when ``--quiet`` is used, as the option suppresses
-        **logging** but not the actual command output.
-        """
-
-        self._logger.print(text, color=color)
-
-    def info(
-        self,
-        key: str,
-        value: Optional[LoggableValue] = None,
-        color: 'tmt.utils.themes.Style' = None,
-        shift: int = 0,
-        topic: Optional[tmt.log.Topic] = None,
-        stacklevel: int = 1,
-    ) -> None:
-        """
-        Show a message unless in quiet mode
-        """
-
-        self._logger.info(
-            key,
-            value=value,
-            color=color,
-            shift=shift,
-            topic=topic,
-            stacklevel=stacklevel + 1,
-        )
-
-    def verbose(
-        self,
-        key: str,
-        value: Optional[LoggableValue] = None,
-        color: 'tmt.utils.themes.Style' = None,
-        shift: int = 0,
-        level: int = 1,
-        topic: Optional[tmt.log.Topic] = None,
-        stacklevel: int = 1,
-    ) -> None:
-        """
-        Show message if in requested verbose mode level
-
-        In quiet mode verbose messages are not displayed.
-        """
-
-        self._logger.verbose(
-            key,
-            value=value,
-            color=color,
-            shift=shift,
-            level=level,
-            topic=topic,
-            stacklevel=stacklevel + 1,
-        )
-
-    def debug(
-        self,
-        key: str,
-        value: Optional[LoggableValue] = None,
-        color: 'tmt.utils.themes.Style' = None,
-        shift: int = 0,
-        level: int = 1,
-        topic: Optional[tmt.log.Topic] = None,
-        stacklevel: int = 1,
-    ) -> None:
-        """
-        Show message if in requested debug mode level
-
-        In quiet mode debug messages are not displayed.
-        """
-
-        self._logger.debug(
-            key,
-            value=value,
-            color=color,
-            shift=shift,
-            level=level,
-            topic=topic,
-            stacklevel=stacklevel + 1,
-        )
-
-    def warn(
-        self,
-        message: str,
-        shift: int = 0,
-        stacklevel: int = 1,
-        source: Optional[str] = None,
-        reason: Optional[str] = None,
-    ) -> None:
-        """
-        Show a yellow warning message on info level, send to stderr
-        """
-
-        self._logger.warning(
-            message,
-            shift=shift,
-            stacklevel=stacklevel + 1,
-            source=source,
-            reason=reason,
-        )
-
-    def fail(self, message: str, shift: int = 0, stacklevel: int = 1) -> None:
-        """
-        Show a red failure message on info level, send to stderr
-        """
-
-        self._logger.fail(message, shift=shift, stacklevel=stacklevel + 1)
 
     def _command_verbose_logger(
         self,

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1798,9 +1798,7 @@ class Common(_CommonBase, tmt.log.Loggable, metaclass=_CommonMeta):
         name: Optional[str] = None,
         workdir: WorkdirArgumentType = None,
         workdir_root: Optional[Path] = None,
-        relative_indent: int = 1,
         cli_invocation: Optional['tmt.cli.CliInvocation'] = None,
-        logger: tmt.log.Logger,
         **kwargs: Any,
     ) -> None:
         """
@@ -1816,8 +1814,6 @@ class Common(_CommonBase, tmt.log.Loggable, metaclass=_CommonMeta):
             parent=parent,
             name=name,
             workdir=workdir,
-            relative_indent=relative_indent,
-            logger=logger,
             **kwargs,
         )
 
@@ -1827,9 +1823,6 @@ class Common(_CommonBase, tmt.log.Loggable, metaclass=_CommonMeta):
 
         self._workdir_root = workdir_root
         self.cli_invocation = cli_invocation
-
-        # Relative log indent level shift against the parent
-        self._relative_indent = relative_indent
 
         # Initialize the workdir if requested
         self._workdir_load(workdir)
@@ -2085,46 +2078,6 @@ class Common(_CommonBase, tmt.log.Loggable, metaclass=_CommonMeta):
             parent = self.parent.opt(option)
         return parent if parent is not None else local
 
-    @property
-    def debug_level(self) -> int:
-        """
-        The current debug level applied to this object
-        """
-
-        return self._logger.debug_level
-
-    @debug_level.setter
-    def debug_level(self, level: int) -> None:
-        """
-        Update the debug level attached to this object
-        """
-
-        self._logger.debug_level = level
-
-    @property
-    def verbosity_level(self) -> int:
-        """
-        The current verbosity level applied to this object
-        """
-
-        return self._logger.verbosity_level
-
-    @verbosity_level.setter
-    def verbosity_level(self, level: int) -> None:
-        """
-        Update the verbosity level attached to this object
-        """
-
-        self._logger.verbosity_level = level
-
-    @property
-    def quietness(self) -> bool:
-        """
-        The current quietness level applied to this object
-        """
-
-        return self._logger.quiet
-
     # TODO: interestingly, the option has its own default, right? So why do we
     # need a default of our own? Because sometimes commands have not been
     # invoked, and there's no CLI invocation to ask for the default value.
@@ -2214,28 +2167,6 @@ class Common(_CommonBase, tmt.log.Loggable, metaclass=_CommonMeta):
             )
 
             raise GeneralError(f"Invalid regular expression '{faulty_pattern}'.") from exc
-
-    def _level(self) -> int:
-        """
-        Hierarchy level
-        """
-
-        if self.parent is None:
-            return -1
-        return self.parent._level() + self._relative_indent
-
-    def _indent(
-        self,
-        key: str,
-        value: Optional[str] = None,
-        color: 'tmt.utils.themes.Style' = None,
-        shift: int = 0,
-    ) -> str:
-        """
-        Indent message according to the object hierarchy
-        """
-
-        return tmt.log.indent(key, value=value, color=color, level=self._level() + shift)
 
     def _command_verbose_logger(
         self,


### PR DESCRIPTION
This will help with:
- standardizing a way to define how the loggable objects should behave (if it should descend or not for example)
- detangle the parent relation in the logging functions

These will be addressed in a later PR