### PR TITLE
Extend Options with allow_erasing and allow_downgrade

### DIFF
--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -329,12 +329,10 @@ class Options:
     #: If set, instruct package manager to install from untrusted sources.
     allow_untrusted: bool = False
 
-    #: If set, allow erasing conflicting or obsoleting packages (``--allowerasing``).
-    #: Supported by DNF4 and DNF5.
+    #: If set, allow erasing conflicting or obsoleting packages during install.
     allow_erasing: bool = False
 
-    #: If set, allow downgrades of transitive dependencies (``--allow-downgrade``).
-    #: DNF5 only; DNF4 handles transitive downgrades automatically.
+    #: If set, allow downgrades of transitive dependencies during install.
     allow_downgrade: bool = False
 
 

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -329,6 +329,14 @@ class Options:
     #: If set, instruct package manager to install from untrusted sources.
     allow_untrusted: bool = False
 
+    #: If set, allow erasing conflicting or obsoleting packages (``--allowerasing``).
+    #: Supported by DNF4 and DNF5.
+    allow_erasing: bool = False
+
+    #: If set, allow downgrades of transitive dependencies (``--allow-downgrade``).
+    #: DNF5 only; DNF4 handles transitive downgrades automatically.
+    allow_downgrade: bool = False
+
 
 class PackageManagerEngine(tmt.utils.Common):
     command: Command

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -59,6 +59,9 @@ class DnfEngine(PackageManagerEngine):
             else:
                 raise GeneralError(f"Unhandled package manager command '{command}'.")
 
+        if options.allow_erasing:
+            extra_options += Command('--allowerasing')
+
         return extra_options
 
     def _construct_presence_script(
@@ -397,6 +400,18 @@ class Dnf5Engine(DnfEngine):
     _base_debuginfo_command = Command('dnf5', 'debuginfo-install')
     skip_missing_packages_option = '--skip-unavailable'
     skip_missing_debuginfo_option = skip_missing_packages_option
+
+    def _extra_dnf_options(self, options: Options, command: Optional[Command] = None) -> Command:
+        """
+        Collect additional options for ``dnf5`` based on given options.
+        """
+
+        extra_options = super()._extra_dnf_options(options, command)
+
+        if options.allow_downgrade:
+            extra_options += Command('--allow-downgrade')
+
+        return extra_options
 
 
 @provides_package_manager('dnf5')

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -430,6 +430,11 @@ class Dnf5(Dnf):
 class YumEngine(DnfEngine):
     _base_command = Command('yum')
 
+    def _extra_dnf_options(self, options: Options, command: Optional[Command] = None) -> Command:
+        if options.allow_erasing:
+            raise PrepareError("Package manager 'yum' does not support '--allowerasing'.")
+        return super()._extra_dnf_options(options, command)
+
     def _yum_config_manager_command(self) -> Command:
         command = Command('yum-config-manager')
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -435,6 +435,8 @@ class YumEngine(DnfEngine):
     def _extra_dnf_options(self, options: Options, command: Optional[Command] = None) -> Command:
         if options.allow_erasing:
             raise PrepareError("Package manager 'yum' does not support '--allowerasing'.")
+        if options.allow_downgrade:
+            raise PrepareError("Package manager 'yum' does not support '--allow-downgrade'.")
         return super()._extra_dnf_options(options, command)
 
     def _yum_config_manager_command(self) -> Command:

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -60,6 +60,7 @@ class DnfEngine(PackageManagerEngine):
                 raise GeneralError(f"Unhandled package manager command '{command}'.")
 
         if options.allow_erasing:
+            # Supported by DNF4 and DNF5; YumEngine raises PrepareError for this flag.
             extra_options += Command('--allowerasing')
 
         return extra_options
@@ -409,6 +410,7 @@ class Dnf5Engine(DnfEngine):
         extra_options = super()._extra_dnf_options(options, command)
 
         if options.allow_downgrade:
+            # DNF4 allows transitive downgrades automatically; this flag is DNF5-specific.
             extra_options += Command('--allow-downgrade')
 
         return extra_options


### PR DESCRIPTION
Add two new fields to the package manager Options:
  
  - `allow_erasing` (`--allowerasing`): lets DNF remove packages that
    obsolete or conflict with a requested install. Supported by DNF4 and
    DNF5.
    
  - `allow_downgrade` (`--allow-downgrade`): lets DNF5 downgrade transitive
    dependencies when a requested package requires an older version. DNF4
    already permits this by default, so the flag is only emitted for DNF5.

  - Both options raise `PrepareError` under `YumEngine` (no equivalent flag).
    
  Fixes #4909