### PR TITLE
Support artifacts on CentOS 7

### DIFF
--- a/tests/prepare/artifact/basic.sh
+++ b/tests/prepare/artifact/basic.sh
@@ -19,12 +19,6 @@ rlJournalStart
             continue
         fi
 
-        if is_centos_7 "$image"; then
-            # TODO(#4941):
-            # Centos 7 not supported because of missing provides resolution on `yum`
-            continue
-        fi
-
         phase_prefix="$(test_phase_prefix $image)"
 
         rlPhaseStartTest "$phase_prefix Test artifact installation"

--- a/tests/prepare/artifact/lib/common.sh
+++ b/tests/prepare/artifact/lib/common.sh
@@ -30,7 +30,9 @@ function build_rpm() {
     local rpm_dir=$LIB_DIR/../rpms/$1
     if [[ ! -d "$rpm_dir/build" ]]; then
         rlRun "pushd $rpm_dir"
-        rlRun "rpmbuild --define='_topdir build' -bb *.spec" 0 "Build rpm"
+        # _topdir: keep all the artifacts in the rpms directory
+        # _binary_payload, _rpmformat: keep the rpms compatible with centos 7
+        rlRun "rpmbuild --define='_topdir build' --define='_binary_payload w9.gzdio' --define='_rpmformat 4' -bb *.spec" 0 "Build rpm"
         rlRun "cp build/RPMS/*/* ./" 0 "Move rpms next to spec file"
         rlRun "popd"
     fi

--- a/tests/prepare/artifact/providers/copr-repository/test.sh
+++ b/tests/prepare/artifact/providers/copr-repository/test.sh
@@ -19,8 +19,7 @@ rlJournalStart
         fi
 
         if is_centos_7 "$image"; then
-            # TODO(#4941):
-            # Centos 7 not supported because of missing provides resolution on `yum`
+            # copr support for CentOS 7  is gone
             continue
         fi
 

--- a/tests/prepare/artifact/providers/copr-repository/test.sh
+++ b/tests/prepare/artifact/providers/copr-repository/test.sh
@@ -19,7 +19,7 @@ rlJournalStart
         fi
 
         if is_centos_7 "$image"; then
-            # copr support for CentOS 7  is gone
+            # copr support for CentOS 7 is gone
             continue
         fi
 

--- a/tests/prepare/artifact/providers/file/data/test.sh
+++ b/tests/prepare/artifact/providers/file/data/test.sh
@@ -3,5 +3,3 @@ set -ex
 
 # verify the package is installed
 rpm -q bar
-# verify package came from the tmt-artifact-shared repository
-dnf info --installed bar | grep -Eq "From repo(sitory)?\s*:\s*tmt-artifact-shared"

--- a/tests/prepare/artifact/providers/file/test.sh
+++ b/tests/prepare/artifact/providers/file/test.sh
@@ -23,12 +23,6 @@ rlJournalStart
             continue
         fi
 
-        if is_centos_7 "$image"; then
-            # TODO(#4941):
-            # Centos 7 not supported because of missing provides resolution on `yum`
-            continue
-        fi
-
         phase_prefix="$(test_phase_prefix $image)"
 
         rlPhaseStartTest "$phase_prefix Test file provider"
@@ -36,10 +30,14 @@ rlJournalStart
             # TODO: get this more dynamically https://github.com/fedora-copr/copr/issues/4119
             rlRun "REMOTE_RPM_URL=https://packages.redhat.com/api/pulp-content/public-copr/lecris/_tmt_test/fedora-rawhide-x86_64/Packages/b/bar-1.0-1.noarch.rpm"
 
-            rlRun "tmt run -i $run --scratch -vvv --all \
-                provision -h $PROVISION_HOW --image $image \
-                prepare --how artifact --provide file:$REMOTE_RPM_URL" \
-                0 "Run remote file"
+
+            if ! is_centos_7 "$image"; then
+                # Remote rpm file is not compatible with CentOS 7. See note in lib/common.sh
+                rlRun "tmt run -i $run --scratch -vvv --all \
+                    provision -h $PROVISION_HOW --image $image \
+                    prepare --how artifact --provide file:$REMOTE_RPM_URL" \
+                    0 "Run remote file"
+            fi
             rlRun "tmt run -i $run --scratch -vvv --all \
                 provision -h $PROVISION_HOW --image $image \
                 prepare --how artifact --provide file:$LIB_DIR/../rpms/bar/bar-1.0-1.noarch.rpm" \

--- a/tests/prepare/artifact/providers/multi/test.sh
+++ b/tests/prepare/artifact/providers/multi/test.sh
@@ -15,7 +15,6 @@ rlJournalStart
     while IFS= read -r image; do
         if ! is_fedora_rawhide "$image"; then
             # Running only against rawhide right now due to hard-coded pattern
-            # TODO(#4941): Make this run more generically
             continue
         fi
 

--- a/tests/prepare/artifact/providers/repository-file/test.sh
+++ b/tests/prepare/artifact/providers/repository-file/test.sh
@@ -19,8 +19,7 @@ rlJournalStart
         fi
 
         if is_centos_7 "$image"; then
-            # TODO(#4941):
-            # Centos 7 not supported because of missing provides resolution on `yum`
+            # RPMs built in copr are incompatible with CentOS 7
             continue
         fi
 

--- a/tests/prepare/artifact/providers/repository-url/test.sh
+++ b/tests/prepare/artifact/providers/repository-url/test.sh
@@ -19,8 +19,7 @@ rlJournalStart
         fi
 
         if is_centos_7 "$image"; then
-            # TODO(#4941):
-            # Centos 7 not supported because of missing provides resolution on `yum`
+            # RPMs built in copr are incompatible with CentOS 7
             continue
         fi
 

--- a/tests/prepare/artifact/verify-installation.sh
+++ b/tests/prepare/artifact/verify-installation.sh
@@ -19,12 +19,6 @@ rlJournalStart
             continue
         fi
 
-        if is_centos_7 "$image"; then
-            # TODO(#4941):
-            # Centos 7 not supported because of missing provides resolution on `yum`
-            continue
-        fi
-
         phase_prefix="$(test_phase_prefix $image)"
 
         rlPhaseStartTest "$phase_prefix Test verify-installation phase injection (verify=true)"

--- a/tests/prepare/verify-installation/test.sh
+++ b/tests/prepare/verify-installation/test.sh
@@ -19,12 +19,6 @@ rlJournalStart
             continue
         fi
 
-        if is_centos_7 "$image"; then
-            # TODO(#4941):
-            # Centos 7 not supported because of missing provides resolution on `yum`
-            continue
-        fi
-
         phase_prefix="$(test_phase_prefix $image)"
 
         rlPhaseStartTest "$phase_prefix Test successful verification"

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -421,6 +421,38 @@ class PackageManagerEngine(tmt.utils.Common):
         """
         raise NotImplementedError
 
+    def _repoquery_script(
+        self,
+        *queries: str,
+        repos: Optional[Sequence[str]] = None,
+        whatprovides: bool = False,
+        installed: bool = False,
+    ) -> ShellScript:
+        """
+        Query info about a package and structure it as a yaml to process.
+
+        An example output is:
+
+        .. code-block:: yaml
+
+            '/usr/bin/cmake':
+            - name: 'cmake'
+              nevra: 'cmake-0:4.3.0-4.fc45.i686'
+              repoid: 'rawhide'
+              from_repo: ''
+            - name: 'cmake'
+              nevra: 'cmake-0:4.3.0-4.fc45.x86_64'
+              repoid: 'rawhide'
+              from_repo: ''
+
+
+        :param queries: entities to query (must be properly shell escaped)
+        :param repos: specific repositories to query
+        :param whatprovides: inject a ``--whatprovides`` flag
+        :param installed: query only installed entities
+        """
+        raise NotImplementedError
+
     def list_packages(self, repository: "Repository") -> ShellScript:
         """
         List packages available in the specified repository.

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -44,11 +44,13 @@ YUM_REPOS_DIR = Path("/etc/yum.repos.d")
 
 class _ResolvedEntry(TypedDict):
     """
-    Single entry from the YAML output of :py:meth:`PackageManagerEngine.resolve_provides`.
+    Single entry from the YAML output of :py:meth:`PackageManagerEngine._repoquery_script`.
     """
 
+    name: str
     nevra: str
     repo_id: str
+    from_repo: str
 
 
 @container(frozen=True)
@@ -492,19 +494,7 @@ class PackageManagerEngine(tmt.utils.Common):
         """
         Resolves each provide to the NEVRAs of packages that provide it.
 
-        The script must emit YAML mapping each provide string to a list of
-        mappings with ``nevra`` and ``repo_id`` keys, or an empty value when
-        nothing provides it, e.g.
-
-        .. code-block:: yaml
-
-            '/usr/bin/cmake':
-                - nevra: 'cmake-0:3.31.6-4.fc43.x86_64'
-                  repo_id: 'updates'
-            '/usr/bin/non-existent-provides':
-            'make':
-                - nevra: 'make-1:4.4.1-8.fc43.x86_64'
-                  repo_id: 'fedora'
+        The output is in a yaml format as defined in :py:meth:`_repoquery_script`.
 
         :param provides: Provides to resolve.
         :param repo_ids: Restrict the query to these repository IDs; searches all enabled

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -49,7 +49,7 @@ class _ResolvedEntry(TypedDict):
 
     name: str
     nevra: str
-    repo_id: str
+    repoid: str
     from_repo: str
 
 
@@ -709,7 +709,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
                 try:
                     result[provide].append(
                         RpmVersion.from_nevra(
-                            resolved_provide['nevra'], repo_id=resolved_provide['repo_id']
+                            resolved_provide['nevra'], repo_id=resolved_provide['repoid']
                         )
                     )
                 except ValueError as error:

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -438,8 +438,8 @@ class PackageManagerEngine(tmt.utils.Common):
         self,
         *package_specs: str,
         repos: Optional[Iterable[str]] = None,
-        whatprovides: bool = False,
-        installed: bool = False,
+        packages_only: bool = True,
+        installed_only: bool = False,
     ) -> ShellScript:
         """
         Query info about a package and structure it as a yaml to process.
@@ -461,8 +461,8 @@ class PackageManagerEngine(tmt.utils.Common):
 
         :param package_specs: packages, capabilities, or other entities to repoquery
         :param repos: specific repositories to query
-        :param whatprovides: inject a ``--whatprovides`` flag
-        :param installed: query only installed entities
+        :param packages_only: query only for package names
+        :param installed_only: query only installed entities
         """
         raise NotImplementedError
 

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -469,16 +469,7 @@ class PackageManagerEngine(tmt.utils.Common):
         """
         List source repositories for each installed package.
 
-        The script must emit one line per package in the format::
-
-            <name> <origin>
-
-        Empty lines are allowed and will be ignored by the caller.  If
-        the origin field is omitted the package is treated as having an
-        unknown source repository (equivalent to
-        :py:attr:`SpecialPackageOrigin.UNKNOWN`).  Packages whose name
-        does not appear in the output at all are treated as not installed
-        (equivalent to :py:attr:`SpecialPackageOrigin.NOT_INSTALLED`).
+        The output is in a yaml format as defined in :py:meth:`_repoquery_script`.
 
         :param packages: Package names to query.
         :returns: A shell script to list source repositories for the given packages.
@@ -668,14 +659,18 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
         )
         script = self.engine.get_package_origin(result.keys())
         output = self.guest.execute(script)
