### PR TITLE
Drop the koji workaround

### DIFF
--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -12,20 +12,6 @@ prepare+:
       - python3-pip
       - python3-pytest
 
-  - how: shell
-    summary: Make sure we run koji commands with automatic retry to avoid 50x errors
-    script: |
-      mkdir -p ~/.koji
-      if [ -f ~/.koji/config ]; then
-        echo "~/.koji/config was already set:"
-        cat ~/.koji/config
-      else
-        cat <<EOF > ~/.koji/config
-      [koji]
-      anon_retry = true
-      EOF
-      fi
-
 # Use the internal executor
 execute:
     how: tmt


### PR DESCRIPTION
Do not remember precisely which version we were waiting for, but there was a new enough update of `koji-1.36.1` and it looks like it has the `anon_retry=True` flip in it. `koji-1.35.3` on epel10 does not have it, but it's only [a matter of time](https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2026-d4960e3461) until that update lands also.