### PR TITLE
Fix failed download and copy of artifact rpms

### DIFF
--- a/tests/prepare/artifact/providers/file/test.sh
+++ b/tests/prepare/artifact/providers/file/test.sh
@@ -57,12 +57,12 @@ rlJournalStart
         rlPhaseEnd
 
         rlPhaseStartTest "$phase_prefix Fail on nonexistent file"
-              rlRun -s "tmt run -i $run --scratch -vvv --all \
-                  provision -h $PROVISION_HOW --image $image \
-                  prepare --how artifact --provide file:/no/such/package.rpm" \
-                  2 "Nonexistent file should fail"
-              rlAssertGrep "No artifacts were downloaded" $rlRun_LOG
-          rlPhaseEnd
+            rlRun -s "tmt run -i $run --scratch -vvv --all \
+                provision -h $PROVISION_HOW --image $image \
+                prepare --how artifact --provide file:/no/such/package.rpm" \
+                2 "Nonexistent file should fail"
+            rlAssertGrep "No artifacts were downloaded" $rlRun_LOG
+        rlPhaseEnd
     done <<< "$IMAGES"
 
     rlPhaseStartCleanup

--- a/tests/prepare/artifact/providers/file/test.sh
+++ b/tests/prepare/artifact/providers/file/test.sh
@@ -55,6 +55,14 @@ rlJournalStart
                 prepare --how artifact --provide file:$LIB_DIR/../rpms/bar" \
                 0 "Run directory"
         rlPhaseEnd
+
+        rlPhaseStartTest "$phase_prefix Fail on nonexistent file"
+              rlRun -s "tmt run -i $run --scratch -vvv --all \
+                  provision -h $PROVISION_HOW --image $image \
+                  prepare --how artifact --provide file:/no/such/package.rpm" \
+                  2 "Nonexistent file should fail"
+              rlAssertGrep "No artifacts were downloaded" $rlRun_LOG
+          rlPhaseEnd
     done <<< "$IMAGES"
 
     rlPhaseStartCleanup

--- a/tmt/steps/prepare/artifact/__init__.py
+++ b/tmt/steps/prepare/artifact/__init__.py
@@ -285,11 +285,12 @@ class PrepareArtifact(PreparePlugin[PrepareArtifactData]):
                 provider.fetch_contents(guest, download_path)
 
                 # Then, have the provider contribute to the shared repository
-                provider.contribute_to_shared_repo(
-                    guest=guest,
-                    source_path=download_path,
-                    shared_repo_dir=shared_repo_dir,
-                )
+                if provider.downloads_artifacts:
+                    provider.contribute_to_shared_repo(
+                        guest=guest,
+                        source_path=download_path,
+                        shared_repo_dir=shared_repo_dir,
+                    )
 
             except tmt.utils.PrepareError:
                 raise

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -222,11 +222,12 @@ class ArtifactProvider(ABC):
                 raise tmt.utils.GeneralError(
                     f"Unexpected error downloading '{artifact}'."
                 ) from error
-        if not downloaded_paths:
-            raise tmt.utils.GeneralError(
-                f"No artifacts were downloaded for provider '{self.raw_id}'. "
-                f"Verify the provider identifier is correct."
-            )
+
+            if not downloaded_paths:
+                raise tmt.utils.PrepareError(
+                    f"No artifacts were downloaded for provider '{self.raw_id}'. "
+                    f"Verify the provider identifier is correct."
+                )
         self.logger.info(f"Successfully downloaded '{len(downloaded_paths)}' artifacts.")
         return downloaded_paths
 

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -223,11 +223,11 @@ class ArtifactProvider(ABC):
                     f"Unexpected error downloading '{artifact}'."
                 ) from error
 
-            if not downloaded_paths:
-                raise tmt.utils.PrepareError(
-                    f"No artifacts were downloaded for provider '{self.raw_id}'. "
-                    f"Verify the provider identifier is correct."
-                )
+        if not downloaded_paths:
+            raise tmt.utils.PrepareError(
+                f"No artifacts were downloaded for provider '{self.raw_id}'. "
+                f"Verify the provider identifier is correct."
+            )
         self.logger.info(f"Successfully downloaded '{len(downloaded_paths)}' artifacts.")
         return downloaded_paths
 

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -218,7 +218,11 @@ class ArtifactProvider(ABC):
                 raise tmt.utils.GeneralError(
                     f"Unexpected error downloading '{artifact}'."
                 ) from error
