### PR TITLE
Disable unsafe ssh options

### DIFF
--- a/docs/releases/pending/5039.fmf
+++ b/docs/releases/pending/5039.fmf
@@ -1,0 +1,4 @@
+description: |
+    SSH options that can execute commands on the runner or set up network
+    forwarding are now blocked when specified via the ``ssh-option`` key in plan metadata.
+    Use the ``--feeling-safe`` option to allow them.

--- a/tests/provision/ssh-options/data/unsafe-ssh-options.fmf
+++ b/tests/provision/ssh-options/data/unsafe-ssh-options.fmf
@@ -8,5 +8,5 @@ discover:
 provision:
   how: virtual
   ssh-option:
-    - PermitLocalCommand=yes
+    - PermitLocalCommand yes
     - LocalCommand=echo "LocalCommand is not allowed"

--- a/tests/provision/ssh-options/data/unsafe-ssh-options.fmf
+++ b/tests/provision/ssh-options/data/unsafe-ssh-options.fmf
@@ -1,0 +1,12 @@
+execute:
+    how: tmt
+discover:
+    how: shell
+    tests:
+    - name: smoke
+      test: echo
+provision:
+  how: virtual
+  ssh-option:
+    - PermitLocalCommand=yes
+    - LocalCommand=echo "LocalCommand is not allowed"

--- a/tests/provision/ssh-options/test.sh
+++ b/tests/provision/ssh-options/test.sh
@@ -34,7 +34,7 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Test unsafe SSH options are not allowed $PROVISION_HOW"
-      rlRun "tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW plan -n unsafe-ssh-options" 2
+      rlRun "TMT_FEELING_SAFE=0 tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW plan -n unsafe-ssh-options" 2
       rlAssertGrep "SSH option 'PermitLocalCommand' is not allowed" "$run/log.txt"
       rlAssertNotGrep "Run command: ssh .*-oPermitLocalCommand yes" "$run/log.txt"
       rlAssertNotGrep "Run command: ssh .*-oLocalCommand=echo \"LocalCommand is not allowed\"" "$run/log.txt"

--- a/tests/provision/ssh-options/test.sh
+++ b/tests/provision/ssh-options/test.sh
@@ -9,20 +9,20 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "Test guest-specific SSH options with provision $PROVISION_HOW"
-        rlRun "tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW --ssh-option ServerAliveCountMax=123456789"
+        rlRun "tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW --ssh-option ServerAliveCountMax=123456789 plan -n plan"
         rlAssertGrep "Run command: ssh .*-oServerAliveCountMax=123456789" "$run/log.txt"
     rlPhaseEnd
 
     rlPhaseStartTest "Test global SSH options with provision $PROVISION_HOW"
-        rlRun "TMT_SSH_SERVER_ALIVE_COUNT_MAX=123456789 tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW"
+        rlRun "TMT_SSH_SERVER_ALIVE_COUNT_MAX=123456789 tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW plan -n plan"
         rlAssertGrep "Run command: ssh .*-oServerAliveCountMax=123456789" "$run/log.txt"
 
-        rlRun "TMT_SSH_ServerAliveCountMax=123456789 tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW"
+        rlRun "TMT_SSH_ServerAliveCountMax=123456789 tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW plan -n plan"
         rlAssertGrep "Run command: ssh .*-oServeralivecountmax=123456789" "$run/log.txt"
     rlPhaseEnd
 
     rlPhaseStartTest "Test global SSH options occur first in ssh parameters $PROVISION_HOW"
-      rlRun "TMT_SSH_SERVER_ALIVE_INTERVAL=7 TMT_SSH_SERVER_ALIVE_COUNT_MAX=9 tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW"
+      rlRun "TMT_SSH_SERVER_ALIVE_INTERVAL=7 TMT_SSH_SERVER_ALIVE_COUNT_MAX=9 tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW plan -n plan"
       # check that default and custom_ssh_options are present
       rlAssertGrep "Run command: ssh .*-oServerAliveInterval=7" "$run/log.txt"
       rlAssertGrep "Run command: ssh .*-oServerAliveInterval=5" "$run/log.txt"
@@ -31,6 +31,19 @@ rlJournalStart
       # check that custom_ssh_options occur before default ssh options
       rlAssertGrep "Run command: ssh .*-oServerAliveInterval=7.*-oServerAliveInterval=5" "$run/log.txt"
       rlAssertGrep "Run command: ssh .*-oServerAliveCountMax=9.*-oServerAliveCountMax=60" "$run/log.txt"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test unsafe SSH options are not allowed $PROVISION_HOW"
+      rlRun "tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW plan -n unsafe-ssh-options" 2
+      rlAssertGrep "SSH option 'PermitLocalCommand' is not allowed" "$run/log.txt"
+      rlAssertNotGrep "Run command: ssh .*-oPermitLocalCommand=yes" "$run/log.txt"
+      rlAssertNotGrep "Run command: ssh .*-oLocalCommand=echo \"LocalCommand is not allowed\"" "$run/log.txt"
+    rlPhaseEnd
+
+    rlPhaseStartTest "Test unsafe SSH options are allowed with --feeling-safe $PROVISION_HOW"
+      rlRun "tmt --feeling-safe run --scratch -vvi $run -a provision -h $PROVISION_HOW plan -n unsafe-ssh-options"
+      rlAssertGrep "Run command: ssh .*-oPermitLocalCommand=yes" "$run/log.txt"
+      rlAssertGrep "Run command: ssh .*-oLocalCommand=echo \"LocalCommand is not allowed\"" "$run/log.txt"
     rlPhaseEnd
 
     rlPhaseStartCleanup

--- a/tests/provision/ssh-options/test.sh
+++ b/tests/provision/ssh-options/test.sh
@@ -36,13 +36,13 @@ rlJournalStart
     rlPhaseStartTest "Test unsafe SSH options are not allowed $PROVISION_HOW"
       rlRun "tmt run --scratch -vvi $run -a provision -h $PROVISION_HOW plan -n unsafe-ssh-options" 2
       rlAssertGrep "SSH option 'PermitLocalCommand' is not allowed" "$run/log.txt"
-      rlAssertNotGrep "Run command: ssh .*-oPermitLocalCommand=yes" "$run/log.txt"
+      rlAssertNotGrep "Run command: ssh .*-oPermitLocalCommand yes" "$run/log.txt"
       rlAssertNotGrep "Run command: ssh .*-oLocalCommand=echo \"LocalCommand is not allowed\"" "$run/log.txt"
     rlPhaseEnd
 
     rlPhaseStartTest "Test unsafe SSH options are allowed with --feeling-safe $PROVISION_HOW"
       rlRun "tmt --feeling-safe run --scratch -vvi $run -a provision -h $PROVISION_HOW plan -n unsafe-ssh-options"
-      rlAssertGrep "Run command: ssh .*-oPermitLocalCommand=yes" "$run/log.txt"
+      rlAssertGrep "Run command: ssh .*-oPermitLocalCommand yes" "$run/log.txt"
       rlAssertGrep "Run command: ssh .*-oLocalCommand=echo \"LocalCommand is not allowed\"" "$run/log.txt"
     rlPhaseEnd
 

