### PR TITLE
Forgiving pattern to match different formatting of "no such option"

### DIFF
--- a/tests/discover/filtering.sh
+++ b/tests/discover/filtering.sh
@@ -99,7 +99,7 @@ rlJournalStart
                           plan --name /plans/sanity/lint \
                           discover -h shell --fmf-id finish 2>&1 | \
                           tee output" 2
-        rlAssertGrep "Error: no such option: --fmf-id" output -i
+        rlAssertGrep "Error: no such option:? '?--fmf-id'?" output -iE
     rlPhaseEnd
 
     # Raise an exception if --fmf-id uses w/o --url and git root doesn't exist


### PR DESCRIPTION
Apparently, sometimes it may include colon and single quotes.

Pull Request Checklist

* [x] implement the feature