-
+        if not downloaded_paths:
+            raise tmt.utils.GeneralError(
+                f"No artifacts were downloaded for provider '{self.raw_id}'. "
+                f"Verify the provider identifier is correct."
+            )
         self.logger.info(f"Successfully downloaded '{len(downloaded_paths)}' artifacts.")
         return downloaded_paths
 

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -347,3 +347,34 @@ def _register_hints(
 
 
 provides_artifact_provider = _PROVIDER_REGISTRY.create_decorator(on_register=_register_hints)
+
+
+def copy_rpms_to_shared_repo(
+    guest: Guest,
+    source_path: Path,
+    shared_repo_dir: Path,
+    logger: tmt.log.Logger,
+) -> None:
+    """
+    Copy RPMs from a provider's download directory into the shared repository.
+
+    :param guest: the guest to run the copy on.
+    :param source_path: directory containing downloaded RPMs.
+    :param shared_repo_dir: shared repository directory to copy into.
+    :param logger: logger instance.
+    :raises PrepareError: when the copy fails for reasons other than missing files.
+    """
+
+    try:
+        guest.execute(
+            ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
+        )
+    except tmt.utils.RunError as error:
+        if error.stderr and "No such file" in error.stderr:
+            logger.warning(f"No artifacts to contribute from '{source_path}'.")
+            return
+        raise tmt.utils.PrepareError(
+            f"Failed to copy artifacts from '{source_path}' to '{shared_repo_dir}'."
+        ) from error
+
+    logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")

--- a/tmt/steps/prepare/artifact/providers/__init__.py
+++ b/tmt/steps/prepare/artifact/providers/__init__.py
@@ -8,7 +8,7 @@ from collections.abc import Iterator, Sequence
 from functools import cached_property
 from re import Pattern
 from shlex import quote
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
 import tmt.log
 import tmt.utils
@@ -114,6 +114,10 @@ class ArtifactProvider(ABC):
 
     #: The PrepareArtifact phase that owns this provider.
     parent: "PrepareArtifact"
+
+    #: Whether this provider downloads individual artifact files.
+    #: Providers that only register repositories should set this to ``False``.
+    downloads_artifacts: ClassVar[bool] = True
 
     def __post_init__(self) -> None:
         self.id = self._extract_provider_id(self.raw_id)
@@ -288,15 +292,11 @@ class ArtifactProvider(ABC):
                 f"Enumerated {len(packages)} packages from repository '{repository.name}'."
             )
 
-    # B027: "... is an empty method in an abstract base class, but has
-    # no abstract decorator" - expected, it's a default implementation
-    # provided for subclasses. It is acceptable to do nothing.
-    def contribute_to_shared_repo(  # noqa: B027
+    def contribute_to_shared_repo(
         self,
         guest: Guest,
         source_path: Path,
         shared_repo_dir: Path,
-        exclude_patterns: Optional[list[Pattern[str]]] = None,
     ) -> None:
         """
         Contribute artifacts to the shared repository.
@@ -309,10 +309,20 @@ class ArtifactProvider(ABC):
         :param source_path: path where the artifacts are located (source for contribution).
         :param shared_repo_dir: path to the shared repository directory where
             artifacts should be contributed.
-        :param exclude_patterns: if set, artifacts whose names match any
-            of the given regular expressions would not be contributed.
         """
-        pass
+        try:
+            guest.execute(
+                ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
+            )
+        except tmt.utils.RunError as error:
+            if error.stderr and "No such file" in error.stderr:
+                self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
+                return
+            raise tmt.utils.PrepareError(
+                f"Failed to copy artifacts from '{source_path}' to '{shared_repo_dir}'."
+            ) from error
+
+        self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")
 
     @property
     def artifact_metadata(self) -> list[dict[str, Any]]:
@@ -347,34 +357,3 @@ def _register_hints(
 
 
 provides_artifact_provider = _PROVIDER_REGISTRY.create_decorator(on_register=_register_hints)
-
-
-def copy_rpms_to_shared_repo(
-    guest: Guest,
-    source_path: Path,
-    shared_repo_dir: Path,
-    logger: tmt.log.Logger,
-) -> None:
-    """
-    Copy RPMs from a provider's download directory into the shared repository.
-
-    :param guest: the guest to run the copy on.
-    :param source_path: directory containing downloaded RPMs.
-    :param shared_repo_dir: shared repository directory to copy into.
-    :param logger: logger instance.
-    :raises PrepareError: when the copy fails for reasons other than missing files.
-    """
-
-    try:
-        guest.execute(
-            ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
-        )
-    except tmt.utils.RunError as error:
-        if error.stderr and "No such file" in error.stderr:
-            logger.warning(f"No artifacts to contribute from '{source_path}'.")
-            return
-        raise tmt.utils.PrepareError(
-            f"Failed to copy artifacts from '{source_path}' to '{shared_repo_dir}'."
-        ) from error
-
-    logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")

--- a/tmt/steps/prepare/artifact/providers/copr_build.py
+++ b/tmt/steps/prepare/artifact/providers/copr_build.py
@@ -228,8 +228,13 @@ class CoprBuildArtifactProvider(ArtifactProvider):
             guest.execute(
                 ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
             )
-        except Exception:
-            self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
-            return
+
+        except tmt.utils.RunError as error:
+            if error.stderr and "No such file" in error.stderr:
+                self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
+                return
+            raise tmt.utils.PrepareError(
+                f"Failed to copy artifacts from '{source_path}' to '{shared_repo_dir}'."
+            ) from error
 
         self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")

--- a/tmt/steps/prepare/artifact/providers/copr_build.py
+++ b/tmt/steps/prepare/artifact/providers/copr_build.py
@@ -5,7 +5,6 @@ Copr Build Artifact Provider
 import types
 from collections.abc import Sequence
 from functools import cached_property
-from shlex import quote
 from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urljoin
 
@@ -19,9 +18,9 @@ from tmt.steps.prepare.artifact.providers import (
     ArtifactInfo,
     ArtifactProvider,
     ArtifactProviderId,
+    copy_rpms_to_shared_repo,
     provides_artifact_provider,
 )
-from tmt.utils import ShellScript
 
 if TYPE_CHECKING:
     from munch import Munch
@@ -224,17 +223,4 @@ class CoprBuildArtifactProvider(ArtifactProvider):
         shared_repo_dir: tmt.utils.Path,
         exclude_patterns: Optional[list[tmt.utils.Pattern[str]]] = None,
     ) -> None:
-        try:
-            guest.execute(
-                ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
-            )
-
-        except tmt.utils.RunError as error:
-            if error.stderr and "No such file" in error.stderr:
-                self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
-                return
-            raise tmt.utils.PrepareError(
-                f"Failed to copy artifacts from '{source_path}' to '{shared_repo_dir}'."
-            ) from error
-
-        self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")
+        copy_rpms_to_shared_repo(guest, source_path, shared_repo_dir, self.logger)

--- a/tmt/steps/prepare/artifact/providers/copr_build.py
+++ b/tmt/steps/prepare/artifact/providers/copr_build.py
@@ -12,13 +12,11 @@ import tmt.log
 import tmt.utils
 import tmt.utils.hints
 from tmt.container import container, simple_field
-from tmt.guest import Guest
 from tmt.package_managers._rpm import RpmVersion
 from tmt.steps.prepare.artifact.providers import (
     ArtifactInfo,
     ArtifactProvider,
     ArtifactProviderId,
-    copy_rpms_to_shared_repo,
     provides_artifact_provider,
 )
 
@@ -215,12 +213,3 @@ class CoprBuildArtifactProvider(ArtifactProvider):
         rpm_metas = self._fetch_results_json() if self.is_pulp else self.build_packages
 
         return [self.make_rpm_artifact(rpm_meta) for rpm_meta in rpm_metas]
-
-    def contribute_to_shared_repo(
-        self,
-        guest: Guest,
-        source_path: tmt.utils.Path,
-        shared_repo_dir: tmt.utils.Path,
-        exclude_patterns: Optional[list[tmt.utils.Pattern[str]]] = None,
-    ) -> None:
-        copy_rpms_to_shared_repo(guest, source_path, shared_repo_dir, self.logger)

--- a/tmt/steps/prepare/artifact/providers/copr_build.py
+++ b/tmt/steps/prepare/artifact/providers/copr_build.py
@@ -224,7 +224,12 @@ class CoprBuildArtifactProvider(ArtifactProvider):
         shared_repo_dir: tmt.utils.Path,
         exclude_patterns: Optional[list[tmt.utils.Pattern[str]]] = None,
     ) -> None:
-        guest.execute(
-            ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
-        )
+        try:
+            guest.execute(
+                ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
+            )
+        except Exception:
+            self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
+            return
+
         self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")

--- a/tmt/steps/prepare/artifact/providers/copr_repository.py
+++ b/tmt/steps/prepare/artifact/providers/copr_repository.py
@@ -67,6 +67,7 @@ class CoprRepositoryProvider(ArtifactProvider):
     """
 
     repository: Optional[Repository] = None
+    downloads_artifacts = False
 
     @classmethod
     def _extract_provider_id(cls, raw_id: str) -> ArtifactProviderId:

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -134,7 +134,12 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
         shared_repo_dir: tmt.utils.Path,
         exclude_patterns: Optional[list[tmt.utils.Pattern[str]]] = None,
     ) -> None:
-        guest.execute(
-            ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
-        )
+        try:
+            guest.execute(
+                ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
+            )
+        except Exception:
+            self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
+            return
+
         self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -138,8 +138,12 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
             guest.execute(
                 ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
             )
-        except Exception:
-            self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
-            return
+        except tmt.utils.RunError as error:
+            if error.stderr and "No such file" in error.stderr:
+                self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
+                return
+            raise tmt.utils.PrepareError(
+                f"Failed to copy artifacts from '{source_path}' to '{shared_repo_dir}'."
+            ) from error
 
         self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -2,7 +2,6 @@ import glob
 import urllib.parse
 from collections.abc import Sequence
 from functools import cached_property
-from shlex import quote
 from typing import ClassVar, Optional
 
 import tmt.utils
@@ -14,9 +13,9 @@ from tmt.steps.prepare.artifact.providers import (
     ArtifactProvider,
     ArtifactProviderId,
     DownloadError,
+    copy_rpms_to_shared_repo,
     provides_artifact_provider,
 )
-from tmt.utils import ShellScript
 
 
 @provides_artifact_provider("file")
@@ -134,16 +133,4 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
         shared_repo_dir: tmt.utils.Path,
         exclude_patterns: Optional[list[tmt.utils.Pattern[str]]] = None,
     ) -> None:
-        try:
-            guest.execute(
-                ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
-            )
-        except tmt.utils.RunError as error:
-            if error.stderr and "No such file" in error.stderr:
-                self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
-                return
-            raise tmt.utils.PrepareError(
-                f"Failed to copy artifacts from '{source_path}' to '{shared_repo_dir}'."
-            ) from error
-
-        self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")
+        copy_rpms_to_shared_repo(guest, source_path, shared_repo_dir, self.logger)

--- a/tmt/steps/prepare/artifact/providers/file.py
+++ b/tmt/steps/prepare/artifact/providers/file.py
@@ -2,7 +2,7 @@ import glob
 import urllib.parse
 from collections.abc import Sequence
 from functools import cached_property
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 import tmt.utils
 from tmt.container import container, simple_field
@@ -13,7 +13,6 @@ from tmt.steps.prepare.artifact.providers import (
     ArtifactProvider,
     ArtifactProviderId,
     DownloadError,
-    copy_rpms_to_shared_repo,
     provides_artifact_provider,
 )
 
@@ -125,12 +124,3 @@ class PackageAsFileArtifactProvider(ArtifactProvider):
             self.logger.info(f"Successfully downloaded: '{artifact.id}'.")
         except Exception as error:
             raise DownloadError(f"Failed to download '{artifact}'.") from error
-
-    def contribute_to_shared_repo(
-        self,
-        guest: Guest,
-        source_path: tmt.utils.Path,
-        shared_repo_dir: tmt.utils.Path,
-        exclude_patterns: Optional[list[tmt.utils.Pattern[str]]] = None,
-    ) -> None:
-        copy_rpms_to_shared_repo(guest, source_path, shared_repo_dir, self.logger)

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -185,9 +185,14 @@ class KojiArtifactProvider(ArtifactProvider):
         shared_repo_dir: tmt.utils.Path,
         exclude_patterns: Optional[list[tmt.utils.Pattern[str]]] = None,
     ) -> None:
-        guest.execute(
-            ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
-        )
+        try:
+            guest.execute(
+                ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
+            )
+        except Exception:
+            self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
+            return
+
         self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")
 
     def make_rpm_artifact(self, rpm_meta: dict[str, Any]) -> ArtifactInfo:

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -13,13 +13,11 @@ import tmt.log
 import tmt.utils
 import tmt.utils.hints
 from tmt.container import container, simple_field
-from tmt.guest import Guest
 from tmt.package_managers._rpm import RpmVersion
 from tmt.steps.prepare.artifact.providers import (
     ArtifactInfo,
     ArtifactProvider,
     ArtifactProviderId,
-    copy_rpms_to_shared_repo,
     provides_artifact_provider,
 )
 
@@ -176,15 +174,6 @@ class KojiArtifactProvider(ArtifactProvider):
                 f"Provider id '{raw_id}' is invalid, how did we get here?"
             ) from exc
         return value
-
-    def contribute_to_shared_repo(
-        self,
-        guest: Guest,
-        source_path: tmt.utils.Path,
-        shared_repo_dir: tmt.utils.Path,
-        exclude_patterns: Optional[list[tmt.utils.Pattern[str]]] = None,
-    ) -> None:
-        copy_rpms_to_shared_repo(guest, source_path, shared_repo_dir, self.logger)
 
     def make_rpm_artifact(self, rpm_meta: dict[str, Any]) -> ArtifactInfo:
         """

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -6,7 +6,6 @@ import types
 from abc import abstractmethod
 from collections.abc import Iterator, Sequence
 from functools import cached_property
