### PR TITLE
Parallelize container install jobs

### DIFF
--- a/plans/provision/container.fmf
+++ b/plans/provision/container.fmf
@@ -31,6 +31,55 @@ adjust+:
 /install:
     discover+:
         test: (install|artifact)
+    # Parallelize for each container, sync with TEST_CONTAINER_IMAGES in tests/images.sh
+    environment+:
+        # See TEST_IMAGE_PREFIX in tests/images.sh
+        TEST_CONTAINER_IMAGES: "localhost/tmt/container/test"
+    /alpine:
+        environment+:
+            TEST_CONTAINER_IMAGES+: /alpine:latest
+    /centos:
+        environment+:
+            TEST_CONTAINER_IMAGES+: /centos
+        /7:
+            environment+:
+                TEST_CONTAINER_IMAGES+: /7/upstream:latest
+        /stream9:
+            environment+:
+                TEST_CONTAINER_IMAGES+: /stream9/upstream:latest
+        /stream10:
+            environment+:
+                TEST_CONTAINER_IMAGES+: /stream10/upstream:latest
+    /fedora:
+        environment+:
+            TEST_CONTAINER_IMAGES+: /fedora
+        /rawhide:
+            environment+:
+                TEST_CONTAINER_IMAGES+: /rawhide/upstream:latest
+        /eln:
+            environment+:
+                TEST_CONTAINER_IMAGES+: /eln/upstream:latest
+        /44:
+            environment+:
+                TEST_CONTAINER_IMAGES+: /44/upstream:latest
+        /43:
+            environment+:
+                TEST_CONTAINER_IMAGES+: /43/upstream:latest
+    /ubi:
+        environment+:
+            TEST_CONTAINER_IMAGES+: /ubi
+        /8:
+            environment+:
+                TEST_CONTAINER_IMAGES+: /8/upstream:latest
+        /9:
+            environment+:
+                TEST_CONTAINER_IMAGES+: /9/upstream:latest
+    /ubuntu/22.04:
+        environment+:
+            TEST_CONTAINER_IMAGES+: /ubuntu/22.04/upstream:latest
+    /debian/12.7:
+        environment+:
+            TEST_CONTAINER_IMAGES+: /debian/12.7/upstream:latest
 
 /ansible:
     discover+:

--- a/tests/finish/ansible/test.sh
+++ b/tests/finish/ansible/test.sh
@@ -9,7 +9,9 @@ rlJournalStart
         if [ "$PROVISION_HOW" = "container" ]; then
             rlRun "IMAGES='$TEST_CONTAINER_IMAGES'"
 
-            build_container_images
+            for image in $IMAGES; do
+                build_container_image "${image#$TEST_IMAGE_PREFIX/}"
+            done
 
         elif [ "$PROVISION_HOW" = "virtual" ]; then
             rlRun "IMAGES='$TEST_VIRTUAL_IMAGES'"

--- a/tests/prepare/ansible/test.sh
+++ b/tests/prepare/ansible/test.sh
@@ -9,7 +9,9 @@ rlJournalStart
         if [ "$PROVISION_HOW" = "container" ]; then
             rlRun "IMAGES='$TEST_CONTAINER_IMAGES'"
 
-            build_container_images
+            for image in $IMAGES; do
+                build_container_image "${image#$TEST_IMAGE_PREFIX/}"
+            done
 
         elif [ "$PROVISION_HOW" = "virtual" ]; then
             rlRun "IMAGES='$TEST_VIRTUAL_IMAGES'"

--- a/tests/prepare/artifact/lib/common.sh
+++ b/tests/prepare/artifact/lib/common.sh
@@ -10,7 +10,9 @@ setup_distro_environment() {
         rlDie "Image mode is not covered"
     elif [ "$PROVISION_HOW" = "container" ]; then
         rlRun "IMAGES='$TEST_CONTAINER_IMAGES'"
-        build_container_images
+        for image in $IMAGES; do
+            build_container_image "${image#$TEST_IMAGE_PREFIX/}"
+        done
     elif [ "$PROVISION_HOW" = "virtual" ]; then
         rlRun "IMAGES='$TEST_VIRTUAL_IMAGES'"
     else

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -79,7 +79,9 @@ rlJournalStart
             rlRun "IMAGES='$TEST_CONTAINER_IMAGES'"
             rlRun "SECONDARY_IMAGES='$TEST_CONTAINER_IMAGES_SECONDARY'"
 
-            build_container_images
+            for image in $IMAGES; do
+                build_container_image "${image#$TEST_IMAGE_PREFIX/}"
+            done
 
         elif [ "$PROVISION_HOW" = "virtual" ]; then
             rlRun "IMAGES='$TEST_VIRTUAL_IMAGES'"

--- a/tests/prepare/install/test.sh
+++ b/tests/prepare/install/test.sh
@@ -16,8 +16,8 @@ function fetch_downloaded_packages () {
         container_id="$(podman run -d $image sleep 3600)"
 
         rlRun "podman exec $container_id bash -c \"set -x; \
-                                                    dnf install -y 'dnf-command(download)' \
-                                                    && dnf download --destdir /tmp tree diffutils \
+                                                    dnf install -y 'dnf-command(download)'; \
+                                                    dnf download --destdir /tmp tree diffutils \
                                                     && mv /tmp/tree*.rpm /tmp/tree.rpm \
                                                     && mv /tmp/diffutils*.rpm /tmp/diffutils.rpm\""
         rlRun "podman cp $container_id:/tmp/tree.rpm $package_cache/"


### PR DESCRIPTION
Split up from #5028. Needed because tests there end up being ~15min/distro (5x time of `/prepare/install`)