-        for line in (output.stdout or '').strip().splitlines():
-            # Empty lines are allowed by the engine contract.
-            if not line.strip():
+        assert output.stdout is not None  # narrow type
+        repoquery_yaml: dict[str, Optional[list[_ResolvedEntry]]] = tmt.utils.from_yaml(
+            output.stdout
+        )
+        for package, query_result in repoquery_yaml.items():
+            if not query_result:
                 continue
-            parts = line.split(maxsplit=1)
-            package = parts[0]
-            # Omitted origin field → unknown source repository.
-            result[package] = parts[1] if len(parts) == 2 else SpecialPackageOrigin.UNKNOWN
+            if len(query_result) > 1:
+                self._logger.debug(f"More than 1 repo provides: {package}", level=1)
+            # TODO: Both from_repo and repoid could be useful to forward
+            origin = query_result[0]["from_repo"]
+            result[package] = origin
         return result
 
     def resolve_provides(

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -46,7 +46,7 @@ class _ResolvedEntry(TypedDict):
     """
     Single entry from the YAML output of :py:meth:`PackageManagerEngine._repoquery_script`.
 
-    Naming convention match the ``dnf repoquery`` query tags. See the ``dnf-repoquery``
+    Naming convention matches the ``dnf repoquery`` query tags. See the ``dnf-repoquery``
     man page for a full breakdown.
     """
 
@@ -437,7 +437,7 @@ class PackageManagerEngine(tmt.utils.Common):
     def _repoquery_script(
         self,
         *package_specs: str,
-        repos: Optional[Sequence[str]] = None,
+        repos: Optional[Iterable[str]] = None,
         whatprovides: bool = False,
         installed: bool = False,
     ) -> ShellScript:

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -53,7 +53,7 @@ class _ResolvedEntry(TypedDict):
     #: Display name of the package.
     name: str
     #: Display name-epoch:version-release.arch of the package. Even epoch 0 is included.
-    nevra: str
+    full_nevra: str
     #: Display id of repository the package is in.
     #:
     #: .. note::
@@ -450,11 +450,11 @@ class PackageManagerEngine(tmt.utils.Common):
 
             '/usr/bin/cmake':
             - name: 'cmake'
-              nevra: 'cmake-0:4.3.0-4.fc45.i686'
+              full_nevra: 'cmake-0:4.3.0-4.fc45.i686'
               repoid: 'rawhide'
               from_repo: ''
             - name: 'cmake'
-              nevra: 'cmake-0:4.3.0-4.fc45.x86_64'
+              full_nevra: 'cmake-0:4.3.0-4.fc45.x86_64'
               repoid: 'rawhide'
               from_repo: ''
 
@@ -720,7 +720,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
                 try:
                     result[provide].append(
                         RpmVersion.from_nevra(
-                            resolved_provide['nevra'], repo_id=resolved_provide['repoid']
+                            resolved_provide['full_nevra'], repo_id=resolved_provide['repoid']
                         )
                     )
                 except ValueError as error:

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -436,7 +436,7 @@ class PackageManagerEngine(tmt.utils.Common):
 
     def _repoquery_script(
         self,
-        *queries: str,
+        *package_specs: str,
         repos: Optional[Sequence[str]] = None,
         whatprovides: bool = False,
         installed: bool = False,
@@ -459,7 +459,8 @@ class PackageManagerEngine(tmt.utils.Common):
               from_repo: ''
 
 
-        :param queries: entities to query (must be properly shell escaped)
+        :param package_specs: packages, capabilities, or other entities to repoquery
+            (must be properly shell escaped)
         :param repos: specific repositories to query
         :param whatprovides: inject a ``--whatprovides`` flag
         :param installed: query only installed entities

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -480,7 +480,7 @@ class PackageManagerEngine(tmt.utils.Common):
     def resolve_provides(
         self,
         provides: Sequence[str],
-        repo_ids: Iterable[str] = (),
+        repo_ids: Optional[Iterable[str]] = None,
     ) -> ShellScript:
         """
         Resolves each provide to the NEVRAs of packages that provide it.
@@ -676,7 +676,7 @@ class PackageManager(tmt.utils.Common, Generic[PackageManagerEngineT]):
     def resolve_provides(
         self,
         provides: Sequence[str],
-        repo_ids: Iterable[str] = (),
+        repo_ids: Optional[Iterable[str]] = None,
     ) -> dict[str, list['RpmVersion']]:
         """
         Map each provide to the :py:class:`RpmVersion` objects of packages that provide it.

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -460,7 +460,6 @@ class PackageManagerEngine(tmt.utils.Common):
 
 
         :param package_specs: packages, capabilities, or other entities to repoquery
-            (must be properly shell escaped)
         :param repos: specific repositories to query
         :param whatprovides: inject a ``--whatprovides`` flag
         :param installed: query only installed entities

--- a/tmt/package_managers/__init__.py
+++ b/tmt/package_managers/__init__.py
@@ -45,11 +45,22 @@ YUM_REPOS_DIR = Path("/etc/yum.repos.d")
 class _ResolvedEntry(TypedDict):
     """
     Single entry from the YAML output of :py:meth:`PackageManagerEngine._repoquery_script`.
+
+    Naming convention match the ``dnf repoquery`` query tags. See the ``dnf-repoquery``
+    man page for a full breakdown.
     """
 
+    #: Display name of the package.
     name: str
+    #: Display name-epoch:version-release.arch of the package. Even epoch 0 is included.
     nevra: str
+    #: Display id of repository the package is in.
+    #:
+    #: .. note::
+    #:    This is different when queried against an installed package or an available one.
+    #:    When querying an installed package the same info is now in the ``from_repo`` tag.
     repoid: str
+    #: Display id of repository the package is installed from. Empty for not installed packages.
     from_repo: str
 
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -435,7 +435,21 @@ class YumEngine(DnfEngine):
         provides: Sequence[str],
         repo_ids: Iterable[str] = (),
     ) -> ShellScript:
-        raise PrepareError("Package manager 'yum' does not support provides resolution.")
+        assert provides, "provides must not be empty"
+        provides_str = ' '.join(escape_installables(*[Package(p) for p in provides]))
+        cmd = Command(
+            'repoquery',
+            '--queryformat',
+            r"- nevra: '%{full_nevra}'\n  repo_id: '%{repoid}'\n",
+            *[f'--repo={repo_id}' for repo_id in repo_ids],
+            '--whatprovides',
+        )
+        return ShellScript(f"""
+        for _provide in {provides_str}; do
+            echo "'$_provide':"
+            {cmd} "$_provide"
+        done
+        """)
 
     def get_package_origin(self, packages: Iterable[str]) -> ShellScript:
         # Real yum 3.x (not a dnf symlink) ships repoquery as a separate

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -438,6 +438,7 @@ class Dnf5(Dnf):
 
 class YumEngine(DnfEngine):
     _base_command = Command('yum')
+    _full_nevra_querytag = "%{nevra}"
 
     def _extra_dnf_options(self, options: Options, command: Optional[Command] = None) -> Command:
         if options.allow_erasing:
@@ -453,6 +454,57 @@ class YumEngine(DnfEngine):
             command = Command(self.guest.facts.sudo_prefix) + command
 
         return command
+
+    def _repoquery_script(
+        self,
+        *queries: str,
+        repos: Optional[Sequence[str]] = None,
+        whatprovides: bool = False,
+        installed: bool = False,
+    ) -> ShellScript:
+        # The same as the dnf one, but
+        # - query_command is `repoquery`
+        # - handling `--installed` is more complicated because `repoid` is replaced with a dummy
+        #   Instead, we use a 2 step process there to get the installed nevra, and query the repoid
+        #   matching it. Duplicate repos should be handled at the higher level.
+        # - `%{from_repo} does not exist
+
+        query_command = Command("repoquery")
+        if repos:
+            query_command += Command(
+                "--disablerepo=*",
+                *[f"--enablerepo={repo_id}" for repo_id in repos],
+            )
+        query_command += Command(
+            "--queryformat",
+            r"- name: '%{name}'\n"
+            rf"  nevra: '{self._full_nevra_querytag}'\n"
+            r"  repo_id: '%{repoid}'\n"
+            r"  from_repo: '%{repoid}'\n",
+        )
+
+        if installed:
+            nevra_query = Command("repoquery", "--installed")
+            if whatprovides:
+                nevra_query += Command("--whatprovides")
+            return ShellScript(f"""
+            for query in {' '.join(queries)}; do
+                echo "'$query':"
+                full_nevra=$({nevra_query} "$query")
+                if [ -n "$full_nevra" ]; then
+                    {query_command} "$full_nevra"
+                fi
+            done
+            """)
+
+        if whatprovides:
+            query_command += Command("--whatprovides")
+        return ShellScript(f"""
+        for query in {' '.join(queries)}; do
+            echo "'$query':"
+            {query_command} "$query"
+        done
+        """)
 
     def enable_repo(self, *repo_ids: str) -> ShellScript:
         return (self._yum_config_manager_command() + Command('--enable', *repo_ids)).to_script()

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -33,7 +33,7 @@ class DnfEngine(PackageManagerEngine):
     def _repoquery_script(
         self,
         *queries: str,
-        repos: Optional[Sequence[str]] = None,
+        repos: Optional[Iterable[str]] = None,
         whatprovides: bool = False,
         installed: bool = False,
     ) -> ShellScript:
@@ -246,12 +246,13 @@ class DnfEngine(PackageManagerEngine):
     def resolve_provides(
         self,
         provides: Sequence[str],
-        repo_ids: Iterable[str] = (),
+        repo_ids: Optional[Iterable[str]] = None,
     ) -> ShellScript:
         assert provides, "provides must not be empty"
         return self._repoquery_script(
             *escape_installables(*[Package(p) for p in provides]),
             whatprovides=True,
+            repos=repo_ids,
         )
 
     def create_repository(self, directory: Path) -> ShellScript:
@@ -436,7 +437,7 @@ class YumEngine(DnfEngine):
     def _repoquery_script(
         self,
         *queries: str,
-        repos: Optional[Sequence[str]] = None,
+        repos: Optional[Iterable[str]] = None,
         whatprovides: bool = False,
         installed: bool = False,
     ) -> ShellScript:

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -50,7 +50,7 @@ class DnfEngine(PackageManagerEngine):
             "--queryformat",
             r"- name: '%{name}'\n"
             rf"  nevra: '{self._full_nevra_querytag}'\n"
-            r"  repo_id: '%{repoid}'\n"
+            r"  repoid: '%{repoid}'\n"
             r"  from_repo: '%{from_repo}'\n",
         )
         if whatprovides:
@@ -458,7 +458,7 @@ class YumEngine(DnfEngine):
             "--queryformat",
             r"- name: '%{name}'\n"
             rf"  nevra: '{self._full_nevra_querytag}'\n"
-            r"  repo_id: '%{repoid}'\n"
+            r"  repoid: '%{repoid}'\n"
             r"  from_repo: '%{repoid}'\n",
         )
 

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -241,16 +241,7 @@ class DnfEngine(PackageManagerEngine):
         ).to_script()
 
     def get_package_origin(self, packages: Iterable[str]) -> ShellScript:
-        return (
-            self.command
-            + Command(
-                'repoquery',
-                '--installed',
-                '--queryformat',
-                r'%{name} %{from_repo}\n',
-                *[Package(p) for p in packages],
-            )
-        ).to_script()
+        return self._repoquery_script(*packages, installed=True)
 
     def resolve_provides(
         self,
@@ -498,13 +489,6 @@ class YumEngine(DnfEngine):
 
     def disable_repo(self, *repo_ids: str) -> ShellScript:
         return (self._yum_config_manager_command() + Command('--disable', *repo_ids)).to_script()
-
-    def get_package_origin(self, packages: Iterable[str]) -> ShellScript:
-        # Real yum 3.x (not a dnf symlink) ships repoquery as a separate
-        # yum-utils plugin and the %{from_repo} queryformat field is not
-        # guaranteed to be available.  Support can be added once tested on
-        # an actual yum 3.x system (RHEL 6 / CentOS 6 era).
-        raise NotImplementedError
 
     # TODO: get rid of those `type: ignore` below. I think it's caused by the
     # decorator, it might be messing with the class inheritance as seen by pyright,

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -258,23 +258,10 @@ class DnfEngine(PackageManagerEngine):
         repo_ids: Iterable[str] = (),
     ) -> ShellScript:
         assert provides, "provides must not be empty"