-from shlex import quote
 from typing import Any, Optional, TypeVar
 from urllib.parse import urljoin
 
@@ -20,9 +19,9 @@ from tmt.steps.prepare.artifact.providers import (
     ArtifactInfo,
     ArtifactProvider,
     ArtifactProviderId,
+    copy_rpms_to_shared_repo,
     provides_artifact_provider,
 )
-from tmt.utils import ShellScript
 
 koji: Optional[types.ModuleType] = None
 
@@ -185,19 +184,7 @@ class KojiArtifactProvider(ArtifactProvider):
         shared_repo_dir: tmt.utils.Path,
         exclude_patterns: Optional[list[tmt.utils.Pattern[str]]] = None,
     ) -> None:
-        try:
-            guest.execute(
-                ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
-            )
-        except tmt.utils.RunError as error:
-            if error.stderr and "No such file" in error.stderr:
-                self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
-                return
-            raise tmt.utils.PrepareError(
-                f"Failed to copy artifacts from '{source_path}' to '{shared_repo_dir}'."
-            ) from error
-
-        self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")
+        copy_rpms_to_shared_repo(guest, source_path, shared_repo_dir, self.logger)
 
     def make_rpm_artifact(self, rpm_meta: dict[str, Any]) -> ArtifactInfo:
         """

--- a/tmt/steps/prepare/artifact/providers/koji.py
+++ b/tmt/steps/prepare/artifact/providers/koji.py
@@ -189,9 +189,13 @@ class KojiArtifactProvider(ArtifactProvider):
             guest.execute(
                 ShellScript(f"cp {quote(str(source_path))}/*.rpm {quote(str(shared_repo_dir))}")
             )
-        except Exception:
-            self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
-            return
+        except tmt.utils.RunError as error:
+            if error.stderr and "No such file" in error.stderr:
+                self.logger.warning(f"No artifacts to contribute from '{source_path}'.")
+                return
+            raise tmt.utils.PrepareError(
+                f"Failed to copy artifacts from '{source_path}' to '{shared_repo_dir}'."
+            ) from error
 
         self.logger.info(f"Contributed artifacts from '{source_path}' to '{shared_repo_dir}'.")
 

--- a/tmt/steps/prepare/artifact/providers/repository.py
+++ b/tmt/steps/prepare/artifact/providers/repository.py
@@ -44,6 +44,7 @@ class RepositoryFileProvider(ArtifactProvider):
     """
 
     repository: Repository = simple_field(init=False)
+    downloads_artifacts = False
 
     @classmethod
     def _extract_provider_id(cls, raw_id: str) -> ArtifactProviderId:

--- a/tmt/steps/prepare/artifact/providers/repository_url.py
+++ b/tmt/steps/prepare/artifact/providers/repository_url.py
@@ -42,6 +42,7 @@ class RepositoryUrlProvider(ArtifactProvider):
     #        is made dynamic.
 
     repository: Repository = simple_field(init=False)
+    downloads_artifacts = False
 
     @classmethod
     def _extract_provider_id(cls, raw_id: str) -> ArtifactProviderId:


### PR DESCRIPTION
Fixes https://github.com/teemtee/tmt/issues/4886 and https://github.com/teemtee/tmt/issues/5018.

Second commit might be irrelevant since the first one raises on the no-download problem. Not sure if a scenario where the `try/except` block would actually go with the `except` clause could happen now, but https://github.com/teemtee/tmt/issues/5020 should introduce an option to allow for this behavior, so I kept the checks.

* [x] implement the feature
* [x] extend the test coverage?
