### PR TITLE
Honor .gitignore in copy_tree and plan rsyncs

### DIFF
--- a/tests/unit/test_filesystem.py
+++ b/tests/unit/test_filesystem.py
@@ -9,7 +9,7 @@ import pytest
 import tmt.log
 import tmt.utils
 import tmt.utils.filesystem
-from tmt.utils import Path
+from tmt.utils import Command, Path
 
 # A dictionary mapping file paths to their content for test setup.
 # This reduces duplication and improves readability in tests.
@@ -206,12 +206,12 @@ def test_fallback_to_shutil_copy_from_cp_failure(
     copy_tree_paths: CopyTreePathConfig,
     root_logger: tmt.log.Logger,
 ):
-    """Test fallback to shutil.copytree when _copy_tree_cp fails."""
+    """Test fallback to shutil.copytree when _copy_tree_cp fails (non-git source)."""
     source_dir, dest_dir, _ = copy_tree_paths
     tmt.utils.filesystem.copy_tree(source_dir, dest_dir, root_logger)
 
     mock_copy_tree_cp.assert_called_once_with(source_dir, dest_dir, root_logger)
-    mock_copy_tree_shutil.assert_called_once_with(source_dir, dest_dir, root_logger)
+    mock_copy_tree_shutil.assert_called_once_with(source_dir, dest_dir, root_logger, [])
 
     # Verify files were copied using the fallback approach (shutil.copytree)
     for file_path in _EXPECTED_TEST_FILES:
