### PR TITLE
Use sandboxed environment for Jinja templates

### DIFF
--- a/docs/ext/generate_hardware_matrix.py
+++ b/docs/ext/generate_hardware_matrix.py
@@ -76,6 +76,7 @@ def generate_hardware_matrix(app: "Sphinx") -> None:
     render_template_file_into_file(
         template_filepath,
         output_filepath,
+        sandboxed=False,
         LOGGER=logger,
         MATRIX=matrix,
         NOTES=notes,

--- a/docs/ext/generate_lint_checks.py
+++ b/docs/ext/generate_lint_checks.py
@@ -37,7 +37,7 @@ def generate_lint_checks(app: "Sphinx") -> None:
         'COLLECTION_LINTERS': _sort_linters(LintableCollection.get_linter_registry()),
     }
 
-    render_template_file_into_file(template_filepath, output_filepath, **linters)
+    render_template_file_into_file(template_filepath, output_filepath, sandboxed=False, **linters)
 
 
 def setup(app: "Sphinx"):

--- a/docs/ext/generate_plugins.py
+++ b/docs/ext/generate_plugins.py
@@ -232,6 +232,7 @@ def generate_plugins(app: "Sphinx") -> None:
         render_template_file_into_file(
             template_filepath,
             output_filepath,
+            sandboxed=False,
             LOGGER=logger,
             STEP=step_name,
             PLUGINS=plugin_generator,

--- a/docs/ext/generate_template_extensions.py
+++ b/docs/ext/generate_template_extensions.py
@@ -23,6 +23,7 @@ def generate_template_extensions(app: "Sphinx") -> None:
     render_template_file_into_file(
         template_filepath,
         output_filepath,
+        sandboxed=False,
         FILTERS=TEMPLATE_FILTERS,
         TESTS=TEMPLATE_TESTS,
     )

--- a/docs/ext/generate_test_runner_guest_matrix.py
+++ b/docs/ext/generate_test_runner_guest_matrix.py
@@ -94,6 +94,7 @@ def generate_test_runner_guest_matrix(app: "Sphinx") -> None:
     render_template_file_into_file(
         template_filepath,
         output_filepath,
+        sandboxed=False,
         LOGGER=logger,
         MATRIX=matrix,
         NOTES=notes.values(),

--- a/tests/report/junit/basic/test.sh
+++ b/tests/report/junit/basic/test.sh
@@ -99,25 +99,25 @@ rlJournalStart
             rlAssertGrep '<testsuite name="/test/beakerlib/fail" disabled="0" errors="0" failures="2" skipped="0" tests="2"' "subresults-out.xml"
 
             # Parent result testsuite must have its respective testcase tag with the same name
-            rlAssertGrep '<testcase name="/test/beakerlib/fail">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/test/beakerlib/fail" time="[[:digit:]]\+">' "subresults-out.xml"
 
             rlAssertGrep '<testsuite name="/test/beakerlib/pass" disabled="0" errors="0" failures="0" skipped="0" tests="2" ' "subresults-out.xml"
-            rlAssertGrep '<testcase name="/test/beakerlib/pass">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/test/beakerlib/pass" time="[[:digit:]]\+">' "subresults-out.xml"
 
             rlAssertGrep '<testsuite name="/test/shell/big-output" disabled="0" errors="0" failures="0" skipped="0" tests="1"' "subresults-out.xml"
-            rlAssertGrep '<testcase name="/test/shell/big-output">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/test/shell/big-output" time="[[:digit:]]\+">' "subresults-out.xml"
 
             rlAssertGrep '<testsuite name="/test/shell/fail" disabled="0" errors="0" failures="1" skipped="0" tests="1"' "subresults-out.xml"
-            rlAssertGrep '<testcase name="/test/shell/fail">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/test/shell/fail" time="[[:digit:]]\+">' "subresults-out.xml"
 
             rlAssertGrep '<testsuite name="/test/shell/subresults/pass" disabled="0" errors="0" failures="0" skipped="0" tests="4"' "subresults-out.xml"
-            rlAssertGrep '<testcase name="/test/shell/subresults/pass">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/test/shell/subresults/pass" time="[[:digit:]]\+">' "subresults-out.xml"
             rlAssertGrep '<testcase name="/pass-subtest/good0">' "subresults-out.xml"
             rlAssertGrep '<testcase name="/pass-subtest/good1">' "subresults-out.xml"
             rlAssertGrep '<testcase name="/pass-subtest/good2">' "subresults-out.xml"
 
             rlAssertGrep '<testsuite name="/test/beakerlib/subresults" disabled="0" errors="1" failures="3" skipped="1" tests="10"' "subresults-out.xml"
-            rlAssertGrep '<testcase name="/test/beakerlib/subresults">' "subresults-out.xml"
+            rlAssertGrep '<testcase name="/test/beakerlib/subresults" time="[[:digit:]]\+">' "subresults-out.xml"
             rlAssertGrep '<testcase name="/phase-setup">' "subresults-out.xml"
             rlAssertGrep '<testcase name="/phase-test-pass">' "subresults-out.xml"
             rlAssertGrep '<testcase name="/phase-test-fail">' "subresults-out.xml"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -21,10 +21,12 @@ import tmt.base.links
 import tmt.base.plan
 import tmt.log
 import tmt.plugins
+import tmt.result
 import tmt.steps.discover
 import tmt.utils
 import tmt.utils.git
 import tmt.utils.jira
+import tmt.utils.templates
 from tmt.log import Logger
 from tmt.utils import (
     Command,
@@ -1825,3 +1827,17 @@ def test_render_command_report_minimal():
 # Finished successfully
 """
     )
+
+
+def test_render_template() -> None:
+    assert tmt.utils.templates.render_template('a {{ "template" | capitalize }}') == 'a Template'
+
+
+def test_render_template_sandbox() -> None:
+    result = tmt.result.BaseResult(name='foo')
+
+    with pytest.raises(GeneralError, match=r"Template used forbidden operation\."):
+        tmt.utils.templates.render_template('{{ RESULT.__init__ }}', RESULT=result)
+
+    with pytest.raises(GeneralError, match=r"Template used forbidden operation\."):
+        tmt.utils.templates.render_template('{{ RESULT.__init__.__globals__ }}', RESULT=result)

--- a/tmt/steps/report/display.py
+++ b/tmt/steps/report/display.py
@@ -39,8 +39,8 @@ DEFAULT_SUBRESULT_CHECK_HEADER_TEMPLATE = """
 """  # noqa: E501
 
 DEFAULT_NOTE_TEMPLATE = """
-{{ "Note:" | style(fg="yellow") }} {{ NOTE_LINES.pop(0) }}
-{% for line in NOTE_LINES %}
+{{ "Note:" | style(fg="yellow") }} {{ NOTE_LINES[0] }}
+{% for line in NOTE_LINES[1:] %}
       {{ line }}
 {% endfor %}
 """

--- a/tmt/steps/report/junit/templates/subresults.xml.j2
+++ b/tmt/steps/report/junit/templates/subresults.xml.j2
@@ -45,7 +45,7 @@
                     `testcase`.
                 #}
                 <!-- The extra test case representing the parent result. -->
-                <testcase name="{{ result.name | e }}" {% if result_test_duration %}time="{{ result_test_duration }}"{% endif %}>
+                <testcase name="{{ result.name | e }}" {% if result.duration %}time="{{ result.duration | duration_to_seconds }}"{% endif %}>
                     {% if result.result.value == 'error' or result.result.value == 'warn' %}
                         <error type="error" message="{{ result.result.value | e }}">{{ result.failure_logs | failures | join("\n") | e }}</error>
                     {% elif result.result.value == 'fail' %}
@@ -61,9 +61,7 @@
                 <!-- End of the extra parent test case. -->
 
                 {% for subresult in result.subresult %}
-                    {% set subresult_test_duration = subresult.duration | duration_to_seconds %}
-
-                    <testcase name="{{ subresult.name | e }}" {% if subresult_test_duration %}time="{{ subresult_test_duration }}"{% endif %}>
+                    <testcase name="{{ subresult.name | e }}" {% if subresult.duration %}time="{{ subresult.duration | duration_to_seconds }}"{% endif %}>
                         {% if subresult.result.value == 'error' or subresult.result.value == 'warn' %}
                             <error type="error" message="{{ subresult.result.value | e }}">{{ subresult.failure_logs | failures | join("\n") | e }}</error>
                         {% elif subresult.result.value == 'fail' %}

--- a/tmt/steps/scripts.py
+++ b/tmt/steps/scripts.py
@@ -107,7 +107,11 @@ class ScriptTemplate(Script):
                 logger=tmt.log.Logger.get_bootstrap_logger(),
                 assert_file=True,
             )
-            rendered_script.write(render_template_file(template_file, None, **self.context))
+            rendered_script.write(
+                render_template_file(
+                    template_file, environment=None, sandboxed=True, **self.context
+                )
+            )
 
         self._rendered_script_path = Path(rendered_script.name)
 

--- a/tmt/utils/templates.py
+++ b/tmt/utils/templates.py
@@ -20,6 +20,7 @@ from typing import (
 import fmf.utils
 import jinja2
 import jinja2.exceptions
+import jinja2.sandbox
 
 from tmt.utils import GeneralError, Path, to_yaml
 from tmt.utils.git import web_git_url
@@ -461,7 +462,9 @@ def default_template_environment() -> jinja2.Environment:
     # we need to explicitly set autoescape=False, as default might change in the future.
     # Potential improvements are being tracked in /teemtee/tmt/issues/2873
 
-    environment = jinja2.Environment()  # noqa: S701
+    environment = jinja2.sandbox.ImmutableSandboxedEnvironment()
+
+    environment.undefined = jinja2.StrictUndefined
 
     environment.filters.update(TEMPLATE_FILTERS)
     environment.tests.update(TEMPLATE_TESTS)
@@ -501,6 +504,14 @@ def render_template(
 
     try:
         return environment.from_string(template).render(**variables).strip()
+
+    except jinja2.exceptions.SecurityError as error:
+        if template_filepath:
+            raise GeneralError(
+                f"Template from '{template_filepath}' used forbidden operation."
+            ) from error
+
+        raise GeneralError("Template used forbidden operation.") from error
 
     except jinja2.exceptions.TemplateSyntaxError as error:
         if template_filepath:

--- a/tmt/utils/templates.py
+++ b/tmt/utils/templates.py
@@ -457,12 +457,11 @@ def default_template_environment() -> jinja2.Environment:
     Adds common filters, and enables block trimming and left strip.
     """
 
-    # S701: `autoescape=False` is dangerous and can lead to XSS.
     # As there can be many different template file formats, used to render various formats,
     # we need to explicitly set autoescape=False, as default might change in the future.
     # Potential improvements are being tracked in /teemtee/tmt/issues/2873
 
-    environment = jinja2.sandbox.ImmutableSandboxedEnvironment()
+    environment = jinja2.sandbox.ImmutableSandboxedEnvironment(autoescape=False)
 
     environment.undefined = jinja2.StrictUndefined
 

--- a/tmt/utils/templates.py
+++ b/tmt/utils/templates.py
@@ -450,18 +450,23 @@ TEMPLATE_TESTS: dict[str, Callable[..., Any]] = {
 }
 
 
-def default_template_environment() -> jinja2.Environment:
+def default_template_environment(sandboxed: bool = True) -> jinja2.Environment:
     """
     Create a Jinja2 environment with default settings.
 
     Adds common filters, and enables block trimming and left strip.
     """
 
+    # S701: Using jinja2 templates with `autoescape=False` is dangerous and can lead to XSS.
     # As there can be many different template file formats, used to render various formats,
     # we need to explicitly set autoescape=False, as default might change in the future.
     # Potential improvements are being tracked in /teemtee/tmt/issues/2873
 
-    environment = jinja2.sandbox.ImmutableSandboxedEnvironment(autoescape=False)
+    environment = (
+        jinja2.sandbox.ImmutableSandboxedEnvironment(autoescape=False)
+        if sandboxed
+        else jinja2.Environment(autoescape=False)  # noqa: S701
+    )
 
     environment.undefined = jinja2.StrictUndefined
 
@@ -478,6 +483,7 @@ def render_template(
     template: str,
     template_filepath: Optional[Path] = None,
     environment: Optional[jinja2.Environment] = None,
+    sandboxed: bool = True,
     **variables: Any,
 ) -> str:
     """
@@ -489,7 +495,7 @@ def render_template(
     :param variables: variables to pass to the template.
     """
 
-    environment = environment or default_template_environment()
+    environment = environment or default_template_environment(sandboxed=sandboxed)
 
     def raise_error(message: str) -> None:
         """
@@ -526,6 +532,7 @@ def render_template(
 def render_template_file(
     template_filepath: Path,
     environment: Optional[jinja2.Environment] = None,
+    sandboxed: bool = True,
     **variables: Any,
 ) -> str:
     """
@@ -538,7 +545,11 @@ def render_template_file(
 
     try:
         return render_template(
-            template_filepath.read_text(), template_filepath, environment, **variables
+            template_filepath.read_text(),
+            template_filepath=template_filepath,
+            environment=environment,
+            sandboxed=sandboxed,
+            **variables,
         )
 
     except FileNotFoundError as error:
@@ -549,6 +560,7 @@ def render_template_file_into_file(
     input_filepath: Path,
     output_filepath: Path,
     environment: Optional[jinja2.Environment] = None,
+    sandboxed: bool = True,
     **variables: Any,
 ) -> None:
     """
@@ -566,7 +578,9 @@ def render_template_file_into_file(
     """
 
     output_filepath.write_text(
-        render_template_file(input_filepath, environment=environment, **variables)
+        render_template_file(
+            input_filepath, environment=environment, sandboxed=sandboxed, **variables
+        )
     )
 
     output_filepath.append_text('\n')


### PR DESCRIPTION
This should prevent templates accessing "private" attributes of objects in their scope. It gives us better control over what code can user-provided templates reach, or even invoke.

Related: https://redhat.atlassian.net/browse/TFT-4838

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage