### PR TITLE
Plan source script shall be guest-specific file

### DIFF
--- a/tests/core/source-script/test.sh
+++ b/tests/core/source-script/test.sh
@@ -13,7 +13,7 @@ rlJournalStart
         # All tests are included in the tmt plan/test itself
         rlRun -s "tmt run --id $run -a provision --how=${PROVISION_HOW}" 0 "Run tests"
         # Make sure the file is still there
-        rlAssertExists $run/plan/data/plan-source-script.sh-default-0-default-0
+        rlAssertExists $run/plan/data/plan-source-script.sh-default-0
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/core/source-script/test.sh
+++ b/tests/core/source-script/test.sh
@@ -13,7 +13,7 @@ rlJournalStart
         # All tests are included in the tmt plan/test itself
         rlRun -s "tmt run --id $run -a provision --how=${PROVISION_HOW}" 0 "Run tests"
         # Make sure the file is still there
-        rlAssertExists $run/plan/data/plan-source-script.sh
+        rlAssertExists $run/plan/data/plan-source-script.sh-default-0-default-0
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -66,10 +66,6 @@ if TYPE_CHECKING:
     import tmt.log
 
 
-#: Filename associated with ``TMT_PLAN_SOURCE_SCRIPT``
-PLAN_SOURCE_SCRIPT_NAME: str = "plan-source-script.sh"
-
-
 class _RemotePlanReference(_RawFmfId):
     importing: Optional[str]
     scope: Optional[str]
