### PR TITLE
Clarify importing multiple remote plans

### DIFF
--- a/spec/plans/import.fmf
+++ b/spec/plans/import.fmf
@@ -88,8 +88,9 @@ description: |
     ``importing`` keys:
 
     .. code-block:: yaml
+        :emphasize-lines: 4,5
 
-      /some-plan:
+        /some-plan:
             plan:
                 import:
                     scope: all-plans

--- a/spec/plans/import.fmf
+++ b/spec/plans/import.fmf
@@ -22,60 +22,19 @@ description: |
     .. code-block:: yaml
 
        /some-plan:
-         plan:
-           import:
-             url: ...
-             name: ...
-             ref: ...
-             path: ...
+            plan:
+                import:
+                    url: ...
+                    name: ...
+                    ref: ...
+                    path: ...
 
     The ``url`` and ``name`` keys are required, ``ref`` and ``path``
     are optional. If ``ref`` is set, the given git ref will be
     checked out before looking for plans; ``path`` defines where in
-    the remote repository the metadata tree lives.
-
-    By default, only a single remote plan is allowed to be imported,
-    and it always replaces the importing plan. To import multiple plans,
-    set ``scope`` key to ``all-plans``:
-
-    .. code-block:: yaml
-
-      /some-plan:
-        plan:
-          import:
-            ...
-
-            # This is the default, only the first discovered plan is imported,
-            # the rest is ignored.
-            scope: first-plan-only
-
-            # To limit the import to one and one plan only, and fail if
-            # more plans would match the criteria:
-            scope: single-plan-only
-
-            # To allow import of multiple plans:
-            scope: all-plans
-
-    If, instead of replacing the current plan, you want to make the imported
-    plans "children" of the current plan with the ``importing``
-    key:
-
-    .. code-block:: yaml
-
-      /some-plan:
-        plan:
-          import:
-            ...
-
-            # This is the default, replace the current plan.
-            importing: replace
-
-            # All imported plans will get their names to begin with `/some-plan/...`.
-            importing: become-parent
-
-    The ``name`` key is treated as a
-    :ref:`regular expression <regular-expressions>`, and only plans with
-    matching names will be imported.
+    the remote repository the metadata tree lives. The ``name`` key is
+    treated as a :ref:`regular expression <regular-expressions>`, and
+    only plans with matching names will be imported.
 
     .. note::
 
@@ -87,8 +46,58 @@ description: |
     the importing plan. See the :ref:`dynamic-ref` section for
     usage details and examples.
 
+    By default, only a single remote plan is allowed to be imported,
+    and it always replaces the importing plan:
+
+    .. code-block:: yaml
+
+      /some-plan:
+            plan:
+                import:
+                    # This is the default, only the first discovered
+                    # plan is imported, the rest is ignored.
+                    scope: first-plan-only
+
+                    # Limit the import to one and only one plan, and
+                    # fail if more plans would match the criteria:
+                    scope: single-plan-only
+
+                    # To allow import of multiple plans:
+                    scope: all-plans
+
+                    ...
+
+    Set the ``importing`` key to ``become-parent`` if you want to keep
+    the imported plan names and make them children of the local
+    importing plan:
+
+    .. code-block:: yaml
+
+      /some-plan:
+            plan:
+                import:
+                    # This is the default, replace the current plan.
+                    importing: replace
+
+                    # Imported plan names will begin with `/some-plan/...`.
+                    importing: become-parent
+
+                    ...
+
+    In order to import multiple plans set both ``scope`` and
+    ``importing`` keys:
+
+    .. code-block:: yaml
+
+      /some-plan:
+            plan:
+                import:
+                    scope: all-plans
+                    importing: become-parent
+                    ...
+
     Plan steps must not be defined in the remote plan reference.
-    The imported plan can be modified in only two ways. First way
+    The imported plan can be modified in several ways. First way
     is via environment and context variables. Imported plan inherits
     all environment and context variables from the importing plan.
     This behavior can be changed by setting the ``inherit-context``
@@ -96,16 +105,16 @@ description: |
 
     .. code-block:: yaml
 
-       /some-plan:
-           context:
-               ...
-           environment:
-               ...
-           plan:
-               import:
-                   ...
-                   inherit-context: false
-                   inherit-environment: false
+        /some-plan:
+            context:
+                ...
+            environment:
+                ...
+            plan:
+                import:
+                    inherit-context: false
+                    inherit-environment: false
+                    ...
 
     .. note::
 
@@ -182,6 +191,8 @@ example:
         import:
             url: https://github.com/teemtee/tmt
             name: /plans/provision/(connect|local)
+            importing: become-parent
+            scope: all-plans
 
 link:
   - relates: https://github.com/teemtee/tmt/issues/975

--- a/spec/plans/import.fmf
+++ b/spec/plans/import.fmf
@@ -84,7 +84,7 @@ description: |
 
                     ...
 
-    In order to import multiple plans set both ``scope`` and
+    In order to import multiple plans, set both ``scope`` and
     ``importing`` keys:
 
     .. code-block:: yaml
@@ -96,12 +96,12 @@ description: |
                     importing: become-parent
                     ...
 
-    Plan steps must not be defined in the remote plan reference.
-    The imported plan can be modified in several ways. First way
-    is via environment and context variables. Imported plan inherits
-    all environment and context variables from the importing plan.
-    This behavior can be changed by setting the ``inherit-context``
-    or ``inherit-environment`` options:
+    Plan steps must not be defined in the remote plan reference. The
+    imported plan can be modified in several ways. The first way is via
+    environment and context variables. The Imported plan inherits all
+    environment and context variables from the importing plan. This
+    behavior can be changed by setting the ``inherit-context`` or
+    ``inherit-environment`` options:
 
     .. code-block:: yaml
 


### PR DESCRIPTION
Make it clear in the specification that both both ``scope`` and ``importing`` keys need to be used when importing multiple remote plans. Fix missing keys in the multiple plans example.

Consistently use 4-space indentation across the whole page as we do throughout the docs. Move `...` to bottom of examples to improve the syntax highlighting in rendered docs.

Pull Request Checklist

* [x] write the documentation