### PR TITLE
Use factory pattern when creating instances of HW constraint classes

### DIFF
--- a/tests/unit/provision/mrack/test_hw.py
+++ b/tests/unit/provision/mrack/test_hw.py
@@ -41,7 +41,16 @@ def test_maximal_constraint(root_logger: Logger) -> None:
     assert result.to_mrack() == {
         'and': [
             {},
+<<<<<<< HEAD
             {'pool': {'_op': '!=', '_value': 'foo.*'}},
+=======
+            {
+                'pool': {
+                    '_op': '!=',
+                    '_value': 'foo.*',
+                },
+            },
+>>>>>>> b38039300 (squash: more tests)
             {},
             {'and': [{}, {}]},
             {'cpu': {'cores': {'_op': '==', '_value': '2'}}},
@@ -211,25 +220,41 @@ def test_disk_size(root_logger: Logger) -> None:
 
 def test_disk_model_name(root_logger: Logger) -> None:
     result = _CONSTRAINT_TRANSFORMERS['disk.model-name'](
+<<<<<<< HEAD
         _parse_requirements({'disk': [{'model-name': 'PERC H310'}]}), root_logger
+=======
+        _parse_requirements({'disk': {'model-name': 'PERC H310'}}), root_logger
+>>>>>>> b38039300 (squash: more tests)
     )
 
     assert result.to_mrack() == {'disk': {'model': {'_op': '==', '_value': 'PERC H310'}}}
 
     result = _CONSTRAINT_TRANSFORMERS['disk.model-name'](
+<<<<<<< HEAD
         _parse_requirements({'disk': [{'model-name': '!= PERC H310'}]}), root_logger
+=======
+        _parse_requirements({'disk': {'model-name': '!= PERC H310'}}), root_logger
+>>>>>>> b38039300 (squash: more tests)
     )
 
     assert result.to_mrack() == {'disk': {'model': {'_op': '!=', '_value': 'PERC H310'}}}
 
     result = _CONSTRAINT_TRANSFORMERS['disk.model-name'](
+<<<<<<< HEAD
         _parse_requirements({'disk': [{'model-name': '~ PERC.*'}]}), root_logger
+=======
+        _parse_requirements({'disk': {'model-name': '~ PERC.*'}}), root_logger
+>>>>>>> b38039300 (squash: more tests)
     )
 
     assert result.to_mrack() == {'disk': {'model': {'_op': 'like', '_value': 'PERC%'}}}
 
     result = _CONSTRAINT_TRANSFORMERS['disk.model-name'](
+<<<<<<< HEAD
         _parse_requirements({'disk': [{'model-name': '!~ PERC.*'}]}), root_logger
+=======
+        _parse_requirements({'disk': {'model-name': '!~ PERC.*'}}), root_logger
+>>>>>>> b38039300 (squash: more tests)
     )
 
     assert result.to_mrack() == {'not': {'disk': {'model': {'_op': 'like', '_value': 'PERC%'}}}}

--- a/tests/unit/provision/mrack/test_hw.py
+++ b/tests/unit/provision/mrack/test_hw.py
@@ -38,27 +38,10 @@ def test_maximal_constraint(root_logger: Logger) -> None:
     assert hw.constraint is not None
 
     result = constraint_to_beaker_filter(hw.constraint, root_logger)
-<<<<<<< HEAD
-    assert result.to_mrack() == {
-        'and': [
-            {},
-<<<<<<< HEAD
-            {'pool': {'_op': '!=', '_value': 'foo.*'}},
-=======
-            {
-                'pool': {
-                    '_op': '!=',
-                    '_value': 'foo.*',
-                },
-            },
->>>>>>> b38039300 (squash: more tests)
-=======
-
     assert result.to_mrack() == {
         'and': [
             {},
             {'pool': {'_op': '!=', '_value': 'foo.*'}},
->>>>>>> f16120b3d (squash: more test fixes)
             {},
             {'and': [{}, {}]},
             {'cpu': {'cores': {'_op': '==', '_value': '2'}}},
@@ -228,41 +211,25 @@ def test_disk_size(root_logger: Logger) -> None:
 
 def test_disk_model_name(root_logger: Logger) -> None:
     result = _CONSTRAINT_TRANSFORMERS['disk.model-name'](
-<<<<<<< HEAD
         _parse_requirements({'disk': [{'model-name': 'PERC H310'}]}), root_logger
-=======
-        _parse_requirements({'disk': {'model-name': 'PERC H310'}}), root_logger
->>>>>>> b38039300 (squash: more tests)
     )
 
     assert result.to_mrack() == {'disk': {'model': {'_op': '==', '_value': 'PERC H310'}}}
 
     result = _CONSTRAINT_TRANSFORMERS['disk.model-name'](
-<<<<<<< HEAD
         _parse_requirements({'disk': [{'model-name': '!= PERC H310'}]}), root_logger
-=======
-        _parse_requirements({'disk': {'model-name': '!= PERC H310'}}), root_logger
->>>>>>> b38039300 (squash: more tests)
     )
 
     assert result.to_mrack() == {'disk': {'model': {'_op': '!=', '_value': 'PERC H310'}}}
 
     result = _CONSTRAINT_TRANSFORMERS['disk.model-name'](
-<<<<<<< HEAD
         _parse_requirements({'disk': [{'model-name': '~ PERC.*'}]}), root_logger
-=======
-        _parse_requirements({'disk': {'model-name': '~ PERC.*'}}), root_logger
->>>>>>> b38039300 (squash: more tests)
     )
 
     assert result.to_mrack() == {'disk': {'model': {'_op': 'like', '_value': 'PERC%'}}}
 
     result = _CONSTRAINT_TRANSFORMERS['disk.model-name'](
-<<<<<<< HEAD
         _parse_requirements({'disk': [{'model-name': '!~ PERC.*'}]}), root_logger
-=======
-        _parse_requirements({'disk': {'model-name': '!~ PERC.*'}}), root_logger
->>>>>>> b38039300 (squash: more tests)
     )
 
     assert result.to_mrack() == {'not': {'disk': {'model': {'_op': 'like', '_value': 'PERC%'}}}}

--- a/tests/unit/provision/mrack/test_hw.py
+++ b/tests/unit/provision/mrack/test_hw.py
@@ -38,6 +38,7 @@ def test_maximal_constraint(root_logger: Logger) -> None:
     assert hw.constraint is not None
 
     result = constraint_to_beaker_filter(hw.constraint, root_logger)
+<<<<<<< HEAD
     assert result.to_mrack() == {
         'and': [
             {},
@@ -51,6 +52,13 @@ def test_maximal_constraint(root_logger: Logger) -> None:
                 },
             },
 >>>>>>> b38039300 (squash: more tests)
+=======
+
+    assert result.to_mrack() == {
+        'and': [
+            {},
+            {'pool': {'_op': '!=', '_value': 'foo.*'}},
+>>>>>>> f16120b3d (squash: more test fixes)
             {},
             {'and': [{}, {}]},
             {'cpu': {'cores': {'_op': '==', '_value': '2'}}},

--- a/tests/unit/provision/mrack/test_hw.py
+++ b/tests/unit/provision/mrack/test_hw.py
@@ -38,7 +38,6 @@ def test_maximal_constraint(root_logger: Logger) -> None:
     assert hw.constraint is not None
 
     result = constraint_to_beaker_filter(hw.constraint, root_logger)
-
     assert result.to_mrack() == {
         'and': [
             {},

--- a/tests/unit/provision/mrack/test_hw.py
+++ b/tests/unit/provision/mrack/test_hw.py
@@ -38,6 +38,7 @@ def test_maximal_constraint(root_logger: Logger) -> None:
     assert hw.constraint is not None
 
     result = constraint_to_beaker_filter(hw.constraint, root_logger)
+
     assert result.to_mrack() == {
         'and': [
             {},

--- a/tmt/hardware/constraints.py
+++ b/tmt/hardware/constraints.py
@@ -8,8 +8,10 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Generic,
     NamedTuple,
     Optional,
+    TypeVar,
     Union,
     cast,
 )
@@ -873,6 +875,42 @@ class TextConstraint(Constraint):
             original_constraint=original_constraint,
             allowed_operators=allowed_operators,
         )
+
+
+ConstraintT = TypeVar('ConstraintT', bound=Constraint, covariant=True)  # noqa: PLC0105
+
+
+# To hold the actual constraint class, we need a mutable container we
+# can refer to in calls and variables. We do not need a callable, which
+# is more common in the "factory" pattern. We cannot use a module-level
+# variable directly: once passed to a call, its value at that moment
+# would be used, while we have to delay the evaluation of the "what class
+# shall I use to create a 'text constraint'?" answer until we really
+# need the answer, not sooner.
+#
+# A mapping or list would work, but custom class can carry constraint
+# type better.
+@container
+class _ConstraintFactory(Generic[ConstraintT]):
+    #: Class whose ``from_specification`` method should be used to create
+    #: new instances of the given constraint type.
+    constraint_class: type[ConstraintT]
+
+
+#: Factory for :py:class:`SizeConstraint` constraints.
+SIZE_CONSTRAINT_FACTORY = _ConstraintFactory(constraint_class=SizeConstraint)
+
+#: Factory for :py:class:`FlagConstraint` constraints.
+FLAG_CONSTRAINT_FACTORY = _ConstraintFactory(constraint_class=FlagConstraint)
+
+#: Factory for :py:class:`IntegerConstraint` constraints.
+INTEGER_CONSTRAINT_FACTORY = _ConstraintFactory(constraint_class=IntegerConstraint)
+
+#: Factory for :py:class:`NumberConstraint` constraints.
+NUMBER_CONSTRAINT_FACTORY = _ConstraintFactory(constraint_class=NumberConstraint)
+
+#: Factory for :py:class:`TextConstraint` constraints.
+TEXT_CONSTRAINT_FACTORY = _ConstraintFactory(constraint_class=TextConstraint)
 
 
 @container(repr=False)

--- a/tmt/hardware/constraints.py
+++ b/tmt/hardware/constraints.py
@@ -891,26 +891,26 @@ ConstraintT = TypeVar('ConstraintT', bound=Constraint, covariant=True)  # noqa: 
 # A mapping or list would work, but custom class can carry constraint
 # type better.
 @container
-class _ConstraintFactory(Generic[ConstraintT]):
+class ConstraintFactory(Generic[ConstraintT]):
     #: Class whose ``from_specification`` method should be used to create
     #: new instances of the given constraint type.
     constraint_class: type[ConstraintT]
 
 
 #: Factory for :py:class:`SizeConstraint` constraints.
-SIZE_CONSTRAINT_FACTORY = _ConstraintFactory(constraint_class=SizeConstraint)
+SIZE_CONSTRAINT_FACTORY = ConstraintFactory(constraint_class=SizeConstraint)
 
 #: Factory for :py:class:`FlagConstraint` constraints.
-FLAG_CONSTRAINT_FACTORY = _ConstraintFactory(constraint_class=FlagConstraint)
+FLAG_CONSTRAINT_FACTORY = ConstraintFactory(constraint_class=FlagConstraint)
 
 #: Factory for :py:class:`IntegerConstraint` constraints.
-INTEGER_CONSTRAINT_FACTORY = _ConstraintFactory(constraint_class=IntegerConstraint)
+INTEGER_CONSTRAINT_FACTORY = ConstraintFactory(constraint_class=IntegerConstraint)
 
 #: Factory for :py:class:`NumberConstraint` constraints.
-NUMBER_CONSTRAINT_FACTORY = _ConstraintFactory(constraint_class=NumberConstraint)
+NUMBER_CONSTRAINT_FACTORY = ConstraintFactory(constraint_class=NumberConstraint)
 
 #: Factory for :py:class:`TextConstraint` constraints.
-TEXT_CONSTRAINT_FACTORY = _ConstraintFactory(constraint_class=TextConstraint)
+TEXT_CONSTRAINT_FACTORY = ConstraintFactory(constraint_class=TextConstraint)
 
 
 @container(repr=False)

--- a/tmt/hardware/requirements.py
+++ b/tmt/hardware/requirements.py
@@ -5,18 +5,20 @@ from typing import Any, Callable, Generic, Optional, Protocol, TypeVar, Union, c
 import tmt.log
 from tmt.container import SpecBasedContainer, container, simple_field
 from tmt.hardware.constraints import (
+    FLAG_CONSTRAINT_FACTORY,
+    INTEGER_CONSTRAINT_FACTORY,
+    NUMBER_CONSTRAINT_FACTORY,
+    SIZE_CONSTRAINT_FACTORY,
+    TEXT_CONSTRAINT_FACTORY,
     And,
     BaseConstraint,
     CompoundConstraint,
     Constraint,
-    FlagConstraint,
-    IntegerConstraint,
-    NumberConstraint,
     Operator,
     Or,
-    SizeConstraint,
     Spec,
     TextConstraint,
+    _ConstraintFactory,
 )
 from tmt.utils import GeneralError, SpecificationError
 
@@ -76,9 +78,10 @@ class _TrivialParser(_Parser[ConstraintT]):
     Base class for simple parser that can be statically defined.
     """
 
-    #: Constraint class whose :py:meth:`Constraint.from_specification`
-    #: method would be used to parse the requirement.
-    constraint_class: type[ConstraintT]
+    #: Constraint class factory whose
+    #: :py:meth:`_ConstraintFactory.constraint_class`
+    #: would be used to parse and represent the requirement.
+    constraint_class_factory: _ConstraintFactory[ConstraintT]
 
     #: Optional keyword arguments to pass to
     #: :py:meth:`Constraint.from_specification` method.
@@ -94,7 +97,7 @@ class SingleLevelParser(_TrivialParser[ConstraintT]):
     """
 
     def parse(self, spec: Spec, peer_index: Optional[int] = None) -> ConstraintT:
-        return self.constraint_class.from_specification(
+        return self.constraint_class_factory.constraint_class.from_specification(
             self.requirement,
             str(spec[self.requirement]),
             **self.kwargs,
@@ -118,7 +121,7 @@ class DoubleLevelParser(_TrivialParser[ConstraintT]):
         return self.requirement.split('.', 1)[1]
 
     def parse(self, spec: Spec, peer_index: Optional[int] = None) -> ConstraintT:
-        return self.constraint_class.from_specification(
+        return self.constraint_class_factory.constraint_class.from_specification(
             self.requirement,
             str(spec[self.child_constraint_name]),
             **self.kwargs,
@@ -163,17 +166,17 @@ def generate_device_parsers(
     device_prefix: str = 'device',
     include_driver: bool = True,
     include_device: bool = True,
-    parser_class: Union[type[DLP[Constraint]], type[IDLP[Constraint]]] = DLP,
+    parser_class: Union[type[DLP[Any]], type[IDLP[Any]]] = DLP,
 ) -> Iterator[Union[DLP[Constraint], IDLP[Constraint]]]:
-    yield parser_class(f'{device_prefix}.vendor', IntegerConstraint)
-    yield parser_class(f'{device_prefix}.vendor-name', TextConstraint)
+    yield parser_class(f'{device_prefix}.vendor', INTEGER_CONSTRAINT_FACTORY)
+    yield parser_class(f'{device_prefix}.vendor-name', TEXT_CONSTRAINT_FACTORY)
 
     if include_device:
-        yield parser_class(f'{device_prefix}.device', IntegerConstraint)
-        yield parser_class(f'{device_prefix}.device-name', TextConstraint)
+        yield parser_class(f'{device_prefix}.device', INTEGER_CONSTRAINT_FACTORY)
+        yield parser_class(f'{device_prefix}.device-name', TEXT_CONSTRAINT_FACTORY)
 
     if include_driver:
-        yield parser_class(f'{device_prefix}.driver', TextConstraint)
+        yield parser_class(f'{device_prefix}.driver', TEXT_CONSTRAINT_FACTORY)
 
 
 def custom_parser(fn: RequirementParser[BaseConstraint]) -> RequirementParser[BaseConstraint]:
@@ -240,74 +243,80 @@ TPM_VERSION_ALLOWED_OPERATORS = (
 #:    order of keys.
 _REQUIREMENT_PARSERS: list[Union[CustomParser[Any], SLP[Any], DLP[Any], IDLP[Any]]] = [
     # arch
-    SLP('arch', TextConstraint),
+    SLP('arch', TEXT_CONSTRAINT_FACTORY),
     # beaker
-    DLP('beaker.panic-watchdog', FlagConstraint),
-    DLP('beaker.pool', TextConstraint, {'allowed_operators': (Operator.EQ, Operator.NEQ)}),
+    DLP('beaker.panic-watchdog', FLAG_CONSTRAINT_FACTORY),
+    DLP(
+        'beaker.pool', TEXT_CONSTRAINT_FACTORY, {'allowed_operators': (Operator.EQ, Operator.NEQ)}
+    ),
     # cpu
-    DLP('cpu.cores', IntegerConstraint),
-    DLP('cpu.cores-per-socket', IntegerConstraint),
-    DLP('cpu.family', IntegerConstraint),
-    DLP('cpu.hyper-threading', FlagConstraint, {'allowed_operators': (Operator.EQ, Operator.NEQ)}),
-    DLP('cpu.model', IntegerConstraint),
-    DLP('cpu.processors', IntegerConstraint),
-    DLP('cpu.sockets', IntegerConstraint),
-    DLP('cpu.threads', IntegerConstraint),
-    DLP('cpu.threads-per-core', IntegerConstraint),
-    DLP('cpu.vendor', IntegerConstraint),
-    DLP('cpu.stepping', IntegerConstraint),
-    DLP('cpu.frequency', NumberConstraint, {'default_unit': 'MHz'}),
-    DLP('cpu.family-name', TextConstraint),
-    DLP('cpu.model-name', TextConstraint),
-    DLP('cpu.vendor-name', TextConstraint),
+    DLP('cpu.cores', INTEGER_CONSTRAINT_FACTORY),
+    DLP('cpu.cores-per-socket', INTEGER_CONSTRAINT_FACTORY),
+    DLP('cpu.family', INTEGER_CONSTRAINT_FACTORY),
+    DLP(
+        'cpu.hyper-threading',
+        FLAG_CONSTRAINT_FACTORY,
+        {'allowed_operators': (Operator.EQ, Operator.NEQ)},
+    ),
+    DLP('cpu.model', INTEGER_CONSTRAINT_FACTORY),
+    DLP('cpu.processors', INTEGER_CONSTRAINT_FACTORY),
+    DLP('cpu.sockets', INTEGER_CONSTRAINT_FACTORY),
+    DLP('cpu.threads', INTEGER_CONSTRAINT_FACTORY),
+    DLP('cpu.threads-per-core', INTEGER_CONSTRAINT_FACTORY),
+    DLP('cpu.vendor', INTEGER_CONSTRAINT_FACTORY),
+    DLP('cpu.stepping', INTEGER_CONSTRAINT_FACTORY),
+    DLP('cpu.frequency', NUMBER_CONSTRAINT_FACTORY, {'default_unit': 'MHz'}),
+    DLP('cpu.family-name', TEXT_CONSTRAINT_FACTORY),
+    DLP('cpu.model-name', TEXT_CONSTRAINT_FACTORY),
+    DLP('cpu.vendor-name', TEXT_CONSTRAINT_FACTORY),
     # device
     *generate_device_parsers(),
     # disk
-    IDLP('disk.size', SizeConstraint),
-    IDLP('disk.logical-sector-size', SizeConstraint),
-    IDLP('disk.physical-sector-size', SizeConstraint),
-    IDLP('disk.model-name', TextConstraint),
-    IDLP('disk.driver', TextConstraint),
+    IDLP('disk.size', SIZE_CONSTRAINT_FACTORY),
+    IDLP('disk.logical-sector-size', SIZE_CONSTRAINT_FACTORY),
+    IDLP('disk.physical-sector-size', SIZE_CONSTRAINT_FACTORY),
+    IDLP('disk.model-name', TEXT_CONSTRAINT_FACTORY),
+    IDLP('disk.driver', TEXT_CONSTRAINT_FACTORY),
     # gpu
     *generate_device_parsers(device_prefix='gpu'),
     # hostname
-    SLP('hostname', TextConstraint),
+    SLP('hostname', TEXT_CONSTRAINT_FACTORY),
     # iommu
-    DLP('iommu.is-supported', FlagConstraint),
-    DLP('iommu.model-name', TextConstraint),
+    DLP('iommu.is-supported', FLAG_CONSTRAINT_FACTORY),
+    DLP('iommu.model-name', TEXT_CONSTRAINT_FACTORY),
     # location
-    DLP('location.lab-controller', TextConstraint),
+    DLP('location.lab-controller', TEXT_CONSTRAINT_FACTORY),
     # memory
-    SLP('memory', SizeConstraint, {'default_unit': 'MiB'}),
+    SLP('memory', SIZE_CONSTRAINT_FACTORY, {'default_unit': 'MiB'}),
     # network
     *generate_device_parsers(device_prefix='network', parser_class=IDLP),
-    IDLP('network.type', TextConstraint),
+    IDLP('network.type', TEXT_CONSTRAINT_FACTORY),
     # system
     *generate_device_parsers(device_prefix='system', include_driver=False, include_device=False),
-    DLP('system.model', IntegerConstraint),
-    DLP('system.numa-nodes', IntegerConstraint),
-    DLP('system.model-name', TextConstraint),
-    DLP('system.type', TextConstraint),
+    DLP('system.model', INTEGER_CONSTRAINT_FACTORY),
+    DLP('system.numa-nodes', INTEGER_CONSTRAINT_FACTORY),
+    DLP('system.model-name', TEXT_CONSTRAINT_FACTORY),
+    DLP('system.type', TEXT_CONSTRAINT_FACTORY),
     # tpm
     DLP(
         'tpm.version',
-        TextConstraint,
+        TEXT_CONSTRAINT_FACTORY,
         {'allowed_operators': TPM_VERSION_ALLOWED_OPERATORS},
     ),
     # virtualization
-    DLP('virtualization.is-virtualized', FlagConstraint),
-    DLP('virtualization.is-supported', FlagConstraint),
-    DLP('virtualization.confidential', FlagConstraint),
-    DLP('virtualization.hypervisor', TextConstraint),
+    DLP('virtualization.is-virtualized', FLAG_CONSTRAINT_FACTORY),
+    DLP('virtualization.is-supported', FLAG_CONSTRAINT_FACTORY),
+    DLP('virtualization.confidential', FLAG_CONSTRAINT_FACTORY),
+    DLP('virtualization.hypervisor', TEXT_CONSTRAINT_FACTORY),
     # zcrypt
-    DLP('zcrypt.adapter', TextConstraint),
-    DLP('zcrypt.mode', TextConstraint),
+    DLP('zcrypt.adapter', TEXT_CONSTRAINT_FACTORY),
+    DLP('zcrypt.mode', TEXT_CONSTRAINT_FACTORY),
 ]
 
 
 @custom_parser
 def parse_boot_method(spec: Spec, peer_index: Optional[int] = None) -> TextConstraint:
-    constraint = TextConstraint.from_specification(
+    constraint = TEXT_CONSTRAINT_FACTORY.constraint_class.from_specification(
         'boot.method', spec['method'], allowed_operators=(Operator.EQ, Operator.NEQ)
     )
 
@@ -325,7 +334,9 @@ def parse_compatible_distro(spec: Spec, peer_index: Optional[int] = None) -> And
     group = And()
 
     for distro in cast(list[str], (spec['distro'] or [])):
-        constraint = TextConstraint.from_specification('compatible.distro', distro)
+        constraint = TEXT_CONSTRAINT_FACTORY.constraint_class.from_specification(
+            'compatible.distro', distro
+        )
 
         constraint.change_operator(Operator.CONTAINS)
 
@@ -339,7 +350,9 @@ def parse_cpu_flag(spec: Spec, peer_index: Optional[int] = None) -> And:
     group = And()
 
     for flag_spec in spec['flag']:
-        constraint = TextConstraint.from_specification('cpu.flag', flag_spec)
+        constraint = TEXT_CONSTRAINT_FACTORY.constraint_class.from_specification(
+            'cpu.flag', flag_spec
+        )
 
         if constraint.operator == Operator.EQ:
             constraint.change_operator(Operator.CONTAINS)

--- a/tmt/hardware/requirements.py
+++ b/tmt/hardware/requirements.py
@@ -14,11 +14,11 @@ from tmt.hardware.constraints import (
     BaseConstraint,
     CompoundConstraint,
     Constraint,
+    ConstraintFactory,
     Operator,
     Or,
     Spec,
     TextConstraint,
-    _ConstraintFactory,
 )
 from tmt.utils import GeneralError, SpecificationError
 
@@ -81,7 +81,7 @@ class _TrivialParser(_Parser[ConstraintT]):
     #: Constraint class factory whose
     #: :py:meth:`_ConstraintFactory.constraint_class`
     #: would be used to parse and represent the requirement.
-    constraint_class_factory: _ConstraintFactory[ConstraintT]
+    constraint_class_factory: ConstraintFactory[ConstraintT]
 
     #: Optional keyword arguments to pass to
     #: :py:meth:`Constraint.from_specification` method.

--- a/tmt/hardware/requirements.py
+++ b/tmt/hardware/requirements.py
@@ -25,8 +25,6 @@ from tmt.utils import GeneralError, SpecificationError
 BaseConstraintT = TypeVar('BaseConstraintT', bound=BaseConstraint, covariant=True)  # noqa: PLC0105
 ConstraintT = TypeVar('ConstraintT', bound=Constraint, covariant=True)  # noqa: PLC0105
 
-BaseConstraintT = TypeVar('BaseConstraintT', bound=BaseConstraint, covariant=True)  # noqa: PLC0105
-ConstraintT = TypeVar('ConstraintT', bound=Constraint, covariant=True)  # noqa: PLC0105
 
 #: Type of a requirement parser.
 class RequirementParser(Protocol, Generic[BaseConstraintT]):
@@ -142,7 +140,7 @@ class IndexedDoubleLevelParser(DoubleLevelParser[ConstraintT]):
         if peer_index is None:
             raise GeneralError('Cannot parse indexed constraint without peer constraint.')
 
-        return self.constraint_class.from_specification(
+        return self.constraint_class_factory.constraint_class.from_specification(
             f'{self.constraint_name}[{peer_index}].{self.child_constraint_name}',
             str(spec[self.child_constraint_name]),
             **self.kwargs,

--- a/tmt/hardware/requirements.py
+++ b/tmt/hardware/requirements.py
@@ -25,6 +25,8 @@ from tmt.utils import GeneralError, SpecificationError
 BaseConstraintT = TypeVar('BaseConstraintT', bound=BaseConstraint, covariant=True)  # noqa: PLC0105
 ConstraintT = TypeVar('ConstraintT', bound=Constraint, covariant=True)  # noqa: PLC0105
 
+BaseConstraintT = TypeVar('BaseConstraintT', bound=BaseConstraint, covariant=True)  # noqa: PLC0105
+ConstraintT = TypeVar('ConstraintT', bound=Constraint, covariant=True)  # noqa: PLC0105
 
 #: Type of a requirement parser.
 class RequirementParser(Protocol, Generic[BaseConstraintT]):

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -18,6 +18,7 @@ import requests
 import tmt
 import tmt.guest
 import tmt.hardware
+import tmt.hardware.constraints
 import tmt.log
 import tmt.steps
 import tmt.steps.provision
@@ -977,8 +978,10 @@ class GuestTestcloud(tmt.GuestSsh):
         if self.memory is None:
             return
 
-        memory_constraint = tmt.hardware.SizeConstraint.from_specification(
-            'memory', str(self.memory)
+        memory_constraint = (
+            tmt.hardware.constraints.SIZE_CONSTRAINT_FACTORY.constraint_class.from_specification(
+                'memory', str(self.memory)
+            )
         )
 
         self.hardware.and_(memory_constraint)
@@ -994,8 +997,10 @@ class GuestTestcloud(tmt.GuestSsh):
         if self.disk is None:
             return
 
-        disk_size_constraint = tmt.hardware.SizeConstraint.from_specification(
-            'disk[0].size', str(self.disk)
+        disk_size_constraint = (
+            tmt.hardware.constraints.SIZE_CONSTRAINT_FACTORY.constraint_class.from_specification(
+                'disk[0].size', str(self.disk)
+            )
         )
 
         self.hardware.and_(disk_size_constraint)

--- a/tmt/steps/provision/testcloud.py
+++ b/tmt/steps/provision/testcloud.py
@@ -18,7 +18,6 @@ import requests
 import tmt
 import tmt.guest
 import tmt.hardware
-import tmt.hardware.constraints
 import tmt.log
 import tmt.steps
 import tmt.steps.provision
@@ -26,6 +25,7 @@ import tmt.utils
 import tmt.utils.wait
 from tmt.container import container, field
 from tmt.guest import CONNECT_TIMEOUT, RebootMode, default_connect_waiting
+from tmt.hardware.constraints import SIZE_CONSTRAINT_FACTORY
 from tmt.utils import (
     Command,
     Path,
@@ -978,10 +978,8 @@ class GuestTestcloud(tmt.GuestSsh):
         if self.memory is None:
             return
 
-        memory_constraint = (
-            tmt.hardware.constraints.SIZE_CONSTRAINT_FACTORY.constraint_class.from_specification(
-                'memory', str(self.memory)
-            )
+        memory_constraint = SIZE_CONSTRAINT_FACTORY.constraint_class.from_specification(
+            'memory', str(self.memory)
         )
 
         self.hardware.and_(memory_constraint)
@@ -997,10 +995,8 @@ class GuestTestcloud(tmt.GuestSsh):
         if self.disk is None:
             return
 
-        disk_size_constraint = (
-            tmt.hardware.constraints.SIZE_CONSTRAINT_FACTORY.constraint_class.from_specification(
-                'disk[0].size', str(self.disk)
-            )
+        disk_size_constraint = SIZE_CONSTRAINT_FACTORY.constraint_class.from_specification(
+            'disk[0].size', str(self.disk)
         )
 
         self.hardware.and_(disk_size_constraint)


### PR DESCRIPTION
This is needed to support custom constraint classes defined by `tmt.hardware` users. Such classes need to be used by `tmt.hardware` when parsing hardware requirements, instead of those provided by tmt itself.

Implements https://github.com/teemtee/tmt/issues/4989

Pull Request Checklist

* [x] implement the feature