### PR TITLE
Drop xfail for /tests/sanity/pip/install on Fedora 45

### DIFF
--- a/tests/sanity/pip/install.fmf
+++ b/tests/sanity/pip/install.fmf
@@ -28,6 +28,6 @@ environment:
         /tmp/venv/bin/tmt --help
 
     adjust+:
-      - when: distro >= fedora-45
+      - when: distro == fedora-rawhide
         result: xfail
         because: Python dependencies on PyPI have not caught up

--- a/tests/sanity/pip/install.fmf
+++ b/tests/sanity/pip/install.fmf
@@ -26,8 +26,3 @@ environment:
     test: |
         /tmp/venv/bin/pip install .[all]
         /tmp/venv/bin/tmt --help
-
-    adjust+:
-      - when: distro == fedora-rawhide
-        result: xfail
-        because: Python dependencies on PyPI have not caught up

--- a/tests/unit/main.fmf
+++ b/tests/unit/main.fmf
@@ -40,9 +40,6 @@ require+:
             We want to run this locally and it's enough to execute
             on a single distro when run in the CI. We don't need
             to exercise this again and again across all distros.
-      - when: distro >= fedora-45
-        result: xfail
-        because: Python dependencies on PyPI have not caught up
 
     /basic:
         summary: Basic unit tests (development packages)


### PR DESCRIPTION
Maybe it's not that needed. At this moment. Who knows about tomorrow.

Pull Request Checklist

* [x] implement the feature