### PR TITLE
Polish copy_tree implementations

### DIFF
--- a/tests/unit/test_filesystem.py
+++ b/tests/unit/test_filesystem.py
@@ -164,14 +164,14 @@ def test_deeply_nested_directories(tmppath: Path, root_logger: tmt.log.Logger):
 
 
 @mock.patch('os.access', return_value=False)
-@mock.patch('tmt.utils.filesystem._copy_tree_cp', return_value=False)
 @mock.patch(
-    'tmt.utils.filesystem._copy_tree_shutil',
-    side_effect=PermissionError("Simulated permission error"),
+    'tmt.utils.filesystem._COPY_TREE_STRATEGIES',
+    (
+        mock.MagicMock(return_value=False),
+        mock.MagicMock(side_effect=PermissionError("Simulated permission error")),
+    ),
 )
 def test_permission_error_handling(
-    mock_shutil,
-    mock_cp,
     mock_access,
     copy_tree_paths: CopyTreePathConfig,
     root_logger: tmt.log.Logger,
@@ -198,20 +198,25 @@ def test_nonexistent_source_directory(tmppath: Path, root_logger: tmt.log.Logger
     assert "not a directory or does not exist" in str(excinfo.value)
 
 
-@mock.patch('tmt.utils.filesystem._copy_tree_shutil', wraps=tmt.utils.filesystem._copy_tree_shutil)
-@mock.patch('tmt.utils.filesystem._copy_tree_cp', return_value=False)
+@mock.patch(
+    'tmt.utils.filesystem._COPY_TREE_STRATEGIES',
+    (
+        mock.MagicMock(return_value=False),
+        mock.MagicMock(wraps=tmt.utils.filesystem._copy_tree_shutil),
+    ),
+)
 def test_fallback_to_shutil_copy_from_cp_failure(
-    mock_copy_tree_cp,
-    mock_copy_tree_shutil,
     copy_tree_paths: CopyTreePathConfig,
     root_logger: tmt.log.Logger,
 ):
     """Test fallback to shutil.copytree when _copy_tree_cp fails."""
     source_dir, dest_dir, _ = copy_tree_paths
+    mock_copy_tree_cp, mock_copy_tree_shutil = tmt.utils.filesystem._COPY_TREE_STRATEGIES
+
     tmt.utils.filesystem.copy_tree(source_dir, dest_dir, root_logger)
 
-    mock_copy_tree_cp.assert_called_once_with(source_dir, dest_dir, root_logger)
-    mock_copy_tree_shutil.assert_called_once_with(source_dir, dest_dir, root_logger)
+    mock_copy_tree_cp.assert_called_once_with(source_dir, dest_dir, mock.ANY)
+    mock_copy_tree_shutil.assert_called_once_with(source_dir, dest_dir, mock.ANY)
 
     # Verify files were copied using the fallback approach (shutil.copytree)
     for file_path in _EXPECTED_TEST_FILES:
@@ -236,16 +241,21 @@ def test_metadata_cp_reflink(copy_tree_paths: CopyTreePathConfig, root_logger: t
     _run_metadata_test_for_item(dest_dir, test_dir)
 
 
-@mock.patch('tmt.utils.filesystem._copy_tree_shutil', wraps=tmt.utils.filesystem._copy_tree_shutil)
-@mock.patch('tmt.utils.filesystem._copy_tree_cp', return_value=False)
+@mock.patch(
+    'tmt.utils.filesystem._COPY_TREE_STRATEGIES',
+    (
+        mock.MagicMock(return_value=False),
+        mock.MagicMock(wraps=tmt.utils.filesystem._copy_tree_shutil),
+    ),
+)
 def test_metadata_preservation_on_cp_failure_fallback_to_shutil(
-    mock_copy_tree_cp,
-    mock_copy_tree_shutil,
     copy_tree_paths: CopyTreePathConfig,
     root_logger: tmt.log.Logger,
 ):
     """Test metadata preservation by shutil.copytree when cp command fails."""
     source_dir, dest_dir, _ = copy_tree_paths
+    mock_copy_tree_cp, mock_copy_tree_shutil = tmt.utils.filesystem._COPY_TREE_STRATEGIES
+
     timestamp = time.time() - 7200  # Two hours ago
 
     test_file = _setup_metadata_test_item(
@@ -262,25 +272,27 @@ def test_metadata_preservation_on_cp_failure_fallback_to_shutil(
 
     tmt.utils.filesystem.copy_tree(source_dir, dest_dir, root_logger)
 
-    mock_copy_tree_cp.assert_called_once_with(source_dir, dest_dir, root_logger)
-    mock_copy_tree_shutil.assert_called_once_with(source_dir, dest_dir, root_logger)
+    mock_copy_tree_cp.assert_called_once_with(source_dir, dest_dir, mock.ANY)
+    mock_copy_tree_shutil.assert_called_once_with(source_dir, dest_dir, mock.ANY)
     _run_metadata_test_for_item(dest_dir, test_file)
     _run_metadata_test_for_item(dest_dir, test_dir)
 
 
 @mock.patch(
-    'tmt.utils.filesystem._copy_tree_shutil',
-    side_effect=OSError("Simulated shutil.copytree failure"),
+    'tmt.utils.filesystem._COPY_TREE_STRATEGIES',
+    (
+        mock.MagicMock(return_value=False),
+        mock.MagicMock(side_effect=OSError("Simulated shutil.copytree failure")),
+    ),
 )
-@mock.patch('tmt.utils.filesystem._copy_tree_cp', return_value=False)
 def test_all_strategies_fail(
-    mock_copy_tree_cp,
-    mock_copy_tree_shutil,
     copy_tree_paths: CopyTreePathConfig,
     root_logger: tmt.log.Logger,
 ):
     """Test GeneralError is raised when all copy strategies fail."""
     source_dir, dest_dir, _ = copy_tree_paths
+    mock_copy_tree_cp, mock_copy_tree_shutil = tmt.utils.filesystem._COPY_TREE_STRATEGIES
+
     with pytest.raises(tmt.utils.GeneralError):
         tmt.utils.filesystem.copy_tree(source_dir, dest_dir, root_logger)
 

--- a/tmt/utils/filesystem.py
+++ b/tmt/utils/filesystem.py
@@ -3,10 +3,15 @@ Utility functions for filesystem operations.
 """
 
 import shutil
+from typing import Callable
 
 import tmt.log
 from tmt._compat.pathlib import Path
-from tmt.utils import Command, GeneralError, RunError
+from tmt._compat.typing import TypeAlias
+from tmt.utils import Command, GeneralError, RunError, show_exception_as_warning
+from tmt.utils.environment import Environment
+
+CopyStrategy: TypeAlias = Callable[[Path, Path, tmt.log.Logger], bool]
 
 
 def _copy_tree_cp(
@@ -17,36 +22,60 @@ def _copy_tree_cp(
     """
     Attempt to copy directory using ``cp -a --reflink=auto``.
 
-    The ``cp`` command itself will fall back to a standard copy if
-    reflink is not supported by the filesystem.
+    ``cp -a --reflink=auto`` provides copy-on-write, and ``cp``'s own
+    fallback).
+
+    * Reflinks provide fast, space-efficient copies that behave like
+      normal copies.
+    * They don't use additional storage space unless the file is
+      modified.
+    * Supported on btrfs (Fedora default since F33) and XFS (CentOS
+      Stream 8+).
+    * Using ``--reflink=auto`` means ``cp`` automatically falls back
+      to standard copy if reflink isn't supported by the filesystem.
 
     :returns: ``True`` if successful, ``False`` if ``cp`` command fails
         with :py:class:`RunError`.
     """
+
+    logger.debug(f"Copy tree '{src}' => '{dst}' using 'cp --reflink=auto' strategy.")
+
     try:
-        # The '/./' at the end of the source path tells cp to copy the *contents* of the directory
-        # rather than creating a new subdirectory in the destination
-        Command('cp', '-a', '--reflink=auto', f"{src}/./", str(dst)).run(
-            cwd=None, logger=logger, join=True, silent=True
+        # The '/./' at the end of the source path tells cp to copy the
+        # *contents* of the directory rather than creating a new
+        # subdirectory in the destination
+        Command('cp', '-a', '--reflink=auto', f"{src}/./", dst).run(
+            cwd=None, environment=Environment.from_environ(), silent=True, logger=logger
         )
-        return True
-    except RunError:
-        return False
+
     # Let other exceptions (e.g. permissions, disk full) propagate
+    except RunError as exc:
+        show_exception_as_warning(
+            exception=exc, message="'cp --reflink=auto' failed", logger=logger
+        )
+
+        return False
+
+    return True
 
 
 def _copy_tree_shutil(
     src: Path,
     dst: Path,
     logger: tmt.log.Logger,
-) -> None:
+) -> bool:
     """
-    Perform copy using shutil.copytree.
+    Perform copy using :py:func:`shutil.copytree`.
 
-    This is typically a fallback strategy. The destination directory must
-    exist before calling this function.
+    * Typically a safe fallback strategy.
+    * Maintains symlinks (``symlinks=True``).
+    * Merges with existing destination directories (``dirs_exist_ok=True``).
+
+    :returns: ``True`` if successful. ``False`` is never returned, failed
+        operations raise an exception.
     """
-    logger.debug(f"Performing shutil.copytree from '{src}' to '{dst}'")
+
+    logger.debug(f"Copy tree '{src}' => '{dst}' using 'shutil.copytree' strategy.")
 
     shutil.copytree(
         src,
@@ -54,6 +83,14 @@ def _copy_tree_shutil(
         symlinks=True,
         dirs_exist_ok=True,
     )
+
+    return True
+
+
+_COPY_TREE_STRATEGIES: tuple[CopyStrategy, ...] = (
+    _copy_tree_cp,
+    _copy_tree_shutil,
+)
 
 
 def copy_tree(
@@ -64,29 +101,11 @@ def copy_tree(
     """
     Copy directory efficiently, trying different strategies.
 
-    Attempts strategies in order:
-
-    #. ``cp -a --reflink=auto`` (copy-on-write, with ``cp``'s own
-       fallback).
-
-       * Reflinks provide fast, space-efficient copies that behave like
-         normal copies
-       * They don't use additional storage space unless the file is
-         modified
-       * Supported on btrfs (Fedora default since F33) and XFS (CentOS
-         Stream 8+)
-       * Using ``--reflink=auto`` means ``cp`` automatically falls back
-         to standard copy if reflink isn't supported by the filesystem
-
-    #. :py:func:`shutil.copytree` as a final fallback.
-
-       * Used if the ``cp`` command fails for any reason
-       * Maintains symlinks (``symlinks=True``)
-       * Merges with existing destination directories (``dirs_exist_ok=True``)
-
-    Symlinks are always preserved. The destination directory `dst` and its
-    parents will be created if they do not exist. File permissions and timestamps
-    are preserved in all copy strategies.
+    * Symlinks are always preserved.
+    * The destination directory ``dst`` and its parents will be created
+      if they do not exist.
+    * File permissions and timestamps are preserved by all copy
+      strategies.
 
     Example usage:
 
@@ -98,41 +117,29 @@ def copy_tree(
         # Copy with relative paths
         copy_tree(workdir / "original", workdir / "backup", logger)
 
-    :param src: Source directory path. Must exist and be a directory.
-    :param dst: Destination directory path.
+    :param src: Source directory path. Must exist, and must be a
+        directory.
+    :param dst: Destination directory path. If it does not exist, it
+        will be created.
     :param logger: Logger to use for debug messages.
     :raises GeneralError: when copying fails using all strategies, or if
         ``src`` does not exist or is not a directory.
     """
-    logger.debug(f"Copying directory tree from '{src}' to '{dst}'")
+
+    logger.debug(f"Copy tree '{src}' => '{dst}'")
 
     if not src.is_dir():
-        # Add an explicit check for src, as 'cp' or 'shutil.copytree' might give
-        # less clear or varied errors. This ensures a consistent error message.
-        raise GeneralError(f"Source '{src}' for copy_tree is not a directory or does not exist.")
+        # Add an explicit check for src, as strategies might give less
+        # clear or varied errors. This ensures a consistent error message.
+        raise GeneralError(f"Source path '{src}' is not a directory or does not exist.")
 
-    # Ensure destination directory `dst` and its parents exist.
-    # This is crucial for `cp` and helpful for `shutil.copytree` (as it creates parent dirs).
+    # Ensure destination directory and its parents exist.
     dst.mkdir(parents=True, exist_ok=True)
 
-    # 1. Try 'cp -a --reflink=auto' copy.
-    #    'cp' itself handles fallback from reflink to standard copy if reflink=auto is used.
-    logger.debug(f"Attempting copy from '{src}' to '{dst}' using 'cp' with reflink")
-    if _copy_tree_cp(src, dst, logger):
-        logger.debug(
-            "Copy finished using 'cp -a --reflink=auto' strategy (or its internal fallback)."
-        )
-        return
+    for strategy in _COPY_TREE_STRATEGIES:
+        try:
+            if strategy(src, dst, logger.descend()):
+                return
 
-    # 2. Fallback to shutil.copytree
-    logger.debug("cp command failed, falling back to shutil.copytree strategy.")
-    try:
-        _copy_tree_shutil(src, dst, logger)
-        logger.debug("Copy finished using shutil.copytree strategy.")
-    except Exception as error:
-        # Catching a broad Exception here because shutil.copytree can raise various errors
-        # (e.g., OSError, FileExistsError if dst is a file after mkdir, etc.)
-        # and we want to wrap them all in GeneralError.
-        raise GeneralError(
-            f"Failed to copy directory tree from '{src}' to '{dst}' using all strategies."
-        ) from error
+        except Exception as exc:
+            raise GeneralError(f"Failed to copy directory tree '{src}' => '{dst}'.") from exc


### PR DESCRIPTION
* caveats moved to their respective docstrings,
* strategies announce themselves in their code,
* when `cp --reflink` strategy fails, log a warning at least,
* `shutil` strategy has same API now,
* a sequence of strategies to run, which simplifies `copy_tree` code
  greatly.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation