### PR TITLE
Include host PATH in podman unshare environment for ansible execution

### DIFF
--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -172,6 +172,25 @@ def test_execute_no_connection_closed(
     assert output.stdout == stdout
 
 
+def test_container_host_side_ansible_inherits_path(root_logger: Logger, monkeypatch: Any) -> None:
+    step = Mock(spec=Provision)
+    step.plan = Mock()
+    step.plan.worktree = Path('/tmp')
+    guest = GuestContainer(logger=root_logger, data=PodmanGuestData(), name='guest', parent=step)
+    guest.container = 'container'
+
+    monkeypatch.setattr(os, 'geteuid', lambda: 1000)
+    monkeypatch.setenv('PATH', '/host/bin')
+    monkeypatch.setattr(guest, '_prepare_command_environment', Mock(return_value=Environment()))
+    run_guest_command = Mock(return_value=CommandOutput(stdout='', stderr=''))
+    monkeypatch.setattr(guest, '_run_guest_command', run_guest_command)
+
+    guest._run_ansible('namespace.playbook')
+
+    assert run_guest_command.call_args.args[0]._command[:2] == ['podman', 'unshare']
+    assert run_guest_command.call_args.kwargs['environment']['PATH'] == '/host/bin'
+
+
 @pytest.mark.containers
 @pytest.mark.parametrize(
     ('container',),  # noqa: PT006

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -438,9 +438,13 @@ class GuestContainer(tmt.Guest):
 
         # As non-root we must run with podman unshare
         podman_command = Command()
+        environment = self._prepare_command_environment()
 
         if os.geteuid() != 0:
             podman_command += ['podman', 'unshare']
+            host_environment = tmt.utils.Environment.from_environ()
+            host_environment.update(environment)
+            environment = host_environment
 
         # TODO: add ansible inventory support
         podman_command += cast(
@@ -461,7 +465,7 @@ class GuestContainer(tmt.Guest):
             return self._run_guest_command(
                 podman_command,
                 cwd=self.parent.plan.worktree,
-                environment=self._prepare_command_environment(),
+                environment=environment,
                 friendly_command=friendly_command,
                 log=log,
                 silent=silent,


### PR DESCRIPTION
#4900 stopped commands from inheriting `os.environ`, and mentioned that callers should include it themselves when needed. The `podman unshare` path in `GuestContainer._run_ansible` wasn't updated though, so podman's Go runtime can't find `ansible-playbook` without PATH.

The fix is to pass the host `PATH` into the subprocess environment when running under
`podman unshare`.

### Reproduce

Any plan with container provisioning and an ansible prepare step, run as a non-root user:

```yaml
provision:
  - how: container
    image: fedora:latest
prepare:
  - how: ansible
    playbook: playbook.yml
```

```
$ tmt run
Error: exec: "ansible-playbook": executable file not found in $PATH
```
Running with `sudo` works fine since it skips `podman unshare` entirely.