--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -8,7 +8,6 @@ import pytest
 from pytest_container.container import ContainerData
 
 from tmt.guest import (
-    UNSAFE_SSH_OPTIONS,
     AnsibleApplicable,
     Guest,
     GuestData,
@@ -358,26 +357,6 @@ class TestPodmanNetworkSetup:
         assert result == ['--network', expected_network]
 
 
-@pytest.mark.parametrize('option_name', sorted(UNSAFE_SSH_OPTIONS))
-def test_unsafe_ssh_option_blocked(
-    root_logger: Logger, option_name: str, monkeypatch: Any
-) -> None:
-    """Unsafe SSH options are rejected without --feeling-safe."""
-    step = Provision(
-        plan=MagicMock(name='mock<plan>', is_dry_run=False), raw_data=[{}], logger=root_logger
-    )
-    guest = GuestSsh(
-        logger=root_logger,
-        parent=step,
-        name='foo',
-        data=GuestSshData(primary_address='bar', ssh_option=[f'{option_name}=echo']),
-    )
-    monkeypatch.setattr(type(guest), 'is_feeling_safe', property(lambda _: False))
-
-    with pytest.raises(GeneralError, match='--feeling-safe'):
-        _ = guest._ssh_options
-
-
 @pytest.mark.parametrize(
     'option',
     [
@@ -404,22 +383,3 @@ def test_unsafe_ssh_option_case_and_separator(
 
     with pytest.raises(GeneralError, match='--feeling-safe'):
         _ = guest._ssh_options
-
-
-def test_unsafe_ssh_option_allowed_with_feeling_safe(
-    root_logger: Logger, monkeypatch: Any
-) -> None:
-    """Unsafe SSH options are permitted when --feeling-safe is active."""
-    step = Provision(
-        plan=MagicMock(name='mock<plan>', is_dry_run=False), raw_data=[{}], logger=root_logger
-    )
-    guest = GuestSsh(
-        logger=root_logger,
-        parent=step,
-        name='foo',
-        data=GuestSshData(primary_address='bar', ssh_option=['ProxyCommand=echo']),
-    )
-    monkeypatch.setattr(type(guest), 'is_feeling_safe', property(lambda _: True))
-
-    options = guest._ssh_options
-    assert '-oProxyCommand=echo' in options._command

--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -378,6 +378,34 @@ def test_unsafe_ssh_option_blocked(
         _ = guest._ssh_options
 
 
+@pytest.mark.parametrize(
+    'option',
+    [
+        'ProxyCommand=echo',  # canonical casing, '=' separator
+        'PROXYCOMMAND=echo',  # all-caps
+        'ProxyCommand echo',  # space separator
+        'proxycommand echo',  # space separator, lowercase
+    ],
+)
+def test_unsafe_ssh_option_case_and_separator(
+    root_logger: Logger, option: str, monkeypatch: Any
+) -> None:
+    """Unsafe option check is case-insensitive and handles both '=' and space separators."""
+    step = Provision(
+        plan=MagicMock(name='mock<plan>', is_dry_run=False), raw_data=[{}], logger=root_logger
+    )
+    guest = GuestSsh(
+        logger=root_logger,
+        parent=step,
+        name='foo',
+        data=GuestSshData(primary_address='bar', ssh_option=[option]),
+    )
+    monkeypatch.setattr(type(guest), 'is_feeling_safe', property(lambda _: False))
+
+    with pytest.raises(GeneralError, match='--feeling-safe'):
+        _ = guest._ssh_options
+
+
 def test_unsafe_ssh_option_allowed_with_feeling_safe(
     root_logger: Logger, monkeypatch: Any
 ) -> None:

--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -364,6 +364,7 @@ class TestPodmanNetworkSetup:
         'PROXYCOMMAND=echo',  # all-caps
         'ProxyCommand echo',  # space separator
         'proxycommand echo',  # space separator, lowercase
+        ' ProxyCommand=echo',  # leading space
     ],
 )
 def test_unsafe_ssh_option_case_and_separator(

--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -8,6 +8,7 @@ import pytest
 from pytest_container.container import ContainerData
 
 from tmt.guest import (
+    UNSAFE_SSH_OPTIONS,
     AnsibleApplicable,
     Guest,
     GuestData,
@@ -22,6 +23,7 @@ from tmt.utils import (
     Command,
     CommandOutput,
     Environment,
+    GeneralError,
     OnProcessEndCallback,
     OnProcessStartCallback,
     Path,
@@ -354,3 +356,42 @@ class TestPodmanNetworkSetup:
 
         # Verify return value includes prefixed network name
         assert result == ['--network', expected_network]
+
+
+@pytest.mark.parametrize('option_name', sorted(UNSAFE_SSH_OPTIONS))
+def test_unsafe_ssh_option_blocked(
+    root_logger: Logger, option_name: str, monkeypatch: Any
+) -> None:
+    """Unsafe SSH options are rejected without --feeling-safe."""
+    step = Provision(
+        plan=MagicMock(name='mock<plan>', is_dry_run=False), raw_data=[{}], logger=root_logger
+    )
+    guest = GuestSsh(
+        logger=root_logger,
+        parent=step,
+        name='foo',
+        data=GuestSshData(primary_address='bar', ssh_option=[f'{option_name}=echo']),
+    )
+    monkeypatch.setattr(type(guest), 'is_feeling_safe', property(lambda _: False))
+
+    with pytest.raises(GeneralError, match='--feeling-safe'):
+        _ = guest._ssh_options
+
+
+def test_unsafe_ssh_option_allowed_with_feeling_safe(
+    root_logger: Logger, monkeypatch: Any
+) -> None:
+    """Unsafe SSH options are permitted when --feeling-safe is active."""
+    step = Provision(
+        plan=MagicMock(name='mock<plan>', is_dry_run=False), raw_data=[{}], logger=root_logger
+    )
+    guest = GuestSsh(
+        logger=root_logger,
+        parent=step,
+        name='foo',
+        data=GuestSshData(primary_address='bar', ssh_option=['ProxyCommand=echo']),
+    )
+    monkeypatch.setattr(type(guest), 'is_feeling_safe', property(lambda _: True))
+
+    options = guest._ssh_options
+    assert '-oProxyCommand=echo' in options._command

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -218,6 +218,28 @@ DEFAULT_SSH_OPTIONS: tmt.utils.RawCommand = [
 #: Identity files (``-i``) are all considered in order.
 BASE_SSH_OPTIONS: tmt.utils.RawCommand = configure_ssh_options() + DEFAULT_SSH_OPTIONS
 
+#: SSH options that allow executing arbitrary commands on the runner or setting up
+#: unintended network forwarding.
+UNSAFE_SSH_OPTIONS: frozenset[str] = frozenset(
+    {
+        # Executes an arbitrary command on the local machine to establish the connection.
+        'proxycommand',
+        # Passes the connection file descriptor to a helper instead of executing
+        # ProxyCommand; still requires a helper program to run locally.
+        'proxyusefdpass',
+        # When set to yes, enables LocalCommand execution after connection.
+        'permitlocalcommand',
+        # Executes a command locally after the connection is established.
+        'localcommand',
+        # Configures local port forwarding (may expose local services to the remote).
+        'localforward',
+        # Configures remote port forwarding (may expose remote services locally).
+        'remoteforward',
+        # Configures dynamic port forwarding / SOCKS proxy.
+        'dynamicforward',
+    }
+)
+
 #: SSH master socket path is limited to this many characters.
 #:
 #: * UNIX socket path is limited to either 108 or 104 characters, depending
@@ -3216,7 +3238,15 @@ class GuestSsh(Guest, CommandCollector):
         if self.is_ssh_multiplexing_enabled:
             options.append(f'-S{self._ssh_master_socket_path}')
 
-        options.extend([f'-o{option}' for option in self.ssh_option])
+        for option in self.ssh_option:
+            # ssh_config(5) keywords are case-insensitive
+            option_name = option.split('=', 1)[0].lower()
+            if option_name in UNSAFE_SSH_OPTIONS and not self.is_feeling_safe:
+                raise GeneralError(
+                    f"SSH option '{option.split('=', 1)[0]}' is not allowed without the "
+                    f"'--feeling-safe' option. "
+                )
+            options.append(f'-o{option}')
 
         return Command(*options)
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -237,6 +237,8 @@ UNSAFE_SSH_OPTIONS: frozenset[str] = frozenset(
         'remoteforward',
         # Configures dynamic port forwarding / SOCKS proxy.
         'dynamicforward',
+        # Executes a command on the local machine to retrieve known host keys.
+        'knownhostscommand',
     }
 )
 
@@ -3239,11 +3241,11 @@ class GuestSsh(Guest, CommandCollector):
             options.append(f'-S{self._ssh_master_socket_path}')
 
         for option in self.ssh_option:
-            option_keyword, *_ = re.split(r'[=\s]', option, maxsplit=1)
+            option_keyword = re.split(r'[=\s]', option.strip(), maxsplit=1)[0]
             if option_keyword.lower() in UNSAFE_SSH_OPTIONS and not self.is_feeling_safe:
                 raise GeneralError(
                     f"SSH option '{option_keyword}' is not allowed without the "
-                    f"'--feeling-safe' option. "
+                    f"'--feeling-safe' option."
                 )
             options.append(f'-o{option}')
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -3239,11 +3239,10 @@ class GuestSsh(Guest, CommandCollector):
             options.append(f'-S{self._ssh_master_socket_path}')
 
         for option in self.ssh_option:
-            # ssh_config(5) keywords are case-insensitive
-            option_name = option.split('=', 1)[0].lower()
-            if option_name in UNSAFE_SSH_OPTIONS and not self.is_feeling_safe:
+            option_keyword, *_ = re.split(r'[=\s]', option, maxsplit=1)
+            if option_keyword.lower() in UNSAFE_SSH_OPTIONS and not self.is_feeling_safe:
                 raise GeneralError(
-                    f"SSH option '{option.split('=', 1)[0]}' is not allowed without the "
+                    f"SSH option '{option_keyword}' is not allowed without the "
                     f"'--feeling-safe' option. "
                 )
             options.append(f'-o{option}')


### PR DESCRIPTION
`--feeling-safe` option must be specified to allow them. Add unit tests and integration tests.

Assisted-by: Cursor AI

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] include a release note
