### PR TITLE
Move python3.15 skips to also include f45

### DIFF
--- a/plans/sanity/main.fmf
+++ b/plans/sanity/main.fmf
@@ -33,6 +33,6 @@ prepare:
   discover+:
     filter+: " & tag: with-tmt"
   adjust+:
-    - when: distro == fedora-rawhide
+    - when: distro >= fedora-45
       enabled: false
       because: Python dependencies on PyPI have not caught up

--- a/tests/precommit/main.fmf
+++ b/tests/precommit/main.fmf
@@ -6,6 +6,6 @@ require:
 tier: 4
 
 adjust+:
-  - when: distro == fedora-rawhide
+  - when: distro >= fedora-45
     result: xfail
     because: Python dependencies on PyPI have not caught up

--- a/tests/sanity/pip/install.fmf
+++ b/tests/sanity/pip/install.fmf
@@ -28,6 +28,6 @@ environment:
         /tmp/venv/bin/tmt --help
 
     adjust+:
-      - when: distro == fedora-rawhide
+      - when: distro >= fedora-45
         result: xfail
         because: Python dependencies on PyPI have not caught up

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -40,7 +40,7 @@ require+:
             We want to run this locally and it's enough to execute
             on a single distro when run in the CI. We don't need
             to exercise this again and again across all distros.
-      - when: distro == fedora-rawhide
+      - when: distro >= fedora-45
         result: xfail
         because: Python dependencies on PyPI have not caught up
 


### PR DESCRIPTION
Seems like #4965 has slipped and we need to cover F45 also