-        provides_str = ' '.join(escape_installables(*[Package(p) for p in provides]))
-        cmd = (
-            self.command
-            + Command(
-                'repoquery',
-                '--queryformat',
-                rf"- nevra: '{self._full_nevra_querytag}'\n  repo_id: '%{{repoid}}'\n",
-                *[f'--repo={repo_id}' for repo_id in repo_ids],
-                '--whatprovides',
-            )
-        ).to_script()
-        return ShellScript(f"""
-        for _provide in {provides_str}; do
-            echo "'$_provide':"
-            {cmd} "$_provide"
-        done
-        """)
+        return self._repoquery_script(
+            *escape_installables(*[Package(p) for p in provides]),
+            whatprovides=True,
+        )
 
     def create_repository(self, directory: Path) -> ShellScript:
         """
@@ -511,27 +498,6 @@ class YumEngine(DnfEngine):
 
     def disable_repo(self, *repo_ids: str) -> ShellScript:
         return (self._yum_config_manager_command() + Command('--disable', *repo_ids)).to_script()
-
-    def resolve_provides(
-        self,
-        provides: Sequence[str],
-        repo_ids: Iterable[str] = (),
-    ) -> ShellScript:
-        assert provides, "provides must not be empty"
-        provides_str = ' '.join(escape_installables(*[Package(p) for p in provides]))
-        cmd = Command(
-            'repoquery',
-            '--queryformat',
-            r"- nevra: '%{full_nevra}'\n  repo_id: '%{repoid}'\n",
-            *[f'--repo={repo_id}' for repo_id in repo_ids],
-            '--whatprovides',
-        )
-        return ShellScript(f"""
-        for _provide in {provides_str}; do
-            echo "'$_provide':"
-            {cmd} "$_provide"
-        done
-        """)
 
     def get_package_origin(self, packages: Iterable[str]) -> ShellScript:
         # Real yum 3.x (not a dnf symlink) ships repoquery as a separate

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -30,6 +30,39 @@ class DnfEngine(PackageManagerEngine):
     #: Equivalent `%full_nevra` repoquery tag
     _full_nevra_querytag: ClassVar[str] = "%{name}-%{evr}.%{arch}"
 
+    def _repoquery_script(
+        self,
+        *queries: str,
+        repos: Optional[Sequence[str]] = None,
+        whatprovides: bool = False,
+        installed: bool = False,
+    ) -> ShellScript:
+
+        query_command = self.command + Command("repoquery")
+        if repos:
+            query_command += Command(
+                "--disablerepo=*",
+                *[f"--enablerepo={repo_id}" for repo_id in repos],
+            )
+        if installed:
+            query_command += Command("--installed")
+        query_command += Command(
+            "--queryformat",
+            r"- name: '%{name}'\n"
+            rf"  nevra: '{self._full_nevra_querytag}'\n"
+            r"  repo_id: '%{repoid}'\n"
+            r"  from_repo: '%{from_repo}'\n",
+        )
+        if whatprovides:
+            query_command += Command("--whatprovides")
+
+        return ShellScript(f"""
+        for query in {' '.join(queries)}; do
+            echo "'$query':"
+            {query_command} "$query"
+        done
+        """)
+
     def prepare_command(self) -> tuple[Command, Command]:
         options = Command('-y')
 
@@ -286,7 +319,6 @@ class Dnf(PackageManager[DnfEngine]):
     probe_priority = 50
 
     def list_packages(self, repository: Repository) -> list[Version]:
-
         script = self.engine.list_packages(repository)
         output = self.guest.execute(script)
         stdout = output.stdout
@@ -348,7 +380,6 @@ class Dnf(PackageManager[DnfEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-
         options = options or Options()
         options.check_first = False
         # Use both install/reinstall to get all packages refreshed
@@ -362,7 +393,6 @@ class Dnf(PackageManager[DnfEngine]):
         *installables: Installable,
         options: Optional[Options] = None,
     ) -> CommandOutput:
-
         output = super().install_debuginfo(*installables, options=options)
 
         # Check the packages are installed because 'debuginfo-install'

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -49,7 +49,7 @@ class DnfEngine(PackageManagerEngine):
         query_command += Command(
             "--queryformat",
             r"- name: '%{name}'\n"
-            rf"  nevra: '{self._full_nevra_querytag}'\n"
+            rf"  full_nevra: '{self._full_nevra_querytag}'\n"
             r"  repoid: '%{repoid}'\n"
             r"  from_repo: '%{from_repo}'\n",
         )
@@ -457,7 +457,7 @@ class YumEngine(DnfEngine):
         query_command += Command(
             "--queryformat",
             r"- name: '%{name}'\n"
-            rf"  nevra: '{self._full_nevra_querytag}'\n"
+            rf"  full_nevra: '{self._full_nevra_querytag}'\n"
             r"  repoid: '%{repoid}'\n"
             r"  from_repo: '%{repoid}'\n",
         )

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -34,8 +34,8 @@ class DnfEngine(PackageManagerEngine):
         self,
         *package_specs: str,
         repos: Optional[Iterable[str]] = None,
-        whatprovides: bool = False,
-        installed: bool = False,
+        packages_only: bool = True,
+        installed_only: bool = False,
     ) -> ShellScript:
 
         query_command = self.command + Command("repoquery")
@@ -44,7 +44,7 @@ class DnfEngine(PackageManagerEngine):
                 "--disablerepo=*",
                 *[f"--enablerepo={repo_id}" for repo_id in repos],
             )
-        if installed:
+        if installed_only:
             query_command += Command("--installed")
         query_command += Command(
             "--queryformat",
@@ -53,7 +53,7 @@ class DnfEngine(PackageManagerEngine):
             r"  repoid: '%{repoid}'\n"
             r"  from_repo: '%{from_repo}'\n",
         )
-        if whatprovides:
+        if not packages_only:
             query_command += Command("--whatprovides")
 
         return ShellScript(f"""
@@ -241,7 +241,7 @@ class DnfEngine(PackageManagerEngine):
         ).to_script()
 
     def get_package_origin(self, packages: Iterable[str]) -> ShellScript:
-        return self._repoquery_script(*packages, installed=True)
+        return self._repoquery_script(*packages, installed_only=True)
 
     def resolve_provides(
         self,
@@ -251,7 +251,7 @@ class DnfEngine(PackageManagerEngine):
         assert provides, "provides must not be empty"
         return self._repoquery_script(
             *provides,
-            whatprovides=True,
+            packages_only=False,
             repos=repo_ids,
         )
 
@@ -438,8 +438,8 @@ class YumEngine(DnfEngine):
         self,
         *package_specs: str,
         repos: Optional[Iterable[str]] = None,
-        whatprovides: bool = False,
-        installed: bool = False,
+        packages_only: bool = True,
+        installed_only: bool = False,
     ) -> ShellScript:
         # The same as the dnf one, but
         # - query_command is `repoquery`
@@ -462,9 +462,9 @@ class YumEngine(DnfEngine):
             r"  from_repo: '%{repoid}'\n",
         )
 
-        if installed:
+        if installed_only:
             nevra_query = Command("repoquery", "--installed")
-            if whatprovides:
+            if not packages_only:
                 nevra_query += Command("--whatprovides")
             return ShellScript(f"""
             for query in {' '.join(package_specs)}; do
@@ -476,7 +476,7 @@ class YumEngine(DnfEngine):
             done
             """)
 
