### PR TITLE
Fix rpm query issue in CentOS7

### DIFF
--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -1,6 +1,7 @@
 import copy
 import re
-from collections.abc import Iterable, Iterator, Sequence
+import shlex
+from collections.abc import Iterable, Sequence
 from typing import ClassVar, Optional, cast
 
 from tmt._compat.pathlib import Path
@@ -491,28 +492,25 @@ class YumEngine(DnfEngine):
     def disable_repo(self, *repo_ids: str) -> ShellScript:
         return (self._yum_config_manager_command() + Command('--disable', *repo_ids)).to_script()
 
-    def _sanitize_rpm_whatprovides(
-        self, installables: Iterable[Installable]
-    ) -> Iterator[Installable]:
+    def _sanitize_rpm_whatprovides(self, original_installable: Installable) -> Installable:
         """
         ``rpm -q --whatprovides`` fails when used on a NEVRA (or other combinations).
 
         This is used to sanitized the nevras out of those queries and replace them with the name
         only.
         """
-        for maybe_nevra in installables:
-            try:
-                rpm_info = RpmVersion.from_nevra(str(maybe_nevra))
-                yield Package(rpm_info.name)
-            except ValueError:
-                yield maybe_nevra
+        try:
+            rpm_info = RpmVersion.from_nevra(str(original_installable))
+            return Package(rpm_info.name)
+        except ValueError:
+            return original_installable
 
     def _construct_presence_script(
         self, *installables: Installable, what_provides: bool = True
     ) -> ShellScript:
         if what_provides:
             return super()._construct_presence_script(
-                *self._sanitize_rpm_whatprovides(installables),
+                *[self._sanitize_rpm_whatprovides(pkg) for pkg in installables],
                 what_provides=what_provides,
             )
         return super()._construct_presence_script(
@@ -521,7 +519,12 @@ class YumEngine(DnfEngine):
         )
 
     def check_presence(self, *installables: Installable) -> ShellScript:
-        return super().check_presence(*self._sanitize_rpm_whatprovides(installables))
+        queries: list[str] = []
+        for original_installable in installables:
+            sanitized = shlex.quote(str(self._sanitize_rpm_whatprovides(original_installable)))
+            original = shlex.quote(str(original_installable))
+            queries.append(f"rpm -q --whatprovides {sanitized} >&2 || echo {original}")
+        return ShellScript("\n".join(queries))
 
     # TODO: get rid of those `type: ignore` below. I think it's caused by the
     # decorator, it might be messing with the class inheritance as seen by pyright,

--- a/tmt/package_managers/dnf.py
+++ b/tmt/package_managers/dnf.py
@@ -1,6 +1,6 @@
 import copy
 import re
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from typing import ClassVar, Optional, cast
 
 from tmt._compat.pathlib import Path
@@ -490,6 +490,38 @@ class YumEngine(DnfEngine):
 
     def disable_repo(self, *repo_ids: str) -> ShellScript:
         return (self._yum_config_manager_command() + Command('--disable', *repo_ids)).to_script()
+
+    def _sanitize_rpm_whatprovides(
+        self, installables: Iterable[Installable]
+    ) -> Iterator[Installable]:
+        """
+        ``rpm -q --whatprovides`` fails when used on a NEVRA (or other combinations).
+
+        This is used to sanitized the nevras out of those queries and replace them with the name
+        only.
+        """
+        for maybe_nevra in installables:
+            try:
+                rpm_info = RpmVersion.from_nevra(str(maybe_nevra))
+                yield Package(rpm_info.name)
+            except ValueError:
+                yield maybe_nevra
+
+    def _construct_presence_script(
+        self, *installables: Installable, what_provides: bool = True
+    ) -> ShellScript:
+        if what_provides:
+            return super()._construct_presence_script(
+                *self._sanitize_rpm_whatprovides(installables),
+                what_provides=what_provides,
+            )
+        return super()._construct_presence_script(
+            *installables,
+            what_provides=what_provides,
+        )
+
+    def check_presence(self, *installables: Installable) -> ShellScript:
+        return super().check_presence(*self._sanitize_rpm_whatprovides(installables))
 
     # TODO: get rid of those `type: ignore` below. I think it's caused by the
     # decorator, it might be messing with the class inheritance as seen by pyright,


### PR DESCRIPTION
`rpm -q --whatprovides` fails when used on a NEVRA (or other combinations) in the rpm version available in CentOS 7

Encountered in #5089 as
```
            cmd: rpm -q --whatprovides bar-0:1.0-1.noarch >&2 || echo bar-0:1.0-1.noarch
            stderr: no package provides bar-0:1.0-1.noarch
            stdout: bar-0:1.0-1.noarch
            cmd: yum install -y  bar-0:1.0-1.noarch && rpm -q --whatprovides bar-0:1.0-1.noarch
            stdout: Loaded plugins: fastestmirror, ovl
            stdout: Loading mirror speeds from cached hostfile
            stdout: Resolving Dependencies
            stdout: --> Running transaction check
            stdout: ---> Package bar.noarch 0:1.0-1 will be installed
            stdout: --> Finished Dependency Resolution
            stdout: 
            stdout: Dependencies Resolved
            stdout: 
            stdout: ================================================================================
            stdout:  Package      Arch            Version        Repository                    Size
            stdout: ================================================================================
            stdout: Installing:
            stdout:  bar          noarch          1.0-1          tmt-artifact-shared          6.0 k
            stdout: 
            stdout: Transaction Summary
            stdout: ================================================================================
            stdout: Install  1 Package
            stdout: 
            stdout: Total download size: 6.0 k
            stdout: Installed size: 0  
            stdout: Downloading packages:
            stdout: Running transaction check
            stdout: Running transaction test
            stdout: Transaction test succeeded
            stdout: Running transaction
            stdout:   Installing : bar-1.0-1.noarch                                             1/1 
            stdout:   Verifying  : bar-1.0-1.noarch                                             1/1 
            stdout: 
            stdout: Installed:
            stdout:   bar.noarch 0:1.0-1                                                            
            stdout: 
            stdout: Complete!
            stdout: no package provides bar-0:1.0-1.noarch
```
And see it failing
```console
[root@cedec654f176 /]# rpm -q --whatprovides bar
bar-1.0-1.noarch
[root@cedec654f176 /]# rpm -q --whatprovides bar-0:1.0-1.noarch
no package provides bar-0:1.0-1.noarch
[root@cedec654f176 /]# rpm -q --whatprovides bar-1.0-1.noarch
no package provides bar-1.0-1.noarch
[root@cedec654f176 /]# rpm -q --whatprovides bar-1.0-1       
no package provides bar-1.0-1
[root@cedec654f176 /]# rpm -q --whatprovides bar-0:1.0-1
no package provides bar-0:1.0-1
[root@cedec654f176 /]# rpm -q --whatprovides bar-1.0    
no package provides bar-1.0
[root@cedec654f176 /]# rpm --version
RPM version 4.11.3
```
(works without `--whatprovides` though)
```console
[root@cedec654f176 /]# rpm -q bar-0:1.0-1.noarch
bar-1.0-1.noarch
```