### PR TITLE
Easily generate quarter news reports

### DIFF
--- a/agents/quarter-news.md
+++ b/agents/quarter-news.md
@@ -1,0 +1,111 @@
+# Quarter News Generation
+
+Generate a high-level quarterly summary of tmt changes for the `docs/news/` directory.
+The audience is tmt users — focus on what matters to someone using the tool, not
+developing it.
+
+## Input
+
+The user provides a quarter (e.g. "2026 Q2") and the range of releases it covers
+(e.g. "1.71 through 1.75"). If the range is not given, check GitHub releases to
+determine which versions fall within the quarter's date range.
+
+## Gathering information
+
+Use two sources and cross-reference them:
+
+1. **Official release notes** at `https://tmt.readthedocs.io/en/stable/releases/index.html`
+   — this is the primary source. Fetch it and extract entries for the relevant versions.
+
+2. **GitHub releases** for `teemtee/tmt` — fetch each release by tag (e.g. `1.71.0`).
+   These contain the full PR changelog and may mention items not highlighted in the
+   official notes.
+
+For items that appear only in the GitHub changelog (not in the official readthedocs
+notes), check the actual PR description to understand the change before including it.
+Items that are purely internal (CI changes, refactoring without behavioral impact,
+test-only changes, dependency updates) should be excluded unless they have a visible
+user impact.
+
+## Filtering criteria
+
+Include:
+
+- New features and user-visible enhancements
+- Bug fixes that affect user experience (especially those mentioned in the official notes)
+- New CLI tools, options, or environment variables
+- Specification additions (new keys, new plugins)
+- Changes to defaults that users need to be aware of
+- Notable improvements to existing plugins
+
+Exclude:
+
+- Internal refactoring without behavioral changes
+- CI/CD pipeline changes
+- Test-only changes
+- Dependency updates (unless they enable new features or noticeably improve performance)
+- Internal plumbing (e.g. code extraction into submodules, dataclass conversions)
+
+When in doubt about whether an item is user-relevant, check whether the official
+readthedocs release notes mention it. If they do, include it. If they don't and the
+PR description describes an internal change, skip it.
+
+## Deduplication with previous quarters
+
+Before finalizing, read the previous quarter's news file (e.g. `docs/news/2026-q1.md`)
+and check for overlapping items. Features introduced in a previous quarter should not
+be re-announced. If the current quarter extends a previously introduced feature,
+frame the entry as a progression ("extended to all phases") rather than presenting
+it as new.
+
+## Output format
+
+Save the file as `docs/news/{year}-q{N}.md`. Follow the format of existing files in
+`docs/news/` exactly:
+
+- Title: `# tmt news {year} Q{N}`
+- Subtitle: `What's new in tmt {first_version}–{last_version}` (use en-dash)
+- Sections with `##` headings, grouped by feature area
+- Bullet points with `*` (not `-`)
+- One blank line between each bullet point
+- Include links to the official tmt documentation at `https://tmt.readthedocs.io/en/stable/`
+  where relevant. Link to specific plugin pages, specification pages, or guide sections.
+  Common link targets:
+  - Plugins: `plugins/provision.html#bootc`, `plugins/prepare.html#artifact`
+  - Spec: `spec/hardware.html#preset`, `spec/plans.html#/spec/plans/environment`
+  - Guide: `guide.html#link-issues`
+  - Overview: `overview.html#plugin-variables`
+  - Stories: `stories/cli.html#try`, `stories/features.html#/stories/features/reboot`
+  - Checks: `plugins/test-checks.html#dmesg`
+  - Contribute: `contribute.html#dry-mode`
+
+## Section organization
+
+Group items into sections by feature area. Use short section names. Example sections
+(not all are needed every quarter):
+
+- Recipes
+- Artifact Verification
+- Provisioning & Guests
+- Test Execution & Duration
+- Test Discovery & Filtering
+- Prepare & Artifact Handling
+- Integrations & Reporting
+- Environment & Hardware
+- Framework & Checks
+- Beakerlib Libraries
+- tmt try
+- Other
+
+Put the most important/interesting sections first. Less prominent items (performance
+tweaks, minor fixes, packaging changes) go into an "Other" section at the end.
+
+Sections with only one item can be merged into a related section or into "Other".
+
+## Style
+
+- Each bullet starts with a bold-ish lead phrase followed by an em-dash and explanation
+- Be concise — one or two sentences per item
+- State what changed and why it matters, not how it was implemented
+- Use backticks for code, commands, environment variables, file paths, and key names
+- Don't use praise, enthusiasm, or exclamation points