@@ -476,7 +472,6 @@ class Plan(
 
         if self.my_run:
             environment['TMT_PLAN_DATA'] = EnvVarValue(self.data_directory)
-            environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(self.plan_source_script)
 
         return environment
 
@@ -719,15 +714,6 @@ class Plan(
         data_directory.mkdir(exist_ok=True, parents=True)
 
         return data_directory
-
-    @functools.cached_property
-    def plan_source_script(self) -> Path:
-        plan_sourced_file_path = self.data_directory / PLAN_SOURCE_SCRIPT_NAME
-        plan_sourced_file_path.touch(exist_ok=True)
-
-        self.debug(f"Create the environment file '{plan_sourced_file_path}'.", level=2)
-
-        return plan_sourced_file_path
 
     @staticmethod
     def edit_template(raw_content: str) -> str:

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -64,10 +64,6 @@ if TYPE_CHECKING:
     import tmt.log
 
 
-#: Filename associated with ``TMT_PLAN_SOURCE_SCRIPT``
-PLAN_SOURCE_SCRIPT_NAME: str = "plan-source-script.sh"
-
-
 class _RemotePlanReference(_RawFmfId):
     importing: Optional[str]
     scope: Optional[str]
@@ -475,7 +471,6 @@ class Plan(
 
         if self.my_run:
             environment['TMT_PLAN_DATA'] = EnvVarValue(self.data_directory)
-            environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(self.plan_source_script)
 
         return environment
 
@@ -716,15 +711,6 @@ class Plan(
         data_directory.mkdir(exist_ok=True, parents=True)
 
         return data_directory
-
-    @functools.cached_property
-    def plan_source_script(self) -> Path:
-        plan_sourced_file_path = self.data_directory / PLAN_SOURCE_SCRIPT_NAME
-        plan_sourced_file_path.touch(exist_ok=True)
-
-        self.debug(f"Create the environment file '{plan_sourced_file_path}'.", level=2)
-
-        return plan_sourced_file_path
 
     @staticmethod
     def edit_template(raw_content: str) -> str:

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -85,6 +85,9 @@ T = TypeVar('T')
 #: Name of the :ref:`plan environment file <step-variables>`.
 PLAN_ENVIRONMENT_FILENAME = 'variables.env'
 
+#: Name of the :ref:`plan source script <step-variables>`.
+PLAN_SOURCE_SCRIPT_FILENAME: str = "plan-source-script.sh"
+
 #: How many seconds to wait for a connection to succeed after guest boot.
 #: This is the default value tmt would use unless told otherwise.
 DEFAULT_CONNECT_TIMEOUT = 2 * 60
@@ -1891,6 +1894,22 @@ class Guest(
 
         return path
 
+    @functools.cached_property
+    def plan_source_script_path(self) -> Optional[Path]:
+        """
+        A path to the :ref:`plan source script <step-variables>` file.
+        """
+
+        if not isinstance(self.parent, tmt.steps.provision.Provision):
+            return None
+
+        path = self.parent.plan.data_directory / f'{PLAN_SOURCE_SCRIPT_FILENAME}-{self.safe_name}'
+        path.touch(exist_ok=True)
+
+        self.debug(f"Create the plan source script  '{path}'.", level=2)
+
+        return path
+
     @property
     def plan_environment(self) -> Environment:
         """
@@ -2236,12 +2255,15 @@ class Guest(
             if isinstance(self.parent, tmt.steps.Step):
                 environment.update(self.parent.plan)
 
-            # TODO: this was owned by plan, but at wrong position, and it will
-            # be owned by plan again once the dust of environment untangling
-            # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
-            # more.
+            # TODO: these are owned by plan, but at wrong position, and
+            # they will be owned by plan again once the dust of environment
+            # untangling settles. Follow https://github.com/teemtee/tmt/issues/4241
+            # for more.
             if self.plan_environment_path:
                 environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+
+            if self.plan_source_script_path:
+                environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(self.plan_source_script_path)
 
         else:
             # Create a copy of given environment - this prevents any

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2012,6 +2012,9 @@ class Guest(
         if self.plan_environment_path is not None:
             environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
 
+        if self.plan_source_script_path:
+            environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(self.plan_source_script_path)
+
         return environment
 
     @classmethod

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -91,6 +91,9 @@ T = TypeVar('T')
 #: Name of the :ref:`plan environment file <step-variables>`.
 PLAN_ENVIRONMENT_FILENAME = 'variables.env'
 
+#: Name of the :ref:`plan source script <step-variables>`.
+PLAN_SOURCE_SCRIPT_FILENAME: str = "plan-source-script.sh"
+
 #: How many seconds to wait for a connection to succeed after guest boot.
 #: This is the default value tmt would use unless told otherwise.
 DEFAULT_CONNECT_TIMEOUT = 2 * 60
@@ -1967,6 +1970,22 @@ class Guest(
 
         return path
 
+    @functools.cached_property
+    def plan_source_script_path(self) -> Optional[Path]:
+        """
+        A path to the :ref:`plan source script <step-variables>` file.
+        """
+
+        if not isinstance(self.parent, tmt.steps.provision.Provision):
+            return None
+
+        path = self.parent.plan.data_directory / f'{PLAN_SOURCE_SCRIPT_FILENAME}-{self.safe_name}'
+        path.touch(exist_ok=True)
+
+        self.debug(f"Create the plan source script  '{path}'.", level=2)
+
+        return path
+
     @property
     def plan_environment(self) -> Environment:
         """
@@ -2325,6 +2344,16 @@ class Guest(
 
             if isinstance(self.parent, tmt.steps.Step):
                 environment.update(self.parent.plan.intrinsic_environment)
+
+            # TODO: these are owned by plan, but at wrong position, and
+            # they will be owned by plan again once the dust of environment
+            # untangling settles. Follow https://github.com/teemtee/tmt/issues/4241
+            # for more.
+            if self.plan_environment_path:
+                environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+
+            if self.plan_source_script_path:
+                environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(self.plan_source_script_path)
 
         else:
             # Create a copy of given environment - this prevents any

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -388,11 +388,17 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
         else:
             environment = self._environment
 
-        # TODO: this was owned by plan, but at wrong position, and it will
-        # be owned by plan again once the dust of environment untangling
-        # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
-        # more.
-        environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.guest.plan_environment_path)
+        # TODO: these are owned by plan, but at wrong position, and
+        # they will be owned by plan again once the dust of environment
+        # untangling settles. Follow https://github.com/teemtee/tmt/issues/4241
+        # for more.
+        if self.guest.plan_environment_path:
+            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(
+                self.guest.plan_environment_path
+            )
+
+        if self.guest.plan_source_script_path:
+            environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(self.guest.plan_source_script_path)
 
         environment.update(
             # Add variables from invocation contexts
@@ -543,7 +549,9 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
                 on_process_end=_reset_process,
                 test_session=True,
                 friendly_command=str(self.test.test),
-                sourced_files=[self.phase.step.plan.plan_source_script],
+                sourced_files=[self.guest.plan_source_script_path]
+                if self.guest.plan_source_script_path
+                else [],
             )
 
             self.start_time = timer.start_time_formatted

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -408,6 +408,29 @@ class TestInvocation(HasStepWorkdir, HasEnvironment, HasIntrinsicEnvironment):
 
         environment.update(self.intrinsic_environment)
 
+        # TODO: these are owned by plan, but at wrong position, and
+        # they will be owned by plan again once the dust of environment
+        # untangling settles. Follow https://github.com/teemtee/tmt/issues/4241
+        # for more.
+        if self.guest.plan_environment_path:
+            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(
+                self.guest.plan_environment_path
+            )
+
+        if self.guest.plan_source_script_path:
+            environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(self.guest.plan_source_script_path)
+
+        environment.update(
+            # Add variables from invocation contexts
+            self.abort,
+            self.reboot,
+            self.restart,
+            self.pidfile,
+            self.restraint,
+            # Add variables the framework wants to expose
+            self.test.test_framework.get_environment_variables(self, self.logger),
+        )
+
         self._environment = environment
 
         return environment
@@ -546,7 +569,9 @@ class TestInvocation(HasStepWorkdir, HasEnvironment, HasIntrinsicEnvironment):
                 on_process_end=_reset_process,
                 test_session=True,
                 friendly_command=str(self.test.test),
-                sourced_files=[self.phase.step.plan.plan_source_script],
+                sourced_files=[self.guest.plan_source_script_path]
+                if self.guest.plan_source_script_path
+                else [],
             )
 
             if error is not None:

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -408,25 +408,13 @@ class TestInvocation(HasStepWorkdir, HasEnvironment, HasIntrinsicEnvironment):
 
         environment.update(self.intrinsic_environment)
 
-        # TODO: these are owned by plan, but at wrong position, and
-        # they will be owned by plan again once the dust of environment
-        # untangling settles. Follow https://github.com/teemtee/tmt/issues/4241
-        # for more.
-        if self.guest.plan_environment_path:
-            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(
-                self.guest.plan_environment_path
-            )
-
-        if self.guest.plan_source_script_path:
-            environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(self.guest.plan_source_script_path)
-
         environment.update(
             # Add variables from invocation contexts
-            self.abort,
-            self.reboot,
-            self.restart,
-            self.pidfile,
-            self.restraint,
+            self.abort.intrinsic_environment,
+            self.reboot.intrinsic_environment,
+            self.restart.intrinsic_environment,
+            self.pidfile.intrinsic_environment,
+            self.restraint.intrinsic_environment,
             # Add variables the framework wants to expose
             self.test.test_framework.get_environment_variables(self, self.logger),
         )

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -150,12 +150,15 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             self.step.plan.environment,
         )
 
-        # TODO: this was owned by plan, but at wrong position, and it will
-        # be owned by plan again once the dust of environment untangling
-        # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
-        # more.
+        # TODO: these are owned by plan, but at wrong position, and
+        # they will be owned by plan again once the dust of environment
+        # untangling settles. Follow https://github.com/teemtee/tmt/issues/4241
+        # for more.
         if guest.plan_environment_path:
             environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(guest.plan_environment_path)
+
+        if guest.plan_source_script_path:
+            environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(guest.plan_source_script_path)
 
         # Give a short summary
         overview = fmf.utils.listed(self.data.script, 'script')
@@ -246,7 +249,9 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
                 command=command,
                 cwd=worktree,
                 environment=environment,
-                sourced_files=[self.step.plan.plan_source_script],
+                sourced_files=[guest.plan_source_script_path]
+                if guest.plan_source_script_path
+                else [],
                 immediately=False,
             )
 

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -154,6 +154,16 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             self.step.plan.environment,
         )
 
+        # TODO: these are owned by plan, but at wrong position, and
+        # they will be owned by plan again once the dust of environment
+        # untangling settles. Follow https://github.com/teemtee/tmt/issues/4241
+        # for more.
+        if guest.plan_environment_path:
+            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(guest.plan_environment_path)
+
+        if guest.plan_source_script_path:
+            environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(guest.plan_source_script_path)
+
         # Give a short summary
         overview = fmf.utils.listed(self.data.script, 'script')
         logger.info('overview', f'{overview} found', 'green')
@@ -243,7 +253,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
                 command=command,
                 cwd=worktree,
                 environment=environment,
-                sourced_files=[self.step.plan.plan_source_script],
+                sourced_files=[guest.plan_source_script_path] if guest.plan_source_script_path else [],
                 immediately=self._execute_immediately,
             )
 

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -154,16 +154,6 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             self.step.plan.environment,
         )
 
