### PR TITLE
Improve runner/guest temporary file/directory helpers

### DIFF
--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 from unittest.mock import MagicMock, Mock
 
 import _pytest.logging
+import _pytest.monkeypatch
 import pytest
 from pytest_container.container import ContainerData
 
@@ -179,18 +180,15 @@ def test_execute_no_connection_closed(
     indirect=["container"],
     ids=[TEST_CONTAINERS[container_name].url for container_name in sorted(TEST_CONTAINERS.keys())],
 )
-def test_mkdtemp(
+def test_guest_tmpdir(
     container: ContainerData,
     guest: GuestContainer,
     root_logger: Logger,
     caplog: _pytest.logging.LogCaptureFixture,
+    monkeypatch: _pytest.monkeypatch.MonkeyPatch,
 ) -> None:
-    guest.execute(ShellScript('mkdir -p /tmp/qux'))
-
-    with guest.mkdtemp(
+    with guest.guest_tmpdir(
         prefix='bar',
-        template='XXXXXXbazXXXXXX',
-        parent=Path('/tmp/qux'),
     ) as path:
         guest.execute(ShellScript(f'ls -al {path}'))
 

--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 from unittest.mock import MagicMock, Mock
 
 import _pytest.logging
+import _pytest.monkeypatch
 import pytest
 from pytest_container.container import ContainerData
 
@@ -182,18 +183,15 @@ def test_execute_no_connection_closed(
     indirect=["container"],
     ids=[TEST_CONTAINERS[container_name].url for container_name in sorted(TEST_CONTAINERS.keys())],
 )
-def test_mkdtemp(
+def test_guest_tmpdir(
     container: ContainerData,
     guest: GuestContainer,
     root_logger: Logger,
     caplog: _pytest.logging.LogCaptureFixture,
+    monkeypatch: _pytest.monkeypatch.MonkeyPatch,
 ) -> None:
-    guest.execute(ShellScript('mkdir -p /tmp/qux'))
-
-    with guest.mkdtemp(
+    with guest.guest_tmpdir(
         prefix='bar',
-        template='XXXXXXbazXXXXXX',
-        parent=Path('/tmp/qux'),
     ) as path:
         guest.execute(ShellScript(f'ls -al {path}'))
 

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -659,7 +659,7 @@ class Plan(
 
         with (
             tempfile.NamedTemporaryFile(mode='w') as excludes_tempfile,
-            self.tmpdir(prefix='rsync-') as rsync_tempdir,
+            self.runner_tmpdir(prefix='rsync-') as rsync_tempdir,
         ):
             excludes_tempfile.write('\n'.join(str(path) for path in ignore))
 

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -678,7 +678,7 @@ class Plan(
 
         with (
             tempfile.NamedTemporaryFile(mode='w') as excludes_tempfile,
-            self.tmpdir(prefix='rsync-') as rsync_tempdir,
+            self.runner_tmpdir(prefix='rsync-') as rsync_tempdir,
         ):
             excludes_tempfile.write('\n'.join(str(path) for path in ignore))
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2774,26 +2774,28 @@ class Guest(
             else:
                 logger.info(log.name, str(log.filepath))
 
-    def _construct_mkdtemp_command(
+    def _construct_mktemp_command(
         self,
+        template: str = 'tmp.XXXXXXXXXX',
         prefix: Optional[str] = None,
-        template: Optional[str] = None,
-        parent: Optional[Path] = None,
+        suffix: Optional[str] = None,
+        directory: bool = False,
     ) -> Command:
-        template = template or 'tmp.XXXXXXXXXX'
-
         if prefix is not None:
             template = f'{prefix}{template}'
 
-        options: list[str] = ['--directory']
+        if suffix is not None:
+            template = f'{template}{suffix}'
 
-        if parent is not None:
-            options += ['-p', str(parent)]
+        options: list[str] = ['-p', str(self.run_tmpdir)]
+
+        if directory:
+            options.append('--directory')
 
         return Command(*('mktemp', *options, template))
 
     @contextlib.contextmanager
-    def mkdtemp(
+    def guest_tmpfile(
         self,
         # Suffix is not supported everywhere, namely Alpine does not
         # recognize it, and even requires template to end with `XXXXXX`.
@@ -2802,17 +2804,67 @@ class Guest(
         # parameter.
         # suffix: Optional[str] = None,
         prefix: Optional[str] = None,
-        template: Optional[str] = None,
-        parent: Optional[Path] = None,
+    ) -> Iterator[Path]:
+        """
+        Create a temporary file.
+
+        Modeled after :py:func:`tempfile.NamedTemporaryFile`, but creates
+        the temporary file on the guest, by invoking ``mktemp``-like
+        command. The implementation may slightly differ, but the temporary
+        file should be created safely, without conflicts, and it should
+        be accessible only to user who created it.
+
+        Since the caller is responsible for removing the file, it is
+        recommended to use it as a context manager, just as one would
+        use :py:func:`tempfile.NamedTemporaryFile`; leaving the context
+        will remove the file:
+
+        .. code-block:: python
+
+            with guest.remote_tmpfile() as path:
+                ...
+
+        :param prefix: if set, the directory name will begin with this
+            string.
+        """
+
+        self.execute(Command('mkdir', '-p', self.run_tmpdir))
+
+        output = self.execute(self._construct_mktemp_command(prefix=prefix))
+
+        if not output.stdout:
+            raise GeneralError(f"Failed to create temporary directory on guest: {output.stderr}")
+
+        path = Path(output.stdout.strip())
+
+        try:
+            yield path
+
+        except Exception as exc:
+            raise exc
+
+        else:
+            self.execute(Command('rm', '-f', path))
+
+    @contextlib.contextmanager
+    def guest_tmpdir(
+        self,
+        # Suffix is not supported everywhere, namely Alpine does not
+        # recognize it, and even requires template to end with `XXXXXX`.
+        # Therefore not supporting this option - in the future, someone
+        # may need it, fix it for all distros, and uncomment the
+        # parameter.
+        # suffix: Optional[str] = None,
+        prefix: Optional[str] = None,
     ) -> Iterator[Path]:
         """
         Create a temporary directory.
 
         Modeled after :py:func:`tempfile.mkdtemp`, but creates the
-        temporary directory on the guest, by invoking ``mktemp -d``. The
-        implementation may slightly differ, but the temporary directory
-        should be created safely, without conflicts, and it should be
-        accessible only to user who created it.
+        temporary directory on the guest, by invoking ``mktemp -d``-like
+        command. The implementation may slightly differ, but the temporary
+        directory should be created safely, without conflicts, and it
+        should be accessible only to user who created it.
 
         Since the caller is responsible for removing the directory, it
         is recommended to use it as a context manager, just as one would
@@ -2821,22 +2873,16 @@ class Guest(
 
         .. code-block:: python
 
-            with guest.mkdtemp() as path:
+            with guest.remote_tmpdir() as path:
                 ...
 
         :param prefix: if set, the directory name will begin with this
             string.
-        :param template: if set, the directory name will follow the
-            given naming scheme: the template must end with 6
-            consecutive ``X``s, i.e. ``XXXXXX``. All ``X`` letters will
-            be replaced with random characters.
-        :param parent: if set, new directory will be created under this
-            path. Otherwise, the default directory is used.
         """
 
-        output = self.execute(
-            self._construct_mkdtemp_command(prefix=prefix, template=template, parent=parent)
-        )
+        self.execute(Command('mkdir', '-p', self.run_tmpdir))
+
+        output = self.execute(self._construct_mktemp_command(prefix=prefix))
 
         if not output.stdout:
             raise GeneralError(f"Failed to create temporary directory on guest: {output.stderr}")
@@ -3726,7 +3772,7 @@ class GuestSsh(Guest, CommandCollector):
             self.debug(f"Copy '{source}' from the guest to '{destination}'.")
 
         try:
-            with self.tmpdir(prefix='rsync-') as rsync_tempdir:
+            with self.runner_tmpdir(prefix='rsync-') as rsync_tempdir:
                 self._run_guest_command(
                     Command(
                         "rsync",

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2821,7 +2821,7 @@ class Guest(
 
         .. code-block:: python
 
-            with guest.remote_tmpfile() as path:
+            with guest.guest_tmpfile() as path:
                 ...
 
         :param prefix: if set, the directory name will begin with this
@@ -2833,7 +2833,7 @@ class Guest(
         output = self.execute(self._construct_mktemp_command(prefix=prefix))
 
         if not output.stdout:
-            raise GeneralError(f"Failed to create temporary directory on guest: {output.stderr}")
+            raise GeneralError(f"Failed to create temporary file on guest: {output.stderr}")
 
         path = Path(output.stdout.strip())
 
@@ -2873,7 +2873,7 @@ class Guest(
 
         .. code-block:: python
 
-            with guest.remote_tmpdir() as path:
+            with guest.guest_tmpdir() as path:
                 ...
 
         :param prefix: if set, the directory name will begin with this
@@ -2882,7 +2882,7 @@ class Guest(
 
         self.execute(Command('mkdir', '-p', self.run_tmpdir))
 
-        output = self.execute(self._construct_mktemp_command(prefix=prefix))
+        output = self.execute(self._construct_mktemp_command(prefix=prefix, directory=True))
 
         if not output.stdout:
             raise GeneralError(f"Failed to create temporary directory on guest: {output.stderr}")

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2828,26 +2828,28 @@ class Guest(
             else:
                 logger.info(log.name, str(log.filepath))
 
-    def _construct_mkdtemp_command(
+    def _construct_mktemp_command(
         self,
+        template: str = 'tmp.XXXXXXXXXX',
         prefix: Optional[str] = None,
-        template: Optional[str] = None,
-        parent: Optional[Path] = None,
+        suffix: Optional[str] = None,
+        directory: bool = False,
     ) -> Command:
-        template = template or 'tmp.XXXXXXXXXX'
-
         if prefix is not None:
             template = f'{prefix}{template}'
 
-        options: list[str] = ['--directory']
+        if suffix is not None:
+            template = f'{template}{suffix}'
 
-        if parent is not None:
-            options += ['-p', str(parent)]
+        options: list[str] = ['-p', str(self.run_tmpdir)]
+
+        if directory:
+            options.append('--directory')
 
         return Command(*('mktemp', *options, template))
 
     @contextlib.contextmanager
-    def mkdtemp(
+    def guest_tmpfile(
         self,
         # Suffix is not supported everywhere, namely Alpine does not
         # recognize it, and even requires template to end with `XXXXXX`.
@@ -2856,17 +2858,67 @@ class Guest(
         # parameter.
         # suffix: Optional[str] = None,
         prefix: Optional[str] = None,
-        template: Optional[str] = None,
-        parent: Optional[Path] = None,
+    ) -> Iterator[Path]:
+        """
+        Create a temporary file.
+
+        Modeled after :py:func:`tempfile.NamedTemporaryFile`, but creates
+        the temporary file on the guest, by invoking ``mktemp``-like
+        command. The implementation may slightly differ, but the temporary
+        file should be created safely, without conflicts, and it should
+        be accessible only to user who created it.
+
+        Since the caller is responsible for removing the file, it is
+        recommended to use it as a context manager, just as one would
+        use :py:func:`tempfile.NamedTemporaryFile`; leaving the context
+        will remove the file:
+
+        .. code-block:: python
+
+            with guest.remote_tmpfile() as path:
+                ...
+
+        :param prefix: if set, the directory name will begin with this
+            string.
+        """
+
+        self.execute(Command('mkdir', '-p', self.run_tmpdir))
+
+        output = self.execute(self._construct_mktemp_command(prefix=prefix))
+
+        if not output.stdout:
+            raise GeneralError(f"Failed to create temporary directory on guest: {output.stderr}")
+
+        path = Path(output.stdout.strip())
+
+        try:
+            yield path
+
+        except Exception as exc:
+            raise exc
+
+        else:
+            self.execute(Command('rm', '-f', path))
+
+    @contextlib.contextmanager
+    def guest_tmpdir(
+        self,
+        # Suffix is not supported everywhere, namely Alpine does not
+        # recognize it, and even requires template to end with `XXXXXX`.
+        # Therefore not supporting this option - in the future, someone
+        # may need it, fix it for all distros, and uncomment the
+        # parameter.
+        # suffix: Optional[str] = None,
+        prefix: Optional[str] = None,
     ) -> Iterator[Path]:
         """
         Create a temporary directory.
 
         Modeled after :py:func:`tempfile.mkdtemp`, but creates the
-        temporary directory on the guest, by invoking ``mktemp -d``. The
-        implementation may slightly differ, but the temporary directory
-        should be created safely, without conflicts, and it should be
-        accessible only to user who created it.
+        temporary directory on the guest, by invoking ``mktemp -d``-like
+        command. The implementation may slightly differ, but the temporary
+        directory should be created safely, without conflicts, and it
+        should be accessible only to user who created it.
 
         Since the caller is responsible for removing the directory, it
         is recommended to use it as a context manager, just as one would
@@ -2875,22 +2927,16 @@ class Guest(
 
         .. code-block:: python
 
-            with guest.mkdtemp() as path:
+            with guest.remote_tmpdir() as path:
                 ...
 
         :param prefix: if set, the directory name will begin with this
             string.
-        :param template: if set, the directory name will follow the
-            given naming scheme: the template must end with 6
-            consecutive ``X``s, i.e. ``XXXXXX``. All ``X`` letters will
-            be replaced with random characters.
-        :param parent: if set, new directory will be created under this
-            path. Otherwise, the default directory is used.
         """
 
-        output = self.execute(
-            self._construct_mkdtemp_command(prefix=prefix, template=template, parent=parent)
-        )
+        self.execute(Command('mkdir', '-p', self.run_tmpdir))
+
+        output = self.execute(self._construct_mktemp_command(prefix=prefix))
 
         if not output.stdout:
             raise GeneralError(f"Failed to create temporary directory on guest: {output.stderr}")
@@ -3796,7 +3842,7 @@ class GuestSsh(Guest, CommandCollector):
             self.debug(f"Copy '{source}' from the guest to '{destination}'.")
 
         try:
-            with self.tmpdir(prefix='rsync-') as rsync_tempdir:
+            with self.runner_tmpdir(prefix='rsync-') as rsync_tempdir:
                 self._run_guest_command(
                     Command(
                         "rsync",

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2875,7 +2875,7 @@ class Guest(
 
         .. code-block:: python
 
-            with guest.remote_tmpfile() as path:
+            with guest.guest_tmpfile() as path:
                 ...
 
         :param prefix: if set, the directory name will begin with this
@@ -2887,7 +2887,7 @@ class Guest(
         output = self.execute(self._construct_mktemp_command(prefix=prefix))
 
         if not output.stdout:
-            raise GeneralError(f"Failed to create temporary directory on guest: {output.stderr}")
+            raise GeneralError(f"Failed to create temporary file on guest: {output.stderr}")
 
         path = Path(output.stdout.strip())
 
@@ -2927,7 +2927,7 @@ class Guest(
 
         .. code-block:: python
 
-            with guest.remote_tmpdir() as path:
+            with guest.guest_tmpdir() as path:
                 ...
 
         :param prefix: if set, the directory name will begin with this
@@ -2936,7 +2936,7 @@ class Guest(
 
         self.execute(Command('mkdir', '-p', self.run_tmpdir))
 
-        output = self.execute(self._construct_mktemp_command(prefix=prefix))
+        output = self.execute(self._construct_mktemp_command(prefix=prefix, directory=True))
 
         if not output.stdout:
             raise GeneralError(f"Failed to create temporary directory on guest: {output.stderr}")

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -251,7 +251,7 @@ class Bootc(PackageManager[BootcEngine]):
         image_tag = f"{LOCALHOST_BOOTC_IMAGE_PREFIX}/bootc/{uuid.uuid4()}"
 
         # Write the final Containerfile
-        with self.guest.mkdtemp() as containerfile_dir:
+        with self.guest.guest_tmpdir() as containerfile_dir:
             containerfile_path = Path(containerfile_dir, 'Containerfile')
 
             containerfile = '\n'.join(self.engine.containerfile_directives)

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -237,7 +237,7 @@ class Bootc(PackageManager[BootcEngine]):
         image_tag = f"{LOCALHOST_BOOTC_IMAGE_PREFIX}/bootc/{uuid.uuid4()}"
 
         # Write the final Containerfile
-        with self.guest.mkdtemp() as containerfile_dir:
+        with self.guest.guest_tmpdir() as containerfile_dir:
             containerfile_path = Path(containerfile_dir, 'Containerfile')
 
             containerfile = '\n'.join(self.engine.containerfile_directives)

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -363,7 +363,7 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin[DiscoverShellData]):
                         "used only when fmf root is the same as git root."
                     )
 
-                with self.tmpdir(prefix='rsync-') as rsync_tempdir:
+                with self.runner_tmpdir(prefix='rsync-') as rsync_tempdir:
                     self.run(
                         Command(
                             "rsync",

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -364,7 +364,7 @@ class DiscoverShell(tmt.steps.discover.DiscoverPlugin[DiscoverShellData]):
                         "used only when fmf root is the same as git root."
                     )
 
-                with self.tmpdir(prefix='rsync-') as rsync_tempdir:
+                with self.runner_tmpdir(prefix='rsync-') as rsync_tempdir:
                     self.run(
                         Command(
                             "rsync",

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1575,7 +1575,32 @@ class HasRunWorkdir(abc.ABC):
         return path
 
     @contextlib.contextmanager
-    def tmpdir(self, prefix: Optional[str] = None, suffix: Optional[str] = None) -> Iterator[Path]:
+    def runner_tmpfile(
+        self, prefix: Optional[str] = None, suffix: Optional[str] = None
+    ) -> Iterator[Path]:
+        """
+        Path to a new, unique temporary file.
+
+        The file is created with the help of
+        :py:func:`tempfile.NamedTemporaryFile`, using it to manage the
+        file itself. The newly created temporary file is
+        located under the :py:attr:`run_tempdir` directory.
+        """
+
+        with tempfile.NamedTemporaryFile(
+            prefix=prefix,
+            suffix=suffix,
+            dir=self.run_tmpdir,
+            delete=False,
+        ) as f:
+            f.close()
+
+            yield Path(f.name)
+
+    @contextlib.contextmanager
+    def runner_tmpdir(
+        self, prefix: Optional[str] = None, suffix: Optional[str] = None
+    ) -> Iterator[Path]:
         """
         Path to a new, unique temporary directory.
 
@@ -1588,7 +1613,7 @@ class HasRunWorkdir(abc.ABC):
         with tempfile.TemporaryDirectory(
             prefix=prefix, suffix=suffix, dir=self.run_tmpdir
         ) as path:
-            yield self.run_tmpdir / path
+            yield Path(path)
 
 
 class HasUserAnchorPath(abc.ABC):

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1595,7 +1595,13 @@ class HasRunWorkdir(abc.ABC):
         ) as f:
             f.close()
 
-            yield Path(f.name)
+            path = Path(f.name)
+
+            try:
+                yield path
+
+            finally:
+                path.unlink(missing_ok=True)
 
     @contextlib.contextmanager
     def runner_tmpdir(

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1008,7 +1008,32 @@ class HasRunWorkdir(abc.ABC):
         return path
 
     @contextlib.contextmanager
-    def tmpdir(self, prefix: Optional[str] = None, suffix: Optional[str] = None) -> Iterator[Path]:
+    def runner_tmpfile(
+        self, prefix: Optional[str] = None, suffix: Optional[str] = None
+    ) -> Iterator[Path]:
+        """
+        Path to a new, unique temporary file.
+
+        The file is created with the help of
+        :py:func:`tempfile.NamedTemporaryFile`, using it to manage the
+        file itself. The newly created temporary file is
+        located under the :py:attr:`run_tempdir` directory.
+        """
+
+        with tempfile.NamedTemporaryFile(
+            prefix=prefix,
+            suffix=suffix,
+            dir=self.run_tmpdir,
+            delete=False,
+        ) as f:
+            f.close()
+
+            yield Path(f.name)
+
+    @contextlib.contextmanager
+    def runner_tmpdir(
+        self, prefix: Optional[str] = None, suffix: Optional[str] = None
+    ) -> Iterator[Path]:
         """
         Path to a new, unique temporary directory.
 
@@ -1021,7 +1046,7 @@ class HasRunWorkdir(abc.ABC):
         with tempfile.TemporaryDirectory(
             prefix=prefix, suffix=suffix, dir=self.run_tmpdir
         ) as path:
-            yield self.run_tmpdir / path
+            yield Path(path)
 
 
 class HasUserAnchorPath(abc.ABC):

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1028,7 +1028,13 @@ class HasRunWorkdir(abc.ABC):
         ) as f:
             f.close()
 
-            yield Path(f.name)
+            path = Path(f.name)
+
+            try:
+                yield path
+
+            finally:
+                path.unlink(missing_ok=True)
 
     @contextlib.contextmanager
     def runner_tmpdir(


### PR DESCRIPTION
* renames: `tmp*` => `runner_tmp*`;
* adds: `runner_tmpfile`, `guest_tmpfile`, `guest_tmpdir`.

Both families work as context managers, have the same API, same parameters.

Related to #2609.

Pull Request Checklist

* [x] implement the feature