### PR TITLE
Add "frozen" variant of Command class, for base commands

### DIFF
--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1881,12 +1881,12 @@ def test_frozen_command_addition() -> None:
     # Also a simple addition, but saved into a variable
     d = a + b
 
-    assert isinstance(d, FrozenCommand)
+    assert isinstance(d, Command)
     assert d.to_element() == 'foo bar baz'
 
     d = a + c
 
-    assert isinstance(d, FrozenCommand)
+    assert isinstance(d, Command)
     assert d.to_element() == 'foo bar quux'
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -29,6 +29,7 @@ from tmt.log import Logger
 from tmt.utils import (
     Command,
     Common,
+    FrozenCommand,
     GeneralError,
     Path,
     ShellScript,
@@ -1825,3 +1826,87 @@ def test_render_command_report_minimal():
 # Finished successfully
 """
     )
+
+
+def test_command_addition() -> None:
+    a = Command('foo', 'bar')
+    b = Command('baz')
+    c = Command('quux')
+
+    # Simple addition
+    assert (a + b).to_element() == 'foo bar baz'
+    assert (a + c).to_element() == 'foo bar quux'
+
+    # Also a simple addition, but saved into a variable
+    d = a + b
+
+    assert isinstance(d, Command)
+    assert d.to_element() == 'foo bar baz'
+
+    d = a + c
+
+    assert isinstance(d, Command)
+    assert d.to_element() == 'foo bar quux'
+
+
+def test_command_inplace_addition() -> None:
+    a = original_a = Command('foo', 'bar')
+    b = Command('baz')
+    c = FrozenCommand('quux')
+
+    a += b
+
+    assert a.to_element() == 'foo bar baz'
+    assert b.to_element() == 'baz'
+    assert a is original_a
+
+    a = original_a = Command('foo', 'bar')
+
+    a += c
+
+    assert a.to_element() == 'foo bar quux'
+    assert c.to_element() == 'quux'
+    assert a is original_a
+
+
+def test_frozen_command_addition() -> None:
+    a = FrozenCommand('foo', 'bar')
+    b = FrozenCommand('baz')
+    c = Command('quux')
+
+    # Simple addition
+    assert (a + b).to_element() == 'foo bar baz'
+    assert (a + c).to_element() == 'foo bar quux'
+
+    # Also a simple addition, but saved into a variable
+    d = a + b
+
+    assert isinstance(d, FrozenCommand)
+    assert d.to_element() == 'foo bar baz'
+
+    d = a + c
+
+    assert isinstance(d, FrozenCommand)
+    assert d.to_element() == 'foo bar quux'
+
+
+def test_frozen_command_inplace_addition() -> None:
+    a = original_a = FrozenCommand('foo', 'bar')
+    b = FrozenCommand('baz')
+    c = Command('quux')
+
+    original_a = a
+
+    with pytest.raises(GeneralError):
+        a += b
+
+    assert a.to_element() == 'foo bar'
+    assert b.to_element() == 'baz'
+    assert a is original_a
+
+    with pytest.raises(GeneralError):
+        a += c
+
+    assert a.to_element() == 'foo bar'
+    assert c.to_element() == 'quux'
+    assert a is original_a

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -31,6 +31,7 @@ from tmt.log import Logger
 from tmt.utils import (
     Command,
     Common,
+    FrozenCommand,
     GeneralError,
     Path,
     ShellScript,
@@ -1842,3 +1843,87 @@ def test_render_template_sandbox() -> None:
 
     with pytest.raises(GeneralError, match=r"Template used forbidden operation\."):
         tmt.utils.templates.render_template('{{ RESULT.__init__.__globals__ }}', RESULT=result)
+
+
+def test_command_addition() -> None:
+    a = Command('foo', 'bar')
+    b = Command('baz')
+    c = Command('quux')
+
+    # Simple addition
+    assert (a + b).to_element() == 'foo bar baz'
+    assert (a + c).to_element() == 'foo bar quux'
+
+    # Also a simple addition, but saved into a variable
+    d = a + b
+
+    assert isinstance(d, Command)
+    assert d.to_element() == 'foo bar baz'
+
+    d = a + c
+
+    assert isinstance(d, Command)
+    assert d.to_element() == 'foo bar quux'
+
+
+def test_command_inplace_addition() -> None:
+    a = original_a = Command('foo', 'bar')
+    b = Command('baz')
+    c = FrozenCommand('quux')
+
+    a += b
+
+    assert a.to_element() == 'foo bar baz'
+    assert b.to_element() == 'baz'
+    assert a is original_a
+
+    a = original_a = Command('foo', 'bar')
+
+    a += c
+
+    assert a.to_element() == 'foo bar quux'
+    assert c.to_element() == 'quux'
+    assert a is original_a
+
+
+def test_frozen_command_addition() -> None:
+    a = FrozenCommand('foo', 'bar')
+    b = FrozenCommand('baz')
+    c = Command('quux')
+
+    # Simple addition
+    assert (a + b).to_element() == 'foo bar baz'
+    assert (a + c).to_element() == 'foo bar quux'
+
+    # Also a simple addition, but saved into a variable
+    d = a + b
+
+    assert isinstance(d, FrozenCommand)
+    assert d.to_element() == 'foo bar baz'
+
+    d = a + c
+
+    assert isinstance(d, FrozenCommand)
+    assert d.to_element() == 'foo bar quux'
+
+
+def test_frozen_command_inplace_addition() -> None:
+    a = original_a = FrozenCommand('foo', 'bar')
+    b = FrozenCommand('baz')
+    c = Command('quux')
+
+    original_a = a
+
+    with pytest.raises(GeneralError):
+        a += b
+
+    assert a.to_element() == 'foo bar'
+    assert b.to_element() == 'baz'
+    assert a is original_a
+
+    with pytest.raises(GeneralError):
+        a += c
+
+    assert a.to_element() == 'foo bar'
+    assert c.to_element() == 'quux'
+    assert a is original_a

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1898,12 +1898,12 @@ def test_frozen_command_addition() -> None:
     # Also a simple addition, but saved into a variable
     d = a + b
 
-    assert isinstance(d, FrozenCommand)
+    assert isinstance(d, Command)
     assert d.to_element() == 'foo bar baz'
 
     d = a + c
 
-    assert isinstance(d, FrozenCommand)
+    assert isinstance(d, Command)
     assert d.to_element() == 'foo bar quux'
 
 

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -24,7 +24,15 @@ import tmt.log
 import tmt.plugins
 import tmt.utils
 from tmt.container import container, simple_field
-from tmt.utils import Command, CommandOutput, GeneralError, Path, PrepareError, ShellScript
+from tmt.utils import (
+    Command,
+    CommandOutput,
+    FrozenCommand,
+    GeneralError,
+    Path,
+    PrepareError,
+    ShellScript,
+)
 
 if TYPE_CHECKING:
     from tmt._compat.typing import TypeAlias
@@ -338,8 +346,8 @@ class Options:
 
 
 class PackageManagerEngine(tmt.utils.Common):
-    command: Command
-    options: Command
+    command: FrozenCommand
+    options: FrozenCommand
 
     def __init__(self, *, guest: 'Guest', logger: tmt.log.Logger) -> None:
         super().__init__(logger=logger)
@@ -349,7 +357,7 @@ class PackageManagerEngine(tmt.utils.Common):
         self.command, self.options = self.prepare_command()
 
     @abc.abstractmethod
-    def prepare_command(self) -> tuple[Command, Command]:
+    def prepare_command(self) -> tuple[FrozenCommand, FrozenCommand]:
         """
         Prepare installation command and subcommand options
         """

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -24,7 +24,15 @@ import tmt.log
 import tmt.plugins
 import tmt.utils
 from tmt.container import container, simple_field
-from tmt.utils import Command, CommandOutput, GeneralError, Path, PrepareError, ShellScript
+from tmt.utils import (
+    Command,
+    CommandOutput,
+    FrozenCommand,
+    GeneralError,
+    Path,
+    PrepareError,
+    ShellScript,
+)
 
 if TYPE_CHECKING:
     from tmt._compat.typing import TypeAlias
@@ -351,8 +359,8 @@ class Options:
 
 
 class PackageManagerEngine(tmt.utils.Common):
-    command: Command
-    options: Command
+    command: FrozenCommand
+    options: FrozenCommand
 
     def __init__(self, *, guest: 'Guest', logger: tmt.log.Logger) -> None:
         super().__init__(logger=logger)
@@ -362,7 +370,7 @@ class PackageManagerEngine(tmt.utils.Common):
         self.command, self.options = self.prepare_command()
 
     @abc.abstractmethod
-    def prepare_command(self) -> tuple[Command, Command]:
+    def prepare_command(self) -> tuple[FrozenCommand, FrozenCommand]:
         """
         Prepare installation command and subcommand options
         """

--- a/tmt/package_managers/apk.py
+++ b/tmt/package_managers/apk.py
@@ -16,6 +16,7 @@ from tmt.package_managers import (
 from tmt.utils import (
     Command,
     CommandOutput,
+    FrozenCommand,
     GeneralError,
     RunError,
     ShellScript,
@@ -35,19 +36,18 @@ PACKAGE_PATH: dict[FileSystemPath, str] = {
 
 
 class ApkEngine(PackageManagerEngine):
-    install_command = Command('add')
+    install_command = FrozenCommand('add')
 
-    def prepare_command(self) -> tuple[Command, Command]:
+    def prepare_command(self) -> tuple[FrozenCommand, FrozenCommand]:
         """
         Prepare installation command for apk
         """
         assert self.guest.facts.sudo_prefix is not None  # Narrow type
-        command = Command('apk')
 
         if self.guest.facts.sudo_prefix:
-            command = Command(self.guest.facts.sudo_prefix, 'apk')
+            return (FrozenCommand(self.guest.facts.sudo_prefix, 'apk'), FrozenCommand())
 
-        return (command, Command())
+        return (FrozenCommand('apk'), FrozenCommand())
 
     def path_to_package(self, path: FileSystemPath) -> Package:
         """

--- a/tmt/package_managers/apt.py
+++ b/tmt/package_managers/apt.py
@@ -16,6 +16,7 @@ from tmt.package_managers import (
 from tmt.utils import (
     Command,
     CommandOutput,
+    FrozenCommand,
     GeneralError,
     RunError,
     ShellScript,
@@ -77,22 +78,20 @@ exit $?
 
 
 class AptEngine(PackageManagerEngine):
-    install_command = Command('install')
+    install_command = FrozenCommand('install')
 
-    def prepare_command(self) -> tuple[Command, Command]:
+    def prepare_command(self) -> tuple[FrozenCommand, FrozenCommand]:
         """
         Prepare installation command for apt
         """
         assert self.guest.facts.sudo_prefix is not None  # Narrow type
 
-        command = Command('apt')
+        options = FrozenCommand('-y')
 
         if self.guest.facts.sudo_prefix:
-            command = Command(self.guest.facts.sudo_prefix, 'apt')
+            return (FrozenCommand(self.guest.facts.sudo_prefix, 'apt'), options)
 
-        options = Command('-y')
-
-        return (command, options)
+        return (FrozenCommand('apt'), options)
 
     def _enable_apt_file(self) -> ShellScript:
         return ShellScript(
@@ -256,7 +255,7 @@ class Apt(PackageManager[AptEngine]):
         re.compile(r'(?:E:\s+)?Unable to locate package\s+([^\s]+)', re.IGNORECASE)
     ]
 
-    probe_command = Command('apt', '--version')
+    probe_command = FrozenCommand('apt', '--version')
 
     def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
         presence_script = self.engine.check_presence(*installables)

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -14,7 +14,7 @@ from tmt.package_managers import (
     PackageManagerEngine,
     provides_package_manager,
 )
-from tmt.utils import Command, CommandOutput, Path, ShellScript
+from tmt.utils import Command, CommandOutput, FrozenCommand, Path, ShellScript
 
 LOCALHOST_BOOTC_IMAGE_PREFIX = "localhost/tmt"
 
@@ -81,24 +81,21 @@ class BootcEngine(PackageManagerEngine):
 
         self.containerfile_directives = []
 
-    def prepare_command(self) -> tuple[Command, Command]:
+    def prepare_command(self) -> tuple[FrozenCommand, FrozenCommand]:
         """
         Prepare installation command for bootc
         """
         assert self.guest.facts.sudo_prefix is not None  # Narrow type
 
-        command = Command('bootc')
-
         if self.guest.facts.sudo_prefix:
-            command = Command(self.guest.facts.sudo_prefix, 'bootc')
+            return (FrozenCommand(self.guest.facts.sudo_prefix, 'bootc'), FrozenCommand())
 
-        return command, Command('')
+        return (FrozenCommand('bootc'), FrozenCommand())
 
     def _get_current_bootc_image(self) -> str:
         """Get the current bootc image running on the system"""
 
-        command, _ = self.prepare_command()
-        command += Command('status', '--json')
+        command = self.command + Command('status', '--json')
 
         if not (output := self.guest.execute(command, silent=True).stdout):
             raise tmt.utils.PrepareError("Failed to get current bootc status: empty output.")
@@ -290,8 +287,9 @@ class Bootc(PackageManager[BootcEngine]):
                 # Switch to the new image for next boot
                 self.info("package", f"switching to new image {image_tag}", "green")
 
-                bootc_command, _ = self.engine.prepare_command()
-                bootc_command += Command('switch', '--transport', 'containers-storage', image_tag)
+                bootc_command = self.engine.command + Command(
+                    'switch', '--transport', 'containers-storage', image_tag
+                )
                 self.guest.execute(bootc_command)
 
                 # Reboot into the new image

--- a/tmt/package_managers/bootc.py
+++ b/tmt/package_managers/bootc.py
@@ -15,7 +15,7 @@ from tmt.package_managers import (
     PackageManagerEngine,
     provides_package_manager,
 )
-from tmt.utils import Command, CommandOutput, Path, ShellScript
+from tmt.utils import Command, CommandOutput, FrozenCommand, Path, ShellScript
 
 LOCALHOST_BOOTC_IMAGE_PREFIX = "localhost/tmt"
 
@@ -82,24 +82,21 @@ class BootcEngine(PackageManagerEngine):
 
         self.containerfile_directives = []
 
-    def prepare_command(self) -> tuple[Command, Command]:
+    def prepare_command(self) -> tuple[FrozenCommand, FrozenCommand]:
         """
         Prepare installation command for bootc
         """
         assert self.guest.facts.sudo_prefix is not None  # Narrow type
 
-        command = Command('bootc')
-
         if self.guest.facts.sudo_prefix:
-            command = Command(self.guest.facts.sudo_prefix, 'bootc')
+            return (FrozenCommand(self.guest.facts.sudo_prefix, 'bootc'), FrozenCommand())
 
-        return command, Command('')
+        return (FrozenCommand('bootc'), FrozenCommand())
 
     def _get_current_bootc_image(self) -> str:
         """Get the current bootc image running on the system"""
 
-        command, _ = self.prepare_command()
-        command += Command('status', '--json')
+        command = self.command + Command('status', '--json')
 
         if not (output := self.guest.execute(command, silent=True).stdout):
             raise tmt.utils.PrepareError("Failed to get current bootc status: empty output.")
@@ -291,8 +288,9 @@ class Bootc(PackageManager[BootcEngine]):
                 # Switch to the new image for next boot
                 self.info("package", f"switching to new image {image_tag}", "green")
 
-                bootc_command, _ = self.engine.prepare_command()
-                bootc_command += Command('switch', '--transport', 'containers-storage', image_tag)
+                bootc_command = self.engine.command + Command(
+                    'switch', '--transport', 'containers-storage', image_tag
+                )
                 self.guest.execute(bootc_command)
 
                 # Reboot into the new image

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -38,7 +38,12 @@ class DnfEngine(PackageManagerEngine):
         options = FrozenCommand('-y')
 
         if self.guest.facts.sudo_prefix:
-            return (FrozenCommand(self.guest.facts.sudo_prefix) + self._base_command, options)
+            return (
+                FrozenCommand.from_command(
+                    Command(self.guest.facts.sudo_prefix) + self._base_command
+                ),
+                options,
+            )
 
         return (self._base_command, options)
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -1,4 +1,3 @@
-import copy
 import re
 from collections.abc import Iterable, Sequence
 from typing import ClassVar, Optional, cast
@@ -18,26 +17,30 @@ from tmt.package_managers import (
     provides_package_manager,
 )
 from tmt.package_managers._rpm import RpmVersion
-from tmt.utils import Command, CommandOutput, GeneralError, PrepareError, ShellScript
+from tmt.utils import (
+    Command,
+    CommandOutput,
+    FrozenCommand,
+    GeneralError,
+    PrepareError,
+    ShellScript,
+)
 
 
 class DnfEngine(PackageManagerEngine):
-    _base_command = Command('dnf')
-    _base_debuginfo_command = Command('debuginfo-install')
+    _base_command = FrozenCommand('dnf')
+    _base_debuginfo_command = FrozenCommand('debuginfo-install')
 
     skip_missing_packages_option = '--skip-broken'
     skip_missing_debuginfo_option = skip_missing_packages_option
 
-    def prepare_command(self) -> tuple[Command, Command]:
-        options = Command('-y')
+    def prepare_command(self) -> tuple[FrozenCommand, FrozenCommand]:
+        options = FrozenCommand('-y')
 
         if self.guest.facts.sudo_prefix:
-            command = Command(self.guest.facts.sudo_prefix) + self._base_command
+            return (FrozenCommand(self.guest.facts.sudo_prefix) + self._base_command, options)
 
-        else:
-            command = copy.deepcopy(self._base_command)
-
-        return (command, options)
+        return (self._base_command, options)
 
     def _extra_dnf_options(self, options: Options, command: Optional[Command] = None) -> Command:
         """
@@ -371,8 +374,8 @@ class Dnf(PackageManager[DnfEngine]):
 
 
 class Dnf5Engine(DnfEngine):
-    _base_command = Command('dnf5')
-    _base_debuginfo_command = Command('dnf5', 'debuginfo-install')
+    _base_command = FrozenCommand('dnf5')
+    _base_debuginfo_command = FrozenCommand('dnf5', 'debuginfo-install')
     skip_missing_packages_option = '--skip-unavailable'
     skip_missing_debuginfo_option = skip_missing_packages_option
 
@@ -399,12 +402,12 @@ class Dnf5(Dnf):
     copr_plugin: ClassVar[str] = 'dnf5-command(copr)'
     config_manager_plugin: ClassVar[str] = 'dnf5-command(config-manager)'
 
-    probe_command = Command('dnf5', '--version')
+    probe_command = FrozenCommand('dnf5', '--version')
     probe_priority = 60
 
 
 class YumEngine(DnfEngine):
-    _base_command = Command('yum')
+    _base_command = FrozenCommand('yum')
 
     def _extra_dnf_options(self, options: Options, command: Optional[Command] = None) -> Command:
         if options.allow_erasing:

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -1,4 +1,3 @@
-import copy
 import re
 import shlex
 from collections.abc import Iterable, Sequence
@@ -19,12 +18,19 @@ from tmt.package_managers import (
     provides_package_manager,
 )
 from tmt.package_managers._rpm import RpmVersion
-from tmt.utils import Command, CommandOutput, GeneralError, PrepareError, ShellScript
+from tmt.utils import (
+    Command,
+    CommandOutput,
+    FrozenCommand,
+    GeneralError,
+    PrepareError,
+    ShellScript,
+)
 
 
 class DnfEngine(PackageManagerEngine):
-    _base_command = Command('dnf')
-    _base_debuginfo_command = Command('debuginfo-install')
+    _base_command = FrozenCommand('dnf')
+    _base_debuginfo_command = FrozenCommand('debuginfo-install')
 
     skip_missing_packages_option = '--skip-broken'
     skip_missing_debuginfo_option = skip_missing_packages_option
@@ -64,16 +70,13 @@ class DnfEngine(PackageManagerEngine):
         done
         """)
 
-    def prepare_command(self) -> tuple[Command, Command]:
-        options = Command('-y')
+    def prepare_command(self) -> tuple[FrozenCommand, FrozenCommand]:
+        options = FrozenCommand('-y')
 
         if self.guest.facts.sudo_prefix:
-            command = Command(self.guest.facts.sudo_prefix) + self._base_command
+            return (FrozenCommand(self.guest.facts.sudo_prefix) + self._base_command, options)
 
-        else:
-            command = copy.deepcopy(self._base_command)
-
-        return (command, options)
+        return (self._base_command, options)
 
     def _extra_dnf_options(self, options: Options, command: Optional[Command] = None) -> Command:
         """
@@ -383,8 +386,8 @@ class Dnf(PackageManager[DnfEngine]):
 
 
 class Dnf5Engine(DnfEngine):
-    _base_command = Command('dnf5')
-    _base_debuginfo_command = Command('dnf5', 'debuginfo-install')
+    _base_command = FrozenCommand('dnf5')
+    _base_debuginfo_command = FrozenCommand('dnf5', 'debuginfo-install')
     skip_missing_packages_option = '--skip-unavailable'
     skip_missing_debuginfo_option = skip_missing_packages_option
     _full_nevra_querytag = "%{full_nevra}"
@@ -412,12 +415,12 @@ class Dnf5(Dnf):
     copr_plugin: ClassVar[str] = 'dnf5-command(copr)'
     config_manager_plugin: ClassVar[str] = 'dnf5-command(config-manager)'
 
-    probe_command = Command('dnf5', '--version')
+    probe_command = FrozenCommand('dnf5', '--version')
     probe_priority = 60
 
 
 class YumEngine(DnfEngine):
-    _base_command = Command('yum')
+    _base_command = FrozenCommand('yum')
     _full_nevra_querytag = "%{nevra}"
 
     def _extra_dnf_options(self, options: Options, command: Optional[Command] = None) -> Command:

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -74,7 +74,12 @@ class DnfEngine(PackageManagerEngine):
         options = FrozenCommand('-y')
 
         if self.guest.facts.sudo_prefix:
-            return (FrozenCommand(self.guest.facts.sudo_prefix) + self._base_command, options)
+            return (
+                FrozenCommand.from_command(
+                    Command(self.guest.facts.sudo_prefix) + self._base_command
+                ),
+                options,
+            )
 
         return (self._base_command, options)
 

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -50,7 +50,7 @@ class MockEngine(PackageManagerEngine):
         if self.guest.root is not None:
             options += Command('-r', self.guest.root)
         options += Command('--pm-cmd')
-        return (FrozenCommand('mock'), FrozenCommand(command=options))
+        return (FrozenCommand('mock'), FrozenCommand.from_command(options))
 
     def check_presence(self, *installables: Installable) -> ShellScript:
         return ShellScript(

--- a/tmt/package_managers/mock.py
+++ b/tmt/package_managers/mock.py
@@ -12,7 +12,7 @@ from tmt.package_managers import (
     provides_package_manager,
 )
 from tmt.steps.provision.mock import GuestMock
-from tmt.utils import Command, CommandOutput, PrepareError, ShellScript
+from tmt.utils import Command, CommandOutput, FrozenCommand, PrepareError, ShellScript
 
 
 class MockEngine(PackageManagerEngine):
@@ -44,13 +44,13 @@ class MockEngine(PackageManagerEngine):
             f'{installword} {extra_options} {" ".join(escape_installables(*installables))}'
         )
 
-    def prepare_command(self) -> tuple[Command, Command]:
+    def prepare_command(self) -> tuple[FrozenCommand, FrozenCommand]:
         options = Command()
         assert isinstance(self.guest, GuestMock)
         if self.guest.root is not None:
             options += Command('-r', self.guest.root)
         options += Command('--pm-cmd')
-        return (Command('mock'), options)
+        return (FrozenCommand('mock'), FrozenCommand(command=options))
 
     def check_presence(self, *installables: Installable) -> ShellScript:
         return ShellScript(
@@ -101,7 +101,7 @@ class _MockPackageManager(PackageManager[MockEngine]):
     * self.guest.execute - execute a command *in the mock shell*.
     """
 
-    probe_command = Command('/usr/bin/false')
+    probe_command = FrozenCommand('/usr/bin/false')
     probe_priority = 130
     _engine_class = MockEngine
 

--- a/tmt/package_managers/rpm_ostree.py
+++ b/tmt/package_managers/rpm_ostree.py
@@ -12,23 +12,32 @@ from tmt.package_managers import (
     escape_installables,
     provides_package_manager,
 )
-from tmt.utils import Command, CommandOutput, GeneralError, PrepareError, RunError, ShellScript
+from tmt.utils import (
+    Command,
+    CommandOutput,
+    FrozenCommand,
+    GeneralError,
+    PrepareError,
+    RunError,
+    ShellScript,
+)
 
 
 class RpmOstreeEngine(PackageManagerEngine):
-    def prepare_command(self) -> tuple[Command, Command]:
+    def prepare_command(self) -> tuple[FrozenCommand, FrozenCommand]:
         """
         Prepare installation command for rpm-ostree
         """
 
         assert self.guest.facts.sudo_prefix is not None  # Narrow type
 
-        command = Command('rpm-ostree')
-
         if self.guest.facts.sudo_prefix:
-            command = Command(self.guest.facts.sudo_prefix, 'rpm-ostree')
+            command = FrozenCommand(self.guest.facts.sudo_prefix, 'rpm-ostree')
 
-        options = Command('--apply-live', '--idempotent', '--allow-inactive', '--assumeyes')
+        else:
+            command = FrozenCommand('rpm-ostree')
+
+        options = FrozenCommand('--apply-live', '--idempotent', '--allow-inactive', '--assumeyes')
 
         return (command, options)
 
@@ -124,7 +133,7 @@ class RpmOstree(PackageManager[RpmOstreeEngine]):
 
     _engine_class = RpmOstreeEngine
 
-    probe_command = Command('stat', '/run/ostree-booted')
+    probe_command = FrozenCommand('stat', '/run/ostree-booted')
     # Needs to be bigger than priorities of `yum`, `dnf` and `dnf5`.
     probe_priority = 100
 

--- a/tmt/steps/prepare/distgit.py
+++ b/tmt/steps/prepare/distgit.py
@@ -255,11 +255,12 @@ class PrepareDistGit(tmt.steps.prepare.PreparePlugin[DistGitData]):
             else:
                 raise tmt.utils.PrepareError('No src.rpm file created by the `rpmbuild -br` call.')
             # Install build requires
-            # Create the package manager command
-            cmd, _ = guest.package_manager.engine.prepare_command()
             # Can't set 'cwd' as the check for its existence fails for local workdir
-            cmd += Command("builddep", "-y", f"SRPMS/{src_rpm_name}")
-            guest.execute(command=cmd, cwd=Path(source_dir))
+            guest.execute(
+                command=guest.package_manager.engine.command
+                + Command("builddep", "-y", f"SRPMS/{src_rpm_name}"),
+                cwd=Path(source_dir),
+            )
 
         # Finally run the rpm-build -bp
         cmd = Command("rpmbuild", "-bp", spec_name, "--nodeps", *dir_defines)

--- a/tmt/steps/prepare/distgit.py
+++ b/tmt/steps/prepare/distgit.py
@@ -256,11 +256,12 @@ class PrepareDistGit(tmt.steps.prepare.PreparePlugin[DistGitData]):
             else:
                 raise tmt.utils.PrepareError('No src.rpm file created by the `rpmbuild -br` call.')
             # Install build requires
-            # Create the package manager command
-            cmd, _ = guest.package_manager.engine.prepare_command()
             # Can't set 'cwd' as the check for its existence fails for local workdir
-            cmd += Command("builddep", "-y", f"SRPMS/{src_rpm_name}")
-            guest.execute(command=cmd, cwd=Path(source_dir))
+            guest.execute(
+                command=guest.package_manager.engine.command
+                + Command("builddep", "-y", f"SRPMS/{src_rpm_name}"),
+                cwd=Path(source_dir),
+            )
 
         # Finally run the rpm-build -bp
         cmd = Command("rpmbuild", "-bp", spec_name, "--nodeps", *dir_defines)

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -41,6 +41,7 @@ from typing import (
     Final,
     Generic,
     Literal,
+    NoReturn,
     Optional,
     TextIO,
     TypeVar,
@@ -1197,17 +1198,23 @@ class Command:
     A command with its arguments.
     """
 
-    def __init__(self, *elements: RawCommandElement) -> None:
-        self._command = [str(element) for element in elements]
+    _command: list[str]
+
+    def __init__(self, *elements: RawCommandElement, command: Optional['Command'] = None) -> None:
+        if command is not None:
+            self._command = command._command[:]
+
+        else:
+            self._command = [str(element) for element in elements]
 
     def __str__(self) -> str:
         return self.to_element()
 
-    def __add__(self, other: Union['Command', RawCommand]) -> 'Command':
+    def __add__(self, other: Union['Command', RawCommand]) -> Self:
         if isinstance(other, Command):
-            return Command(*self._command, *other._command)
+            return self.__class__(*self._command, *other._command)
 
-        return Command(*self._command, *other)
+        return self.__class__(*self._command, *other)
 
     # While the outcome of `+=` can be emulated by `__add__`, it would
     # return new object. Often we just want to add to the existing object,
@@ -1517,6 +1524,15 @@ class Command:
             )
 
         return output
+
+
+class FrozenCommand(Command):
+    def __iadd__(self, other: Union['Command', RawCommand]) -> NoReturn:  # noqa: PYI034
+        # Do not raise `NotImplemented` - interpreter would be free to
+        # change order of operands, or try another method, which we do
+        # not want to allow: someone just tried to modify a frozen command,
+        # an exception is the least we can do to them.
+        raise GeneralError('In-place modification of frozen command is not allowed.')
 
 
 _SANITIZE_NAME_PATTERN: Pattern[str] = re.compile(r'[^\w/-]+')

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -1201,20 +1201,20 @@ class Command:
     _command: list[str]
 
     def __init__(self, *elements: RawCommandElement, command: Optional['Command'] = None) -> None:
-        if command is not None:
-            self._command = command._command[:]
+        self._command = [str(element) for element in elements]
 
-        else:
-            self._command = [str(element) for element in elements]
+    @classmethod
+    def from_command(cls, other: 'Command') -> Self:
+        return cls(*other._command)
 
     def __str__(self) -> str:
         return self.to_element()
 
-    def __add__(self, other: Union['Command', RawCommand]) -> Self:
+    def __add__(self, other: Union['Command', RawCommand]) -> 'Command':
         if isinstance(other, Command):
-            return self.__class__(*self._command, *other._command)
+            return Command(*self._command, *other._command)
 
-        return self.__class__(*self._command, *other)
+        return Command(*self._command, *other)
 
     # While the outcome of `+=` can be emulated by `__add__`, it would
     # return new object. Often we just want to add to the existing object,

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -632,20 +632,20 @@ class Command:
     _command: list[str]
 
     def __init__(self, *elements: RawCommandElement, command: Optional['Command'] = None) -> None:
-        if command is not None:
-            self._command = command._command[:]
+        self._command = [str(element) for element in elements]
 
-        else:
-            self._command = [str(element) for element in elements]
+    @classmethod
+    def from_command(cls, other: 'Command') -> Self:
+        return cls(*other._command)
 
     def __str__(self) -> str:
         return self.to_element()
 
-    def __add__(self, other: Union['Command', RawCommand]) -> Self:
+    def __add__(self, other: Union['Command', RawCommand]) -> 'Command':
         if isinstance(other, Command):
-            return self.__class__(*self._command, *other._command)
+            return Command(*self._command, *other._command)
 
-        return self.__class__(*self._command, *other)
+        return Command(*self._command, *other)
 
     # While the outcome of `+=` can be emulated by `__add__`, it would
     # return new object. Often we just want to add to the existing object,

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -960,7 +960,7 @@ class Command:
 
 
 class FrozenCommand(Command):
-    def __iadd__(self, other: Union['Command', RawCommand]) -> NoReturn:  # noqa: PYI034
+    def __iadd__(self, other: Union['Command', RawCommand]) -> NoReturn:
         # Do not raise `NotImplemented` - interpreter would be free to
         # change order of operands, or try another method, which we do
         # not want to allow: someone just tried to modify a frozen command,

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -41,6 +41,7 @@ from typing import (
     Final,
     Generic,
     Literal,
+    NoReturn,
     Optional,
     TextIO,
     TypeVar,
@@ -628,17 +629,23 @@ class Command:
     A command with its arguments.
     """
 
-    def __init__(self, *elements: RawCommandElement) -> None:
-        self._command = [str(element) for element in elements]
+    _command: list[str]
+
+    def __init__(self, *elements: RawCommandElement, command: Optional['Command'] = None) -> None:
+        if command is not None:
+            self._command = command._command[:]
+
+        else:
+            self._command = [str(element) for element in elements]
 
     def __str__(self) -> str:
         return self.to_element()
 
-    def __add__(self, other: Union['Command', RawCommand]) -> 'Command':
+    def __add__(self, other: Union['Command', RawCommand]) -> Self:
         if isinstance(other, Command):
-            return Command(*self._command, *other._command)
+            return self.__class__(*self._command, *other._command)
 
-        return Command(*self._command, *other)
+        return self.__class__(*self._command, *other)
 
     # While the outcome of `+=` can be emulated by `__add__`, it would
     # return new object. Often we just want to add to the existing object,
@@ -950,6 +957,15 @@ class Command:
             )
 
         return output
+
+
+class FrozenCommand(Command):
+    def __iadd__(self, other: Union['Command', RawCommand]) -> NoReturn:  # noqa: PYI034
+        # Do not raise `NotImplemented` - interpreter would be free to
+        # change order of operands, or try another method, which we do
+        # not want to allow: someone just tried to modify a frozen command,
+        # an exception is the least we can do to them.
+        raise GeneralError('In-place modification of frozen command is not allowed.')
 
 
 _SANITIZE_NAME_PATTERN: Pattern[str] = re.compile(r'[^\w/-]+')


### PR DESCRIPTION
Somme commands serve as basis for other commands, and we must prevent
modification of these base commands. This is related to the recent fix
of `Command.__iadd__`, and even more recent #5001 bug.