### PR TITLE
Propagate default to CLI flag options

### DIFF
--- a/tests/recipe/data/insert.yaml
+++ b/tests/recipe/data/insert.yaml
@@ -35,6 +35,16 @@ plans:
             how: fmf
             order: 50
             url-content-type: git
+            dist-git-source: false
+            dist-git-init: false
+            dist-git-download-only: false
+            dist-git-install-builddeps: false
+            dist-git-merge: false
+            dist-git-remove-fmf-root: false
+            fmf-id: false
+            modified-only: false
+            prune: false
+            sync-repo: false
         tests:
           - name: /discover-shell/shell-test
             discover-phase: discover-shell

--- a/tmt/container/__init__.py
+++ b/tmt/container/__init__.py
@@ -232,7 +232,7 @@ class FieldMetadata(Generic[T]):
                 }
             )
 
-            if self.default is not dataclasses.MISSING and not self.is_flag:
+            if self.default is not dataclasses.MISSING:
                 self._option_kwargs['default'] = self.default
 
             self._option = option(*self._option_args, **self._option_kwargs)


### PR DESCRIPTION
This seems to be an old bug: default values was passed to Click for all options, except the flag ones. I am not sure why this exception, but 1. it seems incorrect, and 2. it causes actual trouble to unrelated code where flag option ends up with `None` as its value when not given on command line.

Pull Request Checklist

* [x] implement the feature