-        if whatprovides:
+        if not packages_only:
             query_command += Command("--whatprovides")
         return ShellScript(f"""
         for query in {' '.join(escape_installables(*[Package(pkg) for pkg in package_specs]))}; do

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -32,7 +32,7 @@ class DnfEngine(PackageManagerEngine):
 
     def _repoquery_script(
         self,
-        *queries: str,
+        *package_specs: str,
         repos: Optional[Iterable[str]] = None,
         whatprovides: bool = False,
         installed: bool = False,
@@ -57,7 +57,7 @@ class DnfEngine(PackageManagerEngine):
             query_command += Command("--whatprovides")
 
         return ShellScript(f"""
-        for query in {' '.join(queries)}; do
+        for query in {' '.join(package_specs)}; do
             echo "'$query':"
             {query_command} "$query"
         done
@@ -436,7 +436,7 @@ class YumEngine(DnfEngine):
 
     def _repoquery_script(
         self,
-        *queries: str,
+        *package_specs: str,
         repos: Optional[Iterable[str]] = None,
         whatprovides: bool = False,
         installed: bool = False,
@@ -467,7 +467,7 @@ class YumEngine(DnfEngine):
             if whatprovides:
                 nevra_query += Command("--whatprovides")
             return ShellScript(f"""
-            for query in {' '.join(queries)}; do
+            for query in {' '.join(package_specs)}; do
                 echo "'$query':"
                 full_nevra=$({nevra_query} "$query")
                 if [ -n "$full_nevra" ]; then
@@ -479,7 +479,7 @@ class YumEngine(DnfEngine):
         if whatprovides:
             query_command += Command("--whatprovides")
         return ShellScript(f"""
-        for query in {' '.join(queries)}; do
+        for query in {' '.join(package_specs)}; do
             echo "'$query':"
             {query_command} "$query"
         done

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -57,7 +57,7 @@ class DnfEngine(PackageManagerEngine):
             query_command += Command("--whatprovides")
 
         return ShellScript(f"""
-        for query in {' '.join(package_specs)}; do
+        for query in {' '.join(escape_installables(*[Package(pkg) for pkg in package_specs]))}; do
             echo "'$query':"
             {query_command} "$query"
         done
@@ -250,7 +250,7 @@ class DnfEngine(PackageManagerEngine):
     ) -> ShellScript:
         assert provides, "provides must not be empty"
         return self._repoquery_script(
-            *escape_installables(*[Package(p) for p in provides]),
+            *provides,
             whatprovides=True,
             repos=repo_ids,
         )
@@ -479,7 +479,7 @@ class YumEngine(DnfEngine):
         if whatprovides:
             query_command += Command("--whatprovides")
         return ShellScript(f"""
-        for query in {' '.join(package_specs)}; do
+        for query in {' '.join(escape_installables(*[Package(pkg) for pkg in package_specs]))}; do
             echo "'$query':"
             {query_command} "$query"
         done


### PR DESCRIPTION
To more easily support the `repoquery` commands on Centos7 it is easier to unify the various `repoquery` commands into a `_repoquery_script` with a fixed format all across and extract the info from that. A breakdown of what is going on here
- [x] Build RPMs compatible with Centos7
- [x] Introduce a `_repoquery_script` helper that constructs the `repoquery`(-like?) commands in a yaml format for further parsing
- [x] Move the other methods that call `repoquery` to the `_repoquery_script` helper
  - [x] `resolve_provides`
  - [x] `get_package_origin`
  - [ ] ~~`list_packages`~~ annoyingly more complicated, postponed
- [x] Enable testing on centos7

Fixes #4941