### PR TITLE
Move Environment class to its own module

### DIFF
--- a/tests/unit/test_guest.py
+++ b/tests/unit/test_guest.py
@@ -21,7 +21,6 @@ from tmt.steps.provision.podman import GuestContainer, PodmanGuestData
 from tmt.utils import (
     Command,
     CommandOutput,
-    Environment,
     GeneralError,
     OnProcessEndCallback,
     OnProcessStartCallback,
@@ -29,6 +28,7 @@ from tmt.utils import (
     RunError,
     ShellScript,
 )
+from tmt.utils.environment import Environment
 from tmt.utils.wait import Waiting
 
 from . import TEST_CONTAINERS

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -8,10 +8,10 @@ import tmt
 import tmt.guest
 import tmt.queue
 import tmt.steps
-import tmt.utils
 from tmt.log import Logger
 from tmt.steps import Phase
 from tmt.utils import GeneralError
+from tmt.utils.environment import Environment
 
 
 class TestPhaseAssertFeelingSafe:
@@ -77,7 +77,7 @@ def fixture_mocked_queue(
             self,
             *,
             guest: tmt.guest.Guest,
-            environment: Optional[tmt.utils.Environment] = None,
+            environment: Optional[Environment] = None,
             logger: Logger,
         ) -> None:
             pass

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -39,6 +39,7 @@ from tmt.utils import (
     duration_to_seconds,
     filter_paths,
 )
+from tmt.utils.environment import Environment
 from tmt.utils.git import (
     clonable_git_url,
     git_add,
@@ -1536,7 +1537,7 @@ _test_format_value_big_list = list(range(1, 20))
             """,  # noqa: E501
         ),
         # environment
-        (tmt.utils.Environment.from_dict({'FOO': 'BAR'}), None, 'FOO\033[0m: BAR'),
+        (Environment.from_dict({'FOO': 'BAR'}), None, 'FOO\033[0m: BAR'),
         # fmf context
         (
             tmt.utils.FmfContext({'foo': ['bar', 'baz']}),

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -64,7 +64,6 @@ from tmt.container import (
 from tmt.lint import LinterOutcome, LinterReturn
 from tmt.result import ResultInterpret
 from tmt.utils import (
-    Environment,
     FmfContext,
     Path,
     ShellScript,
@@ -72,6 +71,7 @@ from tmt.utils import (
     to_yaml,
     verdict,
 )
+from tmt.utils.environment import Environment
 from tmt.utils.themes import style
 
 if TYPE_CHECKING:
@@ -1198,11 +1198,11 @@ class Test(
         normalize=normalize_require,
         exporter=lambda value: [dependency.to_minimal_spec() for dependency in value],
     )
-    environment: tmt.utils.Environment = field(
-        default_factory=tmt.utils.Environment,
-        normalize=tmt.utils.Environment.normalize,
+    environment: Environment = field(
+        default_factory=Environment,
+        normalize=Environment.normalize,
         serialize=lambda environment: environment.to_fmf_spec(),
-        unserialize=lambda serialized: tmt.utils.Environment.from_fmf_spec(serialized),
+        unserialize=lambda serialized: Environment.from_fmf_spec(serialized),
         exporter=lambda environment: environment.to_fmf_spec(),
     )
 

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -49,17 +49,15 @@ from tmt.container import SpecBasedContainer, container, field
 from tmt.lint import LinterOutcome, LinterReturn
 from tmt.utils import (
     Command,
-    Environment,
-    EnvVarValue,
     FmfContext,
     GeneralError,
-    HasEnvironment,
     HasPlanWorkdir,
     HasRunWorkdir,
     HasUserAnchorPath,
     style,
     to_yaml,
 )
+from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
 
 if TYPE_CHECKING:
     import tmt.cli

--- a/tmt/base/run.py
+++ b/tmt/base/run.py
@@ -39,15 +39,14 @@ from tmt.recipe import RecipeManager
 from tmt.result import Result
 from tmt.utils import (
     Command,
-    Environment,
     GeneralError,
-    HasEnvironment,
     HasRunWorkdir,
     HasUserAnchorPath,
     Path,
     StateFormat,
     WorkdirArgumentType,
 )
+from tmt.utils.environment import Environment, HasEnvironment
 
 if TYPE_CHECKING:
     import tmt.cli
@@ -73,7 +72,7 @@ class RunData(SerializableContainer):
     environment: Environment = field(
         default_factory=Environment,
         serialize=lambda environment: environment.to_fmf_spec(),
-        unserialize=lambda serialized: tmt.utils.Environment.from_fmf_spec(serialized),
+        unserialize=lambda serialized: Environment.from_fmf_spec(serialized),
     )
 
 
@@ -333,7 +332,7 @@ class Run(HasRunWorkdir, HasUserAnchorPath, HasEnvironment, tmt.utils.Common):
 
         assert self.tree is not None  # narrow type
 
-        return tmt.utils.Environment.from_cli_options(
+        return Environment.from_cli_options(
             raw_cli_environment_files=self.opt('environment-file') or [],
             raw_cli_environment=self.opt('environment') or [],
             file_root=Path(self.tree.root) if self.tree.root else None,

--- a/tmt/checks/__init__.py
+++ b/tmt/checks/__init__.py
@@ -15,8 +15,6 @@ from tmt.container import (
 from tmt.plugins import PluginRegistry
 from tmt.utils import NormalizeKeysMixin
 from tmt.utils.environment import Environment
-from tmt.utils.environment import EnvVarName as EnvVarName
-from tmt.utils.environment import EnvVarValue as EnvVarValue
 
 if TYPE_CHECKING:
     import tmt.base.core

--- a/tmt/checks/__init__.py
+++ b/tmt/checks/__init__.py
@@ -14,6 +14,9 @@ from tmt.container import (
 )
 from tmt.plugins import PluginRegistry
 from tmt.utils import NormalizeKeysMixin
+from tmt.utils.environment import Environment
+from tmt.utils.environment import EnvVarName as EnvVarName
+from tmt.utils.environment import EnvVarValue as EnvVarValue
 
 if TYPE_CHECKING:
     import tmt.base.core
@@ -163,7 +166,7 @@ class Check(
         *,
         event: CheckEvent,
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list['CheckResult']:
         """
@@ -268,7 +271,7 @@ class CheckPlugin(tmt.utils._CommonBase, Generic[CheckT]):
         *,
         check: CheckT,
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list['CheckResult']:
         return []
@@ -279,7 +282,7 @@ class CheckPlugin(tmt.utils._CommonBase, Generic[CheckT]):
         *,
         check: CheckT,
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list['CheckResult']:
         return []

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -21,6 +21,7 @@ from tmt.utils import (
     render_command_report,
     safe_call,
 )
+from tmt.utils.environment import Environment
 from tmt.utils.hints import hints_as_notes
 
 if TYPE_CHECKING:
@@ -493,7 +494,7 @@ class AvcDenials(CheckPlugin[AvcCheck]):
         *,
         check: 'AvcCheck',
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         if invocation.guest.facts.has_selinux:
@@ -507,7 +508,7 @@ class AvcDenials(CheckPlugin[AvcCheck]):
         *,
         check: 'AvcCheck',
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         if not invocation.guest.facts.has_selinux:

--- a/tmt/checks/coredump.py
+++ b/tmt/checks/coredump.py
@@ -9,6 +9,7 @@ from tmt.checks import Check, CheckPlugin, _RawCheck, provides_check
 from tmt.container import container, field
 from tmt.result import CheckResult, ResultOutcome, save_failures
 from tmt.utils import Command, Path, ShellScript
+from tmt.utils.environment import Environment
 
 if TYPE_CHECKING:
     from tmt.guest import Guest
@@ -530,7 +531,7 @@ class Coredump(CheckPlugin[CoredumpCheck]):
         *,
         check: "CoredumpCheck",
         invocation: "TestInvocation",
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         """Check for crashes before the test starts."""
@@ -568,7 +569,7 @@ class Coredump(CheckPlugin[CoredumpCheck]):
         *,
         check: "CoredumpCheck",
         invocation: "TestInvocation",
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         """Check for crashes after the test finishes."""

--- a/tmt/checks/dmesg.py
+++ b/tmt/checks/dmesg.py
@@ -11,6 +11,7 @@ from tmt.container import container, field
 from tmt.guest import GuestCapability
 from tmt.result import CheckResult, ResultOutcome, save_failures
 from tmt.utils import Path, Stopwatch
+from tmt.utils.environment import Environment
 from tmt.utils.hints import hints_as_notes
 
 if TYPE_CHECKING:
@@ -211,7 +212,7 @@ class Dmesg(CheckPlugin[DmesgCheck]):
         *,
         check: 'DmesgCheck',
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         if not invocation.guest.facts.has_capability(GuestCapability.SYSLOG_ACTION_READ_ALL):
@@ -232,7 +233,7 @@ class Dmesg(CheckPlugin[DmesgCheck]):
         *,
         check: 'DmesgCheck',
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         if not invocation.guest.facts.has_capability(GuestCapability.SYSLOG_ACTION_READ_ALL):

--- a/tmt/checks/internal/abort.py
+++ b/tmt/checks/internal/abort.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 import tmt.log
-import tmt.utils
 from tmt.checks import CheckPlugin, provides_check
 from tmt.checks.internal import InternalCheck
 from tmt.container import container
@@ -9,6 +8,7 @@ from tmt.result import CheckResult, ResultOutcome
 from tmt.steps.context.abort import AbortStep
 from tmt.steps.execute import TestInvocation
 from tmt.utils import ProcessExitCodes
+from tmt.utils.environment import Environment
 
 CHECK_NAME = 'internal/abort'
 
@@ -41,7 +41,7 @@ class Abort(CheckPlugin[AbortCheck]):
         *,
         check: 'AbortCheck',
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         if (

--- a/tmt/checks/internal/guest.py
+++ b/tmt/checks/internal/guest.py
@@ -7,6 +7,7 @@ from tmt.checks.internal import InternalCheck
 from tmt.container import container
 from tmt.result import CheckResult, ResultOutcome
 from tmt.steps.execute import TestInvocation
+from tmt.utils.environment import Environment
 
 CHECK_NAME = 'internal/guest'
 
@@ -40,7 +41,7 @@ class GuestFailures(CheckPlugin[GuestCheck]):
         *,
         check: 'GuestCheck',
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         if any(isinstance(exc, tmt.utils.RebootTimeoutError) for exc in invocation.exceptions):

--- a/tmt/checks/internal/interrupt.py
+++ b/tmt/checks/internal/interrupt.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 import tmt.log
-import tmt.utils
 import tmt.utils.signals
 from tmt.checks import CheckPlugin, provides_check
 from tmt.checks.internal import InternalCheck
@@ -9,6 +8,7 @@ from tmt.container import container
 from tmt.result import CheckResult, ResultOutcome
 from tmt.steps.execute import TestInvocation
 from tmt.utils import ProcessExitCodes
+from tmt.utils.environment import Environment
 
 CHECK_NAME = 'internal/interrupt'
 
@@ -41,7 +41,7 @@ class Interrupt(CheckPlugin[InterruptCheck]):
         *,
         check: 'InterruptCheck',
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         if invocation.return_code in (ProcessExitCodes.SIGINT, ProcessExitCodes.SIGTERM) or any(

--- a/tmt/checks/internal/invocation.py
+++ b/tmt/checks/internal/invocation.py
@@ -8,6 +8,7 @@ from tmt.container import container
 from tmt.result import CheckResult, ResultOutcome
 from tmt.steps.execute import TestInvocation
 from tmt.utils import ProcessExitCodes
+from tmt.utils.environment import Environment
 
 CHECK_NAME = 'internal/invocation'
 
@@ -41,7 +42,7 @@ class Invocation(CheckPlugin[InvocationCheck]):
         *,
         check: 'InvocationCheck',
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         if ProcessExitCodes.is_pidfile(invocation.return_code):

--- a/tmt/checks/internal/permission.py
+++ b/tmt/checks/internal/permission.py
@@ -1,13 +1,13 @@
 from typing import Optional
 
 import tmt.log
-import tmt.utils
 from tmt.checks import CheckPlugin, provides_check
 from tmt.checks.internal import InternalCheck
 from tmt.container import container
 from tmt.result import CheckResult, ResultOutcome
 from tmt.steps.execute import TestInvocation
 from tmt.utils import ProcessExitCodes
+from tmt.utils.environment import Environment
 
 CHECK_NAME = 'internal/permission'
 
@@ -40,7 +40,7 @@ class Permission(CheckPlugin[PermissionCheck]):
         *,
         check: 'PermissionCheck',
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         if invocation.return_code == ProcessExitCodes.PERMISSION_DENIED:

--- a/tmt/checks/internal/timeout.py
+++ b/tmt/checks/internal/timeout.py
@@ -1,13 +1,13 @@
 from typing import Optional
 
 import tmt.log
-import tmt.utils
 from tmt.checks import CheckPlugin, provides_check
 from tmt.checks.internal import InternalCheck
 from tmt.container import container
 from tmt.result import CheckResult, ResultOutcome
 from tmt.steps.execute import TestInvocation
 from tmt.utils import ProcessExitCodes
+from tmt.utils.environment import Environment
 
 CHECK_NAME = 'internal/timeout'
 
@@ -40,7 +40,7 @@ class Timeout(CheckPlugin[TimeoutCheck]):
         *,
         check: 'TimeoutCheck',
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         if invocation.return_code == ProcessExitCodes.TIMEOUT:

--- a/tmt/checks/journal.py
+++ b/tmt/checks/journal.py
@@ -8,6 +8,7 @@ from tmt.checks import Check, CheckPlugin, _RawCheck, provides_check
 from tmt.container import container, field
 from tmt.result import CheckResult, ResultOutcome, save_failures
 from tmt.utils import Path, ShellScript, Stopwatch
+from tmt.utils.environment import Environment
 from tmt.utils.hints import hints_as_notes
 
 if TYPE_CHECKING:
@@ -301,7 +302,7 @@ class Journal(CheckPlugin[JournalCheck]):
         *,
         check: 'JournalCheck',
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         if not invocation.guest.facts.has_systemd:
@@ -323,7 +324,7 @@ class Journal(CheckPlugin[JournalCheck]):
         *,
         check: 'JournalCheck',
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         if not invocation.guest.facts.has_systemd:

--- a/tmt/checks/watchdog.py
+++ b/tmt/checks/watchdog.py
@@ -16,6 +16,7 @@ from tmt.checks import Check, CheckPlugin, provides_check
 from tmt.container import container, field
 from tmt.result import CheckResult, ResultOutcome
 from tmt.utils import Path, format_timestamp, render_run_exception_streams
+from tmt.utils.environment import Environment
 
 if TYPE_CHECKING:
     from tmt.steps.execute import TestInvocation
@@ -443,7 +444,7 @@ class Watchdog(CheckPlugin[WatchdogCheck]):
         *,
         check: WatchdogCheck,
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         # Setup a logger
@@ -502,7 +503,7 @@ class Watchdog(CheckPlugin[WatchdogCheck]):
         *,
         check: WatchdogCheck,
         invocation: 'TestInvocation',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> list[CheckResult]:
         watchdog_logger = logger.clone()

--- a/tmt/cli/_root.py
+++ b/tmt/cli/_root.py
@@ -35,6 +35,7 @@ import tmt.utils.jira
 from tmt.cli import CliInvocation, Context, ContextObject, CustomGroup, pass_context
 from tmt.options import Deprecated, create_options_decorator, option
 from tmt.utils import Command, GeneralError, Path, effective_workdir_root
+from tmt.utils.environment import Environment
 
 if TYPE_CHECKING:
     import tmt.steps.cleanup
@@ -1999,7 +2000,7 @@ def setup_completion(shell: str, install: bool, context: Context, logger: tmt.lo
     completions = (
         Command('tmt')
         .run(
-            environment=tmt.utils.Environment.from_dict(env_var),
+            environment=Environment.from_dict(env_var),
             cwd=None,
             logger=context.obj.logger,
         )

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -1115,7 +1115,7 @@ def read_nitrate_case(
         echo(style('contact: ', fg='green') + data['contact'])
     # Environment
     if testcase.arguments:
-        data['environment'] = tmt.utils.Environment.from_sequence(testcase.arguments, logger)
+        data['environment'] = Environment.from_sequence(testcase.arguments, logger)
         if not data['environment']:
             data.pop('environment')
         else:

--- a/tmt/convert.py
+++ b/tmt/convert.py
@@ -19,6 +19,7 @@ import tmt.identifier
 import tmt.log
 import tmt.utils
 from tmt.utils import ConvertError, GeneralError, Path, format_value
+from tmt.utils.environment import Environment
 from tmt.utils.structured_field import StructuredField
 from tmt.utils.themes import style
 
@@ -1309,7 +1310,7 @@ def relevancy_to_adjust(
             rule['enabled'] = False
         else:
             try:
-                rule['environment'] = tmt.utils.Environment.from_sequence(decision, logger)
+                rule['environment'] = Environment.from_sequence(decision, logger)
             except tmt.utils.GeneralError as error:
                 raise ConvertError(
                     f"Invalid test case relevancy decision '{decision}'."

--- a/tmt/frameworks/__init__.py
+++ b/tmt/frameworks/__init__.py
@@ -6,6 +6,9 @@ import tmt.plugins
 import tmt.result
 import tmt.utils
 from tmt.guest import TransferOptions
+from tmt.utils.environment import Environment
+from tmt.utils.environment import EnvVarName as EnvVarName
+from tmt.utils.environment import EnvVarValue as EnvVarValue
 
 if TYPE_CHECKING:
     from tmt.base.core import DependencySimple, Test
@@ -53,7 +56,7 @@ class TestFramework(abc.ABC):
         cls,
         invocation: 'TestInvocation',
         logger: tmt.log.Logger,
-    ) -> tmt.utils.Environment:
+    ) -> Environment:
         """
         Provide additional environment variables for the test.
 
@@ -64,7 +67,7 @@ class TestFramework(abc.ABC):
             might have already collected.
         """
 
-        return tmt.utils.Environment()
+        return Environment()
 
     @classmethod
     def get_test_command(

--- a/tmt/frameworks/__init__.py
+++ b/tmt/frameworks/__init__.py
@@ -7,8 +7,6 @@ import tmt.result
 import tmt.utils
 from tmt.guest import TransferOptions
 from tmt.utils.environment import Environment
-from tmt.utils.environment import EnvVarName as EnvVarName
-from tmt.utils.environment import EnvVarValue as EnvVarValue
 
 if TYPE_CHECKING:
     from tmt.base.core import DependencySimple, Test

--- a/tmt/frameworks/beakerlib.py
+++ b/tmt/frameworks/beakerlib.py
@@ -10,7 +10,8 @@ import tmt.utils
 from tmt.frameworks import TestFramework, provides_framework
 from tmt.guest import TransferOptions
 from tmt.result import ResultOutcome, save_failures
-from tmt.utils import Environment, EnvVarValue, GeneralError, Path
+from tmt.utils import GeneralError, Path
+from tmt.utils.environment import Environment, EnvVarValue
 
 if TYPE_CHECKING:
     from tmt.base.core import DependencySimple, Test
@@ -74,7 +75,7 @@ class Beakerlib(TestFramework):
     @classmethod
     def get_environment_variables(
         cls, invocation: 'TestInvocation', logger: tmt.log.Logger
-    ) -> tmt.utils.Environment:
+    ) -> Environment:
         # The beakerlib calls the command in this variable in the following way:
         # $BEAKERLIB_COMMAND_REPORT_RESULT "$testname" "$result" "$logfile" "$score"
         # - https://github.com/beakerlib/beakerlib/blob/5a85937f557b735f32996eb55cd6b9a33f3fe653/src/testing.sh#L1076

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -70,7 +70,6 @@ from tmt.utils import (
     effective_workdir_root,
 )
 from tmt.utils.environment import Environment, EnvVarValue
-from tmt.utils.environment import EnvVarName as EnvVarName
 from tmt.utils.hints import get_hint
 from tmt.utils.wait import Deadline, Waiting
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -60,8 +60,6 @@ from tmt.package_managers import (
 )
 from tmt.utils import (
     Command,
-    Environment,
-    EnvVarValue,
     GeneralError,
     OnProcessEndCallback,
     OnProcessStartCallback,
@@ -71,6 +69,8 @@ from tmt.utils import (
     configure_constant,
     effective_workdir_root,
 )
+from tmt.utils.environment import Environment, EnvVarValue
+from tmt.utils.environment import EnvVarName as EnvVarName
 from tmt.utils.hints import get_hint
 from tmt.utils.wait import Deadline, Waiting
 
@@ -1350,11 +1350,11 @@ class GuestData(
         unserialize=lambda serialized: GuestFacts.from_serialized(serialized),
     )
 
-    environment: tmt.utils.Environment = field(
-        default_factory=tmt.utils.Environment,
-        normalize=tmt.utils.Environment.normalize,
+    environment: Environment = field(
+        default_factory=Environment,
+        normalize=Environment.normalize,
         serialize=lambda environment: environment.to_fmf_spec(),
-        unserialize=lambda serialized: tmt.utils.Environment.from_fmf_spec(serialized),
+        unserialize=lambda serialized: Environment.from_fmf_spec(serialized),
         exporter=lambda environment: environment.to_fmf_spec(),
         help="""
             Environment variables to be defined for this guest. These will be available
@@ -1679,7 +1679,7 @@ class CommandCollector(abc.ABC):
         *,
         sourced_files: Optional[list[Path]] = None,
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
     ) -> None:
         """
         Collect a command for later batch execution.
@@ -1765,7 +1765,7 @@ class Guest(
 
     hardware: Optional[tmt.hardware.Hardware]
 
-    environment: tmt.utils.Environment
+    environment: Environment
 
     ansible: Optional[GuestAnsible]
 
@@ -1926,7 +1926,7 @@ class Guest(
             and self.plan_environment_path.exists()
             and self.plan_environment_path.stat().st_size > 0
         ):
-            return tmt.utils.Environment.from_file(
+            return Environment.from_file(
                 filename=self.plan_environment_path.name,
                 root=self.plan_environment_path.parent,
                 logger=self._logger,
@@ -2241,8 +2241,8 @@ class Guest(
     # go away while works on https://github.com/teemtee/tmt/pull/4364
     # continue.
     def _prepare_command_environment(
-        self, environment: Optional[tmt.utils.Environment] = None
-    ) -> tmt.utils.Environment:
+        self, environment: Optional[Environment] = None
+    ) -> Environment:
         """
         Prepare meaningful environment for a command.
 
@@ -2253,7 +2253,7 @@ class Guest(
         """
 
         if environment is None:
-            environment = tmt.utils.Environment()
+            environment = Environment()
 
             environment.update(self.environment)
 
@@ -2280,7 +2280,7 @@ class Guest(
         friendly_command: Optional[str] = None,
         silent: bool = False,
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         interactive: bool = False,
         log: Optional[tmt.log.LoggingFunction] = None,
         **kwargs: Any,
@@ -2411,7 +2411,7 @@ class Guest(
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: Literal[True] = True,
@@ -2431,7 +2431,7 @@ class Guest(
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: Literal[False] = False,
@@ -2451,7 +2451,7 @@ class Guest(
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,
@@ -3007,7 +3007,7 @@ class GuestSsh(Guest, CommandCollector):
         *,
         sourced_files: Optional[list[Path]] = None,
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
     ) -> None:
         """
         Collect a command for image mode container build.
@@ -3466,7 +3466,7 @@ class GuestSsh(Guest, CommandCollector):
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: Literal[True] = True,
@@ -3486,7 +3486,7 @@ class GuestSsh(Guest, CommandCollector):
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: Literal[False] = False,
@@ -3505,7 +3505,7 @@ class GuestSsh(Guest, CommandCollector):
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,

--- a/tmt/libraries/beakerlib.py
+++ b/tmt/libraries/beakerlib.py
@@ -14,7 +14,8 @@ from tmt.base.core import Dependency, DependencyFmfId, DependencySimple
 from tmt.container import container, simple_field
 from tmt.convert import write
 from tmt.steps.discover import Discover
-from tmt.utils import Command, Environment, EnvVarValue, Path
+from tmt.utils import Command, Path
+from tmt.utils.environment import Environment, EnvVarValue
 
 from . import Library, LibraryError
 

--- a/tmt/log.py
+++ b/tmt/log.py
@@ -52,6 +52,7 @@ from tmt.container import SpecBasedContainer, container, simple_field
 if TYPE_CHECKING:
     import tmt.cli
     import tmt.utils
+    import tmt.utils.environment
     import tmt.utils.themes
 
 # Log in workdir
@@ -96,7 +97,7 @@ LoggableValue = Union[
     int,
     bool,
     float,
-    'tmt.utils.Environment',
+    'tmt.utils.environment.Environment',
     'tmt.utils.FmfContext',
     'tmt.utils.Path',
     'tmt.utils.Command',

--- a/tmt/policy.py
+++ b/tmt/policy.py
@@ -8,6 +8,7 @@ from tmt._compat.pydantic import ValidationError
 from tmt.container import PYDANTIC_V1, ConfigDict, MetadataContainer, metadata_field
 from tmt.log import Logger, Topic
 from tmt.utils import FieldValueSource, Path, ShellScript
+from tmt.utils.environment import Environment
 from tmt.utils.templates import render_template
 
 if TYPE_CHECKING:
@@ -122,7 +123,7 @@ class Instruction(MetadataContainer):
 
         if isinstance(
             current_value,
-            (float, int, bool, str, list, dict, ShellScript, tmt.utils.Environment),
+            (float, int, bool, str, list, dict, ShellScript, Environment),
         ):
             current_value = set_key(
                 key,

--- a/tmt/recipe.py
+++ b/tmt/recipe.py
@@ -16,7 +16,8 @@ from tmt.log import Logger
 from tmt.result import ResultInterpret
 from tmt.steps import STEPS, Step, _RawStepData
 from tmt.steps.discover import Discover, TestOrigin
-from tmt.utils import Common, Environment, FmfContext, NormalizeKeysMixin, Path, ShellScript
+from tmt.utils import Common, FmfContext, NormalizeKeysMixin, Path, ShellScript
+from tmt.utils.environment import Environment
 
 if TYPE_CHECKING:
     from tmt.base.core import (

--- a/tmt/steps/__init__.py
+++ b/tmt/steps/__init__.py
@@ -62,9 +62,6 @@ from tmt.utils import (
     DEFAULT_NAME,
     Command,
     CommandOutput,
-    Environment,
-    EnvVarName,
-    EnvVarValue,
     GeneralError,
     HasPhaseWorkdir,
     HasPlanWorkdir,
@@ -75,6 +72,7 @@ from tmt.utils import (
     ShellScript,
     Stopwatch,
 )
+from tmt.utils.environment import Environment, EnvVarName, EnvVarValue
 from tmt.utils.templates import render_template
 
 if TYPE_CHECKING:
@@ -2916,7 +2914,7 @@ class Plugin(BasePlugin[StepDataT, PluginReturnValueT]):
         self,
         *,
         guest: 'Guest',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> PluginReturnValueT:
         """
@@ -3303,7 +3301,7 @@ class Login(Action):
     def _login(
         self,
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
     ) -> None:
         """
         Run the interactive command
@@ -3371,7 +3369,7 @@ class Login(Action):
         self,
         results: list['tmt.result.Result'],
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
     ) -> None:
         """
         Check and login after test execution

--- a/tmt/steps/cleanup/__init__.py
+++ b/tmt/steps/cleanup/__init__.py
@@ -15,8 +15,6 @@ from tmt.steps import (
     PluginTask,
 )
 from tmt.utils.environment import Environment
-from tmt.utils.environment import EnvVarName as EnvVarName
-from tmt.utils.environment import EnvVarValue as EnvVarValue
 
 
 @container

--- a/tmt/steps/cleanup/__init__.py
+++ b/tmt/steps/cleanup/__init__.py
@@ -14,6 +14,9 @@ from tmt.steps import (
     PluginOutcome,
     PluginTask,
 )
+from tmt.utils.environment import Environment
+from tmt.utils.environment import EnvVarName as EnvVarName
+from tmt.utils.environment import EnvVarValue as EnvVarValue
 
 
 @container
@@ -43,7 +46,7 @@ class CleanupPlugin(tmt.steps.Plugin[CleanupStepDataT, PluginOutcome]):
         self,
         *,
         guest: 'Guest',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> PluginOutcome:
         self.go_prolog(logger)

--- a/tmt/steps/cleanup/internal.py
+++ b/tmt/steps/cleanup/internal.py
@@ -3,9 +3,9 @@ from typing import Optional
 import tmt.log
 import tmt.steps
 import tmt.steps.cleanup
-import tmt.utils
 from tmt.container import container
 from tmt.guest import Guest
+from tmt.utils.environment import Environment
 
 
 @container
@@ -26,7 +26,7 @@ class CleanupInternal(tmt.steps.cleanup.CleanupPlugin[CleanupInternalData]):
         self,
         *,
         guest: 'Guest',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> tmt.steps.PluginOutcome:
         """

--- a/tmt/steps/context/abort.py
+++ b/tmt/steps/context/abort.py
@@ -4,7 +4,8 @@ import tmt.log
 import tmt.steps.scripts
 import tmt.utils
 from tmt.container import container
-from tmt.utils import Environment, HasEnvironment, Path
+from tmt.utils import Path
+from tmt.utils.environment import Environment, HasEnvironment
 
 
 class AbortStep(tmt.utils.GeneralError):

--- a/tmt/steps/context/pidfile.py
+++ b/tmt/steps/context/pidfile.py
@@ -83,7 +83,8 @@ import tmt.steps
 from tmt.container import container
 from tmt.guest import Guest, TransferOptions
 from tmt.steps import safe_filename
-from tmt.utils import Environment, EnvVarValue, HasEnvironment, Path, ShellScript
+from tmt.utils import Path, ShellScript
+from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
 from tmt.utils.templates import render_template
 
 TEST_PIDFILE_FILENAME = 'tmt-test.pid'

--- a/tmt/steps/context/reboot.py
+++ b/tmt/steps/context/reboot.py
@@ -8,7 +8,8 @@ import tmt.steps.scripts
 import tmt.utils
 from tmt.container import MetadataContainer, container
 from tmt.guest import Guest, RebootMode, SoftRebootModes
-from tmt.utils import Environment, EnvVarValue, HasEnvironment, Path, ShellScript
+from tmt.utils import Path, ShellScript
+from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
 from tmt.utils.wait import Deadline, Waiting
 
 if TYPE_CHECKING:

--- a/tmt/steps/context/restart.py
+++ b/tmt/steps/context/restart.py
@@ -4,7 +4,7 @@ import tmt.log
 import tmt.utils
 from tmt.container import container
 from tmt.guest import Guest
-from tmt.utils import Environment, EnvVarValue, HasEnvironment
+from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
 
 if TYPE_CHECKING:
     from tmt.steps.context.reboot import RebootContext

--- a/tmt/steps/context/restraint.py
+++ b/tmt/steps/context/restraint.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import tmt.log
 from tmt.container import container
-from tmt.utils import Environment, EnvVarValue, HasEnvironment
+from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
 
 
 @container

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -28,7 +28,9 @@ import tmt.utils.git
 import tmt.utils.url
 from tmt.plugins import PluginRegistry
 from tmt.steps import Action
-from tmt.utils import Command, Environment, EnvVarValue, GeneralError, Path
+from tmt.utils import Command, GeneralError, Path
+from tmt.utils.environment import Environment, EnvVarValue
+from tmt.utils.environment import EnvVarName as EnvVarName
 
 
 def normalize_ref(

--- a/tmt/steps/discover/__init__.py
+++ b/tmt/steps/discover/__init__.py
@@ -30,7 +30,6 @@ from tmt.plugins import PluginRegistry
 from tmt.steps import Action
 from tmt.utils import Command, GeneralError, Path
 from tmt.utils.environment import Environment, EnvVarValue
-from tmt.utils.environment import EnvVarName as EnvVarName
 
 
 def normalize_ref(

--- a/tmt/steps/discover/shell.py
+++ b/tmt/steps/discover/shell.py
@@ -29,6 +29,7 @@ from tmt.utils import (
     Path,
     ShellScript,
 )
+from tmt.utils.environment import Environment
 
 T = TypeVar('T', bound='TestDescription')
 
@@ -143,11 +144,11 @@ class TestDescription(
             for recommend in serialized_recommends
         ],
     )
-    environment: tmt.utils.Environment = field(
-        default_factory=tmt.utils.Environment,
-        normalize=tmt.utils.Environment.normalize,
+    environment: Environment = field(
+        default_factory=Environment,
+        normalize=Environment.normalize,
         serialize=lambda environment: environment.to_fmf_spec(),
-        unserialize=lambda serialized: tmt.utils.Environment.from_fmf_spec(serialized),
+        unserialize=lambda serialized: Environment.from_fmf_spec(serialized),
         exporter=lambda environment: environment.to_fmf_spec(),
     )
     check: list[tmt.checks.Check] = field(

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -41,9 +41,6 @@ from tmt.steps.discover import Discover, DiscoverPlugin
 from tmt.utils import (
     Command,
     CommandOutput,
-    Environment,
-    EnvVarValue,
-    HasEnvironment,
     HasStepWorkdir,
     Path,
     ProcessExitCodes,
@@ -51,6 +48,8 @@ from tmt.utils import (
     Stopwatch,
     configure_bool_constant,
 )
+from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
+from tmt.utils.environment import EnvVarName as EnvVarName
 
 if TYPE_CHECKING:
     import tmt.base.plan
@@ -700,7 +699,7 @@ class ExecutePlugin(tmt.steps.Plugin[ExecuteStepDataT, None]):
         self,
         *,
         guest: 'Guest',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> None:
         self.go_prolog(logger)

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -49,7 +49,6 @@ from tmt.utils import (
     configure_bool_constant,
 )
 from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
-from tmt.utils.environment import EnvVarName as EnvVarName
 
 if TYPE_CHECKING:
     import tmt.base.plan

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -19,7 +19,8 @@ from tmt.steps.execute import (
     TestInvocation,
 )
 from tmt.steps.report.display import ResultRenderer
-from tmt.utils import Environment, ShellScript
+from tmt.utils import ShellScript
+from tmt.utils.environment import Environment
 from tmt.utils.themes import style
 
 #
@@ -502,7 +503,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
         self,
         *,
         guest: 'Guest',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> None:
         """

--- a/tmt/steps/execute/upgrade.py
+++ b/tmt/steps/execute/upgrade.py
@@ -21,7 +21,8 @@ from tmt.steps.execute import ExecutePlugin
 from tmt.steps.execute.internal import ExecuteInternal, ExecuteInternalData
 from tmt.steps.prepare import PreparePlugin
 from tmt.steps.prepare.install import PrepareInstallData
-from tmt.utils import Environment, EnvVarValue, Path
+from tmt.utils import Path
+from tmt.utils.environment import Environment, EnvVarValue
 
 STATUS_VARIABLE = 'IN_PLACE_UPGRADE'
 BEFORE_UPGRADE_PREFIX = 'old'
@@ -281,7 +282,7 @@ class ExecuteUpgrade(ExecuteInternal):
         self,
         *,
         guest: tmt.guest.Guest,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> None:
         """

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -18,8 +18,6 @@ from tmt.steps import (
     sync_with_guests,
 )
 from tmt.utils.environment import Environment
-from tmt.utils.environment import EnvVarName as EnvVarName
-from tmt.utils.environment import EnvVarValue as EnvVarValue
 
 
 @container

--- a/tmt/steps/finish/__init__.py
+++ b/tmt/steps/finish/__init__.py
@@ -17,6 +17,9 @@ from tmt.steps import (
     PullTask,
     sync_with_guests,
 )
+from tmt.utils.environment import Environment
+from tmt.utils.environment import EnvVarName as EnvVarName
+from tmt.utils.environment import EnvVarValue as EnvVarValue
 
 
 @container
@@ -43,7 +46,7 @@ class FinishPlugin(tmt.steps.Plugin[FinishStepDataT, PluginOutcome]):
         self,
         *,
         guest: 'Guest',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> PluginOutcome:
         self.go_prolog(logger)

--- a/tmt/steps/prepare/__init__.py
+++ b/tmt/steps/prepare/__init__.py
@@ -4,7 +4,6 @@ import fmf.utils
 
 import tmt.log
 import tmt.steps
-import tmt.utils
 from tmt.container import container, simple_field
 from tmt.guest import Guest
 from tmt.plugins import PluginRegistry
@@ -18,6 +17,7 @@ from tmt.steps import (
     sync_with_guests,
 )
 from tmt.utils import uniq
+from tmt.utils.environment import Environment
 
 if TYPE_CHECKING:
     import tmt.base.core
@@ -53,7 +53,7 @@ class PreparePlugin(tmt.steps.Plugin[PrepareStepDataT, PluginOutcome]):
         self,
         *,
         guest: 'tmt.guest.Guest',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> PluginOutcome:
         """

--- a/tmt/steps/prepare/ansible.py
+++ b/tmt/steps/prepare/ansible.py
@@ -23,6 +23,7 @@ from tmt.utils import (
     normalize_string_list,
     retry_session,
 )
+from tmt.utils.environment import Environment
 
 
 class _RawAnsibleStepData(tmt.steps._RawStepData, total=False):
@@ -177,7 +178,7 @@ class PrepareAnsible(tmt.steps.prepare.PreparePlugin[PrepareAnsibleData]):
         self,
         *,
         guest: 'Guest',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> tmt.steps.PluginOutcome:
         """

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -25,7 +25,10 @@ from tmt.steps.prepare.verify_installation import (
     PrepareVerifyInstallation,  # pyright: ignore[reportUnknownVariableType]
     PrepareVerifyInstallationData,
 )
-from tmt.utils import Environment, Path
+from tmt.utils import Path
+from tmt.utils.environment import Environment
+from tmt.utils.environment import EnvVarName as EnvVarName
+from tmt.utils.environment import EnvVarValue as EnvVarValue
 
 
 @container

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -27,8 +27,6 @@ from tmt.steps.prepare.verify_installation import (
 )
 from tmt.utils import Path
 from tmt.utils.environment import Environment
-from tmt.utils.environment import EnvVarName as EnvVarName
-from tmt.utils.environment import EnvVarValue as EnvVarValue
 
 
 @container

--- a/tmt/steps/prepare/distgit.py
+++ b/tmt/steps/prepare/distgit.py
@@ -11,6 +11,7 @@ from tmt.package_managers import Package
 from tmt.steps.prepare import PreparePlugin
 from tmt.steps.prepare.install import PrepareInstallData
 from tmt.utils import Command, Path, ShellScript, uniq
+from tmt.utils.environment import Environment
 
 if TYPE_CHECKING:
     import tmt.base.core
@@ -184,7 +185,7 @@ class PrepareDistGit(tmt.steps.prepare.PreparePlugin[DistGitData]):
         self,
         *,
         guest: 'Guest',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> tmt.steps.PluginOutcome:
         """
@@ -196,7 +197,7 @@ class PrepareDistGit(tmt.steps.prepare.PreparePlugin[DistGitData]):
         if self.is_dry_run:
             return outcome
 
-        environment = environment or tmt.utils.Environment()
+        environment = environment or Environment()
 
         # Packages required for this plugin to work and additional required packages
         explicit_requires = [Package(p) for p in self.get('require', [])] + [Package('rpm-build')]

--- a/tmt/steps/prepare/feature/__init__.py
+++ b/tmt/steps/prepare/feature/__init__.py
@@ -16,6 +16,9 @@ from tmt.container import container
 from tmt.guest import Guest
 from tmt.plugins import PluginRegistry
 from tmt.utils import Path
+from tmt.utils.environment import Environment
+from tmt.utils.environment import EnvVarName as EnvVarName
+from tmt.utils.environment import EnvVarValue as EnvVarValue
 from tmt.utils.templates import render_template
 
 FEATURE_PLAYEBOOK_RESOURCE = 'steps/prepare/feature'
@@ -348,7 +351,7 @@ class PrepareFeature(tmt.steps.prepare.PreparePlugin[PrepareFeatureData]):
         self,
         *,
         guest: 'Guest',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> tmt.steps.PluginOutcome:
         """

--- a/tmt/steps/prepare/feature/__init__.py
+++ b/tmt/steps/prepare/feature/__init__.py
@@ -17,8 +17,6 @@ from tmt.guest import Guest
 from tmt.plugins import PluginRegistry
 from tmt.utils import Path
 from tmt.utils.environment import Environment
-from tmt.utils.environment import EnvVarName as EnvVarName
-from tmt.utils.environment import EnvVarValue as EnvVarValue
 from tmt.utils.templates import render_template
 
 FEATURE_PLAYEBOOK_RESOURCE = 'steps/prepare/feature'

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -22,6 +22,7 @@ from tmt.package_managers import (
     PackageUrl,
 )
 from tmt.utils import Path
+from tmt.utils.environment import Environment
 
 
 @container
@@ -402,7 +403,7 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
         self,
         *,
         guest: 'Guest',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> tmt.steps.PluginOutcome:
         """

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -13,7 +13,8 @@ import tmt.utils.git
 from tmt.container import container, field
 from tmt.guest import DEFAULT_PULL_OPTIONS, Guest, TransferOptions
 from tmt.steps import safe_filename
-from tmt.utils import Command, EnvVarValue, ShellScript, Stopwatch
+from tmt.utils import Command, ShellScript, Stopwatch
+from tmt.utils.environment import Environment, EnvVarValue
 
 PREPARE_WRAPPER_FILENAME = 'tmt-prepare-wrapper.sh'
 
@@ -120,7 +121,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
         self,
         *,
         guest: 'Guest',
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         logger: tmt.log.Logger,
     ) -> tmt.steps.PluginOutcome:
         """
@@ -143,7 +144,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             phase=self, guest=guest, logger=logger
         )
 
-        environment = environment or tmt.utils.Environment()
+        environment = environment or Environment()
         environment.update(
             guest.environment,
             guest.plan_environment,
@@ -238,7 +239,7 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
 
         def _invoke_script(
             command: ShellScript,
-            environment: tmt.utils.Environment,
+            environment: Environment,
         ) -> Optional[tmt.utils.CommandOutput]:
             guest.push(source=self.phase_workdir)
 

--- a/tmt/steps/prepare/verify_installation.py
+++ b/tmt/steps/prepare/verify_installation.py
@@ -10,7 +10,7 @@ from tmt.log import Logger
 from tmt.package_managers import SpecialPackageOrigin
 from tmt.result import PhaseResult, ResultGuestData, ResultOutcome
 from tmt.steps.prepare import PreparePlugin, PrepareStepData
-from tmt.utils import Environment
+from tmt.utils.environment import Environment
 
 
 @container

--- a/tmt/steps/provision/bootc.py
+++ b/tmt/steps/provision/bootc.py
@@ -14,6 +14,7 @@ from tmt.container import container, field
 from tmt.package_managers.bootc import LOCALHOST_BOOTC_IMAGE_PREFIX
 from tmt.steps.provision.testcloud import GuestTestcloud
 from tmt.utils import Path
+from tmt.utils.environment import Environment
 from tmt.utils.templates import render_template
 
 if TYPE_CHECKING:
@@ -25,9 +26,7 @@ DEFAULT_IMAGE_BUILDER = "quay.io/centos-bootc/bootc-image-builder:latest"
 CONTAINER_STORAGE_DIR = tmt.utils.Path("/var/lib/containers/storage")
 
 PODMAN_MACHINE_NAME = 'podman-machine-tmt'
-PODMAN_ENV = tmt.utils.Environment.from_dict(
-    {"CONTAINER_CONNECTION": f'{PODMAN_MACHINE_NAME}-root'}
-)
+PODMAN_ENV = Environment.from_dict({"CONTAINER_CONNECTION": f'{PODMAN_MACHINE_NAME}-root'})
 
 DEFAULT_PODMAN_MACHINE_CPU = 2
 DEFAULT_PODMAN_MACHINE_MEM: 'Size' = tmt.hardware.UNITS('2048 MB')

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -15,12 +15,12 @@ from tmt.guest import RebootMode, TransferOptions
 from tmt.steps import Step
 from tmt.utils import (
     Command,
-    EnvVarValue,
     OnProcessEndCallback,
     OnProcessStartCallback,
     Path,
     ShellScript,
 )
+from tmt.utils.environment import Environment, EnvVarValue
 from tmt.utils.hints import get_hint
 from tmt.utils.wait import Waiting
 
@@ -65,10 +65,10 @@ class GuestLocal(tmt.Guest):
     # the environment with the tmt process environment, since the guest
     # is the same as the runner.
     def _prepare_command_environment(
-        self, environment: Optional[tmt.utils.Environment] = None
-    ) -> tmt.utils.Environment:
+        self, environment: Optional[Environment] = None
+    ) -> Environment:
         if environment is None:
-            environment = tmt.utils.Environment.from_environ()
+            environment = Environment.from_environ()
 
             environment.update(self.environment)
 
@@ -149,7 +149,7 @@ class GuestLocal(tmt.Guest):
         self,
         command: Union[Command, ShellScript],
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,

--- a/tmt/steps/provision/mock.py
+++ b/tmt/steps/provision/mock.py
@@ -20,6 +20,7 @@ from tmt._compat.typing import Self
 from tmt.container import container, field
 from tmt.guest import RebootMode
 from tmt.utils import Command, OnProcessEndCallback, OnProcessStartCallback, Path, ShellScript
+from tmt.utils.environment import Environment
 from tmt.utils.wait import Waiting
 
 MOCK_PIPE: Path = Path('/srv/tmt-mock')
@@ -319,7 +320,7 @@ class MockShell:
         command: Command,
         *,
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         friendly_command: Optional[str] = None,
         log: Optional[tmt.log.LoggingFunction] = None,
         silent: bool = False,
@@ -580,7 +581,7 @@ class GuestMock(tmt.Guest):
         self,
         command: Union[Command, ShellScript],
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -24,6 +24,7 @@ from tmt.utils import (
     ShellScript,
     retry,
 )
+from tmt.utils.environment import Environment
 from tmt.utils.hints import get_hint
 from tmt.utils.wait import Deadline, Waiting
 
@@ -258,7 +259,7 @@ class GuestContainer(tmt.Guest):
 
         # Filter out variables with newlines - podman's env-file format
         # does not support multiline values (one line = one variable)
-        filtered_environment = tmt.utils.Environment()
+        filtered_environment = Environment()
         for key, value in environment.items():
             if '\n' in value:
                 self.warn(
@@ -487,7 +488,7 @@ class GuestContainer(tmt.Guest):
         try:
             return self._run_guest_command(
                 Command('podman') + command,
-                environment=tmt.utils.Environment.from_environ(),
+                environment=Environment.from_environ(),
                 silent=silent,
                 **kwargs,
             )
@@ -506,7 +507,7 @@ class GuestContainer(tmt.Guest):
         self,
         command: Union[tmt.utils.Command, tmt.utils.ShellScript],
         cwd: Optional[Path] = None,
-        environment: Optional[tmt.utils.Environment] = None,
+        environment: Optional[Environment] = None,
         friendly_command: Optional[str] = None,
         test_session: bool = False,
         immediately: bool = True,

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -28,7 +28,7 @@ import unicodedata
 import urllib.parse
 import warnings
 from collections import Counter
-from collections.abc import Iterable, Iterator, Mapping, Sequence
+from collections.abc import Iterable, Iterator
 from math import ceil
 from re import Pattern
 from threading import RLock, Thread
@@ -75,6 +75,7 @@ from tmt._compat.pathlib import Path
 from tmt._compat.typing import ParamSpec, Self
 from tmt.container import container
 from tmt.log import LoggableValue
+from tmt.utils.environment import Environment
 from tmt.utils.themes import style
 
 if TYPE_CHECKING:
@@ -82,7 +83,7 @@ if TYPE_CHECKING:
     import tmt.base.run
     import tmt.cli
     import tmt.utils.themes
-    from tmt._compat.typing import TypeAlias
+    from tmt._compat.typing import TypeAlias as TypeAlias
     from tmt.guest import GuestLog
     from tmt.hardware.constraints import Size
 
@@ -352,6 +353,8 @@ class FmfContext(dict[str, list[str]]):
             -c arch=x86_64,ppc64 -> {'arch': ['x86_64', 'ppc64']}
         """
 
+        from tmt.utils.environment import Environment
+
         raw_fmf_context: dict[str, list[str]] = {}
         for key, value in Environment.from_sequence(spec, logger).items():
             if not value.strip():
@@ -424,566 +427,6 @@ class FmfContext(dict[str, list[str]]):
         """
 
         return FmfContext(serialized)
-
-
-#: A type of environment variable name.
-EnvVarName: 'TypeAlias' = str
-
-# This one is not an alias: a full-fledged class makes type linters
-# enforce strict instantiation of objects rather than accepting
-# strings where `EnvVarValue` is expected.
-
-
-class EnvVarValue(str):
-    """
-    A type of environment variable value
-    """
-
-    def __new__(cls, raw_value: Any) -> Self:
-        if isinstance(raw_value, str):
-            return str.__new__(cls, raw_value)
-
-        if isinstance(raw_value, Path):
-            return str.__new__(cls, str(raw_value))
-
-        raise GeneralError(
-            f"Only strings and paths can be environment variables, '{type(raw_value)}' found."
-        )
-
-
-class HasEnvironment(abc.ABC):
-    """
-    A class that provides :py:attr:`environment` attribute.
-    """
-
-    @property
-    @abc.abstractmethod
-    def environment(self) -> 'Environment':
-        """
-        Environment variables this object wants to expose to user commands.
-        """
-
-        raise NotImplementedError
-
-
-class Environment(dict[str, EnvVarValue]):
-    """
-    Represents a set of environment variables.
-
-    See https://tmt.readthedocs.io/en/latest/spec/tests.html#environment,
-    https://tmt.readthedocs.io/en/latest/spec/plans.html#environment and
-    https://tmt.readthedocs.io/en/latest/spec/plans.html#environment-file.
-    """
-
-    def __init__(self, data: Optional[dict[EnvVarName, EnvVarValue]] = None) -> None:
-        super().__init__(data or {})
-
-    @classmethod
-    def from_dotenv(cls, content: str) -> 'Environment':
-        """
-        Construct environment from a ``.env`` format.
-
-        :param content: string containing variables defined in the "dotenv"
-            format, https://hexdocs.pm/dotenvy/dotenv-file-format.html.
-        """
-
-        environment = Environment()
-
-        try:
-            for line in shlex.split(content, comments=True):
-                key, value = line.split("=", maxsplit=1)
-
-                environment[key] = EnvVarValue(value)
-
-        except Exception as exc:
-            raise GeneralError("Failed to extract variables from 'dotenv' format.") from exc
-
-        return environment
-
-    @classmethod
-    def from_yaml(cls, content: str) -> 'Environment':
-        """
-        Construct environment from a YAML format.
-
-        :param content: string containing variables defined in a YAML
-            dictionary, i.e. ``key: value`` entries.
-        """
-
-        try:
-            yaml = YAML(typ="safe").load(content)
-
-        except Exception as exc:
-            raise GeneralError('Failed to extract variables from YAML format.') from exc
-
-        # Handle empty file as an empty environment
-        if yaml is None:
-            return Environment()
-
-        if not isinstance(yaml, dict):
-            raise GeneralError(
-                'Failed to extract variables from YAML format, '
-                'YAML defining variables must be a dictionary.'
-            )
-
-        if any(isinstance(v, (dict, list)) for v in yaml.values()):
-            raise GeneralError(
-                'Failed to extract variables from YAML format, '
-                'only primitive types are accepted as values.'
-            )
-
-        return Environment({key: EnvVarValue(str(value)) for key, value in yaml.items()})
-
-    @classmethod
-    def from_yaml_file(
-        cls,
-        filepath: Path,
-        logger: tmt.log.Logger,
-    ) -> 'Environment':
-        """
-        Construct environment from a YAML file.
-
-        File is expected to contain variables in a YAML dictionary, i.e.
-        ``key: value`` entries. Only primitive types - strings, numbers,
-        booleans - are allowed as values.
-
-        :param path: path to the file with variables.
-        :param logger: used for logging.
-        """
-
-        try:
-            content = filepath.read_text()
-
-        except Exception as exc:
-            raise GeneralError(
-                f"Failed to extract variables from YAML file '{filepath}'."
-            ) from exc
-
-        return cls.from_yaml(content)
-
-    @classmethod
-    def from_sequence(
-        cls,
-        raw_variables: Union[str, Sequence[str]],
-        logger: tmt.log.Logger,
-    ) -> 'Environment':
-        """
-        Construct environment from a sequence of variables.
-
-        Variables may be specified in two ways:
-
-        * ``NAME=VALUE`` pairs, or
-        * ``@foo.yaml`` signaling variables to be read from a file.
-
-        If a "variable" starts with ``@``, it is treated as a path to
-        a YAML or DOTENV file that contains key/value pairs which are then
-        transparently loaded and added to the final environment.
-
-        :param raw_variables: string or a sequence of strings containing
-            variables. The acceptable formats are:
-
-            * ``'X=1'``
-            * ``'X=1 Y=2 Z=3'``
-            * ``['X=1', 'Y=2', 'Z=3']``
-            * ``['X=1 Y=2 Z=3', 'A=1 B=2 C=3']``
-            * ``'TXT="Some text with spaces in it"'``
-            * ``@foo.yaml``
-            * ``@../../bar.yaml``
-            * ``@foo.env``
-        """
-
-        if isinstance(raw_variables, str):
-            variables: Iterable[str] = [raw_variables]
-
-        else:
-            variables = raw_variables
-
-        result = Environment()
-
-        for variable in variables:
-            if variable is None:
-                continue
-            for var in shlex.split(variable):
-                if var.startswith('@'):
-                    if not var[1:]:
-                        raise GeneralError(f"Invalid variable file specification '{var}'.")
-
-                    filename = var[1:]
-                    environment = cls.from_file(filename=filename, logger=logger)
-
-                    if not environment:
-                        logger.warning(f"Empty environment file '{filename}'.")
-
-                    result.update(environment)
-
-                else:
-                    matched = re.match("([^=]+)=(.*)", var)
-                    if not matched:
-                        raise GeneralError(f"Invalid variable specification '{var}'.")
-                    name, value = matched.groups()
-                    result[name] = EnvVarValue(value)
-
-        return result
-
-    @classmethod
-    def from_file(
-        cls,
-        *,
-        filename: str,
-        root: Optional[Path] = None,
-        logger: tmt.log.Logger,
-    ) -> 'Environment':
-        """
-        Construct environment from a file.
-
-        YAML files - recognized by ``.yaml`` or ``.yml`` suffixes - or
-        ``.env``-like files are supported.
-
-        .. code-block:: bash
-
-           A=B
-           C=D
-
-        .. code-block:: yaml
-
-           A: B
-           C: D
-
-        .. note::
-
-            For loading environment variables from multiple files, see
-            :py:meth:`Environment.from_files`.
-        """
-
-        root = root or Path.cwd()
-        filename = filename.strip()
-        environment_filepath: Optional[Path] = None
-
-        # Fetch a remote file
-        if filename.startswith("http"):
-            # Create retry session for longer retries, see #1229
-            session = retry_session.create(
-                allowed_methods=('GET',),
-                logger=logger,
-            )
-            try:
-                response = session.get(filename)
-                response.raise_for_status()
-                content = response.text
-            except requests.RequestException as error:
-                raise GeneralError(
-                    f"Failed to extract variables from URL '{filename}'."
-                ) from error
-
-        # Read a local file
-        else:
-            # Ensure we don't escape from the metadata tree root
-
-            root = root.resolve()
-            environment_filepath = root.joinpath(filename).resolve()
-
-            if not environment_filepath.is_relative_to(root):
-                raise GeneralError(
-                    f"Failed to extract variables from file '{environment_filepath}' as it "
-                    f"lies outside the metadata tree root '{root}'."
-                )
-            if not environment_filepath.is_file():
-                raise GeneralError(f"File '{environment_filepath}' doesn't exist.")
-
-            content = environment_filepath.read_text()
-
-        # Parse yaml file
-        if Path(filename).suffix.lower() in ('.yaml', '.yml'):
-            environment = cls.from_yaml(content)
-
-        else:
-            environment = cls.from_dotenv(content)
-
-        if not environment:
-            logger.warning(f"Empty environment file '{filename}'.")
-
-            return Environment()
-
-        return environment
-
-    @classmethod
-    def from_files(
-        cls,
-        *,
-        filenames: Iterable[str],
-        root: Optional[Path] = None,
-        logger: tmt.log.Logger,
-    ) -> 'Environment':
-        """
-        Read environment variables from the given list of files.
-
-        Files should be in YAML format (``.yaml`` or ``.yml`` suffixes), or in dotenv format.
-
-        .. code-block:: bash
-
-           A=B
-           C=D
-
-        .. code-block:: yaml
-
-           A: B
-           C: D
-
-        Path to each file should be relative to the metadata tree root.
-
-        .. note::
-
-            For loading environment variables from a single file, see
-            :py:meth:`Environment.from_file`, which is a method called
-            for each file, accumulating data from all input files.
-        """
-
-        root = root or Path.cwd()
-
-        result = Environment()
-
-        for filename in filenames:
-            result.update(cls.from_file(filename=filename, root=root, logger=logger))
-
-        return result
-
-    @classmethod
-    def from_cli_options(
-        cls,
-        *,
-        raw_cli_environment_files: Sequence[str],
-        raw_cli_environment: Sequence[str],
-        file_root: Optional[Path] = None,
-        logger: tmt.log.Logger,
-    ) -> Self:
-        """
-        Extract environment variables from CLI options.
-
-        Combines ``--environment-file`` and ``--environment`` options
-        into a set of environment variables. Both options are optional,
-        and there is a clear order of preference, which is,
-        from the least preferred:
-
-        * ``--environment-file``
-        * ``--environment``
-
-          .. note::
-
-             This set includes also files with environment variables
-             when such files are pointed at using the ``@<filepath>``
-             form.
-
-        :param raw_cli_environment_files: content of the `--environment-file``
-            CLI option.
-        :param raw_cli_environment: content of the ``--environment`` CLI
-            option.
-        """
-
-        # Combine all sources into one mapping, honor the order in which
-        # they override other sources.
-        return cls(
-            {
-                **cls.from_files(
-                    filenames=raw_cli_environment_files,
-                    root=file_root,
-                    logger=logger,
-                ),
-                **cls.from_sequence(
-                    raw_variables=raw_cli_environment,
-                    logger=logger,
-                ),
-            }
-        )
-
-    @classmethod
-    def from_fmf_keys(
-        cls,
-        *,
-        raw_fmf_environment_files: Sequence[str],
-        raw_fmf_environment: Mapping[str, Any],
-        file_root: Optional[Path] = None,
-        logger: tmt.log.Logger,
-    ) -> Self:
-        """
-        Extract environment variables from fmf keys.
-
-        Combines ``environment-file`` and ``environment`` fmf keys
-        into a set of environment variables. Both keys are optional,
-        and there is a clear order of preference, which is,
-        from the least preferred:
-
-        * ``environment-file``
-        * ``environment``
-
-          .. note::
-
-             This set includes also files with environment variables
-             when such files are pointed at using the ``@<filepath>``
-             form.
-
-        :param raw_fmf_environment_files: content of the `environment-file``
-            key.
-        :param raw_fmf_environment: content of the ``environment`` key.
-        """
-
-        # Combine all sources into one mapping, honor the order in which
-        # they override other sources.
-        return cls(
-            {
-                **cls.from_files(
-                    filenames=raw_fmf_environment_files,
-                    root=file_root,
-                    logger=logger,
-                ),
-                **cls.from_dict(
-                    raw_fmf_environment,
-                ),
-            }
-        )
-
-    @classmethod
-    def from_dict(cls, data: Optional[Mapping[str, Any]] = None) -> 'Environment':
-        """
-        Create environment variables from a dictionary
-        """
-
-        if not data:
-            return Environment()
-
-        return Environment({str(key): EnvVarValue(str(value)) for key, value in data.items()})
-
-    @classmethod
-    def from_environ(cls) -> 'Environment':
-        """
-        Extract environment variables from the live environment
-        """
-
-        return Environment({key: EnvVarValue(value) for key, value in os.environ.items()})
-
-    @classmethod
-    def from_fmf_context(cls, fmf_context: FmfContext) -> 'Environment':
-        """
-        Create environment variables from an fmf context
-        """
-
-        return Environment(
-            {key: EnvVarValue(','.join(value)) for key, value in fmf_context.items()}
-        )
-
-    @classmethod
-    def from_fmf_spec(cls, data: Optional[dict[str, Any]] = None) -> 'Environment':
-        """
-        Create environment from an fmf specification
-        """
-
-        if not data:
-            return Environment()
-
-        return Environment({key: EnvVarValue(str(value)) for key, value in data.items()})
-
-    def to_fmf_spec(self) -> dict[str, str]:
-        """
-        Convert to an fmf specification
-        """
-
-        return {key: str(value) for key, value in self.items()}
-
-    def to_popen(self) -> dict[str, str]:
-        """
-        Convert to a form accepted by :py:class:`subprocess.Popen`
-        """
-
-        return self.to_environ()
-
-    def to_environ(self) -> dict[str, str]:
-        """
-        Convert to a form compatible with :py:attr:`os.environ`
-        """
-
-        return {key: str(value) for key, value in self.items()}
-
-    def to_shell(self) -> list[str]:
-        """
-        Convert to a form accepted by shell commands.
-
-        .. code-block:: python
-
-            >>> Environment({'FOO': EnvVarValue('bar'), 'BAZ': EnvVarValue('qu ux')}).to_shell()
-            ['FOO=bar', "BAZ='qu ux'"]
-        """
-
-        return [f"{key}={shlex.quote(str(value))}" for key, value in self.items()]
-
-    def to_shell_exports(self) -> list['ShellScript']:
-        """
-        Convert to a sequence of ``export`` shell commands.
-
-        .. code-block:: python
-
-            >>> Environment({'FOO': EnvVarValue('bar'), 'BAZ': EnvVarValue('qu ux')}).to_shell_exports()
-            [ShellScript("export FOO=bar"), ShellScript("export BAZ='qu ux'")]
-        """  # noqa: E501
-
-        return [ShellScript(f'export {variable}') for variable in self.to_shell()]
-
-    def copy(self) -> 'Environment':
-        return Environment(self)
-
-    def update(  # type: ignore[override]
-        self, *others: Union[dict[str, EnvVarValue], HasEnvironment]
-    ) -> None:
-        for other in others:
-            if isinstance(other, dict):
-                super().update(other)
-
-            else:
-                super().update(other.environment)
-
-    @classmethod
-    def normalize(
-        cls,
-        key_address: str,
-        value: Any,
-        logger: tmt.log.Logger,
-    ) -> 'Environment':
-        """
-        Normalize value of ``environment`` key
-        """
-
-        # Note: this normalization callback is an exception, it does not
-        # bother with CLI input. Environment handling is complex, and CLI
-        # options have their special handling. The `environment` as an
-        # fmf key does not really have a 1:1 CLI option, the corresponding
-        # options are always "special".
-        if value is None:
-            return cls()
-
-        if isinstance(value, dict):
-            return cls({k: EnvVarValue(str(v)) for k, v in value.items()})
-
-        raise NormalizationError(key_address, value, 'unset or a dictionary')
-
-    @contextlib.contextmanager
-    def as_environ(self) -> Iterator[None]:
-        """
-        A context manager replacing :py:attr:`os.environ` with this environment.
-
-        When left, the original content of ``os.environ`` is restored.
-
-        .. warning::
-
-            This method is not thread safe! Beware of using it in code
-            that runs in multiple threads, e.g. from
-            provision/prepare/execute/finish phases.
-        """
-
-        environ_backup = os.environ.copy()
-        os.environ.clear()
-        os.environ.update(self.to_environ())
-        try:
-            yield
-        finally:
-            os.environ.clear()
-            os.environ.update(environ_backup)
 
 
 # Workdir argument type, can be True, a string, a path or None
@@ -1254,7 +697,7 @@ class Command:
         *,
         cwd: Optional[Path],
         shell: bool = False,
-        environment: Optional[Environment] = None,
+        environment: Optional['Environment'] = None,
         dry: bool = False,
         join: bool = False,
         interactive: bool = False,
@@ -1307,6 +750,8 @@ class Command:
         :param logger: logger to use for logging.
         :returns: command output, bundled in a :py:class:`CommandOutput` tuple.
         """
+
+        from tmt.utils.environment import Environment
 
         # A bit of logging - command, default message, error message for later...
 
@@ -2376,7 +1821,7 @@ class Common(_CommonBase, metaclass=_CommonMeta):
         cwd: Optional[Path] = None,
         ignore_dry: bool = False,
         shell: bool = False,
-        environment: Optional[Environment] = None,
+        environment: Optional['Environment'] = None,
         interactive: bool = False,
         join: bool = False,
         log: Optional[tmt.log.LoggingFunction] = None,

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -83,7 +83,6 @@ if TYPE_CHECKING:
     import tmt.base.run
     import tmt.cli
     import tmt.utils.themes
-    from tmt._compat.typing import TypeAlias as TypeAlias
     from tmt.guest import GuestLog
     from tmt.hardware.constraints import Size
 
@@ -352,8 +351,6 @@ class FmfContext(dict[str, list[str]]):
             -c distro=fedora-33 -> {'distro': ['fedora']}
             -c arch=x86_64,ppc64 -> {'arch': ['x86_64', 'ppc64']}
         """
-
-        from tmt.utils.environment import Environment
 
         raw_fmf_context: dict[str, list[str]] = {}
         for key, value in Environment.from_sequence(spec, logger).items():

--- a/tmt/utils/environment.py
+++ b/tmt/utils/environment.py
@@ -528,6 +528,8 @@ class Environment(dict[str, EnvVarValue]):
             [ShellScript("export FOO=bar"), ShellScript("export BAZ='qu ux'")]
         """  # noqa: E501
 
+        from tmt.utils import ShellScript
+
         return [ShellScript(f'export {variable}') for variable in self.to_shell()]
 
     def copy(self) -> 'Environment':

--- a/tmt/utils/environment.py
+++ b/tmt/utils/environment.py
@@ -1,0 +1,601 @@
+import abc
+import contextlib
+import os
+import re
+import shlex
+from collections.abc import Generator, Iterable, Mapping, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Optional,
+    Union,
+    cast,
+)
+
+import requests
+
+import tmt.log
+from tmt._compat.pathlib import Path
+from tmt._compat.typing import Self
+
+if TYPE_CHECKING:
+    from tmt._compat.typing import TypeAlias
+    from tmt.utils import FmfContext, ShellScript
+
+
+#: A type of environment variable name.
+EnvVarName: 'TypeAlias' = str
+
+# This one is not an alias: a full-fledged class makes type linters
+# enforce strict instantiation of objects rather than accepting
+# strings where `EnvVarValue` is expected.
+
+
+class EnvVarValue(str):
+    """
+    A type of environment variable value
+    """
+
+    def __new__(cls, raw_value: Any) -> Self:
+        if isinstance(raw_value, str):
+            return str.__new__(cls, raw_value)
+
+        if isinstance(raw_value, Path):
+            return str.__new__(cls, str(raw_value))
+
+        from tmt.utils import GeneralError
+
+        raise GeneralError(
+            f"Only strings and paths can be environment variables, '{type(raw_value)}' found."
+        )
+
+
+class HasEnvironment(abc.ABC):
+    """
+    A class that provides :py:attr:`environment` attribute.
+    """
+
+    @property
+    @abc.abstractmethod
+    def environment(self) -> 'Environment':
+        """
+        Environment variables this object wants to expose to user commands.
+        """
+
+        raise NotImplementedError
+
+
+class Environment(dict[str, EnvVarValue]):
+    """
+    Represents a set of environment variables.
+
+    See https://tmt.readthedocs.io/en/latest/spec/tests.html#environment,
+    https://tmt.readthedocs.io/en/latest/spec/plans.html#environment and
+    https://tmt.readthedocs.io/en/latest/spec/plans.html#environment-file.
+    """
+
+    def __init__(self, data: Optional[dict[EnvVarName, EnvVarValue]] = None) -> None:
+        super().__init__(data or {})
+
+    @classmethod
+    def from_dotenv(cls, content: str) -> 'Environment':
+        """
+        Construct environment from a ``.env`` format.
+
+        :param content: string containing variables defined in the "dotenv"
+            format, https://hexdocs.pm/dotenvy/dotenv-file-format.html.
+        """
+
+        environment = Environment()
+
+        try:
+            for line in shlex.split(content, comments=True):
+                key, value = line.split("=", maxsplit=1)
+
+                environment[key] = EnvVarValue(value)
+
+        except Exception as exc:
+            from tmt.utils import GeneralError
+
+            raise GeneralError("Failed to extract variables from 'dotenv' format.") from exc
+
+        return environment
+
+    @classmethod
+    def from_yaml(cls, content: str) -> 'Environment':
+        """
+        Construct environment from a YAML format.
+
+        :param content: string containing variables defined in a YAML
+            dictionary, i.e. ``key: value`` entries.
+        """
+
+        from tmt.utils import yaml_to_dict
+
+        data = yaml_to_dict(content)
+
+        if any(isinstance(v, (dict, list)) for v in data.values()):
+            from tmt.utils import GeneralError
+
+            raise GeneralError(
+                'Failed to extract variables from YAML format, '
+                'only primitive types are accepted as values.'
+            )
+
+        return Environment({key: EnvVarValue(str(value)) for key, value in data.items()})
+
+    @classmethod
+    def from_yaml_file(
+        cls,
+        filepath: Path,
+        logger: tmt.log.Logger,
+    ) -> 'Environment':
+        """
+        Construct environment from a YAML file.
+
+        File is expected to contain variables in a YAML dictionary, i.e.
+        ``key: value`` entries. Only primitive types - strings, numbers,
+        booleans - are allowed as values.
+
+        :param path: path to the file with variables.
+        :param logger: used for logging.
+        """
+
+        try:
+            content = filepath.read_text()
+
+        except Exception as exc:
+            from tmt.utils import GeneralError
+
+            raise GeneralError(
+                f"Failed to extract variables from YAML file '{filepath}'."
+            ) from exc
+
+        return cls.from_yaml(content)
+
+    @classmethod
+    def from_sequence(
+        cls,
+        raw_variables: Union[str, Sequence[str]],
+        logger: tmt.log.Logger,
+    ) -> 'Environment':
+        """
+        Construct environment from a sequence of variables.
+
+        Variables may be specified in two ways:
+
+        * ``NAME=VALUE`` pairs, or
+        * ``@foo.yaml`` signaling variables to be read from a file.
+
+        If a "variable" starts with ``@``, it is treated as a path to
+        a YAML or DOTENV file that contains key/value pairs which are then
+        transparently loaded and added to the final environment.
+
+        :param raw_variables: string or a sequence of strings containing
+            variables. The acceptable formats are:
+
+            * ``'X=1'``
+            * ``'X=1 Y=2 Z=3'``
+            * ``['X=1', 'Y=2', 'Z=3']``
+            * ``['X=1 Y=2 Z=3', 'A=1 B=2 C=3']``
+            * ``'TXT="Some text with spaces in it"'``
+            * ``@foo.yaml``
+            * ``@../../bar.yaml``
+            * ``@foo.env``
+        """
+
+        if isinstance(raw_variables, str):
+            variables: Iterable[str] = [raw_variables]
+
+        else:
+            variables = raw_variables
+
+        result = Environment()
+
+        for variable in variables:
+            if variable is None:  # type: ignore[reportUnnecessary,unused-ignore]
+                continue
+            for var in shlex.split(variable):
+                if var.startswith('@'):
+                    if not var[1:]:
+                        from tmt.utils import GeneralError
+
+                        raise GeneralError(f"Invalid variable file specification '{var}'.")
+
+                    filename = var[1:]
+                    environment = cls.from_file(filename=filename, logger=logger)
+
+                    if not environment:
+                        logger.warning(f"Empty environment file '{filename}'.")
+
+                    result.update(environment)
+
+                else:
+                    matched = re.match("([^=]+)=(.*)", var)
+                    if not matched:
+                        from tmt.utils import GeneralError
+
+                        raise GeneralError(f"Invalid variable specification '{var}'.")
+                    name, value = matched.groups()
+                    result[name] = EnvVarValue(value)
+
+        return result
+
+    @classmethod
+    def from_file(
+        cls,
+        *,
+        filename: str,
+        root: Optional[Path] = None,
+        logger: tmt.log.Logger,
+    ) -> 'Environment':
+        """
+        Construct environment from a file.
+
+        YAML files - recognized by ``.yaml`` or ``.yml`` suffixes - or
+        ``.env``-like files are supported.
+
+        .. code-block:: bash
+
+           A=B
+           C=D
+
+        .. code-block:: yaml
+
+           A: B
+           C: D
+
+        .. note::
+
+            For loading environment variables from multiple files, see
+            :py:meth:`Environment.from_files`.
+        """
+
+        root = root or Path.cwd()
+        filename = filename.strip()
+        environment_filepath: Optional[Path] = None
+
+        # Fetch a remote file
+        if filename.startswith("http"):
+            from tmt.utils import retry_session
+
+            # Create retry session for longer retries, see #1229
+            session = retry_session.create(
+                allowed_methods=('GET',),
+                logger=logger,
+            )
+            try:
+                response = session.get(filename)
+                response.raise_for_status()
+                content = response.text
+            except requests.RequestException as error:
+                from tmt.utils import GeneralError
+
+                raise GeneralError(
+                    f"Failed to extract variables from URL '{filename}'."
+                ) from error
+
+        # Read a local file
+        else:
+            # Ensure we don't escape from the metadata tree root
+
+            root = root.resolve()
+            environment_filepath = root.joinpath(filename).resolve()
+
+            if not environment_filepath.is_relative_to(root):
+                from tmt.utils import GeneralError
+
+                raise GeneralError(
+                    f"Failed to extract variables from file '{environment_filepath}' as it "
+                    f"lies outside the metadata tree root '{root}'."
+                )
+            if not environment_filepath.is_file():
+                from tmt.utils import GeneralError
+
+                raise GeneralError(f"File '{environment_filepath}' doesn't exist.")
+
+            content = environment_filepath.read_text()
+
+        # Parse yaml file
+        if Path(filename).suffix.lower() in ('.yaml', '.yml'):
+            environment = cls.from_yaml(content)
+
+        else:
+            environment = cls.from_dotenv(content)
+
+        if not environment:
+            logger.warning(f"Empty environment file '{filename}'.")
+
+            return Environment()
+
+        return environment
+
+    @classmethod
+    def from_files(
+        cls,
+        *,
+        filenames: Iterable[str],
+        root: Optional[Path] = None,
+        logger: tmt.log.Logger,
+    ) -> 'Environment':
+        """
+        Read environment variables from the given list of files.
+
+        Files should be in YAML format (``.yaml`` or ``.yml`` suffixes), or in dotenv format.
+
+        .. code-block:: bash
+
+           A=B
+           C=D
+
+        .. code-block:: yaml
+
+           A: B
+           C: D
+
+        Path to each file should be relative to the metadata tree root.
+
+        .. note::
+
+            For loading environment variables from a single file, see
+            :py:meth:`Environment.from_file`, which is a method called
+            for each file, accumulating data from all input files.
+        """
+
+        root = root or Path.cwd()
+
+        result = Environment()
+
+        for filename in filenames:
+            result.update(cls.from_file(filename=filename, root=root, logger=logger))
+
+        return result
+
+    @classmethod
+    def from_cli_options(
+        cls,
+        *,
+        raw_cli_environment_files: Sequence[str],
+        raw_cli_environment: Sequence[str],
+        file_root: Optional[Path] = None,
+        logger: tmt.log.Logger,
+    ) -> Self:
+        """
+        Extract environment variables from CLI options.
+
+        Combines ``--environment-file`` and ``--environment`` options
+        into a set of environment variables. Both options are optional,
+        and there is a clear order of preference, which is,
+        from the least preferred:
+
+        * ``--environment-file``
+        * ``--environment``
+
+          .. note::
+
+             This set includes also files with environment variables
+             when such files are pointed at using the ``@<filepath>``
+             form.
+
+        :param raw_cli_environment_files: content of the `--environment-file``
+            CLI option.
+        :param raw_cli_environment: content of the ``--environment`` CLI
+            option.
+        """
+
+        # Combine all sources into one mapping, honor the order in which
+        # they override other sources.
+        return cls(
+            {
+                **cls.from_files(
+                    filenames=raw_cli_environment_files,
+                    root=file_root,
+                    logger=logger,
+                ),
+                **cls.from_sequence(
+                    raw_variables=raw_cli_environment,
+                    logger=logger,
+                ),
+            }
+        )
+
+    @classmethod
+    def from_fmf_keys(
+        cls,
+        *,
+        raw_fmf_environment_files: Sequence[str],
+        raw_fmf_environment: Mapping[str, Any],
+        file_root: Optional[Path] = None,
+        logger: tmt.log.Logger,
+    ) -> Self:
+        """
+        Extract environment variables from fmf keys.
+
+        Combines ``environment-file`` and ``environment`` fmf keys
+        into a set of environment variables. Both keys are optional,
+        and there is a clear order of preference, which is,
+        from the least preferred:
+
+        * ``environment-file``
+        * ``environment``
+
+          .. note::
+
+             This set includes also files with environment variables
+             when such files are pointed at using the ``@<filepath>``
+             form.
+
+        :param raw_fmf_environment_files: content of the `environment-file``
+            key.
+        :param raw_fmf_environment: content of the ``environment`` key.
+        """
+
+        # Combine all sources into one mapping, honor the order in which
+        # they override other sources.
+        return cls(
+            {
+                **cls.from_files(
+                    filenames=raw_fmf_environment_files,
+                    root=file_root,
+                    logger=logger,
+                ),
+                **cls.from_dict(
+                    raw_fmf_environment,
+                ),
+            }
+        )
+
+    @classmethod
+    def from_dict(cls, data: Optional[Mapping[str, Any]] = None) -> 'Environment':
+        """
+        Create environment variables from a dictionary
+        """
+
+        if not data:
+            return Environment()
+
+        return Environment({str(key): EnvVarValue(str(value)) for key, value in data.items()})
+
+    @classmethod
+    def from_environ(cls) -> 'Environment':
+        """
+        Extract environment variables from the live environment
+        """
+
+        return Environment({key: EnvVarValue(value) for key, value in os.environ.items()})
+
+    @classmethod
+    def from_fmf_context(cls, fmf_context: 'FmfContext') -> 'Environment':
+        """
+        Create environment variables from an fmf context
+        """
+
+        return Environment(
+            {key: EnvVarValue(','.join(value)) for key, value in fmf_context.items()}
+        )
+
+    @classmethod
+    def from_fmf_spec(cls, data: Optional[dict[str, Any]] = None) -> 'Environment':
+        """
+        Create environment from an fmf specification
+        """
+
+        if not data:
+            return Environment()
+
+        return Environment({key: EnvVarValue(str(value)) for key, value in data.items()})
+
+    def to_fmf_spec(self) -> dict[str, str]:
+        """
+        Convert to an fmf specification
+        """
+
+        return {key: str(value) for key, value in self.items()}
+
+    def to_popen(self) -> dict[str, str]:
+        """
+        Convert to a form accepted by :py:class:`subprocess.Popen`
+        """
+
+        return self.to_environ()
+
+    def to_environ(self) -> dict[str, str]:
+        """
+        Convert to a form compatible with :py:attr:`os.environ`
+        """
+
+        return {key: str(value) for key, value in self.items()}
+
+    def to_shell(self) -> list[str]:
+        """
+        Convert to a form accepted by shell commands.
+
+        .. code-block:: python
+
+            >>> Environment({'FOO': EnvVarValue('bar'), 'BAZ': EnvVarValue('qu ux')}).to_shell()
+            ['FOO=bar', "BAZ='qu ux'"]
+        """
+
+        return [f"{key}={shlex.quote(str(value))}" for key, value in self.items()]
+
+    def to_shell_exports(self) -> list['ShellScript']:
+        """
+        Convert to a sequence of ``export`` shell commands.
+
+        .. code-block:: python
+
+            >>> Environment({'FOO': EnvVarValue('bar'), 'BAZ': EnvVarValue('qu ux')}).to_shell_exports()
+            [ShellScript("export FOO=bar"), ShellScript("export BAZ='qu ux'")]
+        """  # noqa: E501
+
+        return [ShellScript(f'export {variable}') for variable in self.to_shell()]
+
+    def copy(self) -> 'Environment':
+        return Environment(self)
+
+    def update(  # type: ignore[override]
+        self, *others: Union[dict[str, EnvVarValue], HasEnvironment]
+    ) -> None:
+        for other in others:
+            if isinstance(other, dict):
+                super().update(other)
+
+            else:
+                super().update(other.environment)
+
+    @classmethod
+    def normalize(
+        cls,
+        key_address: str,
+        value: Any,
+        logger: tmt.log.Logger,
+    ) -> 'Environment':
+        """
+        Normalize value of ``environment`` key
+        """
+
+        # Note: this normalization callback is an exception, it does not
+        # bother with CLI input. Environment handling is complex, and CLI
+        # options have their special handling. The `environment` as an
+        # fmf key does not really have a 1:1 CLI option, the corresponding
+        # options are always "special".
+        if value is None:
+            return cls()
+
+        if isinstance(value, dict):
+            # redundant-cast: mypy sees it as redundant, pyright does
+            # need it, since `isinstance(value, dict)` says nothing
+            # about types of keys or values.
+            return cls(
+                {
+                    k: EnvVarValue(str(v))
+                    for k, v in cast(dict[Any, Any], value).items()  # type: ignore[redundant-cast]
+                }
+            )
+
+        from tmt.utils import NormalizationError
+
+        raise NormalizationError(key_address, value, 'unset or a dictionary')
+
+    @contextlib.contextmanager
+    def as_environ(self) -> Generator[None]:
+        """
+        A context manager replacing :py:attr:`os.environ` with this environment.
+
+        When left, the original content of ``os.environ`` is restored.
+
+        .. warning::
+
+            This method is not thread safe! Beware of using it in code
+            that runs in multiple threads, e.g. from
+            provision/prepare/execute/finish phases.
+        """
+
+        environ_backup = os.environ.copy()
+        os.environ.clear()
+        os.environ.update(self.to_environ())
+        try:
+            yield
+        finally:
+            os.environ.clear()
+            os.environ.update(environ_backup)

--- a/tmt/utils/git.py
+++ b/tmt/utils/git.py
@@ -19,13 +19,13 @@ from tmt.utils import (
     Command,
     CommandOutput,
     Common,
-    Environment,
     GeneralError,
     GitUrlError,
     MetadataError,
     Path,
     RunError,
 )
+from tmt.utils.environment import Environment
 
 if TYPE_CHECKING:
     import tmt.base.core


### PR DESCRIPTION
Making `tmt.utils` smaller, but also part of the secrets implementation: by moving `Environment` and few other bits, it should be possible to close access to `os.environ`.

A lot of changes, but just moves - some `tmt.utils.Environment` turned into `from tmt.utils.environment import Environment` + bare `Environment`; the string would have to change anyway, so at least we can treat `Environment` as a well-known name in the codebase.

Related to #2609.

Pull Request Checklist

* [x] implement the feature