@@ -263,7 +263,7 @@ def test_metadata_preservation_on_cp_failure_fallback_to_shutil(
     tmt.utils.filesystem.copy_tree(source_dir, dest_dir, root_logger)
 
     mock_copy_tree_cp.assert_called_once_with(source_dir, dest_dir, root_logger)
-    mock_copy_tree_shutil.assert_called_once_with(source_dir, dest_dir, root_logger)
+    mock_copy_tree_shutil.assert_called_once_with(source_dir, dest_dir, root_logger, [])
     _run_metadata_test_for_item(dest_dir, test_file)
     _run_metadata_test_for_item(dest_dir, test_dir)
 
@@ -279,7 +279,7 @@ def test_all_strategies_fail(
     copy_tree_paths: CopyTreePathConfig,
     root_logger: tmt.log.Logger,
 ):
-    """Test GeneralError is raised when all copy strategies fail."""
+    """Test GeneralError is raised when all copy strategies fail (non-git source)."""
     source_dir, dest_dir, _ = copy_tree_paths
     with pytest.raises(tmt.utils.GeneralError):
         tmt.utils.filesystem.copy_tree(source_dir, dest_dir, root_logger)
@@ -311,3 +311,220 @@ def test_copy_to_existing_destination(
     # Check symlink if supported
     if symlinks_supported:
         assert Path.is_symlink(dest_dir / "symlink.txt")
+
+
+@mock.patch('tmt.utils.filesystem.tmt.utils.git.git_ignore')
+def test_get_git_excludes(
+    mock_git_ignore,
+    tmppath: Path,
+    root_logger: tmt.log.Logger,
+):
+    """Test _get_git_excludes returns .git and gitignored paths."""
+    source_dir = tmppath / "src"
+    source_dir.mkdir()
+    mock_git_ignore.return_value = [Path('build/'), Path('cache.pyc')]
+
+    result = tmt.utils.filesystem._get_git_excludes(source_dir, root_logger)
+
+    mock_git_ignore.assert_called_once_with(root=source_dir, logger=root_logger)
+    assert Path('.git') in result
+    assert Path('build/') in result
+    assert Path('cache.pyc') in result
+
+
+@mock.patch(
+    'tmt.utils.filesystem.tmt.utils.git.git_ignore',
+    side_effect=tmt.utils.RunError('git failed', tmt.utils.Command('git'), 1),
+)
+def test_get_git_excludes_git_ignore_fails(
+    mock_git_ignore,
+    tmppath: Path,
+    root_logger: tmt.log.Logger,
+):
+    """Test _get_git_excludes returns empty list when git_ignore fails."""
+    source_dir = tmppath / "src"
+    source_dir.mkdir()
+
+    result = tmt.utils.filesystem._get_git_excludes(source_dir, root_logger)
+
+    assert result == []
+
+
+def test_copy_tree_rsync_with_gitignore_filter(tmppath: Path, root_logger: tmt.log.Logger):
+    """Test that _copy_tree_rsync uses native .gitignore filtering."""
+    source_dir = tmppath / "src"
+    dest_dir = tmppath / "dst"
+    source_dir.mkdir()
+    dest_dir.mkdir()
+
+    (source_dir / "keep.txt").write_text("keep")
+    (source_dir / ".gitignore").write_text("build/\n")
+    (source_dir / "build").mkdir()
+    (source_dir / "build" / "output.o").write_text("compiled")
+    (source_dir / ".git").mkdir()
+    (source_dir / ".git" / "config").write_text("gitconfig")
+
+    result = tmt.utils.filesystem._copy_tree_rsync(source_dir, dest_dir, root_logger, source_dir)
+
+    assert result is True
+    assert (dest_dir / "keep.txt").exists()
+    assert (dest_dir / "keep.txt").read_text() == "keep"
+    assert (dest_dir / ".gitignore").exists()
+    assert not (dest_dir / "build").exists()
+    assert not (dest_dir / ".git").exists()
+
+
+def test_copy_tree_shutil_with_excludes(tmppath: Path, root_logger: tmt.log.Logger):
+    """Test that _copy_tree_shutil excludes specified paths, including nested ones."""
+    source_dir = tmppath / "src"
+    dest_dir = tmppath / "dst"
+    source_dir.mkdir()
+    dest_dir.mkdir()
+
+    (source_dir / "keep.txt").write_text("keep")
+    (source_dir / "build").mkdir()
+    (source_dir / "build" / "output.o").write_text("compiled")
+    (source_dir / ".git").mkdir()
+    (source_dir / ".git" / "config").write_text("gitconfig")
+    (source_dir / "sub").mkdir()
+    (source_dir / "sub" / "nested.txt").write_text("nested")
+    (source_dir / "sub" / "keep_nested.txt").write_text("keep nested")
+
+    excludes = [Path('.git'), Path('build/'), Path('sub/nested.txt')]
+
+    tmt.utils.filesystem._copy_tree_shutil(source_dir, dest_dir, root_logger, excludes)
+
+    assert (dest_dir / "keep.txt").exists()
+    assert (dest_dir / "keep.txt").read_text() == "keep"
+    assert not (dest_dir / "build").exists()
+    assert not (dest_dir / ".git").exists()
+
+    # Nested file matching a full relative path exclude should be excluded ...
+    assert not (dest_dir / "sub" / "nested.txt").exists()
+    # ... while sibling files in the same subdirectory are still copied.
+    assert (dest_dir / "sub" / "keep_nested.txt").exists()
+    assert (dest_dir / "sub" / "keep_nested.txt").read_text() == "keep nested"
+
+
+def test_copy_tree_honors_gitignore(tmppath: Path, root_logger: tmt.log.Logger):
+    """Test that copy_tree excludes .gitignore'd files when source is a git repo."""
+    source_dir = tmppath / "git_repo"
+    dest_dir = tmppath / "dest"
+    source_dir.mkdir()
+
+    # Initialize a git repo
+    Command('git', 'init').run(cwd=source_dir, logger=root_logger)
+    Command('git', 'config', 'user.email', 'test@test.com').run(
+        cwd=source_dir,
+        logger=root_logger,
+    )
+    Command('git', 'config', 'user.name', 'Test').run(
+        cwd=source_dir,
+        logger=root_logger,
+    )
+
+    # Create tracked files
+    (source_dir / "tracked.txt").write_text("tracked content")
+    (source_dir / "src").mkdir()
+    (source_dir / "src" / "main.py").write_text("print('hello')")
+
+    # Create .gitignore
+    (source_dir / ".gitignore").write_text("build/\n*.pyc\n")
+
+    # Git add and commit tracked files
+    Command('git', 'add', '.').run(cwd=source_dir, logger=root_logger)
+    Command('git', 'commit', '-m', 'init').run(cwd=source_dir, logger=root_logger)
+
+    # Create ignored files (after commit so they are untracked+ignored)
+    (source_dir / "build").mkdir()
+    (source_dir / "build" / "output.o").write_text("compiled")
+    (source_dir / "src" / "cache.pyc").write_text("bytecode")
+
+    tmt.utils.filesystem.copy_tree(source_dir, dest_dir, root_logger)
+
+    # Tracked files should be copied
+    assert (dest_dir / "tracked.txt").exists()
+    assert (dest_dir / "tracked.txt").read_text() == "tracked content"
+    assert (dest_dir / "src" / "main.py").exists()
+    assert (dest_dir / ".gitignore").exists()
+
+    # Ignored files should NOT be copied
+    assert not (dest_dir / "build").exists()
+    assert not (dest_dir / "src" / "cache.pyc").exists()
+
+    # .git directory should NOT be copied
+    assert not (dest_dir / ".git").exists()
+
+
+def test_copy_tree_honors_gitignore_from_subdirectory(tmppath: Path, root_logger: tmt.log.Logger):
+    """
+    Test that copy_tree correctly excludes gitignored paths when the copy
+    source is a subdirectory of the git repository root.
+
+    Regression test: ``git ls-files`` must be run with the copy source as
+    its working directory so returned paths are relative to it, matching
+    what rsync/shutil need. Previously exclude paths were computed relative
+    to the git repository root instead, which misaligned them whenever
+    ``src`` was not the repository root itself.
+    """
+    repo_root = tmppath / "repo"
+    dest_dir = tmppath / "dest"
+    repo_root.mkdir()
+
+    Command('git', 'init').run(cwd=repo_root, logger=root_logger)
+    Command('git', 'config', 'user.email', 'test@test.com').run(
+        cwd=repo_root,
+        logger=root_logger,
+    )
+    Command('git', 'config', 'user.name', 'Test').run(
+        cwd=repo_root,
+        logger=root_logger,
+    )
+
+    # .gitignore lives at the repository root and applies to the whole tree.
+    (repo_root / ".gitignore").write_text("build/\n*.pyc\n")
+
+    # The directory we will actually copy is a subdirectory of the repo root.
+    source_dir = repo_root / "project"
+    source_dir.mkdir()
+    (source_dir / "tracked.txt").write_text("tracked content")
+    (source_dir / "src").mkdir()
+    (source_dir / "src" / "main.py").write_text("print('hello')")
+
+    Command('git', 'add', '.').run(cwd=repo_root, logger=root_logger)
+    Command('git', 'commit', '-m', 'init').run(cwd=repo_root, logger=root_logger)
+
+    # Create ignored files inside the subdirectory being copied, after the commit.
+    (source_dir / "build").mkdir()
+    (source_dir / "build" / "output.o").write_text("compiled")
+    (source_dir / "src" / "cache.pyc").write_text("bytecode")
+
+    tmt.utils.filesystem.copy_tree(source_dir, dest_dir, root_logger)
+
+    # Tracked files should be copied
+    assert (dest_dir / "tracked.txt").exists()
+    assert (dest_dir / "tracked.txt").read_text() == "tracked content"
+    assert (dest_dir / "src" / "main.py").exists()
+
+    # Ignored files should NOT be copied
+    assert not (dest_dir / "build").exists()
+    assert not (dest_dir / "src" / "cache.pyc").exists()
+
+
+def test_copy_tree_non_git_repo_copies_everything(tmppath: Path, root_logger: tmt.log.Logger):
+    """Test that copy_tree copies everything when source is not a git repo."""
+    source_dir = tmppath / "not_git"
+    dest_dir = tmppath / "dest"
+    source_dir.mkdir()
+
+    (source_dir / "file.txt").write_text("content")
+    (source_dir / "build").mkdir()
+    (source_dir / "build" / "output.o").write_text("compiled")
+    (source_dir / ".gitignore").write_text("build/\n")
+
+    tmt.utils.filesystem.copy_tree(source_dir, dest_dir, root_logger)
+
+    # Everything should be copied since this is not a git repo
+    assert (dest_dir / "file.txt").exists()
+    assert (dest_dir / "build" / "output.o").exists()
+    assert (dest_dir / ".gitignore").exists()

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -29,6 +29,7 @@ import tmt.steps.provision
 import tmt.steps.report
 import tmt.templates
 import tmt.utils
+import tmt.utils.filesystem
 import tmt.utils.git
 import tmt.utils.jira
 from tmt._compat.pathlib import Path
@@ -659,37 +660,17 @@ class Plan(
             self.worktree.mkdir(exist_ok=True)
             return
 
-        # Sync metadata root to the worktree, honoring .gitignore; xref
-        # https://stackoverflow.com/questions/13713101/rsync-exclude-according-to-gitignore-hgignore-svnignore-like-filter-c
         self.debug(f"Sync the worktree to '{self.worktree}'.", level=2)
 
-        # Collect parent .gitignore filters when tree_root is a
-        # subdirectory of the git repository root.
-        parent_filters: list[str] = []
         git_root = tmt.utils.git.git_root(fmf_root=tree_root, logger=self._logger)
-        if git_root:
-            current = tree_root.resolve()
-            root = git_root.resolve()
-            while current != root:
-                current = current.parent
-                gitignore = current / '.gitignore'
-                if gitignore.is_file():
-                    parent_filters.extend(('--filter', f'dir-merge,- {gitignore}'))
 
         with self.tmpdir(prefix='rsync-') as rsync_tempdir:
-            self.run(
-                Command(
-                    "rsync",
-                    "-ar",
-                    '--temp-dir',
-                    rsync_tempdir,
-                    *parent_filters,
-                    "--include=**.gitignore",
-                    "--exclude=/.git",
-                    "--filter=:- .gitignore",
-                    f"{tree_root}/",
-                    self.worktree,
-                )
+            tmt.utils.filesystem.rsync_with_gitignore_filter(
+                tree_root,
+                self.worktree,
+                self._logger,
+                git_root=git_root,
+                temp_dir=rsync_tempdir,
             )
 
     @functools.cached_property

--- a/tmt/base/plan.py
+++ b/tmt/base/plan.py
@@ -659,43 +659,34 @@ class Plan(
             self.worktree.mkdir(exist_ok=True)
             return
 
-        # Sync metadata root to the worktree
+        # Sync metadata root to the worktree, honoring .gitignore; xref
+        # https://stackoverflow.com/questions/13713101/rsync-exclude-according-to-gitignore-hgignore-svnignore-like-filter-c
         self.debug(f"Sync the worktree to '{self.worktree}'.", level=2)
 
-        ignore: list[Path] = [Path('.git')]
-
-        # If we're in a git repository, honor .gitignore; xref
-        # https://stackoverflow.com/questions/13713101/rsync-exclude-according-to-gitignore-hgignore-svnignore-like-filter-c
+        # Collect parent .gitignore filters when tree_root is a
+        # subdirectory of the git repository root.
+        parent_filters: list[str] = []
         git_root = tmt.utils.git.git_root(fmf_root=tree_root, logger=self._logger)
         if git_root:
-            ignore.extend(tmt.utils.git.git_ignore(root=git_root, logger=self._logger))
+            current = tree_root.resolve()
+            root = git_root.resolve()
+            while current != root:
+                current = current.parent
+                gitignore = current / '.gitignore'
+                if gitignore.is_file():
+                    parent_filters.extend(('--filter', f'dir-merge,- {gitignore}'))
 
-        self.debug(
-            "Ignoring the following paths during worktree sync",
-            tmt.utils.format_value(ignore),
-            level=4,
-        )
-
-        with (
-            tempfile.NamedTemporaryFile(mode='w') as excludes_tempfile,
-            self.tmpdir(prefix='rsync-') as rsync_tempdir,
-        ):
-            excludes_tempfile.write('\n'.join(str(path) for path in ignore))
-
-            # Make sure ignored paths are saved before telling rsync to use them.
-            # With Python 3.12, we could use `delete_on_false=False` and call `close()`.
-            excludes_tempfile.flush()
-
-            # Note: rsync doesn't use reflinks right now, so in the future it'd be even better to
-            # use e.g. `cp` but filtering out the above.
+        with self.tmpdir(prefix='rsync-') as rsync_tempdir:
             self.run(
                 Command(
                     "rsync",
                     "-ar",
                     '--temp-dir',
                     rsync_tempdir,
-                    "--exclude-from",
-                    excludes_tempfile.name,
+                    *parent_filters,
+                    "--include=**.gitignore",
+                    "--exclude=/.git",
+                    "--filter=:- .gitignore",
                     f"{tree_root}/",
                     self.worktree,
                 )

--- a/tmt/utils/filesystem.py
+++ b/tmt/utils/filesystem.py
@@ -3,10 +3,41 @@ Utility functions for filesystem operations.
 """
 
 import shutil
+from typing import Optional
 
 import tmt.log
+import tmt.utils.git
 from tmt._compat.pathlib import Path
 from tmt.utils import Command, GeneralError, RunError
+
+
+def _git_root(src: Path, logger: tmt.log.Logger) -> Optional[Path]:
+    """
+    Return the git repository root containing ``src``, or ``None``.
+    """
+    try:
+        return tmt.utils.git.git_root(fmf_root=src, logger=logger)
+    except Exception:
+        return None
+
+
+def _get_git_excludes(src: Path, logger: tmt.log.Logger) -> list[Path]:
+    """
+    Collect paths to exclude based on git configuration.
+
+    Used only as input for the :py:func:`shutil.copytree` fallback.
+    Returns ``.git`` plus all paths ignored by git, or an empty list
+    on failure.
+    """
+    excludes: list[Path] = [Path('.git')]
+
+    try:
+        excludes.extend(tmt.utils.git.git_ignore(root=src, logger=logger))
+    except Exception:
+        logger.debug("Failed to collect git-ignored paths, proceeding without exclusions.")
+        return []
+
+    return excludes
 
 
 def _copy_tree_cp(
@@ -24,35 +55,94 @@ def _copy_tree_cp(
         with :py:class:`RunError`.
     """
     try:
-        # The '/./' at the end of the source path tells cp to copy the *contents* of the directory
-        # rather than creating a new subdirectory in the destination
         Command('cp', '-a', '--reflink=auto', f"{src}/./", str(dst)).run(
             cwd=None, logger=logger, join=True, silent=True
         )
         return True
     except RunError:
         return False
-    # Let other exceptions (e.g. permissions, disk full) propagate
+
+
+def _copy_tree_rsync(
+    src: Path,
+    dst: Path,
+    logger: tmt.log.Logger,
+    git_root: Path,
+) -> bool:
+    """
+    Copy directory using ``rsync -a`` with native ``.gitignore``
+    filtering.
+
+    Uses rsync's ``--filter=':- .gitignore'`` to honour
+    ``.gitignore`` rules at every directory level within the source
+    tree, without needing ``git`` to be invoked.  When ``src`` is a
+    subdirectory of the repository, any ``.gitignore`` files between
+    ``src`` and ``git_root`` are included as additional merge filters
+    so that repository-wide ignore rules still apply.
+
+    The ``.git`` directory is always excluded.
+
+    :returns: ``True`` if successful, ``False`` if ``rsync`` command
+        fails with :py:class:`RunError`.
+    """
+    try:
+        parent_filters: list[str] = []
+        current = src.resolve()
+        root = git_root.resolve()
+        while current != root:
+            current = current.parent
+            gitignore = current / '.gitignore'
+            if gitignore.is_file():
+                parent_filters.extend(('--filter', f'dir-merge,- {gitignore}'))
+
+        Command(
+            'rsync',
+            '-a',
+            *parent_filters,
+            "--include=**.gitignore",
+            "--exclude=/.git",
+            "--filter=:- .gitignore",
+            f"{src}/",
+            str(dst),
+        ).run(cwd=None, logger=logger, join=True, silent=True)
+
+        return True
+    except RunError:
+        return False
 
 
 def _copy_tree_shutil(
     src: Path,
     dst: Path,
     logger: tmt.log.Logger,
+    excludes: list[Path],
 ) -> None:
     """
     Perform copy using shutil.copytree.
 
     This is typically a fallback strategy. The destination directory must
     exist before calling this function.
+
+    :param excludes: list of relative paths to exclude from the copy.
     """
     logger.debug(f"Performing shutil.copytree from '{src}' to '{dst}'")
+
+    exclude_names = {str(path).rstrip('/') for path in excludes}
+
+    def _ignore(directory: str, contents: list[str]) -> set[str]:
+        rel = Path(directory).relative_to(src)
+        return {
+            name
+            for name in contents
+            if str(rel / name).rstrip('/') in exclude_names or name.rstrip('/') in exclude_names
+        }
 
     shutil.copytree(
         src,
         dst,
         symlinks=True,
         dirs_exist_ok=True,
+        ignore=_ignore if excludes else None,
     )
 
 
@@ -64,39 +154,27 @@ def copy_tree(
     """
     Copy directory efficiently, trying different strategies.
 
-    Attempts strategies in order:
+    Files and directories ignored by git (per ``.gitignore`` rules) and
+    the ``.git`` directory itself are excluded from the copy when the
+    source is inside a git repository. When outside a git repo, all
+    files are copied.
 
-    #. ``cp -a --reflink=auto`` (copy-on-write, with ``cp``'s own
-       fallback).
+    Attempts strategies in order, depending on context:
 
-       * Reflinks provide fast, space-efficient copies that behave like
-         normal copies
-       * They don't use additional storage space unless the file is
-         modified
-       * Supported on btrfs (Fedora default since F33) and XFS (CentOS
-         Stream 8+)
-       * Using ``--reflink=auto`` means ``cp`` automatically falls back
-         to standard copy if reflink isn't supported by the filesystem
+    When inside a git repository:
 
-    #. :py:func:`shutil.copytree` as a final fallback.
+    #. ``rsync -a`` with native ``.gitignore`` filtering via
+       ``--filter=':- .gitignore'``.
+    #. :py:func:`shutil.copytree` with ``ignore`` as a fallback.
 
-       * Used if the ``cp`` command fails for any reason
-       * Maintains symlinks (``symlinks=True``)
-       * Merges with existing destination directories (``dirs_exist_ok=True``)
+    When outside a git repository:
+
+    #. ``cp -a --reflink=auto`` (copy-on-write when supported).
+    #. :py:func:`shutil.copytree` as a fallback.
 
     Symlinks are always preserved. The destination directory `dst` and its
     parents will be created if they do not exist. File permissions and timestamps
     are preserved in all copy strategies.
-
-    Example usage:
-
-    .. code-block:: python
-
-        # Copy a directory tree with all its content
-        copy_tree(Path("/path/to/source"), Path("/path/to/destination"), logger)
-
-        # Copy with relative paths
-        copy_tree(workdir / "original", workdir / "backup", logger)
 
     :param src: Source directory path. Must exist and be a directory.
     :param dst: Destination directory path.
@@ -107,32 +185,38 @@ def copy_tree(
     logger.debug(f"Copying directory tree from '{src}' to '{dst}'")
 
     if not src.is_dir():
-        # Add an explicit check for src, as 'cp' or 'shutil.copytree' might give
-        # less clear or varied errors. This ensures a consistent error message.
         raise GeneralError(f"Source '{src}' for copy_tree is not a directory or does not exist.")
 
-    # Ensure destination directory `dst` and its parents exist.
-    # This is crucial for `cp` and helpful for `shutil.copytree` (as it creates parent dirs).
     dst.mkdir(parents=True, exist_ok=True)
 
-    # 1. Try 'cp -a --reflink=auto' copy.
-    #    'cp' itself handles fallback from reflink to standard copy if reflink=auto is used.
-    logger.debug(f"Attempting copy from '{src}' to '{dst}' using 'cp' with reflink")
-    if _copy_tree_cp(src, dst, logger):
-        logger.debug(
-            "Copy finished using 'cp -a --reflink=auto' strategy (or its internal fallback)."
-        )
-        return
+    git_root = _git_root(src, logger)
 
-    # 2. Fallback to shutil.copytree
-    logger.debug("cp command failed, falling back to shutil.copytree strategy.")
-    try:
-        _copy_tree_shutil(src, dst, logger)
-        logger.debug("Copy finished using shutil.copytree strategy.")
-    except Exception as error:
-        # Catching a broad Exception here because shutil.copytree can raise various errors
-        # (e.g., OSError, FileExistsError if dst is a file after mkdir, etc.)
-        # and we want to wrap them all in GeneralError.
-        raise GeneralError(
-            f"Failed to copy directory tree from '{src}' to '{dst}' using all strategies."
-        ) from error
+    if git_root is not None:
+        logger.debug(f"Attempting copy from '{src}' to '{dst}' using rsync with .gitignore filter")
+        if _copy_tree_rsync(src, dst, logger, git_root):
+            logger.debug("Copy finished using rsync strategy.")
+            return
+
+        logger.debug("rsync failed, falling back to shutil.copytree strategy.")
+        excludes = _get_git_excludes(src, logger)
+        try:
+            _copy_tree_shutil(src, dst, logger, excludes)
+            logger.debug("Copy finished using shutil.copytree strategy.")
+        except Exception as error:
+            raise GeneralError(
+                f"Failed to copy directory tree from '{src}' to '{dst}' using all strategies."
+            ) from error
+    else:
+        logger.debug(f"Attempting copy from '{src}' to '{dst}' using cp with reflink")
+        if _copy_tree_cp(src, dst, logger):
+            logger.debug("Copy finished using cp --reflink=auto strategy.")
+            return
+
+        logger.debug("cp command failed, falling back to shutil.copytree strategy.")
+        try:
+            _copy_tree_shutil(src, dst, logger, [])
+            logger.debug("Copy finished using shutil.copytree strategy.")
+        except Exception as error:
+            raise GeneralError(
+                f"Failed to copy directory tree from '{src}' to '{dst}' using all strategies."
+            ) from error

--- a/tmt/utils/filesystem.py
+++ b/tmt/utils/filesystem.py
@@ -63,12 +63,14 @@ def _copy_tree_cp(
         return False
 
 
-def _copy_tree_rsync(
+def rsync_with_gitignore_filter(
     src: Path,
     dst: Path,
     logger: tmt.log.Logger,
-    git_root: Path,
-) -> bool:
+    *,
+    git_root: Optional[Path] = None,
+    temp_dir: Optional[Path] = None,
+) -> None:
     """
     Copy directory using ``rsync -a`` with native ``.gitignore``
     filtering.
@@ -76,36 +78,58 @@ def _copy_tree_rsync(
     Uses rsync's ``--filter=':- .gitignore'`` to honour
     ``.gitignore`` rules at every directory level within the source
     tree, without needing ``git`` to be invoked.  When ``src`` is a
-    subdirectory of the repository, any ``.gitignore`` files between
+    subdirectory of ``git_root``, any ``.gitignore`` files between
     ``src`` and ``git_root`` are included as additional merge filters
     so that repository-wide ignore rules still apply.
 
     The ``.git`` directory is always excluded.
 
-    :returns: ``True`` if successful, ``False`` if ``rsync`` command
-        fails with :py:class:`RunError`.
+    :param git_root: path to the git repository root.  When ``None``,
+        only ``.gitignore`` files inside ``src`` are honoured.
+    :param temp_dir: optional directory for rsync temporary files,
+        useful when the default temp directory is on a different
+        filesystem.
+    :raises RunError: when the rsync command fails.
     """
-    try:
-        parent_filters: list[str] = []
+
+    parent_filters: list[str] = []
+    if git_root:
         current = src.resolve()
         root = git_root.resolve()
-        while current != root:
+        while current not in (root, current.parent):
             current = current.parent
             gitignore = current / '.gitignore'
             if gitignore.is_file():
                 parent_filters.extend(('--filter', f'dir-merge,- {gitignore}'))
 
-        Command(
-            'rsync',
-            '-a',
-            *parent_filters,
-            "--include=**.gitignore",
-            "--exclude=/.git",
-            "--filter=:- .gitignore",
-            f"{src}/",
-            str(dst),
-        ).run(cwd=None, logger=logger, join=True, silent=True)
+    temp_dir_args = ('--temp-dir', str(temp_dir)) if temp_dir else ()
 
+    Command(
+        'rsync',
+        '-a',
+        *temp_dir_args,
+        *parent_filters,
+        "--include=**.gitignore",
+        "--exclude=/.git",
+        "--filter=:- .gitignore",
+        f"{src}/",
+        str(dst),
+    ).run(cwd=None, logger=logger, join=True, silent=True)
+
+
+def _copy_tree_rsync(
+    src: Path,
+    dst: Path,
+    logger: tmt.log.Logger,
+    git_root: Path,
+) -> bool:
+    """
+    :py:func:`rsync_with_gitignore_filter` wrapper returning a
+    boolean success status for the :py:func:`copy_tree` fallback
+    chain.
+    """
+    try:
+        rsync_with_gitignore_filter(src, dst, logger, git_root=git_root)
         return True
     except RunError:
         return False


### PR DESCRIPTION
Hopefully resolves https://github.com/teemtee/tmt/issues/4062, though it also mentions .dockerignore, which I didn't take into consideration. 

The rsync `--filter=':- .gitignore'` solution comes from  this [stackoverflow post](https://stackoverflow.com/questions/13713101/rsync-exclude-according-to-gitignore-hgignore-svnignore-like-filter-c) answers.

Make copy_tree exclude .git/ and gitignored files when the source directory is inside a git repository. Uses rsync's native .gitignore filtering via --filter=':- .gitignore', with shutil.copytree as fallback. When outside a git repo, preserves the original cp -a --reflink=auto strategy for copy-on-write support.

Pull Request Checklist

* [x] implement the feature
* [ ] write the documentation
* [x] extend the test coverage
* [ ] update the specification
* [ ] adjust plugin docstring
* [ ] modify the json schema
* [ ] mention the version
* [ ] include a release note
