### PR TITLE
Pass the CLI invocation to the runner

### DIFF
--- a/tmt/base/run.py
+++ b/tmt/base/run.py
@@ -247,6 +247,8 @@ class Run(HasRunWorkdir, HasUserAnchorPath, HasEnvironment, tmt.utils.Common):
             name='tmt runner',
             logger=self._logger,
         )
+        guest_runner.cli_invocation = self.cli_invocation
+
         # Override some facts that we do not want to expose
         # No sudo access on the runner
         guest_runner.facts.can_sudo = False


### PR DESCRIPTION
The `GuestLocal` runner was created without a parent or `cli_invocation`, so CLI flags like `--dry` were always resolved to their defaults. Pass the run instance's CLI invocation explicitly so the runner inherits flags correctly.

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