--- a/docs/news/2026-q1.md
+++ b/docs/news/2026-q1.md
@@ -1,0 +1,99 @@
+# tmt news 2026 Q1
+
+What’s new in tmt 1.65–1.70
+
+## Provisioning & Guests
+
+* UEFI/BIOS boot selection implemented for [virtual](https://tmt.readthedocs.io/en/stable/plugins/provision.html#plugins-provision-virtual-testcloud) guests via [boot.method](https://tmt.readthedocs.io/en/stable/spec/hardware.html#boot) hardware constraint.
+
+* Confidential VM support — implemented new [virtualization.confidential](https://tmt.readthedocs.io/en/stable/spec/hardware.html#virtualization) hardware requirement.
+
+* Device passthrough for containers — `expose-device` key (e.g. /dev/kvm) with safety-gated `--exposable-runner-devices` option in the [container](https://tmt.readthedocs.io/en/stable/plugins/provision.html#container) plugin.
+
+* Container TTY always enabled — ensures subprocesses get terminated properly on timeout, matching SSH guest behavior.
+
+* Container environment variables at startup — plan variables are now passed via `podman run --env-file` in the [container](https://tmt.readthedocs.io/en/stable/plugins/provision.html#container) plugin.
+
+* Podman network race condition fixed — unique network names prevent collisions in parallel runs, with a new `network-prefix` key.
+
+* [Artemis](https://tmt.readthedocs.io/en/stable/plugins/provision.html#artemis) plugin updated to support API v0.0.84.
+
+* [Beaker](https://tmt.readthedocs.io/en/stable/plugins/provision.html#beaker) plugin: removed `job_owner` workaround, requires `mrack` >= 1.21.0.
+
+## Test Execution & Duration
+
+* The [duration](https://tmt.readthedocs.io/en/stable/spec/tests.html#duration) is now enforced across reboots/restarts — previously each invocation got full budget, tests could run forever. Now measured end-to-end.
+
+* The [upgrade](https://tmt.readthedocs.io/en/stable/plugins/execute.html#upgrade) execute plugin supports multiple `discover` phases — tests from all phases run before and after upgrade.
+
+* The `tmt run login --test` command no longer adds spurious login at the last step.
+
+## Prepare & Artifact Handling
+
+* [prepare/artifact](https://tmt.readthedocs.io/en/stable/plugins/prepare.html#artifact) plugin (tech preview) — unified way to prepare artifacts from Koji, Copr, repos, with configurable repository priority.
+
+* [prepare/verify-installation](https://tmt.readthedocs.io/en/stable/plugins/prepare.html#verify-installation) plugin — verifies packages were installed from expected repositories.
+
+* [prepare/shell](https://tmt.readthedocs.io/en/stable/plugins/prepare.html#shell) supports Image Mode — commands built into a Containerfile, applied via bootc switch.
+
+* Better install failure reporting — tmt now tells you which packages failed and which tests needed them.
+
+* Fixed local RPM install regression in Image Mode.
+
+## Plans & Discovery
+
+* The [adjust-plans](https://tmt.readthedocs.io/en/stable/spec/plans.html#import-plans) key for imports — selectively modify steps when importing remote plans.
+
+* Recipes using `tmt run --recipe` — experimental support for loading test recipes.
+
+* The [fmf](https://tmt.readthedocs.io/en/stable/plugins/discover.html#fmf) discover plugin can adjust individual tests via the `test` key.
+
+* The [shell](https://tmt.readthedocs.io/en/stable/plugins/discover.html#shell) discover supports `url-content-type` and properly installs require/recommend dependencies.
+
+* The `repository` and `revision` keys have been deprecated in [discover/fmf](https://tmt.readthedocs.io/en/stable/plugins/discover.html#fmf) — use `url`/`ref` instead.
+
+* [Policies](https://tmt.readthedocs.io/en/stable/spec/policy.html) can now be applied to plans and their phases.
+
+* `tmt plan export` now preserves [extra-\*](https://tmt.readthedocs.io/en/stable/spec/core.html#extra) custom metadata.
+
+## Reporting & Logging
+
+* Prepare phase results are now shown in the [display](https://tmt.readthedocs.io/en/stable/plugins/report.html#display) report plugin.
+
+* [JUnit](https://tmt.readthedocs.io/en/stable/plugins/report.html#junit) report fixed — `skip` result correctly maps to `skipped`, `pending` maps to `error`.
+
+* Warnings saved to `warnings.yaml` under the run workdir.
+
+* Log prefixes changed from out/err to `stdout`/`stderr`.
+
+* Noisy `sudo -n true` messages removed from verbose output.
+
+## Beakerlib Libraries
+
+* Libraries can now be referenced without `url`/`path` — resolved relative to the test’s tmt tree.
+
+* Fixed bug with multiple libraries sharing the same repo but different name.
+
+* Failing git clones no longer retried for the same URL.
+
+## Resilience & HTTP
+
+* Retry session defaults improved: 3 to 10 retries, 0.1 to 1 backoff factor, configurable via `TMT_RETRY_SESSION_RETRIES` / `TMT_RETRY_SESSION_BACKOFF_FACTOR` environment variables.
+
+## Infrastructure & Packaging
+
+* Container images now include `tini` as an init process to properly handle signals and reap zombie processes.
+
+* `tmt+all` metapackage fixed — was missing `tmt+link-jira` and `tmt+provision-bootc`.
+
+* The `bootc` plugin is now usable on EPEL without `podman-machine`.
+
+* Copr `epel-6` support has been dropped.
+
+## Documentation
+
+* New guide sections: [Parametrize Tests](https://tmt.readthedocs.io/en/stable/guide.html#parametrize-tests), [Execute Tests](https://tmt.readthedocs.io/en/stable/guide.html#execute-tests), [Tree Handling](https://tmt.readthedocs.io/en/stable/code/trees.html#tree-handling).
+
+* A new section [Glossary](https://tmt.readthedocs.io/en/stable/glossary.html) with term definitions has been kicked off.
+
+* [Context](https://tmt.readthedocs.io/en/stable/spec/plans.html#context) specification clarified: no auto-detection from provisioned environment

--- a/docs/news/2026-q1.md
+++ b/docs/news/2026-q1.md
@@ -1,6 +1,6 @@
 # tmt news 2026 Q1
 
-What’s new in tmt 1.65–1.70
+What's new in tmt 1.65–1.70
 
 ## Provisioning & Guests
 
@@ -8,7 +8,7 @@ What’s new in tmt 1.65–1.70
 
 * Confidential VM support — implemented new [virtualization.confidential](https://tmt.readthedocs.io/en/stable/spec/hardware.html#virtualization) hardware requirement.
 
-* Device passthrough for containers — `expose-device` key (e.g. /dev/kvm) with safety-gated `--exposable-runner-devices` option in the [container](https://tmt.readthedocs.io/en/stable/plugins/provision.html#container) plugin.
+* Device passthrough for containers — `expose-device` key (e.g. /dev/kvm) with safety-gated `--exposable-runner-devices` option in the [container](https://tmt.readthedocs.io/en/stable/plugins/provision.html#container) plugin.
 
 * Container TTY always enabled — ensures subprocesses get terminated properly on timeout, matching SSH guest behavior.
 

--- a/docs/news/2026-q2.md
+++ b/docs/news/2026-q2.md
@@ -1,0 +1,73 @@
+# tmt news 2026 Q2
+
+What's new in tmt 1.71–1.75
+
+## Recipes
+
+* Full [recipe](https://tmt.readthedocs.io/en/stable/spec/recipe.html) loading — all phases can now be loaded directly from a recipe file. The feature remains experimental.
+
+* Recipe loading without fmf tree — recipes can now be loaded even when the current directory lacks an fmf tree.
+
+* New `tmt-recipe-tool` CLI (in teemtee/tools repo) — produces a recipe containing only tests matching specific outcomes (fail, error, warn) and can optionally rerun them.
+
+## Artifact Verification
+
+* The [artifact](https://tmt.readthedocs.io/en/stable/plugins/prepare.html#artifact) plugin now automatically verifies that required/recommended packages were installed from the expected artifact repository.
+
+* Artifact verification now correctly handles virtual provides and file paths (like `/usr/bin/make`) via `repoquery --whatprovides`.
+
+## Provisioning & Guests
+
+* [EPEL](https://tmt.readthedocs.io/en/stable/plugins/prepare-feature.html#epel) and [CRB](https://tmt.readthedocs.io/en/stable/plugins/prepare-feature.html#crb) in Image Mode — the `epel` and `crb` feature plugins now work in [image mode](https://tmt.readthedocs.io/en/stable/plugins/provision.html#bootc) using Containerfile-based workflows instead of Ansible playbooks.
+
+* Containerfile transfer fix — the generated Containerfile for [bootc](https://tmt.readthedocs.io/en/stable/plugins/provision.html#bootc) builds is now transferred via `push()` instead of SSH command inlining, preventing `ARG_MAX` overflow with large plan environments.
+
+* [Cleanup](https://tmt.readthedocs.io/en/stable/spec/plans.html#/spec/plans/cleanup) for failed guests — the cleanup step now runs for all provisioned guests, including those that failed to become ready.
+
+* Guest-specific plan [environment](https://tmt.readthedocs.io/en/stable/spec/plans.html#/spec/plans/environment) file — the plan environment file is now per-guest rather than shared, fixing a race condition where the last guest's file would overwrite the others.
+
+* `tmt-reboot` in shell plugins — the [tmt-reboot](https://tmt.readthedocs.io/en/stable/stories/features.html#/stories/features/reboot) script now works in prepare/shell and finish/shell plugins, consistent with how reboot works in tests.
+
+## Test Discovery & Filtering
+
+* Disabled remote plans not imported — disabled remote plans are skipped during `tmt run` and `tmt plan ls --enabled`, allowing plan URLs to be non-publicly accessible.
+
+* [Modified-only](https://tmt.readthedocs.io/en/stable/plugins/discover.html#modified-tests) path fix — modifying files in `/tests/foo` no longer incorrectly triggers tests in `/tests/foo-other`.
+
+## Integrations & Reporting
+
+* [Jira](https://tmt.readthedocs.io/en/stable/guide.html#link-issues) Cloud support — `tmt link` and `tmt test create` updated for Jira Cloud. The `email` key is now required in the `issue-tracker` config.
+
+* `web-link` field in [results](https://tmt.readthedocs.io/en/stable/spec/results.html) — test results now carry a browsable URL to the test's fmf metadata source, usable directly by reporting tools.
+
+* Custom results fallback — when custom [results](https://tmt.readthedocs.io/en/stable/spec/results.html) are missing, `output.txt` is referenced in result logs so test output remains available.
+
+## Environment & Hardware
+
+* [Plugin variables](https://tmt.readthedocs.io/en/stable/overview.html#plugin-variables) applied universally — `TMT_PLUGIN_*` variables are now recognized even when the corresponding plugin is not explicitly specified on the command line.
+
+* [Hardware presets](https://tmt.readthedocs.io/en/stable/spec/hardware.html#preset) specification — users can define named hardware profiles in YAML files and reference them via a `preset` key under [hardware](https://tmt.readthedocs.io/en/stable/spec/hardware.html). Ready for early feedback.
+
+## Framework & Checks
+
+* Framework/check package installation — packages required by test frameworks and checks are now installed during the prepare phase (order 70), simplifying beakerlib installation from EPEL on CentOS Stream.
+
+* [dmesg](https://tmt.readthedocs.io/en/stable/plugins/test-checks.html#dmesg) check path fix — the dmesg plugin now requires `/bin/dmesg`, fixing operation on older systems like RHEL-6.
+
+## tmt try
+
+* Beakerlib library cache cleared on re-run during [tmt try](https://tmt.readthedocs.io/en/stable/stories/cli.html#try) sessions, fixing stale library issues.
+
+* FIPS enable order fixed in [tmt try](https://tmt.readthedocs.io/en/stable/stories/cli.html#try) — FIPS enablement now runs after dependency installation to avoid FIPS-incompatible digest issues.
+
+## Other
+
+* [tmt clean](https://tmt.readthedocs.io/en/stable/examples.html#clean) shows disk space freed — displays per-workdir size and total freed space.
+
+* [Dry mode](https://tmt.readthedocs.io/en/stable/contribute.html#dry-mode) semantics documented — the Contribute guide now defines what `--dry` should and should not skip, with per-step behavior guidelines.
+
+* C-based YAML parser — `ruamel.yaml.clib` used by default, speeding up large `results.yaml` file operations.
+
+* Multiple [state formats](https://tmt.readthedocs.io/en/stable/overview.html#command-variables) — state files now support JSON in addition to YAML, selectable via `TMT_STATE_FORMAT`.
+
+* Shebang preservation — shebangs in helper scripts (`tmt-reboot`, `tmt-report-result`) are no longer altered during RPM packaging, fixing execution on older systems.


### PR DESCRIPTION
We are asked to provide an overview of the most interesting stuff achieved during the quarter. Adding reports for the last two quarters and a skill to simplify the generation in the future. The `md` format is used so that we can easily copy & paste the formatted content into the overall report if needed.

Pull Request Checklist

* [x] write the documentation