-        # TODO: these are owned by plan, but at wrong position, and
-        # they will be owned by plan again once the dust of environment
-        # untangling settles. Follow https://github.com/teemtee/tmt/issues/4241
-        # for more.
-        if guest.plan_environment_path:
-            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(guest.plan_environment_path)
-
-        if guest.plan_source_script_path:
-            environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(guest.plan_source_script_path)
-
         # Give a short summary
         overview = fmf.utils.listed(self.data.script, 'script')
         logger.info('overview', f'{overview} found', 'green')
@@ -253,7 +243,9 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
                 command=command,
                 cwd=worktree,
                 environment=environment,
-                sourced_files=[guest.plan_source_script_path] if guest.plan_source_script_path else [],
+                sourced_files=[guest.plan_source_script_path]
+                if guest.plan_source_script_path
+                else [],
                 immediately=self._execute_immediately,
             )
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -75,12 +75,15 @@ class GuestLocal(tmt.Guest):
             if isinstance(self.parent, tmt.steps.Step):
                 environment.update(self.parent.plan)
 
-            # TODO: this was owned by plan, but at wrong position, and it will
-            # be owned by plan again once the dust of environment untangling
-            # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
-            # more.
+            # TODO: these are owned by plan, but at wrong position, and
+            # they will be owned by plan again once the dust of environment
+            # untangling settles. Follow https://github.com/teemtee/tmt/issues/4241
+            # for more.
             if self.plan_environment_path:
                 environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+
