### PR TITLE
Inherit the tmt process environment when running `ansible-playbook`

### DIFF
--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -3410,7 +3410,9 @@ class GuestSsh(Guest, CommandCollector):
                 friendly_command=friendly_command,
                 silent=silent,
                 cwd=parent.plan.worktree,
-                environment=self._prepare_command_environment(),
+                # Ansible runs on the control node, so it inherits the tmt
+                # process (parent) environment.
+                environment=Environment.from_environ(),
                 log=log,
             )
         except tmt.utils.RunError as exc:

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2273,6 +2273,9 @@ class Guest(
 
         return environment
 
+    # TODO: the existence of this method is very questionable, it may
+    # go away while works on https://github.com/teemtee/tmt/pull/4364
+    # continue.
     def _prepare_ansible_command_environment(
         self, environment: Optional[Environment] = None
     ) -> Environment:

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -2273,6 +2273,31 @@ class Guest(
 
         return environment
 
+    def _prepare_ansible_command_environment(
+        self, environment: Optional[Environment] = None
+    ) -> Environment:
+        """
+        Prepare environment for an ``ansible-playbook`` command.
+
+        Unlike commands running on the guest, ``ansible-playbook`` runs on the
+        control node and therefore inherits the tmt (parent) process
+        environment, extended with the command environment prepared for the
+        guest.
+
+        :param environment: if set, it is passed to
+            :py:meth:`_prepare_command_environment` as the desired command
+            environment.
+        :returns: the tmt process environment merged with the prepared command
+            environment.
+        """
+
+        return Environment(
+            {
+                **Environment.from_environ(),
+                **self._prepare_command_environment(environment),
+            }
+        )
+
     def _run_guest_command(
         self,
         command: Command,
@@ -3410,9 +3435,7 @@ class GuestSsh(Guest, CommandCollector):
                 friendly_command=friendly_command,
                 silent=silent,
                 cwd=parent.plan.worktree,
-                # Ansible runs on the control node, so it inherits the tmt
-                # process (parent) environment.
-                environment=Environment.from_environ(),
+                environment=self._prepare_ansible_command_environment(),
                 log=log,
             )
         except tmt.utils.RunError as exc:

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -131,7 +131,9 @@ class GuestLocal(tmt.Guest):
                     '-i', 'localhost,',
                     playbook,
                 ),
-                environment=self._prepare_command_environment(),
+                # Ansible runs on the control node, so it inherits the tmt
+                # process (parent) environment.
+                environment=Environment.from_environ(),
                 friendly_command=friendly_command,
                 log=log,
                 silent=silent,

--- a/tmt/steps/provision/local.py
+++ b/tmt/steps/provision/local.py
@@ -131,9 +131,7 @@ class GuestLocal(tmt.Guest):
                     '-i', 'localhost,',
                     playbook,
                 ),
-                # Ansible runs on the control node, so it inherits the tmt
-                # process (parent) environment.
-                environment=Environment.from_environ(),
+                environment=self._prepare_ansible_command_environment(),
                 friendly_command=friendly_command,
                 log=log,
                 silent=silent,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -462,7 +462,9 @@ class GuestContainer(tmt.Guest):
             return self._run_guest_command(
                 podman_command,
                 cwd=self.parent.plan.worktree,
-                environment=self._prepare_command_environment(),
+                # Ansible runs on the control node, so it inherits the tmt
+                # process (parent) environment.
+                environment=Environment.from_environ(),
                 friendly_command=friendly_command,
                 log=log,
                 silent=silent,

--- a/tmt/steps/provision/podman.py
+++ b/tmt/steps/provision/podman.py
@@ -462,9 +462,7 @@ class GuestContainer(tmt.Guest):
             return self._run_guest_command(
                 podman_command,
                 cwd=self.parent.plan.worktree,
-                # Ansible runs on the control node, so it inherits the tmt
-                # process (parent) environment.
-                environment=Environment.from_environ(),
+                environment=self._prepare_ansible_command_environment(),
                 friendly_command=friendly_command,
                 log=log,
                 silent=silent,


### PR DESCRIPTION
Run `ansible-playbook` with `tmt` process environment. Testing Farm needs to adjust the `PATH` so `ansible` version we freeze is used instead of the system one.

Assisted-by: Claude Code

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [ ] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
