### PR TITLE
Add a "collection of results" class for collection-wide actions

### DIFF
--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -13,7 +13,7 @@ from tmt.result import (
     Result,
     ResultInterpret,
     ResultOutcome,
-    results_to_exit_code,
+    Results,
 )
 from tmt.utils import Common, Path
 
@@ -131,10 +131,8 @@ def assert_result(case: Union[CheckPhasesCase, CheckPhasesDuplicateCase], result
     ),
 )
 def test_result_to_exit_code(outcomes: list[ResultOutcome], expected_exit_code: int) -> None:
-    assert (
-        results_to_exit_code([MagicMock(result=outcome) for outcome in outcomes])
-        == expected_exit_code
-    )
+    results = Results([MagicMock(result=outcome) for outcome in outcomes])
+    assert results.to_exit_code() is expected_exit_code
 
 
 @pytest.mark.parametrize(

--- a/tmt/base/run.py
+++ b/tmt/base/run.py
@@ -19,7 +19,6 @@ import fmf.utils
 import tmt.config
 import tmt.log
 import tmt.policy
-import tmt.result
 import tmt.steps
 import tmt.steps.cleanup
 import tmt.steps.execute
@@ -36,7 +35,7 @@ from tmt.container import (
     field,
 )
 from tmt.recipe import RecipeManager
-from tmt.result import Result
+from tmt.result import Results
 from tmt.utils import (
     Command,
     Environment,
@@ -551,10 +550,10 @@ class Run(HasRunWorkdir, HasUserAnchorPath, HasEnvironment, tmt.utils.Common):
         interesting_results = execute.enabled or report.enabled
 
         # Gather all results and give an overall summary
-        results = [result for plan in self.plans for result in plan.execute.results()]
+        results = Results(result for plan in self.plans for result in plan.execute.results())
         if interesting_results:
             self.info('')
-            self.info('total', Result.summary(results), color='cyan')
+            self.info('total', results.summary(), color='cyan')
 
         # Remove the workdir if enabled
         if self.remove and self.plans[0].cleanup.enabled:
@@ -570,7 +569,7 @@ class Run(HasRunWorkdir, HasUserAnchorPath, HasEnvironment, tmt.utils.Common):
             raise SystemExit(0)
 
         # Return appropriate exit code based on the total stats
-        raise SystemExit(tmt.result.results_to_exit_code(results, bool(execute.enabled)))
+        raise SystemExit(results.to_exit_code(execute_enabled=bool(execute.enabled)))
 
     def follow(self) -> None:
         """

--- a/tmt/base/run.py
+++ b/tmt/base/run.py
@@ -20,7 +20,6 @@ from click.core import ParameterSource
 import tmt.config
 import tmt.log
 import tmt.policy
-import tmt.result
 import tmt.steps
 import tmt.steps.cleanup
 import tmt.steps.execute
@@ -37,7 +36,7 @@ from tmt.container import (
     field,
 )
 from tmt.recipe import RecipeManager
-from tmt.result import Result
+from tmt.result import Results
 from tmt.utils import (
     Command,
     FmfContext,
@@ -583,10 +582,10 @@ class Run(HasRunWorkdir, HasUserAnchorPath, HasEnvironment, tmt.utils.Common):
         interesting_results = execute.enabled or report.enabled
 
         # Gather all results and give an overall summary
-        results = [result for plan in self.plans for result in plan.execute.results()]
+        results = Results(result for plan in self.plans for result in plan.execute.results())
         if interesting_results:
             self.info('')
-            self.info('total', Result.summary(results), color='cyan')
+            self.info('total', results.summary(), color='cyan')
 
         # Remove the workdir if enabled
         if self.remove and self.plans[0].cleanup.enabled:
@@ -602,7 +601,7 @@ class Run(HasRunWorkdir, HasUserAnchorPath, HasEnvironment, tmt.utils.Common):
             raise SystemExit(0)
 
         # Return appropriate exit code based on the total stats
-        raise SystemExit(tmt.result.results_to_exit_code(results, bool(execute.enabled)))
+        raise SystemExit(results.to_exit_code(execute_enabled=bool(execute.enabled)))
 
     def follow(self) -> None:
         """

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -1,5 +1,5 @@
 import enum
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, cast
 
 import fmf.utils
 
@@ -13,8 +13,12 @@ from tmt.utils.themes import style
 
 if TYPE_CHECKING:
     import tmt.base.core
+    import tmt.cli
     import tmt.guest
     import tmt.steps.execute
+
+
+ResultT = TypeVar('ResultT', bound='BaseResult')
 
 
 class ResultOutcome(enum.Enum):
@@ -512,25 +516,43 @@ class Result(BaseResult):
             {option: value for option, value in self.to_serialized().items() if option in options}
         )
 
-    @staticmethod
-    def total(results: list['Result']) -> dict[ResultOutcome, int]:
+    @property
+    def failure_logs(self) -> list[Path]:
         """
-        Return dictionary with total stats for given results
+        Return paths to all failure logs from the result
+        """
+
+        failure_logs = super().failure_logs
+        for check in self.check:
+            failure_logs += check.failure_logs
+        return list(set(failure_logs))
+
+
+class Results(list[ResultT]):
+    """
+    A collection of results.
+
+    Effectively a fancy list of results, with a few helper methods for
+    the collection as a whole.
+    """
+
+    def total(self) -> dict[ResultOutcome, int]:
+        """
+        Return dictionary with total stats.
         """
 
         stats = dict.fromkeys(RESULT_OUTCOME_COLORS, 0)
 
-        for result in results:
+        for result in self:
             stats[result.result] += 1
         return stats
 
-    @staticmethod
-    def summary(results: list['Result']) -> str:
+    def summary(self) -> str:
         """
-        Prepare a nice human summary of provided results
+        Prepare a nice human summary of results.
         """
 
-        stats = Result.total(results)
+        stats = self.total()
         comments = []
         if stats.get(ResultOutcome.PASS):
             passed = ' ' + style('passed', fg='green')
@@ -556,60 +578,53 @@ class Result(BaseResult):
         # FIXME: cast() - https://github.com/teemtee/fmf/issues/185
         return cast(str, fmf.utils.listed(comments or ['no results found']))
 
-    @property
-    def failure_logs(self) -> list[Path]:
+    def to_exit_code(self, execute_enabled: bool = True) -> 'tmt.cli.TmtExitCode':
         """
-        Return paths to all failure logs from the result
+        Map results to a tmt exit code.
+
+        :param execute_enabled: if set, the :py:mod:`tmt.steps.execute`
+            step was enabled.
+        :raises tmt.utils.GeneralError: when it was not possible to map
+            results to any defined exit code.
         """
 
-        failure_logs = super().failure_logs
-        for check in self.check:
-            failure_logs += check.failure_logs
-        return list(set(failure_logs))
+        from tmt.cli import TmtExitCode
 
+        stats = self.total()
 
-def results_to_exit_code(results: list[Result], execute_enabled: bool = True) -> int:
-    """
-    Map results to a tmt exit code
-    """
+        # Quoting the specification:
 
-    from tmt.cli import TmtExitCode
+        # "No test results found."
+        if sum(stats.values()) == 0:
+            return TmtExitCode.NO_RESULTS_FOUND
 
-    stats = Result.total(results)
+        # "Errors occurred during test execution."
+        if stats[ResultOutcome.ERROR]:
+            return TmtExitCode.ERROR
 
-    # Quoting the specification:
+        # "There was a fail or warn identified, but no error."
+        if stats[ResultOutcome.FAIL] + stats[ResultOutcome.WARN]:
+            return TmtExitCode.FAIL
 
-    # "No test results found."
-    if sum(stats.values()) == 0:
-        return TmtExitCode.NO_RESULTS_FOUND
+        # "Tests were executed, and all reported the ``skip`` result."
+        if sum(stats.values()) == stats[ResultOutcome.SKIP]:
+            return TmtExitCode.ALL_TESTS_SKIPPED
 
-    # "Errors occurred during test execution."
-    if stats[ResultOutcome.ERROR]:
-        return TmtExitCode.ERROR
+        # "No errors or fails, but there are pending tests."
+        if execute_enabled and stats[ResultOutcome.PENDING]:
+            return TmtExitCode.ERROR
 
-    # "There was a fail or warn identified, but no error."
-    if stats[ResultOutcome.FAIL] + stats[ResultOutcome.WARN]:
-        return TmtExitCode.FAIL
+        # "At least one test passed, there was no fail, warn or error."
+        if (
+            sum(stats.values())
+            == stats[ResultOutcome.PASS]
+            + stats[ResultOutcome.INFO]
+            + stats[ResultOutcome.SKIP]
+            + stats[ResultOutcome.PENDING]
+        ):
+            return TmtExitCode.SUCCESS
 
-    # "Tests were executed, and all reported the ``skip`` result."
-    if sum(stats.values()) == stats[ResultOutcome.SKIP]:
-        return TmtExitCode.ALL_TESTS_SKIPPED
-
-    # "No errors or fails, but there are pending tests."
-    if execute_enabled and stats[ResultOutcome.PENDING]:
-        return TmtExitCode.ERROR
-
-    # "At least one test passed, there was no fail, warn or error."
-    if (
-        sum(stats.values())
-        == stats[ResultOutcome.PASS]
-        + stats[ResultOutcome.INFO]
-        + stats[ResultOutcome.SKIP]
-        + stats[ResultOutcome.PENDING]
-    ):
-        return TmtExitCode.SUCCESS
-
-    raise GeneralError("Unhandled combination of test result.")
+        raise GeneralError("Unhandled combination of test result.")
 
 
 def save_failures(

--- a/tmt/result.py
+++ b/tmt/result.py
@@ -1,5 +1,15 @@
 import enum
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Optional,
+    SupportsIndex,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 import fmf.utils
 
@@ -535,6 +545,26 @@ class Results(list[ResultT]):
     Effectively a fancy list of results, with a few helper methods for
     the collection as a whole.
     """
+
+    @overload
+    def __getitem__(self, i: SupportsIndex) -> ResultT:
+        pass
+
+    @overload
+    def __getitem__(self, i: slice) -> 'Results[ResultT]':
+        pass
+
+    def __getitem__(self, i: Union[SupportsIndex, slice]) -> Union[ResultT, 'Results[ResultT]']:
+        if isinstance(i, slice):
+            return Results(super().__getitem__(i))
+
+        return super().__getitem__(i)
+
+    def __add__(self, other: 'Results[ResultT]') -> 'Results[ResultT]':  # type: ignore[override]
+        return Results(super().__add__(other))
+
+    def copy(self) -> 'Results[ResultT]':
+        return Results(super().copy())
 
     def total(self) -> dict[ResultOutcome, int]:
         """

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -57,7 +57,7 @@ from tmt.container import (
     simple_field,
 )
 from tmt.options import ClickOptionDecoratorType, option
-from tmt.result import ResultOutcome
+from tmt.result import BaseResult, ResultOutcome, Results
 from tmt.utils import (
     DEFAULT_NAME,
     Command,
@@ -1030,7 +1030,7 @@ class Step(
         self,
         result_class: type[ResultT],
         allow_missing: bool = False,
-    ) -> list[ResultT]:
+    ) -> tmt.result.Results[ResultT]:
         """
         Load results of this step from the workdir
         """
@@ -1040,19 +1040,19 @@ class Step(
         try:
             raw_results: list[Any] = self.plan.my_run.read_state(self.step_workdir / 'results')
 
-            return [result_class.from_serialized(raw_result) for raw_result in raw_results]
+            return Results(result_class.from_serialized(raw_result) for raw_result in raw_results)
 
         except tmt.utils.FileError as exc:
             if allow_missing:
                 self.debug(f'{self.__class__.__name__} results not found.', level=2)
-                return []
+                return Results()
 
             raise GeneralError('Cannot load step results.') from exc
 
         except Exception as exc:
             raise GeneralError('Cannot load step results.') from exc
 
-    def _save_results(self, results: Sequence['BaseResult']) -> None:
+    def _save_results(self, results: Sequence[BaseResult]) -> None:
         """
         Save results of this step to the workdir
         """

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -56,7 +56,7 @@ from tmt.container import (
     simple_field,
 )
 from tmt.options import ClickOptionDecoratorType, option
-from tmt.result import ResultOutcome
+from tmt.result import BaseResult, ResultOutcome, Results
 from tmt.utils import (
     DEFAULT_NAME,
     Command,
@@ -1005,7 +1005,7 @@ class Step(
         self,
         result_class: type[ResultT],
         allow_missing: bool = False,
-    ) -> list[ResultT]:
+    ) -> tmt.result.Results[ResultT]:
         """
         Load results of this step from the workdir
         """
@@ -1015,19 +1015,19 @@ class Step(
         try:
             raw_results: list[Any] = self.plan.my_run.read_state(self.step_workdir / 'results')
 
-            return [result_class.from_serialized(raw_result) for raw_result in raw_results]
+            return Results(result_class.from_serialized(raw_result) for raw_result in raw_results)
 
         except tmt.utils.FileError as exc:
             if allow_missing:
                 self.debug(f'{self.__class__.__name__} results not found.', level=2)
-                return []
+                return Results()
 
             raise GeneralError('Cannot load step results.') from exc
 
         except Exception as exc:
             raise GeneralError('Cannot load step results.') from exc
 
-    def _save_results(self, results: Sequence['BaseResult']) -> None:
+    def _save_results(self, results: Sequence[BaseResult]) -> None:
         """
         Save results of this step to the workdir
         """

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -82,7 +82,7 @@ if TYPE_CHECKING:
     import tmt.steps.context.restart
     from tmt.base.plan import Plan
     from tmt.guest import Guest, TransferOptions
-    from tmt.result import BaseResult, PhaseResult
+    from tmt.result import PhaseResult
 
 
 DEFAULT_ALLOWED_HOW_PATTERN: Pattern[str] = re.compile(r'.*')

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -1005,7 +1005,7 @@ class Step(
         self,
         result_class: type[ResultT],
         allow_missing: bool = False,
-    ) -> tmt.result.Results[ResultT]:
+    ) -> Results[ResultT]:
         """
         Load results of this step from the workdir
         """

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -30,6 +30,7 @@ from tmt.result import (
     ResultGuestData,
     ResultInterpret,
     ResultOutcome,
+    Results,
 )
 from tmt.steps import Action, ActionTask, PluginTask, Step
 from tmt.steps.context.abort import AbortContext, AbortStep
@@ -750,19 +751,19 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
             if self.should_run_again:
                 assert self.parent is not None  # narrow type
                 assert isinstance(self.parent, Execute)  # narrow type
-                self.parent._results = [
+                self.parent._results = Results(
                     result
                     for result in self.parent._results
                     if not (
                         test.name == result.name and test.serial_number == result.serial_number
                     )
-                ]
+                )
 
         # Keep old results in another variable to have numbers only for actually executed tests
         if self.should_run_again:
             assert self.parent is not None  # narrow type
             assert isinstance(self.parent, Execute)  # narrow type
-            self.parent._old_results = self.parent._results[:]
+            self.parent._old_results = Results(self.parent._results[:])
             self.parent._results.clear()
 
         return invocations
@@ -1079,8 +1080,8 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
 
         super().__init__(plan=plan, raw_data=raw_data, logger=logger)
         # List of Result() objects representing test results
-        self._results: list[tmt.Result] = []
-        self._old_results: list[tmt.Result] = []
+        self._results: Results[Result] = Results()
+        self._old_results: Results[Result] = Results()
 
     @property
     def _preserved_workdir_members(self) -> set[str]:
@@ -1197,9 +1198,9 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
             # Replace existing pending result with the new one.
             results_to_save[(result.serial_number, result.name, result.guest.name)] = result
 
-        self._results = list(results_to_save.values())
+        self._results = Results(results_to_save.values())
 
-    def create_results(self, tests: list['tmt.steps.discover.TestOrigin']) -> list['Result']:
+    def create_results(self, tests: list['tmt.steps.discover.TestOrigin']) -> Results[Result]:
         """
         Get all available results from tests. For tests not yet executed, create a pending
         result.
@@ -1207,7 +1208,7 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
 
         guests = self.plan.provision.get_guests_info()
 
-        results = []
+        results: Results[Result] = Results()
         for result, test_origin in self.results_for_tests(tests):
             if result:
                 results.append(result)
@@ -1327,7 +1328,7 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
 
         self._assert_required_tests_executed()
 
-    def results(self) -> list["tmt.result.Result"]:
+    def results(self) -> 'tmt.result.Results[tmt.result.Result]':
         """
         Results from executed tests
 

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -767,7 +767,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
         if self.should_run_again:
             assert self.parent is not None  # narrow type
             assert isinstance(self.parent, Execute)  # narrow type
-            self.parent._old_results = Results(self.parent._results[:])
+            self.parent._old_results = self.parent._results.copy()
             self.parent._results.clear()
 
         return invocations
@@ -1342,7 +1342,7 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
 
         self._assert_required_tests_executed()
 
-    def results(self) -> 'tmt.result.Results[tmt.result.Result]':
+    def results(self) -> Results[Result]:
         """
         Results from executed tests
 

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -30,6 +30,7 @@ from tmt.result import (
     ResultGuestData,
     ResultInterpret,
     ResultOutcome,
+    Results,
 )
 from tmt.steps import Action, ActionTask, PluginTask, Step
 from tmt.steps.context.abort import AbortContext, AbortStep
@@ -754,19 +755,19 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
             if self.should_run_again:
                 assert self.parent is not None  # narrow type
                 assert isinstance(self.parent, Execute)  # narrow type
-                self.parent._results = [
+                self.parent._results = Results(
                     result
                     for result in self.parent._results
                     if not (
                         test.name == result.name and test.serial_number == result.serial_number
                     )
-                ]
+                )
 
         # Keep old results in another variable to have numbers only for actually executed tests
         if self.should_run_again:
             assert self.parent is not None  # narrow type
             assert isinstance(self.parent, Execute)  # narrow type
-            self.parent._old_results = self.parent._results[:]
+            self.parent._old_results = Results(self.parent._results[:])
             self.parent._results.clear()
 
         return invocations
@@ -1085,8 +1086,8 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
 
         super().__init__(plan=plan, raw_data=raw_data, logger=logger)
         # List of Result() objects representing test results
-        self._results: list[tmt.Result] = []
-        self._old_results: list[tmt.Result] = []
+        self._results: Results[Result] = Results()
+        self._old_results: Results[Result] = Results()
 
     @property
     def _preserved_workdir_members(self) -> set[str]:
@@ -1203,9 +1204,9 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
             # Replace existing pending result with the new one.
             results_to_save[(result.serial_number, result.name, result.guest.name)] = result
 
-        self._results = list(results_to_save.values())
+        self._results = Results(results_to_save.values())
 
-    def create_results(self, tests: list['tmt.steps.discover.TestOrigin']) -> list['Result']:
+    def create_results(self, tests: list['tmt.steps.discover.TestOrigin']) -> Results[Result]:
         """
         Get all available results from tests. For tests not yet executed, create a pending
         result.
@@ -1213,7 +1214,7 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
 
         guests = self.plan.provision.get_guests_info()
 
-        results = []
+        results: Results[Result] = Results()
         for result, test_origin in self.results_for_tests(tests):
             if result:
                 results.append(result)
@@ -1341,7 +1342,7 @@ class Execute(tmt.steps.StepWithQueue[ExecuteStepData, None]):
 
         self._assert_required_tests_executed()
 
-    def results(self) -> list["tmt.result.Result"]:
+    def results(self) -> 'tmt.result.Results[tmt.result.Result]':
         """
         Results from executed tests
 

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -10,6 +10,7 @@ import tmt.log
 import tmt.steps
 import tmt.utils
 from tmt.container import container, field, key_to_option
+from tmt.result import Results
 from tmt.steps.discover import Discover, DiscoverPlugin, DiscoverStepData, normalize_ref
 from tmt.steps.discover.fmf import (
     DiscoverFmf,
@@ -567,7 +568,7 @@ class ExecuteUpgrade(ExecuteInternal):
             if result.name.startswith(f'/{prefix}/')
         ]
 
-        self.step.plan.execute._results = [
+        self.step.plan.execute._results = Results(
             result for result in results if result.name not in old_result_names
-        ]
+        )
         self.step.plan.execute.save()

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -10,6 +10,7 @@ import tmt.log
 import tmt.steps
 import tmt.utils
 from tmt.container import container, field, key_to_option
+from tmt.result import Results
 from tmt.steps.discover import Discover, DiscoverPlugin, DiscoverStepData, normalize_ref
 from tmt.steps.discover.fmf import (
     DiscoverFmf,
@@ -568,7 +569,7 @@ class ExecuteUpgrade(ExecuteInternal):
             if result.name.startswith(f'/{prefix}/')
         ]
 
-        self.step.plan.execute._results = [
+        self.step.plan.execute._results = Results(
             result for result in results if result.name not in old_result_names
-        ]
+        )
         self.step.plan.execute.save()

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -8,7 +8,7 @@ import tmt.utils
 from tmt.container import container, simple_field
 from tmt.guest import Guest
 from tmt.plugins import PluginRegistry
-from tmt.result import PhaseResult, ResultGuestData, ResultOutcome
+from tmt.result import PhaseResult, ResultGuestData, ResultOutcome, Results
 from tmt.steps import (
     Action,
     PluginOutcome,
@@ -115,7 +115,7 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
 
     _plugin_base_class = PreparePlugin
 
-    results: list[PhaseResult]
+    results: Results[PhaseResult]
 
     @property
     def _preserved_workdir_members(self) -> set[str]:
@@ -145,7 +145,7 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
 
         super().__init__(plan=plan, raw_data=raw_data, logger=logger)
 
-        self.results = []
+        self.results = Results()
         self.preparations_applied = 0
 
     def load(self) -> None:
@@ -403,7 +403,7 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
                     ],
                 )
 
-        self.results: list[PhaseResult] = []
+        self.results: Results[PhaseResult] = Results()
         exceptions: list[Exception] = []
 
         def _record_exception(

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -7,7 +7,7 @@ import tmt.steps
 from tmt.container import container, simple_field
 from tmt.guest import Guest
 from tmt.plugins import PluginRegistry
-from tmt.result import PhaseResult, ResultGuestData, ResultOutcome
+from tmt.result import PhaseResult, ResultGuestData, ResultOutcome, Results
 from tmt.steps import (
     Action,
     PluginOutcome,
@@ -115,7 +115,7 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
 
     _plugin_base_class = PreparePlugin
 
-    results: list[PhaseResult]
+    results: Results[PhaseResult]
 
     @property
     def _preserved_workdir_members(self) -> set[str]:
@@ -145,7 +145,7 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
 
         super().__init__(plan=plan, raw_data=raw_data, logger=logger)
 
-        self.results = []
+        self.results = Results()
         self.preparations_applied = 0
 
     def load(self) -> None:
@@ -407,7 +407,7 @@ class Prepare(tmt.steps.StepWithQueue[PrepareStepData, PluginOutcome]):
                     ],
                 )
 
-        self.results: list[PhaseResult] = []
+        self.results: Results[PhaseResult] = Results()
         exceptions: list[Exception] = []
 
         def _record_exception(

--- a/tmt/steps/report/__init__.py
+++ b/tmt/steps/report/__init__.py
@@ -1,7 +1,6 @@
 from typing import Optional, TypeVar, Union, cast
 
 import tmt.log
-import tmt.result
 import tmt.steps
 from tmt.container import container
 from tmt.plugins import PluginRegistry
@@ -79,7 +78,7 @@ class Report(tmt.steps.Step):
         Give a concise report summary
         """
 
-        summary = tmt.result.Result.summary(self.plan.execute.results())
+        summary = self.plan.execute.results().summary()
         self.info('summary', summary, 'green', shift=1)
 
     def go(self, force: bool = False) -> None:


### PR DESCRIPTION
Sevral methods are tied to the `Result` class, but apply to a `list[Result]`. Instead, let's have a class representing a collection of results, and let that one own the collection-level operations like `summary`.

Pull Request Checklist

* [x] implement the feature