+            if self.plan_source_script_path:
+                environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(self.plan_source_script_path)
 
         else:
             environment = super()._prepare_command_environment(environment=environment)

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -81,6 +81,16 @@ class GuestLocal(tmt.Guest):
             if isinstance(self.parent, tmt.steps.Step):
                 environment.update(self.parent.plan.intrinsic_environment)
 
+            # TODO: these are owned by plan, but at wrong position, and
+            # they will be owned by plan again once the dust of environment
+            # untangling settles. Follow https://github.com/teemtee/tmt/issues/4241
+            # for more.
+            if self.plan_environment_path:
+                environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+
+            if self.plan_source_script_path:
+                environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(self.plan_source_script_path)
+
         else:
             environment = super()._prepare_command_environment(environment=environment)
 

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -81,16 +81,6 @@ class GuestLocal(tmt.Guest):
             if isinstance(self.parent, tmt.steps.Step):
                 environment.update(self.parent.plan.intrinsic_environment)
 
-            # TODO: these are owned by plan, but at wrong position, and
-            # they will be owned by plan again once the dust of environment
-            # untangling settles. Follow https://github.com/teemtee/tmt/issues/4241
-            # for more.
-            if self.plan_environment_path:
-                environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
-
-            if self.plan_source_script_path:
-                environment['TMT_PLAN_SOURCE_SCRIPT'] = EnvVarValue(self.plan_source_script_path)
-
         else:
             environment = super()._prepare_command_environment(environment=environment)
 


### PR DESCRIPTION
Similarly to plan environment file, plan source script also must be made guest-specific: as phases run on multiple guests at the same time, they modify their local file, stored on the guest, which may then be pulled by tmt into singular location, over writing each other.

Now, the situation is not as worse as it was in case of the environment file, since tmt does not pull the plan source script on purpose, and it certainly is not pushed to guests, but the principle is the same: multiple phases touch "one" file, on their guests, and tmt is not aware the file may be very different. By moving the ownership of the path to guest, and adding the suffix, we prevent any future confusion should we start pulling/pushing the file(s).

Pull Request Checklist

* [x] implement the feature