### PR TITLE
Add matrix plan shaper for expanding plans across variable combinations

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1126,6 +1126,10 @@ The syntax is the same as in ``adjust`` and :tmt:story:`/spec/context`.
 
 
 
+.. include:: guide/matrix.inc.rst
+
+
+
 .. _multihost-testing:
 
 Multihost Testing

--- a/docs/guide/matrix.inc.rst
+++ b/docs/guide/matrix.inc.rst
@@ -1,0 +1,109 @@
+.. _matrix:
+
+Matrix
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you need to run the same tests across multiple configurations,
+the ``matrix`` key in a plan lets you define variables and their
+values, and automatically expand them into separate test runs. Instead of
+duplicating plans that differ only in a few parameters:
+
+.. code-block:: yaml
+
+    # Without matrix: four nearly identical plans
+
+    /plans/test-debug-fedora:
+        summary: Run tests in debug mode on Fedora
+        provision:
+            how: container
+            image: fedora
+        environment:
+            MODE: debug
+        discover:
+            how: fmf
+        execute:
+            how: tmt
+
+    /plans/test-debug-ubuntu:
+        summary: Run tests in debug mode on Ubuntu
+        provision:
+            how: container
+            image: ubuntu
+        environment:
+            MODE: debug
+        discover:
+            how: fmf
+        execute:
+            how: tmt
+
+    /plans/test-release-fedora:
+        summary: Run tests in release mode on Fedora
+        provision:
+            how: container
+            image: fedora
+        environment:
+            MODE: release
+        discover:
+            how: fmf
+        execute:
+            how: tmt
+
+    /plans/test-release-ubuntu:
+        summary: Run tests in release mode on Ubuntu
+        provision:
+            how: container
+            image: ubuntu
+        environment:
+            MODE: release
+        discover:
+            how: fmf
+        execute:
+            how: tmt
+
+You can write a single plan with a ``matrix``:
+
+.. code-block:: yaml
+
+    summary: Run tests across modes and distros
+    matrix:
+        mode: [debug, release]
+        distro: [fedora, ubuntu]
+    provision:
+        how: container
+        image: $TMT_MATRIX_DISTRO
+    discover:
+        how: fmf
+    execute:
+        how: tmt
+
+This produces four derived plans named after their combination
+values:
+
+* ``/plans/test.debug-fedora``
+* ``/plans/test.debug-ubuntu``
+* ``/plans/test.release-fedora``
+* ``/plans/test.release-ubuntu``
+
+Each plan has the matrix values available as environment variables
+``TMT_MATRIX_MODE`` and ``TMT_MATRIX_DISTRO``. The
+``$TMT_MATRIX_DISTRO`` reference in the provision step is expanded
+to the actual value for each combination. Test scripts can also
+read these variables directly, for example ``$TMT_MATRIX_MODE`` in
+a shell test.
+
+Filtering from the Command Line
+------------------------------------------------------------------
+
+Use ``--matrix-filter`` to run only specific combinations without
+modifying the plan:
+
+.. code-block:: shell
+
+    # Run only debug combinations
+    tmt run --matrix-filter mode=debug
+
+    # Run a single specific combination
+    tmt run --matrix-filter mode=debug --matrix-filter distro=fedora
+
+Multiple filters are combined with AND logic, so all specified
+filters must match for a combination to run.

--- a/tests/core/about/test_about.py
+++ b/tests/core/about/test_about.py
@@ -63,7 +63,7 @@ EXPECTED_PLUGIN_LIST = {
         "rpm-ostree",
         "yum",
     ],
-    "plan_shapers": ["max-tests", "repeat"],
+    "plan_shapers": ["matrix", "max-tests", "repeat"],
     "prepare.artifact.providers": [
         "brew.build",
         "brew.nvr",

--- a/tests/unit/test_matrix.py
+++ b/tests/unit/test_matrix.py
@@ -1,0 +1,183 @@
+import pytest
+
+from tmt.plugins.plan_shapers.matrix import (
+    MatrixCombination,
+    combination_name,
+    compute_combinations,
+    filter_combinations,
+    parse_matrix,
+)
+
+
+class TestComputeCombinations:
+    def test_single_variable(self):
+        result = compute_combinations({'mode': ['debug', 'release']})
+        assert result == [
+            {'mode': 'debug'},
+            {'mode': 'release'},
+        ]
+
+    def test_two_variables(self):
+        result = compute_combinations({
+            'mode': ['debug', 'release'],
+            'distro': ['fedora', 'ubuntu'],
+        })
+        assert result == [
+            {'mode': 'debug', 'distro': 'fedora'},
+            {'mode': 'debug', 'distro': 'ubuntu'},
+            {'mode': 'release', 'distro': 'fedora'},
+            {'mode': 'release', 'distro': 'ubuntu'},
+        ]
+
+    def test_three_variables(self):
+        result = compute_combinations({
+            'a': ['1', '2'],
+            'b': ['x', 'y'],
+            'c': ['p'],
+        })
+        assert result == [
+            {'a': '1', 'b': 'x', 'c': 'p'},
+            {'a': '1', 'b': 'y', 'c': 'p'},
+            {'a': '2', 'b': 'x', 'c': 'p'},
+            {'a': '2', 'b': 'y', 'c': 'p'},
+        ]
+
+    def test_single_value_per_variable(self):
+        result = compute_combinations({
+            'mode': ['debug'],
+            'distro': ['fedora'],
+        })
+        assert result == [{'mode': 'debug', 'distro': 'fedora'}]
+
+    def test_empty_variables(self):
+        result = compute_combinations({})
+        assert result == [{}]
+
+    def test_empty_value_list(self):
+        result = compute_combinations({'mode': []})
+        assert result == []
+
+    def test_preserves_variable_order(self):
+        result = compute_combinations({
+            'z_last': ['1'],
+            'a_first': ['2'],
+        })
+        assert list(result[0].keys()) == ['z_last', 'a_first']
+
+
+class TestParseMatrix:
+    def test_basic(self):
+        node_data = {
+            'matrix': {
+                'mode': ['debug', 'release'],
+            },
+        }
+        result = parse_matrix(node_data)
+        assert result == {'mode': ['debug', 'release']}
+
+    def test_stringifies_numeric_values(self):
+        node_data = {
+            'matrix': {
+                'python': [3.9, 3.11],
+            },
+        }
+        result = parse_matrix(node_data)
+        assert result == {'python': ['3.9', '3.11']}
+
+    def test_scalar_value_wrapped_in_list(self):
+        node_data = {
+            'matrix': {
+                'mode': 'debug',
+            },
+        }
+        result = parse_matrix(node_data)
+        assert result == {'mode': ['debug']}
+
+    def test_missing_matrix_key(self):
+        result = parse_matrix({})
+        assert result == {}
+
+    def test_boolean_values_lowercase(self):
+        node_data = {
+            'matrix': {
+                'flag': [True, False],
+            },
+        }
+        result = parse_matrix(node_data)
+        assert result == {'flag': ['true', 'false']}
+
+    def test_integer_values(self):
+        node_data = {
+            'matrix': {
+                'count': [1, 2, 3],
+            },
+        }
+        result = parse_matrix(node_data)
+        assert result == {'count': ['1', '2', '3']}
+
+    def test_does_not_mutate_node_data(self):
+        node_data = {
+            'matrix': {
+                'mode': ['debug', 'release'],
+            },
+        }
+        parse_matrix(node_data)
+        assert node_data == {
+            'matrix': {
+                'mode': ['debug', 'release'],
+            },
+        }
+
+
+class TestCombinationName:
+    def test_single_value(self):
+        assert combination_name({'mode': 'debug'}) == 'debug'
+
+    def test_multiple_values(self):
+        assert combination_name({'mode': 'debug', 'distro': 'fedora'}) == 'debug-fedora'
+
+    def test_preserves_order(self):
+        combo: MatrixCombination = {'z': '1', 'a': '2'}
+        assert combination_name(combo) == '1-2'
+
+    def test_empty_combination(self):
+        assert combination_name({}) == ''
+
+
+class TestFilterCombinations:
+    @pytest.fixture()
+    def combinations(self) -> list[MatrixCombination]:
+        return [
+            {'mode': 'debug', 'distro': 'fedora'},
+            {'mode': 'debug', 'distro': 'ubuntu'},
+            {'mode': 'release', 'distro': 'fedora'},
+            {'mode': 'release', 'distro': 'ubuntu'},
+        ]
+
+    def test_single_filter(self, combinations: list[MatrixCombination]):
+        result = filter_combinations(combinations, ('mode=debug',))
+        assert result == [
+            {'mode': 'debug', 'distro': 'fedora'},
+            {'mode': 'debug', 'distro': 'ubuntu'},
+        ]
+
+    def test_multiple_filters_and(self, combinations: list[MatrixCombination]):
+        result = filter_combinations(combinations, ('mode=debug', 'distro=fedora'))
+        assert result == [{'mode': 'debug', 'distro': 'fedora'}]
+
+    def test_no_match(self, combinations: list[MatrixCombination]):
+        result = filter_combinations(combinations, ('mode=profile',))
+        assert result == []
+
+    def test_nonexistent_key(self, combinations: list[MatrixCombination]):
+        result = filter_combinations(combinations, ('arch=x86_64',))
+        assert result == []
+
+    def test_filter_value_containing_equals(self, combinations: list[MatrixCombination]):
+        combos = [{'expr': 'x=1'}, {'expr': 'x=2'}]
+        result = filter_combinations(combos, ('expr=x=1',))
+        assert result == [{'expr': 'x=1'}]
+
+    def test_empty_filters(self, combinations: list[MatrixCombination]):
+        result = filter_combinations(combinations, ())
+        assert result == combinations

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -1,6 +1,8 @@
+import copy
 import enum
 import functools
 import itertools
+import os
 import re
 import shutil
 import tempfile
@@ -320,6 +322,7 @@ class Plan(
         self._derived_plans = []
         self._fmf_context_from_importing = inherited_fmf_context or FmfContext()
         self._environment_from_importing = inherited_environment or Environment()
+        self._matrix_environment = Environment()
 
         # Check for possible remote plan reference first
         reference = self.node.get(['plan', 'import'])  # pyright: ignore[reportUnknownVariableType]
@@ -541,6 +544,7 @@ class Plan(
         * importing plan's environment,
         * ``--environment`` and ``--environment-file`` options,
         * run's environment,
+        * matrix environment variables (``TMT_MATRIX_*``),
         * plan's properties.
         """
 
@@ -551,6 +555,7 @@ class Plan(
                     **self._environment_from_importing,
                     **self._environment_from_cli,
                     **self.my_run.environment,
+                    **self._matrix_environment,
                     **self._environment_from_intrinsics,
                 }
             )
@@ -560,6 +565,7 @@ class Plan(
                 **self._environment_from_fmf,
                 **self._environment_from_importing,
                 **self._environment_from_cli,
+                **self._matrix_environment,
                 **self._environment_from_intrinsics,
             }
         )
@@ -1639,7 +1645,12 @@ class Plan(
 
         return self._imported_plans
 
-    def derive_plan(self, derived_id: int, tests: dict[str, list[Test]]) -> 'Plan':
+    def derive_plan(
+        self,
+        derived_id: int | str,
+        tests: dict[str, list[Test]],
+        extra_environment: Optional[Environment] = None,
+    ) -> 'Plan':
         """
         Create a new plan derived from this one.
 
@@ -1648,14 +1659,41 @@ class Plan(
         New plan will have its own workdir, a copy of this plan's
         workdir.
 
-        :param derived_id: arbitrary number marking the new plan as Nth
-            plan derived from this plan.
+        :param derived_id: identifier for the derived plan, appended
+            to this plan's name.
         :param tests: lists of tests to limit the new plan to.
+        :param extra_environment: additional environment variables
+            to inject into the derived plan, also available for
+            variable expansion in node data.
         """
 
-        derived_plan = Plan(
-            node=self.node, run=self.my_run, logger=self._logger, name=f'{self.name}.{derived_id}'
-        )
+        saved_env: dict[str, Optional[str]] = {}
+        original_data: Optional[dict[str, Any]] = None
+
+        if extra_environment:
+            original_data = copy.deepcopy(self.node.data)
+            for key, value in extra_environment.items():
+                saved_env[key] = os.environ.get(key)
+                os.environ[key] = str(value)
+
+        try:
+            derived_plan = Plan(
+                node=self.node, run=self.my_run, logger=self._logger,
+                name=f'{self.name}.{derived_id}',
+            )
+        finally:
+            if extra_environment:
+                assert original_data is not None
+                self.node.data.clear()
+                self.node.data.update(original_data)
+                for key, orig_value in saved_env.items():
+                    if orig_value is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = orig_value
+
+        if extra_environment:
+            derived_plan._matrix_environment = extra_environment
 
         derived_plan._original_plan = self
         derived_plan._original_plan_fmf_id = self.fmf_id

--- a/tmt/plugins/plan_shapers/matrix.py
+++ b/tmt/plugins/plan_shapers/matrix.py
@@ -1,0 +1,142 @@
+import collections
+import itertools
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from tmt.base.core import Test
+    from tmt.base.plan import Plan
+    from tmt.options import ClickOptionDecoratorType
+    from tmt.steps.discover import TestOrigin
+
+from tmt.plugins.plan_shapers import PlanShaper, provides_plan_shaper
+from tmt.utils import EnvVarValue, Environment
+
+MatrixCombination = dict[str, str]
+
+
+def compute_combinations(
+    variables: dict[str, list[str]],
+) -> list[MatrixCombination]:
+    """
+    Compute the cartesian product of all matrix variables.
+    """
+
+    var_names = list(variables.keys())
+
+    return [
+        {name: value for name, value in zip(var_names, values)}
+        for values in itertools.product(*variables.values())
+    ]
+
+
+def _stringify(value: Any) -> str:
+    """
+    Convert a YAML value to string, preserving lowercase for booleans.
+    """
+
+    if isinstance(value, bool):
+        return 'true' if value else 'false'
+    return str(value)
+
+
+def parse_matrix(node_data: dict[str, Any]) -> dict[str, list[str]]:
+    """
+    Parse the ``matrix`` key from plan node data.
+
+    :returns: a dict mapping variable names to their values.
+    """
+
+    matrix = node_data.get('matrix', {})
+
+    return {
+        key: [_stringify(v) for v in values] if isinstance(values, list) else [_stringify(values)]
+        for key, values in matrix.items()
+    }
+
+
+def combination_name(combination: MatrixCombination) -> str:
+    """
+    Create a human-readable name from a matrix combination.
+    """
+
+    return '-'.join(combination.values())
+
+
+def filter_combinations(
+    combinations: list[MatrixCombination],
+    filters: tuple[str, ...],
+) -> list[MatrixCombination]:
+    """
+    Filter combinations by ``KEY=VALUE`` filters. All filters must match.
+    """
+
+    parsed: dict[str, str] = {}
+    for f in filters:
+        key, _, value = f.partition('=')
+        parsed[key] = value
+
+    return [
+        combo for combo in combinations
+        if all(combo.get(k) == v for k, v in parsed.items())
+    ]
+
+
+@provides_plan_shaper('matrix')
+class MatrixPlanShaper(PlanShaper):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def run_options(cls) -> list['ClickOptionDecoratorType']:
+        from tmt.options import option
+        return [
+            option(
+                '--matrix-filter',
+                metavar='KEY=VALUE',
+                help='Run only matrix combinations matching this filter. Can be specified multiple times.',
+                multiple=True,
+                default=(),
+            )
+        ]
+
+    _inspected_plan_names: list[str] = []
+
+    @classmethod
+    def check(cls, plan: 'Plan', tests: list['TestOrigin']) -> bool:
+        if plan.name in cls._inspected_plan_names:
+            return False
+        return bool(plan.node.data.get('matrix'))
+
+    @classmethod
+    def apply(cls, plan: 'Plan', tests: list['TestOrigin']) -> Iterator['Plan']:
+        assert plan.my_run is not None
+
+        if plan.name in cls._inspected_plan_names:
+            return
+
+        cls._inspected_plan_names.append(plan.name)
+
+        variables = parse_matrix(plan.node.data)
+        combinations = compute_combinations(variables)
+
+        matrix_filters = plan.my_run.opt('matrix_filter') or ()
+        if matrix_filters:
+            combinations = filter_combinations(combinations, matrix_filters)
+
+        plan.info(f'Expanding matrix into {len(combinations)} combinations.')
+
+        batch: dict[str, list['Test']] = collections.defaultdict(list)
+        for test_origin in tests:
+            batch[test_origin.phase].append(test_origin.test)
+
+        for combo in combinations:
+            name = combination_name(combo)
+            matrix_env = Environment({
+                f'TMT_MATRIX_{key.upper()}': EnvVarValue(value)
+                for key, value in combo.items()
+            })
+            derived_plan = plan.derive_plan(name, batch, extra_environment=matrix_env)
+
+            cls._inspected_plan_names.append(derived_plan.name)
+            yield derived_plan


### PR DESCRIPTION
This PR adds a `matrix` plan shaper that lets users define variables and their values in a plan and automatically expands them into derived plans via cartesian product. Instead of duplicating near-identical plans that differ only in configuration, users write a single plan with a `matrix:` key and tmt generates the combinations at runtime. Each derived plan gets `TMT_MATRIX_*` environment variables, which are available both for variable expansion in plan configuration (e.g., `$TMT_MATRIX_DISTRO` in a provision step) and directly in test scripts.

I've recently started using tmt, and noticed I'd been writing a lot of repeat tests to test against different configurations. Similar to github actions feature, I thought this could be nicely solved with a tmt matrix feature. This feature makes it much nicer to write tests IMO.

#3873 — Documents the workarounds users currently rely on to parameterize tests. The matrix feature directly addresses this use case.
#3516 — The repeat plan shaper that established the plan shaper pattern this implementation follows.

Please note that I added tests and documentation for this new feature. Let me know of any feedback you have!