### PR TITLE
Separate intrinsic environment variables

### DIFF
--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -57,7 +57,7 @@ from tmt.utils import (
     style,
     to_yaml,
 )
-from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
+from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment, HasIntrinsicEnvironment
 
 if TYPE_CHECKING:
     import tmt.cli
@@ -224,6 +224,7 @@ class Plan(
     HasUserAnchorPath,
     HasPlanWorkdir,
     HasEnvironment,
+    HasIntrinsicEnvironment,
     Core,
     tmt.export.Exportable['Plan'],
     tmt.lint.Lintable['Plan'],
@@ -458,11 +459,7 @@ class Plan(
     _environment_from_importing: Environment = field(default_factory=Environment, internal=True)
 
     @property
-    def _environment_from_intrinsics(self) -> Environment:
-        """
-        Environment variables derived from the plan properties.
-        """
-
+    def intrinsic_environment(self) -> Environment:
         environment = Environment(
             {
                 'TMT_VERSION': EnvVarValue(tmt.__version__),
@@ -549,7 +546,6 @@ class Plan(
                     **self._environment_from_importing,
                     **self._environment_from_cli,
                     **self.my_run.environment,
-                    **self._environment_from_intrinsics,
                 }
             )
 
@@ -558,7 +554,6 @@ class Plan(
                 **self._environment_from_fmf,
                 **self._environment_from_importing,
                 **self._environment_from_cli,
-                **self._environment_from_intrinsics,
             }
         )
 

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -336,7 +336,11 @@ class Plan(
                 self._initialize_worktree()
 
         # Expand all environment and context variables in the node
-        with self.environment.as_environ():
+        environment = Environment()
+
+        environment.update(self.environment, self.intrinsic_environment)
+
+        with environment.as_environ():
             expand_node_data(node.data, self.fmf_context)  # pyright: ignore[reportUnknownVariableType, reportUnknownArgumentType]
 
         # Initialize test steps

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1939,7 +1939,8 @@ class Guest(
     def intrinsic_environment(self) -> Environment:
         environment = Environment()
 
-        environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+        if self.plan_environment_path is not None:
+            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
 
         return environment
 

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -40,6 +40,7 @@ import tmt.package_managers
 import tmt.steps
 import tmt.steps.scripts
 import tmt.utils
+import tmt.utils.environment
 import tmt.utils.wait
 from tmt._compat.typing import Self
 from tmt.ansible import (
@@ -1718,6 +1719,7 @@ class Guest(
     # TODO: `Guest` does "have" environment, but it's a genuine attribute,
     # not a property, and this interface will not work.
     # tmt.utils.HasEnvironment,
+    tmt.utils.environment.HasIntrinsicEnvironment,
     tmt.utils.Common,
 ):
     """
@@ -1932,6 +1934,14 @@ class Guest(
             )
 
         return Environment()
+
+    @property
+    def intrinsic_environment(self) -> Environment:
+        environment = Environment()
+
+        environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+
+        return environment
 
     @classmethod
     def options(cls, how: Optional[str] = None) -> list[tmt.options.ClickOptionDecoratorType]:
@@ -2257,14 +2267,12 @@ class Guest(
             environment.update(self.environment)
 
             if isinstance(self.parent, tmt.steps.Step):
-                environment.update(self.parent.plan)
+                environment.update(self.parent.plan.environment)
 
-            # TODO: this was owned by plan, but at wrong position, and it will
-            # be owned by plan again once the dust of environment untangling
-            # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
-            # more.
-            if self.plan_environment_path:
-                environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+            environment.update(self.intrinsic_environment)
+
+            if isinstance(self.parent, tmt.steps.Step):
+                environment.update(self.parent.plan.intrinsic_environment)
 
         else:
             # Create a copy of given environment - this prevents any

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -42,6 +42,7 @@ import tmt.package_managers
 import tmt.steps
 import tmt.steps.scripts
 import tmt.utils
+import tmt.utils.environment
 import tmt.utils.feeling_safe
 import tmt.utils.wait
 from tmt._compat.typing import Self
@@ -1769,6 +1770,7 @@ class Guest(
     # TODO: `Guest` does "have" environment, but it's a genuine attribute,
     # not a property, and this interface will not work.
     # tmt.utils.HasEnvironment,
+    tmt.utils.environment.HasIntrinsicEnvironment,
     tmt.utils.Common,
 ):
     """
@@ -1983,6 +1985,14 @@ class Guest(
             )
 
         return Environment()
+
+    @property
+    def intrinsic_environment(self) -> Environment:
+        environment = Environment()
+
+        environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+
+        return environment
 
     @classmethod
     def options(cls, how: Optional[str] = None) -> list[tmt.options.ClickOptionDecoratorType]:
@@ -2308,14 +2318,12 @@ class Guest(
             environment.update(self.environment)
 
             if isinstance(self.parent, tmt.steps.Step):
-                environment.update(self.parent.plan)
+                environment.update(self.parent.plan.environment)
 
-            # TODO: this was owned by plan, but at wrong position, and it will
-            # be owned by plan again once the dust of environment untangling
-            # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
-            # more.
-            if self.plan_environment_path:
-                environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+            environment.update(self.intrinsic_environment)
+
+            if isinstance(self.parent, tmt.steps.Step):
+                environment.update(self.parent.plan.intrinsic_environment)
 
         else:
             # Create a copy of given environment - this prevents any

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -1990,7 +1990,8 @@ class Guest(
     def intrinsic_environment(self) -> Environment:
         environment = Environment()
 
-        environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+        if self.plan_environment_path is not None:
+            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
 
         return environment
 

--- a/tmt/steps/context/abort.py
+++ b/tmt/steps/context/abort.py
@@ -5,7 +5,7 @@ import tmt.steps.scripts
 import tmt.utils
 from tmt.container import container
 from tmt.utils import Path
-from tmt.utils.environment import Environment, HasEnvironment
+from tmt.utils.environment import Environment, HasIntrinsicEnvironment
 
 
 class AbortStep(tmt.utils.GeneralError):
@@ -15,7 +15,7 @@ class AbortStep(tmt.utils.GeneralError):
 
 
 @container
-class AbortContext(HasEnvironment):
+class AbortContext(HasIntrinsicEnvironment):
     """
     Provides API for handling a phase-requested abort of a step.
     """
@@ -43,5 +43,5 @@ class AbortContext(HasEnvironment):
         return self.request_path.exists()
 
     @property
-    def environment(self) -> Environment:
+    def intrinsic_environment(self) -> Environment:
         return Environment()

--- a/tmt/steps/context/pidfile.py
+++ b/tmt/steps/context/pidfile.py
@@ -84,7 +84,7 @@ from tmt.container import container
 from tmt.guest import Guest, TransferOptions
 from tmt.steps import safe_filename
 from tmt.utils import Path, ShellScript
-from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
+from tmt.utils.environment import Environment, EnvVarValue, HasIntrinsicEnvironment
 from tmt.utils.templates import render_template
 
 TEST_PIDFILE_FILENAME = 'tmt-test.pid'
@@ -193,7 +193,7 @@ def effective_pidfile_root() -> Path:
 
 
 @container
-class PidFileContext(HasEnvironment):
+class PidFileContext(HasIntrinsicEnvironment):
     #: Phase owning this context.
     phase: tmt.steps.BasePlugin[Any, Any]
 
@@ -220,7 +220,7 @@ class PidFileContext(HasEnvironment):
         return effective_pidfile_root() / TEST_PIDFILE_LOCK_FILENAME
 
     @property
-    def environment(self) -> Environment:
+    def intrinsic_environment(self) -> Environment:
         return Environment(
             {
                 'TMT_TEST_PIDFILE': EnvVarValue(self.pidfile_path),

--- a/tmt/steps/context/reboot.py
+++ b/tmt/steps/context/reboot.py
@@ -9,7 +9,7 @@ import tmt.utils
 from tmt.container import MetadataContainer, container
 from tmt.guest import Guest, RebootMode, SoftRebootModes
 from tmt.utils import Path, ShellScript
-from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
+from tmt.utils.environment import Environment, EnvVarValue, HasIntrinsicEnvironment
 from tmt.utils.wait import Deadline, Waiting
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ class RebootData(MetadataContainer):
 
 
 @container
-class RebootContext(HasEnvironment):
+class RebootContext(HasIntrinsicEnvironment):
     """
     Tracks information about guest reboots.
     """
@@ -76,7 +76,7 @@ class RebootContext(HasEnvironment):
         return self.soft_requested or self.hard_requested
 
     @property
-    def environment(self) -> Environment:
+    def intrinsic_environment(self) -> Environment:
         environment = Environment()
 
         # Set all supported reboot variables

--- a/tmt/steps/context/restart.py
+++ b/tmt/steps/context/restart.py
@@ -4,14 +4,14 @@ import tmt.log
 import tmt.utils
 from tmt.container import container
 from tmt.guest import Guest
-from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
+from tmt.utils.environment import Environment, EnvVarValue, HasIntrinsicEnvironment
 
 if TYPE_CHECKING:
     from tmt.steps.context.reboot import RebootContext
 
 
 @container
-class RestartContext(HasEnvironment):
+class RestartContext(HasIntrinsicEnvironment):
     """
     Tracks information about restarts of an action, e.g. a test script.
     """
@@ -50,7 +50,7 @@ class RestartContext(HasEnvironment):
         return self.is_requested_test()
 
     @property
-    def environment(self) -> Environment:
+    def intrinsic_environment(self) -> Environment:
         return Environment({'TMT_TEST_RESTART_COUNT': EnvVarValue(str(self.restart_counter))})
 
     def handle_restart(self, reboot: Optional['RebootContext'] = None) -> bool:

--- a/tmt/steps/context/restraint.py
+++ b/tmt/steps/context/restraint.py
@@ -2,11 +2,11 @@ from typing import Optional
 
 import tmt.log
 from tmt.container import container
-from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
+from tmt.utils.environment import Environment, EnvVarValue, HasIntrinsicEnvironment
 
 
 @container
-class RestraintContext(HasEnvironment):
+class RestraintContext(HasIntrinsicEnvironment):
     """
     Provides restraint-related context for execution.
     """
@@ -22,7 +22,7 @@ class RestraintContext(HasEnvironment):
     taskname: Optional[str] = None
 
     @property
-    def environment(self) -> Environment:
+    def intrinsic_environment(self) -> Environment:
         environment = Environment()
 
         environment["TMT_RESTRAINT_COMPATIBLE"] = EnvVarValue(str(int(self.enabled)))

--- a/tmt/steps/execute/__init__.py
+++ b/tmt/steps/execute/__init__.py
@@ -48,7 +48,7 @@ from tmt.utils import (
     Stopwatch,
     configure_bool_constant,
 )
-from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
+from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment, HasIntrinsicEnvironment
 
 if TYPE_CHECKING:
     import tmt.base.plan
@@ -111,7 +111,7 @@ ExecuteStepDataT = TypeVar('ExecuteStepDataT', bound=ExecuteStepData)
 
 
 @container
-class TestInvocation(HasStepWorkdir, HasEnvironment):
+class TestInvocation(HasStepWorkdir, HasEnvironment, HasIntrinsicEnvironment):
     """
     A bundle describing one test invocation.
 
@@ -353,13 +353,47 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
         )
 
     @property
+    def intrinsic_environment(self) -> Environment:
+        # narrow type
+        assert isinstance(self.phase.step.plan.my_run, tmt.base.run.Run)
+
+        environment = Environment()
+
+        environment["TMT_TEST_NAME"] = EnvVarValue(self.test.name)
+        environment["TMT_TEST_INVOCATION_PATH"] = EnvVarValue(self.path)
+        environment["TMT_TEST_DATA"] = EnvVarValue(self.test_data_path)
+        environment["TMT_TEST_SUBMITTED_FILES"] = EnvVarValue(self.submission_log_path)
+        environment['TMT_TEST_SERIAL_NUMBER'] = EnvVarValue(str(self.test.serial_number))
+        environment["TMT_TEST_METADATA"] = EnvVarValue(self.path / TEST_METADATA_FILENAME)
+
+        environment['TMT_TEST_ITERATION_ID'] = EnvVarValue(
+            f"{self.phase.step.plan.my_run.unique_id}-{self.test.serial_number}"
+        )
+
+        environment['TMT_SOURCE_DIR'] = EnvVarValue(self.discover_phase.source_dir)
+
+        environment.update(
+            # Add variables from plan
+            self.phase.step.plan.intrinsic_environment,
+            # Add variables from guest
+            self.guest.intrinsic_environment,
+            # Add variables from invocation contexts
+            self.abort.intrinsic_environment,
+            self.reboot.intrinsic_environment,
+            self.restart.intrinsic_environment,
+            self.pidfile.intrinsic_environment,
+            self.restraint.intrinsic_environment,
+            # Add variables the framework wants to expose
+            self.test.test_framework.get_environment_variables(self, self.logger),
+        )
+
+        return environment
+
+    @property
     def environment(self) -> Environment:
         if self._environment is None:
             # narrow type
-            assert isinstance(self.phase.parent, Execute)
-
-            # narrow type
-            assert isinstance(self.phase.parent.plan.my_run, tmt.base.run.Run)
+            assert isinstance(self.phase.step.plan.my_run, tmt.base.run.Run)
 
             environment = Environment()
 
@@ -367,41 +401,13 @@ class TestInvocation(HasStepWorkdir, HasEnvironment):
                 self.guest.environment,
                 self.test.environment,
                 self.guest.plan_environment,
-                self.phase.parent.plan.environment,
+                self.phase.step.plan.environment,
             )
-
-            environment["TMT_TEST_NAME"] = EnvVarValue(self.test.name)
-            environment["TMT_TEST_INVOCATION_PATH"] = EnvVarValue(self.path)
-            environment["TMT_TEST_DATA"] = EnvVarValue(self.test_data_path)
-            environment["TMT_TEST_SUBMITTED_FILES"] = EnvVarValue(self.submission_log_path)
-            environment['TMT_TEST_SERIAL_NUMBER'] = EnvVarValue(str(self.test.serial_number))
-            environment["TMT_TEST_METADATA"] = EnvVarValue(self.path / TEST_METADATA_FILENAME)
-
-            environment['TMT_TEST_ITERATION_ID'] = EnvVarValue(
-                f"{self.phase.parent.plan.my_run.unique_id}-{self.test.serial_number}"
-            )
-
-            environment['TMT_SOURCE_DIR'] = EnvVarValue(self.discover_phase.source_dir)
 
         else:
             environment = self._environment
 
-        # TODO: this was owned by plan, but at wrong position, and it will
-        # be owned by plan again once the dust of environment untangling
-        # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
-        # more.
-        environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.guest.plan_environment_path)
-
-        environment.update(
-            # Add variables from invocation contexts
-            self.abort,
-            self.reboot,
-            self.restart,
-            self.pidfile,
-            self.restraint,
-            # Add variables the framework wants to expose
-            self.test.test_framework.get_environment_variables(self, self.logger),
-        )
+        environment.update(self.intrinsic_environment)
 
         self._environment = environment
 

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -151,13 +151,6 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             self.step.plan.environment,
         )
 
-        # TODO: this was owned by plan, but at wrong position, and it will
-        # be owned by plan again once the dust of environment untangling
-        # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
-        # more.
-        if guest.plan_environment_path:
-            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(guest.plan_environment_path)
-
         # Give a short summary
         overview = fmf.utils.listed(self.data.script, 'script')
         logger.info('overview', f'{overview} found', 'green')
@@ -269,8 +262,12 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             script_log_filepath.touch()
 
             script_environment = environment.copy()
-            script_environment.update(reboot_context)
-            script_environment.update(pidfile_context)
+            script_environment.update(
+                self.step.plan.intrinsic_environment,
+                guest.intrinsic_environment,
+                reboot_context.intrinsic_environment,
+                pidfile_context.intrinsic_environment,
+            )
 
             pull_options = DEFAULT_PULL_OPTIONS.copy()
             pull_options.exclude.append(str(script_log_filepath))

--- a/tmt/steps/prepare/shell.py
+++ b/tmt/steps/prepare/shell.py
@@ -154,13 +154,6 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             self.step.plan.environment,
         )
 
-        # TODO: this was owned by plan, but at wrong position, and it will
-        # be owned by plan again once the dust of environment untangling
-        # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
-        # more.
-        if guest.plan_environment_path:
-            environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(guest.plan_environment_path)
-
         # Give a short summary
         overview = fmf.utils.listed(self.data.script, 'script')
         logger.info('overview', f'{overview} found', 'green')
@@ -272,8 +265,12 @@ class PrepareShell(tmt.steps.prepare.PreparePlugin[PrepareShellData]):
             script_log_filepath.touch()
 
             script_environment = environment.copy()
-            script_environment.update(reboot_context)
-            script_environment.update(pidfile_context)
+            script_environment.update(
+                self.step.plan.intrinsic_environment,
+                guest.intrinsic_environment,
+                reboot_context.intrinsic_environment,
+                pidfile_context.intrinsic_environment,
+            )
 
             pull_options = DEFAULT_PULL_OPTIONS.copy()
             pull_options.exclude.append(str(script_log_filepath))

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -20,7 +20,7 @@ from tmt.utils import (
     Path,
     ShellScript,
 )
-from tmt.utils.environment import Environment, EnvVarValue
+from tmt.utils.environment import Environment
 from tmt.utils.hints import get_hint
 from tmt.utils.wait import Waiting
 
@@ -73,14 +73,12 @@ class GuestLocal(tmt.Guest):
             environment.update(self.environment)
 
             if isinstance(self.parent, tmt.steps.Step):
-                environment.update(self.parent.plan)
+                environment.update(self.parent.plan.environment)
 
-            # TODO: this was owned by plan, but at wrong position, and it will
-            # be owned by plan again once the dust of environment untangling
-            # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
-            # more.
-            if self.plan_environment_path:
-                environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+            environment.update(self.intrinsic_environment)
+
+            if isinstance(self.parent, tmt.steps.Step):
+                environment.update(self.parent.plan.intrinsic_environment)
 
         else:
             environment = super()._prepare_command_environment(environment=environment)

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -20,7 +20,7 @@ from tmt.utils import (
     Path,
     ShellScript,
 )
-from tmt.utils.environment import Environment, EnvVarValue
+from tmt.utils.environment import Environment
 from tmt.utils.feeling_safe import UB_PROVISION_LOCAL_PLUGIN
 from tmt.utils.hints import get_hint
 from tmt.utils.wait import Waiting

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -74,14 +74,12 @@ class GuestLocal(tmt.Guest):
             environment.update(self.environment)
 
             if isinstance(self.parent, tmt.steps.Step):
-                environment.update(self.parent.plan)
+                environment.update(self.parent.plan.environment)
 
-            # TODO: this was owned by plan, but at wrong position, and it will
-            # be owned by plan again once the dust of environment untangling
-            # settles. Follow https://github.com/teemtee/tmt/issues/4241 for
-            # more.
-            if self.plan_environment_path:
-                environment['TMT_PLAN_ENVIRONMENT_FILE'] = EnvVarValue(self.plan_environment_path)
+            environment.update(self.intrinsic_environment)
+
+            if isinstance(self.parent, tmt.steps.Step):
+                environment.update(self.parent.plan.intrinsic_environment)
 
         else:
             environment = super()._prepare_command_environment(environment=environment)

--- a/tmt/utils/environment.py
+++ b/tmt/utils/environment.py
@@ -1,3 +1,25 @@
+"""
+Handling of environment variables in tmt.
+
+User-owned vs tmt-owned variables
+=================================
+
+tmt separates environment variables based on their ownership:
+
+* Variables provided by user - usually there is no special label used in
+  code when speaking about user-provided variables. See
+  :py:class:`HasEnvironment` for classes that have some user-owned
+  variables to share.
+* Variables owned by tmt - called "intrinsic" variables in code,
+  see :py:class:`HasIntrinsicEnvironment` for classes that own some
+  variables on behalf of tmt.
+
+The separation exists to provide clear barrier: tmt-owned variables are
+supposed to be the most powerful ones, and they shall overwrite
+user-provided variables of the same name. When building an environment,
+the intrinsic ones must come after all user-provided ones.
+"""
+
 import abc
 import contextlib
 import os
@@ -59,7 +81,22 @@ class HasEnvironment(abc.ABC):
     @abc.abstractmethod
     def environment(self) -> 'Environment':
         """
-        Environment variables this object wants to expose to user commands.
+        User-owned environment variables this object wants to expose to user commands.
+        """
+
+        raise NotImplementedError
+
+
+class HasIntrinsicEnvironment(abc.ABC):
+    """
+    A class that provides :py:attr:`intrinsic_environment` attribute.
+    """
+
+    @property
+    @abc.abstractmethod
+    def intrinsic_environment(self) -> 'Environment':
+        """
+        tmt-owned environment variables this object wants to expose to user commands.
         """
 
         raise NotImplementedError
@@ -536,14 +573,10 @@ class Environment(dict[str, EnvVarValue]):
         return Environment(self)
 
     def update(  # type: ignore[override]
-        self, *others: Union[dict[str, EnvVarValue], HasEnvironment]
+        self, *others: 'Environment'
     ) -> None:
         for other in others:
-            if isinstance(other, dict):
-                super().update(other)
-
-            else:
-                super().update(other.environment)
+            super().update(other)
 
     @classmethod
     def normalize(


### PR DESCRIPTION
tmt-owned variables are no longer included in the
`HasEnvironment.environment` return values. Separating the user-owned and tmt-owned variables will give us precise control over their ordering.

Patch is also dropping support of `Environment.update(foo: HasEnvironment)` shortcut - an actual `Environment` instances are required now. Once a class offers both user-provided and tmt-owned variables, `update()` would have hard time to pick which set to include in the target environment ("both" might also be an answer...).

This should be the penultimate patch of the environment precedence series; the next and almost-final patch will provide unified helper to construct environments so they follow the same process.

Related to #4241.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation