### PR TITLE
Move the `--condition` option under `--feeling-safe`

### DIFF
--- a/docs/releases/pending/condition.fmf
+++ b/docs/releases/pending/condition.fmf
@@ -1,0 +1,5 @@
+description: |
+  The ``--condition`` option now requires ``--feeling-safe`` to be
+  enabled. This option evaluates arbitrary Python expressions using
+  ``eval()`` and could be exploited through CLI option injection
+  when tmt is invoked programmatically with untrusted input.

--- a/tests/plan/select/test.sh
+++ b/tests/plan/select/test.sh
@@ -45,7 +45,7 @@ rlJournalStart
     done
 
     rlPhaseStartTest "tmt plan ls --condition requires --feeling-safe"
-        rlRun -s "tmt plan ls --condition 'True'" 2
+        rlRun -s "TMT_FEELING_SAFE=0 tmt plan ls --condition 'True'" 2
         rlAssertGrep "requires the '--feeling-safe' option" $rlRun_LOG
     rlPhaseEnd
 
@@ -65,7 +65,7 @@ rlJournalStart
     done
 
     rlPhaseStartCleanup
-        rlRun "rm -r $tmp" 0 "Remove temporary run workdir"
+        rlRun "rm -rf $tmp" 0 "Remove temporary run workdir"
         rlRun "rm $output" 0 "Remove output file"
     rlPhaseEnd
 rlJournalEnd

--- a/tests/plan/select/test.sh
+++ b/tests/plan/select/test.sh
@@ -44,6 +44,17 @@ rlJournalStart
         rlPhaseEnd
     done
 
+    rlPhaseStartTest "tmt plan ls --condition requires --feeling-safe"
+        rlRun -s "tmt plan ls --condition 'True'" 2
+        rlAssertGrep "requires the '--feeling-safe' option" $rlRun_LOG
+    rlPhaseEnd
+
+    rlPhaseStartTest "tmt plan ls --condition with --feeling-safe"
+        rlRun -s "tmt --feeling-safe plan ls --condition 'True'"
+        rlAssertGrep "/plans/features/core" $rlRun_LOG
+        rlAssertGrep "/plans/features/basic" $rlRun_LOG
+    rlPhaseEnd
+
     for exclude in '-x' '--exclude'; do
         rlPhaseStartTest "tmt plan ls $exclude <regex>"
             rlRun "tmt plan ls | tee $output"

--- a/tests/test/select/test.sh
+++ b/tests/test/select/test.sh
@@ -106,16 +106,16 @@ rlJournalStart
 
     rlPhaseStartTest "Select tests using a condition"
         # Enabled
-        rlRun "tmt test ls --condition 'enabled == True' | grep -v 'warn: ' | tee $output"
+        rlRun "tmt --feeling-safe test ls --condition 'enabled == True' | grep -v 'warn: ' | tee $output"
         rlAssertGrep '/tests/enabled/default' $output
         rlAssertGrep '/tests/enabled/defined' $output
         rlAssertNotGrep '/tests/enabled/disabled' $output
-        rlRun "tmt test ls --condition 'enabled == False' | grep -v 'warn: ' | tee $output"
+        rlRun "tmt --feeling-safe test ls --condition 'enabled == False' | grep -v 'warn: ' | tee $output"
         rlAssertNotGrep '/tests/enabled/default' $output
         rlAssertNotGrep '/tests/enabled/defined' $output
         rlAssertGrep '/tests/enabled/disabled' $output
 
-        for tmt in 'tmt test ls' 'tmt run -rv discover finish test'; do
+        for tmt in 'tmt --feeling-safe test ls' 'tmt --feeling-safe run -rv discover finish test'; do
             if [[ "$tmt" == *" run "* ]]; then
                 redirect="2>&1 >/dev/null"
             else

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -2270,6 +2270,12 @@ class Tree(tmt.utils.Common):
         Apply filters and conditions, return pruned nodes
         """
 
+        if conditions and not self.is_feeling_safe:
+            raise tmt.utils.GeneralError(
+                "The '--condition' option evaluates arbitrary Python expressions "
+                "and requires the '--feeling-safe' option."
+            )
+
         result = []
         for node in nodes:
             filter_vars = copy.deepcopy(node._metadata)

--- a/tmt/base/core.py
+++ b/tmt/base/core.py
@@ -2257,6 +2257,25 @@ class Tree(tmt.utils.Common):
         """
         return self._custom_fmf_context or super().fmf_context
 
+    def _collect_cli_conditions(self, cls: type[tmt.utils.Common]) -> list[str]:
+        """
+        Collect ``--condition`` options from the command line
+
+        Get conditions for the given class. Also ensure that the
+        ``--feeling-safe`` option is enabled as these can
+        potentially be dangerous.
+        """
+
+        cli_conditions: list[str] = list(cls._opt('conditions', []))
+
+        if cli_conditions and not self.is_feeling_safe:
+            raise tmt.utils.GeneralError(
+                "The '--condition' option evaluates arbitrary Python expressions "
+                "and requires the '--feeling-safe' option."
+            )
+
+        return cli_conditions
+
     def _filters_conditions(
         self,
         nodes: Sequence[CoreT],
@@ -2269,12 +2288,6 @@ class Tree(tmt.utils.Common):
         """
         Apply filters and conditions, return pruned nodes
         """
-
-        if conditions and not self.is_feeling_safe:
-            raise tmt.utils.GeneralError(
-                "The '--condition' option evaluates arbitrary Python expressions "
-                "and requires the '--feeling-safe' option."
-            )
 
         result = []
         for node in nodes:
@@ -2416,7 +2429,7 @@ class Tree(tmt.utils.Common):
 
         if apply_command_line:
             filters += list(Test._opt('filters', []))
-            conditions += list(Test._opt('conditions', []))
+            conditions += self._collect_cli_conditions(Test)
             includes += list(Test._opt('include', []))
             excludes += list(Test._opt('exclude', []))
             cmd_line_names = list(Test._opt('names', []))
@@ -2528,7 +2541,7 @@ class Tree(tmt.utils.Common):
         if apply_command_line:
             names += list(Plan._opt('names', []))
             filters += list(Plan._opt('filters', []))
-            conditions += list(Plan._opt('conditions', []))
+            conditions += self._collect_cli_conditions(Plan)
             excludes += list(Plan._opt('exclude', []))
 
         # Sanitize plan names to make sure no name includes control character
@@ -2657,7 +2670,7 @@ class Tree(tmt.utils.Common):
         if apply_command_line:
             names += list(Story._opt('names', []))
             filters += list(Story._opt('filters', []))
-            conditions += list(Story._opt('conditions', []))
+            conditions += self._collect_cli_conditions(Story)
             excludes += list(Story._opt('exclude', []))
 
         # Sanitize story names to make sure no name includes control character

--- a/tmt/options.py
+++ b/tmt/options.py
@@ -349,7 +349,7 @@ FILTERING_OPTIONS: list[ClickOptionDecoratorType] = [
         'conditions',
         metavar="EXPR",
         multiple=True,
-        help="Use arbitrary Python expression for filtering.",
+        help="Use arbitrary Python expression for filtering (requires --feeling-safe).",
     ),
     option(
         '--enabled',
@@ -390,7 +390,7 @@ FILTERING_OPTIONS_LONG: list[ClickOptionDecoratorType] = [
         'conditions',
         metavar="EXPR",
         multiple=True,
-        help="Use arbitrary Python expression for filtering.",
+        help="Use arbitrary Python expression for filtering (requires --feeling-safe).",
     ),
     option(
         '--enabled',


### PR DESCRIPTION
The `--condition` option evaluates arbitrary Python expressions and thus should be only used when user is sure that the input is safe.

Related: https://redhat.atlassian.net/browse/TFT-4849

Pull Request Checklist

* [x] implement the feature
* [x] extend the test coverage
* [x] include a release note