### PR TITLE
CLI invocations cannot drop incompatible keys

### DIFF
--- a/tests/core/phases/data/plans.fmf
+++ b/tests/core/phases/data/plans.fmf
@@ -27,3 +27,8 @@ execute:
 /without-how:
   report:
     - order: 60
+
+/with-incompatible-keys:
+  report:
+    - how: html
+      file: junit.xml

--- a/tests/core/phases/test.sh
+++ b/tests/core/phases/test.sh
@@ -196,6 +196,34 @@ default-1:html:never"
         rlAssertEquals "default-0 shall be set to html how" "$(cat $rlRun_LOG)" "default-0:html"
     rlPhaseEnd
 
+    rlPhaseStartTest "Test --update-missing skips incompatible keys"
+        rlRun -s "$run plan -n /with-incompatible-keys \
+            report --update-missing -h junit"
+
+        # `how` must remain untouched, and `file` must remain untouched - CLI invocation is not
+        # compatible with `html`, proper application would leave out `file` key as it's not part
+        # of the shared base.
+        rlAssertGrep "output: junit.xml" $rlRun_LOG
+
+        check "with-incompatible-keys" "One 'html' phase shall exist" "default-0:html:50"
+
+        rlRun -s "yq '.data | .[] | \"\\(.name):\\(.how)\"' $rundir/plans/with-incompatible-keys/report/step.yaml"
+        rlAssertEquals "default-0 shall be set to html how" "$(cat $rlRun_LOG)" "default-0:html"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test --update-missing reports incompatible keys"
+        rlRun -s "$run plan -n /with-report \
+            report --update-missing -h junit --file foo.xml"
+
+        rlAssertGrep "warn: Cannot fully update report phase 'default-0' with 'file' key from command line. Key is recognized by plugin 'junit' but not by plugin 'html'." $rlRun_LOG
+        rlAssertGrep "output: $rundir/plans/with-report/report/default-0/index.html" $rlRun_LOG
+
+        check "with-report" "One 'html' phase shall exist" "default-0:html:50"
+
+        rlRun -s "yq '.data | .[] | \"\\(.name):\\(.how)\"' $rundir/plans/with-report/report/step.yaml"
+        rlAssertEquals "default-0 shall be set to html how" "$(cat $rlRun_LOG)" "default-0:html"
+    rlPhaseEnd
+
     rlPhaseStartTest "Test /with-order"
         rlRun -s "$run plan -n /with-order"
 

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -1417,25 +1417,44 @@ class Step(
                 else:
                     debug3('incompatible step data')
 
+                    # This is very crude - we can find more overlaps between plugins, e.g. `image`
+                    # key is shared by many, yet not available from the base.
                     data_base = cast(
                         type[BasePlugin[StepData, Any]], self._plugin_base_class
                     ).get_data_class()
 
-                    debug3('compatible base', f'{data_base.__module__}.{data_base.__name__}')
-                    debug3('compatible keys', ', '.join(k for k in data_base.keys()))  # noqa: SIM118
+                    compatible_keys = list(data_base.keys())
 
-                    # Copy compatible keys only, ignore everything else
-                    # SIM118: Use `{key} in {dict}` instead of `{key} in {dict}.keys()`.
-                    # "Type[StepData]" has no attribute "__iter__" (not iterable), and
-                    # even though ruff thinks StepData looks like a dict, it's not one.
-                    # ignore[literal-required]: we do create raw step data, but _RawStepData
-                    # is very minimal.
-                    raw_datum = cast(
+                    debug3('compatible base', f'{data_base.__module__}.{data_base.__name__}')
+                    debug3('compatible keys', ', '.join(compatible_keys))
+
+                    # First, report keys that were set by user but we cannot apply them because
+                    # they are not compatible between plugins.
+                    for key in incoming_raw_datum:
+                        if key in compatible_keys:
+                            continue
+
+                        if invocation.option_sources.get(key) not in (
+                            ParameterSource.COMMANDLINE,
+                            ParameterSource.ENVIRONMENT,
+                        ):
+                            continue
+
+                        self.warn(
+                            f"Cannot fully update {self.step_name} phase"
+                            f" '{raw_datum.get('name')}' with '{key}' key from command line."
+                            f" Key is recognized by plugin '{how}'"
+                            f" but not by plugin '{raw_datum.get('how')}'."
+                        )
+
+                    # Then, reduce the incoming datum to only those keys that can affect the target
+                    # datum. Keys that our outside of the compatibility window cannot be applied.
+                    incoming_raw_datum = cast(
                         _RawStepData,
                         {
-                            key: raw_datum[key]  # type: ignore[literal-required]
-                            for key in data_base.keys()  # noqa: SIM118
-                            if key in raw_datum
+                            key: value
+                            for key, value in incoming_raw_datum.items()
+                            if key in compatible_keys
                         },
                     )
 


### PR DESCRIPTION
When a CLI invocation of `--how foo` was applied to `how: bar` phase, some fmf keys were dropped. Keys considered not compatible, i.e. not defined by the shared base step data class, would be replaced with the default value of the plugin from the CLI invocation.

Leaving aside the question of what makes keys compatible, patch fixes how phase and CLI invocation are amended when two incompatible plugins meet, and adds a warning to report keys that have valid values on command line, but are not compatible with the target phase.

See #4890 for the original bug.

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage