### PR TITLE
Add Jira export plugin and extend JiraInstance utilities

### DIFF
--- a/docs/releases/pending/5132.fmf
+++ b/docs/releases/pending/5132.fmf
@@ -1,0 +1,19 @@
+description: |
+    New ``jira`` export plugin allows synchronizing test metadata
+    with a Jira instance.
+
+    Use ``tmt tests export --how jira`` to create or update
+    ``Test Case`` work items in a Jira project from fmf metadata.
+    Credentials are provided via ``--jira-url``, ``--jira-user``
+    and ``--jira-token`` options or the corresponding
+    ``TMT_PLUGIN_EXPORT_JIRA_*`` environment variables. Use
+    ``--create`` to create new test cases and ``--link-jira`` to
+    write the Jira issue URL back into the fmf ``link`` section
+    as an ``implements`` relation for future lookups.
+
+    .. code-block:: shell
+
+        tmt tests export --how jira --create --link-jira \
+            --jira-url https://issues.redhat.com \
+            --jira-user me@example.com --jira-token TOKEN \
+            --project-id RHELTEST

--- a/stories/cli/test.fmf
+++ b/stories/cli/test.fmf
@@ -131,6 +131,48 @@ story: 'As a user I want to comfortably work with tests'
           - implemented-by: /tmt/export/polarion.py
           - verified-by: /plans/remote/polarion
 
+    /jira:
+        story: 'I want to export test metadata into Jira.'
+        example: tmt test export --how jira --create --link-jira --project-id RHELTEST
+        description: |
+            Export test metadata to a Jira project as ``Test Case``
+            work items. Authentication uses a Jira API token with
+            HTTP Basic Auth. Provide credentials via CLI options or
+            environment variables:
+
+            .. code-block:: shell
+
+                export TMT_PLUGIN_EXPORT_JIRA_URL=https://issues.redhat.com
+                export TMT_PLUGIN_EXPORT_JIRA_USER=me@example.com
+                export TMT_PLUGIN_EXPORT_JIRA_TOKEN=<token>
+
+            The following ``fmf`` attributes are exported to the
+            corresponding Jira ``Test Case`` fields:
+
+            * ``summary`` — summary
+            * ``description`` — description
+            * ``id`` — ``ID`` custom field used for future lookup
+            * ``component`` — components
+            * ``tag`` + ``Tier{N}`` — labels
+            * ``contact`` — assignee (email resolved to a Jira Cloud
+              ``accountId`` via the user search API)
+            * ``enabled`` — status (``Active`` or ``Retired``)
+            * ``link[test-script]`` or ``extra-task`` or repo URL
+              — ``URL`` custom field
+            * ``link[implements]`` matching the Polarion URL
+              — ``External issue URL`` custom field
+
+            ``verifies`` links are recreated as Jira issue links:
+            links to issues on the same instance become ``tests``
+            issue links; Bugzilla links become remote links.
+
+            After a successful export, add ``--link-jira`` to
+            write an ``implements`` link back to the fmf metadata
+            so that subsequent exports and reports can locate the
+            Jira ``Test Case`` without a UUID search.
+        link:
+          - implemented-by: /tmt/export/jira.py
+
 /filter:
     story: 'Filter available tests'
     description: |

--- a/tests/test/export/test.sh
+++ b/tests/test/export/test.sh
@@ -58,7 +58,7 @@ rlJournalStart
     # 2 - (negative) format testing
     rlPhaseStartTest "Invalid format"
         rlRun -s "tmt tests export --how weird" 2
-        rlAssertGrep "Error: Invalid value for '-h' / '--how': 'weird' is not one of 'dict', 'json', 'nitrate', 'polarion', 'template', 'yaml'." $rlRun_LOG
+        rlAssertGrep "Error: Invalid value for '-h' / '--how': 'weird' is not one of 'dict', 'json', 'jira', 'nitrate', 'polarion', 'template', 'yaml'." $rlRun_LOG
     rlPhaseEnd
 
     # 3 - fmf-id testing

--- a/tests/unit/test_export_jira.py
+++ b/tests/unit/test_export_jira.py
@@ -1,0 +1,580 @@
+import logging
+import unittest.mock
+from typing import Any, Optional
+
+import fmf
+import pytest
+
+import tmt.base.core
+import tmt.log
+from tests import CliRunner, reset_common
+from tmt.export.jira import _build_fields, _text_to_adf
+from tmt.identifier import ID_KEY
+from tmt.utils import ConvertError, Path
+from tmt.utils.jira import JiraInstance
+
+
+class FakeIssueType:
+    def __init__(self, type_id: str, name: str) -> None:
+        self.id = type_id
+        self.name = name
+
+
+class FakeUser:
+    def __init__(self, account_id: str, email_address: str) -> None:
+        self.accountId = account_id
+        self.emailAddress = email_address
+
+
+class FakeIssueRef:
+    def __init__(self, key: str) -> None:
+        self.key = key
+
+
+class FakeIssueLink:
+    def __init__(self, inward: Optional[str] = None, outward: Optional[str] = None) -> None:
+        if inward:
+            self.inwardIssue = FakeIssueRef(inward)
+        if outward:
+            self.outwardIssue = FakeIssueRef(outward)
+
+
+class FakeStatus:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class FakeIssueFields:
+    def __init__(
+        self,
+        status_name: str,
+        issuelinks: list[FakeIssueLink],
+        custom_fields: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self.status = FakeStatus(status_name)
+        self.issuelinks = issuelinks
+        if custom_fields:
+            for k, v in custom_fields.items():
+                setattr(self, k, v)
+
+
+class FakeIssue:
+    def __init__(
+        self,
+        key: str,
+        status_name: str = 'New',
+        issuelinks: Optional[list[FakeIssueLink]] = None,
+        custom_fields: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self.key = key
+        self.fields = FakeIssueFields(status_name, issuelinks or [], custom_fields)
+        self.updated_fields: Optional[dict[str, Any]] = None
+
+    def update(self, fields: dict[str, Any]) -> None:
+        self.updated_fields = fields
+
+
+class FakeRemoteLinkObject:
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+
+class FakeRemoteLink:
+    def __init__(self, link_id: int, url: str) -> None:
+        self.id = link_id
+        self.object = FakeRemoteLinkObject(url)
+
+
+class FakeJiraClient:
+    """Fakes the parts of the ``jira.JIRA`` SDK client used by ``JiraInstance``."""
+
+    def __init__(self) -> None:
+        self.fields_response: list[dict[str, str]] = [
+            {'id': 'customfield_10591', 'name': 'ID'},
+            {'id': 'customfield_10933', 'name': 'URL'},
+            {'id': 'customfield_10766', 'name': 'External issue URL'},
+        ]
+        self.issue_types_response: list[FakeIssueType] = [FakeIssueType('10239', 'Test Case')]
+        self.search_result: dict[str, Any] = {'issues': []}
+        self.create_result_key = 'RHELTEST-100'
+        self.issues: dict[str, FakeIssue] = {}
+        self.transitions_response: list[dict[str, Any]] = [
+            {'id': '3', 'to': {'name': 'Active'}},
+            {'id': '4', 'to': {'name': 'Retired'}},
+        ]
+        self.users: list[FakeUser] = []
+        self.remote_links_map: dict[str, list[FakeRemoteLink]] = {}
+        self.created_issues: list[dict[str, Any]] = []
+        self.created_issue_links: list[tuple[str, str, str]] = []
+        self.created_remote_links: list[tuple[str, dict[str, Any]]] = []
+        self.transitioned: list[tuple[str, str]] = []
+
+    def fields(self) -> list[dict[str, str]]:
+        return self.fields_response
+
+    def issue_types_for_project(self, project_id: str) -> list[FakeIssueType]:
+        return self.issue_types_response
+
+    def search_issues(
+        self,
+        jql_str: str,
+        maxResults: int = 50,  # noqa: N803
+        json_result: bool = False,
+        fields: Any = None,
+    ) -> dict[str, Any]:
+        return self.search_result
+
+    def search_users(self, query: Optional[str] = None, **kwargs: Any) -> list[FakeUser]:
+        return self.users
+
+    def create_issue(self, fields: dict[str, Any]) -> FakeIssue:
+        self.created_issues.append(fields)
+        return FakeIssue(self.create_result_key)
+
+    def issue(self, key: str, fields: Any = None, **kwargs: Any) -> FakeIssue:
+        return self.issues.setdefault(key, FakeIssue(key))
+
+    def transitions(self, issue: str) -> list[dict[str, Any]]:
+        return self.transitions_response
+
+    def transition_issue(self, issue: str, transition: str) -> None:
+        self.transitioned.append((issue, transition))
+
+    def create_issue_link(self, type_: str, inwardIssue: str, outwardIssue: str) -> None:  # noqa: N803
+        self.created_issue_links.append((type_, inwardIssue, outwardIssue))
+
+    def add_remote_link(self, issue: str, destination: dict[str, Any]) -> None:
+        self.created_remote_links.append((issue, destination))
+
+    def remote_links(self, issue: str) -> list[FakeRemoteLink]:
+        return self.remote_links_map.get(issue, [])
+
+
+@pytest.fixture(name='fake_jira')
+def fixture_fake_jira() -> FakeJiraClient:
+    return FakeJiraClient()
+
+
+@pytest.fixture(autouse=True)
+def _mock_network(fake_jira: FakeJiraClient) -> Any:
+    with (
+        unittest.mock.patch('jira.JIRA', return_value=fake_jira),
+        unittest.mock.patch('tmt.utils.git.validate_git_status', return_value=(True, '')),
+        # Avoid a live lookup against a real Polarion instance when ~/.pylero
+        # happens to be configured on the machine running the tests.
+        unittest.mock.patch('tmt.export.jira._find_polarion_case_url', return_value=None),
+    ):
+        yield
+    # CliRunner options are cached on Common-derived classes; clean up so a
+    # test module collected after this one (e.g. via `pytest tests/unit`)
+    # doesn't inherit them.
+    reset_common()
+
+
+@pytest.fixture(name='jira_instance')
+def fixture_jira_instance(fake_jira: FakeJiraClient, _mock_network: Any) -> JiraInstance:
+    logger = tmt.log.Logger(actual_logger=logging.getLogger('tmt'))
+    return JiraInstance(url='https://x', email='u', token='fake-token', logger=logger)  # noqa: S106
+
+
+CREDENTIALS = [
+    '--jira-url',
+    'https://issues.redhat.com',
+    '--jira-user',
+    'me@example.com',
+    '--jira-token',
+    'dummy-token',
+    '--project-id',
+    'RHELTEST',
+]
+
+
+@pytest.fixture(name='fmf_root')
+def fixture_fmf_root(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> Any:
+    # A prior CliRunner invocation (e.g. --dry) leaves its options cached on
+    # Common-derived classes; reset before creating the fixture's Test node.
+    reset_common()
+    root = Path(tmp_path) / 'tree'
+    fmf.Tree.init(path=root)
+    logger = tmt.log.Logger(actual_logger=logging.getLogger('tmt'))
+    tmt.base.core.Test.create(names=['test'], template='shell', path=root, logger=logger)
+
+    # Match the nitrate/polarion export test pattern: run from inside the
+    # test's own fmf directory and select it via '.', since the positional
+    # export argument is a name filter, not a filesystem path.
+    monkeypatch.chdir(root / 'test')
+    return root
+
+
+def find_test_node(root: Any) -> fmf.Tree:
+    return fmf.Tree(root).find('/test')
+
+
+FIELD_IDS = {
+    'tmt_id': 'customfield_10591',
+    'url': 'customfield_10933',
+    'external_issue_url': 'customfield_10766',
+}
+
+
+class TestBuildFields:
+    def test_minimal(self) -> None:
+        fields = _build_fields(
+            project_id='RHELTEST',
+            summary='Check something',
+            description=None,
+            uuid='abc-123',
+            components=[],
+            labels=[],
+            contact_account_id=None,
+            script_url=None,
+            polarion_case_url=None,
+            field_ids=FIELD_IDS,
+        )
+        assert fields == {'summary': 'Check something', 'customfield_10591': 'abc-123'}
+
+    def test_full(self) -> None:
+        fields = _build_fields(
+            project_id='RHELTEST',
+            summary='Check something',
+            description='Longer text',
+            uuid='abc-123',
+            components=['kernel'],
+            labels=['Tier1'],
+            contact_account_id='712020:abc-123',
+            script_url='https://example.com/test.sh',
+            polarion_case_url='https://polarion.example.com/case/1',
+            field_ids=FIELD_IDS,
+            issue_type_id='10239',
+        )
+        assert fields['project'] == {'key': 'RHELTEST'}
+        assert fields['issuetype'] == {'id': '10239'}
+        assert fields['description'] == _text_to_adf('Longer text')
+        assert fields['customfield_10591'] == 'abc-123'
+        assert fields['components'] == [{'name': 'kernel'}]
+        assert fields['labels'] == ['Tier1']
+        assert fields['assignee'] == {'accountId': '712020:abc-123'}
+        assert fields['customfield_10933'] == 'https://example.com/test.sh'
+        assert fields['customfield_10766'] == 'https://polarion.example.com/case/1'
+
+
+class TestTextToAdf:
+    def test_empty(self) -> None:
+        assert _text_to_adf('') == {
+            'type': 'doc',
+            'version': 1,
+            'content': [{'type': 'paragraph', 'content': []}],
+        }
+
+    def test_multiline(self) -> None:
+        adf = _text_to_adf('first\n\nsecond')
+        assert [p['content'][0]['text'] for p in adf['content']] == ['first', 'second']
+
+
+class TestFieldJqlId:
+    def test_extracts_numeric_suffix(self) -> None:
+        assert JiraInstance.field_jql_id('customfield_10591') == '10591'
+
+
+class TestResolveIssueTypeId:
+    def test_found(self, jira_instance: JiraInstance, fake_jira: FakeJiraClient) -> None:
+        fake_jira.issue_types_response = [
+            FakeIssueType('10239', 'Test Case'),
+            FakeIssueType('10300', 'Test Result'),
+        ]
+        assert jira_instance.resolve_issue_type_id('RHELTEST', 'Test Case') == '10239'
+
+    def test_not_found_raises(
+        self, jira_instance: JiraInstance, fake_jira: FakeJiraClient
+    ) -> None:
+        fake_jira.issue_types_response = [FakeIssueType('10239', 'Test Case')]
+        with pytest.raises(ConvertError, match="No 'Bug' issue type found"):
+            jira_instance.resolve_issue_type_id('RHELTEST', 'Bug')
+
+    def test_result_is_cached(
+        self, jira_instance: JiraInstance, fake_jira: FakeJiraClient
+    ) -> None:
+        fake_jira.issue_types_response = [FakeIssueType('10239', 'Test Case')]
+        assert jira_instance.resolve_issue_type_id('RHELTEST', 'Test Case') == '10239'
+        fake_jira.issue_types_response = []  # would now fail if not cached
+        assert jira_instance.resolve_issue_type_id('RHELTEST', 'Test Case') == '10239'
+
+
+class TestResolveFieldId:
+    def test_found(self, jira_instance: JiraInstance) -> None:
+        assert jira_instance.resolve_field_id('ID') == 'customfield_10591'
+
+    def test_not_found_raises(
+        self, jira_instance: JiraInstance, fake_jira: FakeJiraClient
+    ) -> None:
+        fake_jira.fields_response = []
+        with pytest.raises(ConvertError, match="No 'ID' custom field found"):
+            jira_instance.resolve_field_id('ID')
+
+    def test_ambiguous_raises(
+        self, jira_instance: JiraInstance, fake_jira: FakeJiraClient
+    ) -> None:
+        fake_jira.fields_response = [
+            {'id': 'customfield_10591', 'name': 'ID'},
+            {'id': 'customfield_99999', 'name': 'ID'},
+        ]
+        with pytest.raises(ConvertError, match="Multiple fields named 'ID'"):
+            jira_instance.resolve_field_id('ID')
+
+    def test_result_is_cached(
+        self, jira_instance: JiraInstance, fake_jira: FakeJiraClient
+    ) -> None:
+        assert jira_instance.resolve_field_id('ID') == 'customfield_10591'
+        fake_jira.fields_response = []  # would now fail if not cached
+        assert jira_instance.resolve_field_id('ID') == 'customfield_10591'
+        assert jira_instance.resolve_field_id('URL') == 'customfield_10933'
+
+
+class TestResolveTransitionId:
+    def test_found(self, jira_instance: JiraInstance) -> None:
+        assert jira_instance.resolve_transition_id('RHELTEST-1', 'Active') == '3'
+
+    def test_not_found_raises(
+        self, jira_instance: JiraInstance, fake_jira: FakeJiraClient
+    ) -> None:
+        fake_jira.transitions_response = [{'id': '3', 'to': {'name': 'Active'}}]
+        with pytest.raises(ConvertError, match="No transition to status 'Retired'"):
+            jira_instance.resolve_transition_id('RHELTEST-1', 'Retired')
+
+
+class TestResolveAccountId:
+    def test_exact_match(self, jira_instance: JiraInstance, fake_jira: FakeJiraClient) -> None:
+        fake_jira.users = [FakeUser('712020:abc', 'me@example.com')]
+        assert jira_instance.resolve_account_id('me@example.com') == '712020:abc'
+
+    def test_no_exact_match_returns_none(
+        self, jira_instance: JiraInstance, fake_jira: FakeJiraClient
+    ) -> None:
+        # A non-matching query can fall back to returning unrelated users.
+        fake_jira.users = [FakeUser('712020:abc', 'someone-else@example.com')]
+        assert jira_instance.resolve_account_id('me@example.com') is None
+
+
+class TestExportToJira:
+    def test_missing_required_options(self, fmf_root: Any) -> None:
+        output = CliRunner().invoke('tests', 'export', '--how', 'jira', '.')
+        assert output.exit_code != 0
+        assert 'Missing required Jira options' in str(output.exception)
+
+    def test_create_dry_run(self, fmf_root: Any, fake_jira: FakeJiraClient) -> None:
+        node_before = find_test_node(fmf_root)
+        assert ID_KEY not in node_before.data
+
+        output = CliRunner().invoke(
+            'tests',
+            'export',
+            '--how',
+            'jira',
+            '--create',
+            '--dry',
+            *CREDENTIALS,
+            '.',
+        )
+        assert output.exit_code == 0, output.output
+        assert 'would be created' in output.output
+        # Dry run must not create the issue nor touch fmf metadata.
+        assert not fake_jira.created_issues
+        assert ID_KEY not in find_test_node(fmf_root).data
+
+    def test_create(self, fmf_root: Any, fake_jira: FakeJiraClient) -> None:
+        expected_summary = find_test_node(fmf_root).data['summary']
+
+        output = CliRunner().invoke(
+            'tests',
+            'export',
+            '--how',
+            'jira',
+            '--create',
+            *CREDENTIALS,
+            '.',
+        )
+        assert output.exit_code == 0, output.output
+        assert "Test case 'RHELTEST-100' created." in output.output
+
+        assert len(fake_jira.created_issues) == 1
+        assert fake_jira.created_issues[0]['summary'] == expected_summary
+
+        # A freshly created, enabled test case must be transitioned to Active.
+        assert fake_jira.transitioned == [('RHELTEST-100', '3')]
+
+        # The UUID generated for the export must be written back to fmf.
+        assert ID_KEY in find_test_node(fmf_root).data
+
+    def test_create_required_without_flag_fails(self, fmf_root: Any) -> None:
+        output = CliRunner().invoke(
+            'tests',
+            'export',
+            '--how',
+            'jira',
+            *CREDENTIALS,
+            '.',
+        )
+        assert output.exit_code != 0
+        assert 'Use --create to create a new test case' in str(output.exception)
+        assert ID_KEY not in find_test_node(fmf_root).data
+
+    def test_existing_case_copies_uuid_from_jira_if_missing_in_fmf(
+        self, fmf_root: Any, fake_jira: FakeJiraClient
+    ) -> None:
+        node = find_test_node(fmf_root)
+        with node as data:
+            data['link'] = [{'implements': 'https://issues.redhat.com/browse/RHELTEST-42'}]
+
+        fake_jira.issues['RHELTEST-42'] = FakeIssue(
+            'RHELTEST-42',
+            custom_fields={'customfield_10591': 'from-jira-uuid-1234'},
+        )
+
+        output = CliRunner().invoke(
+            'tests',
+            'export',
+            '--how',
+            'jira',
+            *CREDENTIALS,
+            '.',
+        )
+        assert output.exit_code == 0, output.output
+        assert "Test case 'RHELTEST-42' updated." in output.output
+        assert find_test_node(fmf_root).data[ID_KEY] == 'from-jira-uuid-1234'
+        assert fake_jira.issues['RHELTEST-42'].updated_fields is not None
+        assert (
+            fake_jira.issues['RHELTEST-42'].updated_fields['customfield_10591']
+            == 'from-jira-uuid-1234'
+        )
+
+    def test_existing_case_generates_uuid_if_missing_in_both(
+        self, fmf_root: Any, fake_jira: FakeJiraClient
+    ) -> None:
+        node = find_test_node(fmf_root)
+        with node as data:
+            data['link'] = [{'implements': 'https://issues.redhat.com/browse/RHELTEST-42'}]
+
+        fake_jira.issues['RHELTEST-42'] = FakeIssue('RHELTEST-42')
+
+        output = CliRunner().invoke(
+            'tests',
+            'export',
+            '--how',
+            'jira',
+            *CREDENTIALS,
+            '.',
+        )
+        assert output.exit_code == 0, output.output
+        assert "Test case 'RHELTEST-42' updated." in output.output
+        saved_uuid = find_test_node(fmf_root).data.get(ID_KEY)
+        assert saved_uuid is not None
+        assert fake_jira.issues['RHELTEST-42'].updated_fields is not None
+        assert fake_jira.issues['RHELTEST-42'].updated_fields['customfield_10591'] == saved_uuid
+
+    def test_link_jira_writes_implements_link(
+        self, fmf_root: Any, fake_jira: FakeJiraClient
+    ) -> None:
+        output = CliRunner().invoke(
+            'tests',
+            'export',
+            '--how',
+            'jira',
+            '--create',
+            '--link-jira',
+            *CREDENTIALS,
+            '.',
+        )
+        assert output.exit_code == 0, output.output
+
+        node = find_test_node(fmf_root)
+        implements = [
+            link['implements'] for link in node.data.get('link', []) if 'implements' in link
+        ]
+        assert implements == ['https://issues.redhat.com/browse/RHELTEST-100']
+
+    def test_existing_case_update_dry_run(self, fmf_root: Any, fake_jira: FakeJiraClient) -> None:
+        with find_test_node(fmf_root) as data:
+            data[ID_KEY] = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+        fake_jira.search_result = {'issues': [{'key': 'RHELTEST-42'}]}
+
+        output = CliRunner().invoke(
+            'tests',
+            'export',
+            '--how',
+            'jira',
+            '--dry',
+            *CREDENTIALS,
+            '.',
+        )
+        assert output.exit_code == 0, output.output
+        assert "Test case 'RHELTEST-42' would be updated." in output.output
+        assert not fake_jira.created_issues
+        assert 'RHELTEST-42' not in fake_jira.issues
+
+    def test_existing_case_is_updated(self, fmf_root: Any, fake_jira: FakeJiraClient) -> None:
+        # Simulate a test that was already exported once: it already carries
+        # a tmt UUID, which is how find_jira_case_key() locates it in Jira.
+        with find_test_node(fmf_root) as data:
+            data[ID_KEY] = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+        fake_jira.search_result = {'issues': [{'key': 'RHELTEST-42'}]}
+
+        output = CliRunner().invoke(
+            'tests',
+            'export',
+            '--how',
+            'jira',
+            *CREDENTIALS,
+            '.',
+        )
+        assert output.exit_code == 0, output.output
+        assert "Test case 'RHELTEST-42' updated." in output.output
+        assert not fake_jira.created_issues
+        assert fake_jira.issues['RHELTEST-42'].updated_fields is not None
+
+    def test_verifies_links_recreated_and_deduplicated(
+        self, fmf_root: Any, fake_jira: FakeJiraClient
+    ) -> None:
+        node = find_test_node(fmf_root)
+        with node as data:
+            data['link'] = [
+                {'verifies': 'https://issues.redhat.com/browse/RHELTEST-1'},
+                {'verifies': 'https://bugzilla.redhat.com/show_bug.cgi?id=123'},
+                {'verifies': 'https://bugzilla.mozilla.org/show_bug.cgi?id=456'},
+            ]
+
+        # RHELTEST-1 is already linked; the Bugzilla remote links are not.
+        fake_jira.issues['RHELTEST-100'] = FakeIssue(
+            'RHELTEST-100', issuelinks=[FakeIssueLink(inward='RHELTEST-1')]
+        )
+
+        output = CliRunner().invoke(
+            'tests',
+            'export',
+            '--how',
+            'jira',
+            '--create',
+            *CREDENTIALS,
+            '.',
+        )
+        assert output.exit_code == 0, output.output
+        # Already linked -- must not be recreated.
+        assert not fake_jira.created_issue_links
+        # Not yet linked -- must be created exactly once.
+        assert fake_jira.created_remote_links == [
+            (
+                'RHELTEST-100',
+                {
+                    'url': 'https://bugzilla.redhat.com/show_bug.cgi?id=123',
+                    'title': 'BZ#123',
+                },
+            ),
+            (
+                'RHELTEST-100',
+                {
+                    'url': 'https://bugzilla.mozilla.org/show_bug.cgi?id=456',
+                    'title': 'BZ#456',
+                },
+            ),
+        ]

--- a/tmt/cli/_root.py
+++ b/tmt/cli/_root.py
@@ -877,7 +877,28 @@ _test_export_default = 'yaml'
 )
 @option(
     '--project-id',
-    help='Use specific Polarion project ID.',
+    help='Use specific Polarion or Jira project ID.',
+)
+@option(
+    '--jira-url',
+    envvar='TMT_PLUGIN_EXPORT_JIRA_URL',
+    help='Jira instance base URL, e.g. ``https://issues.redhat.com``.',
+)
+@option(
+    '--jira-token',
+    envvar='TMT_PLUGIN_EXPORT_JIRA_TOKEN',
+    help='Jira API token for authentication.',
+)
+@option(
+    '--jira-user',
+    envvar='TMT_PLUGIN_EXPORT_JIRA_USER',
+    help='Jira user email for authentication.',
+)
+@option(
+    '--link-jira / --no-link-jira',
+    default=False,
+    is_flag=True,
+    help='Add Jira link to fmf testcase metadata as an implements relation.',
 )
 @option(
     '--link-polarion / --no-link-polarion',

--- a/tmt/export/jira.py
+++ b/tmt/export/jira.py
@@ -1,0 +1,457 @@
+"""
+Export tmt test cases to Jira as TestCase work items.
+"""
+
+import email.utils
+import re
+from typing import Any, Optional
+
+from click import echo
+
+import tmt.base.core
+import tmt.convert
+import tmt.export
+import tmt.utils.git
+from tmt.identifier import ID_KEY, add_uuid_if_not_defined
+from tmt.utils import ConvertError
+from tmt.utils.jira import JiraInstance
+from tmt.utils.themes import style
+
+# Issue link type for test case → requirement relationship
+LINK_TYPE_TESTS = 'pair'  # outward="tests", inward="is tested by"
+
+RE_BUGZILLA_ID = re.compile(r'show_bug\.cgi\?(?:.*&)?id=(\d+)')
+
+
+def _text_to_adf(text: str) -> dict[str, Any]:
+    """Convert plain text to Atlassian Document Format (ADF)."""
+    paragraphs = [
+        {
+            'type': 'paragraph',
+            'content': [{'type': 'text', 'text': line}],
+        }
+        for line in text.splitlines()
+        if line.strip()
+    ]
+    return {
+        'type': 'doc',
+        'version': 1,
+        'content': paragraphs or [{'type': 'paragraph', 'content': []}],
+    }
+
+
+def find_jira_case_key(
+    test: tmt.base.core.Test,
+    jira_instance: JiraInstance,
+    project_id: str,
+    url: str,
+    field_tmt_id: str,
+) -> Optional[str]:
+    """
+    Find an existing Jira TestCase key for the given test.
+
+    Lookup order:
+    1. An 'implements' link in fmf pointing to this Jira instance.
+    2. tmt UUID stored in ``field_tmt_id`` (the ``ID`` field).
+    """
+    # 1. implements link pointing to this Jira instance
+    if test.link:
+        for link in test.link.get('implements'):
+            target = str(link.target)
+            prefix = f'{url}/browse/'
+            if target.startswith(prefix):
+                key = target[len(prefix) :]
+                echo(style(f"Found via implements link: '{key}'.", fg='blue'))
+                return key
+
+    # 2. UUID via the ID custom field
+    uuid = test.node.get(ID_KEY)
+    if uuid:
+        field_jql = JiraInstance.field_jql_id(field_tmt_id)
+        issues = jira_instance.search_issues(
+            f'project="{project_id}" AND issuetype="Test Case" AND cf[{field_jql}]="{uuid}"',
+            max_results=1,
+            fields=[],
+        )
+        if issues:
+            key = str(issues[0]['key'])
+            echo(style(f"Found via UUID: '{key}'.", fg='blue'))
+            return key
+
+    return None
+
+
+def _find_polarion_case_url(test: tmt.base.core.Test) -> Optional[str]:
+    """
+    Find the Polarion test case URL for this test.
+
+    Checks 'implements' links in fmf first (written by a prior Polarion export),
+    then falls back to a live Polarion API lookup when pylero is available.
+    """
+    if test.link:
+        for link in test.link.get('implements'):
+            if isinstance(link.target, tmt.base.core.FmfId):
+                continue
+            target = str(link.target)
+            if 'polarion' in target.lower():
+                return target
+
+    # Live lookup — optional, requires pylero + ~/.pylero
+    try:
+        from tmt.export.polarion import (
+            PolarionWorkItem,
+            find_polarion_case_ids,
+            import_polarion,
+        )
+
+        import_polarion()
+        case_id, pol_project_id = find_polarion_case_ids(test.node)
+        if case_id and pol_project_id:
+            server_url = str(PolarionWorkItem._session._server.url).rstrip('/')
+            return f'{server_url}/#/project/{pol_project_id}/workitem?id={case_id}'
+    except Exception as error:
+        test._logger.debug(f"Live Polarion lookup failed: {error}")
+
+    return None
+
+
+def _create_issue_links(
+    test: tmt.base.core.Test,
+    case_key: str,
+    jira_instance: JiraInstance,
+    url: str,
+) -> None:
+    """
+    Recreate fmf 'verifies' links as Jira issue links or remote links.
+
+    - Links to issues on the same Jira instance become issue links of type 'pair'
+      (RHELTEST tests RHEL-XXXX).
+    - Links to Bugzilla become remote links on the TestCase.
+
+    Existing links are checked first so repeated exports of the same
+    test don't keep adding duplicates.
+    """
+    if not test.link:
+        return
+
+    verifies_targets = [
+        str(link.target)
+        for link in test.link.get('verifies')
+        if not isinstance(link.target, tmt.base.core.FmfId)
+    ]
+    if not verifies_targets:
+        return
+
+    import jira as jira_module
+
+    browse_prefix = f'{url}/browse/'
+    linked_keys = jira_instance.get_linked_issue_keys(case_key)
+    linked_remote_urls = jira_instance.get_linked_remote_urls(case_key)
+
+    for target in verifies_targets:
+        # Same Jira instance — create a proper issue link
+        if target.startswith(browse_prefix):
+            req_key = target[len(browse_prefix) :]
+            if req_key in linked_keys:
+                echo(style('verifies: ', fg='green') + f'{req_key} (already linked)')
+                continue
+            try:
+                jira_instance.jira.create_issue_link(
+                    type=LINK_TYPE_TESTS, inwardIssue=req_key, outwardIssue=case_key
+                )
+                echo(style('verifies: ', fg='green') + req_key)
+            except jira_module.JIRAError as err:
+                echo(style(f"Warning: could not link to '{req_key}': {err}", fg='yellow'))
+            continue
+
+        # Bugzilla — create a remote link
+        bz_match = RE_BUGZILLA_ID.search(target)
+        if bz_match:
+            bz_id = bz_match.group(1)
+            if target in linked_remote_urls:
+                echo(style('verifies (BZ): ', fg='green') + f'{bz_id} (already linked)')
+                continue
+            try:
+                jira_instance.jira.add_remote_link(
+                    case_key, destination={'url': target, 'title': f'BZ#{bz_id}'}
+                )
+                echo(style('verifies (BZ): ', fg='green') + bz_id)
+            except jira_module.JIRAError as err:
+                echo(style(f"Warning: could not add BZ remote link '{bz_id}': {err}", fg='yellow'))
+            continue
+
+        echo(style("Skipping unrecognised verifies link: ", fg='yellow') + target)
+
+
+def _build_fields(
+    project_id: str,
+    summary: str,
+    description: Optional[str],
+    uuid: str,
+    components: list[str],
+    labels: list[str],
+    contact_account_id: Optional[str],
+    script_url: Optional[str],
+    polarion_case_url: Optional[str],
+    field_ids: dict[str, str],
+    issue_type_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    Assemble Jira field dict for create or update.
+
+    :param field_ids: resolved custom field IDs, keyed by ``'tmt_id'``,
+        ``'url'`` and ``'external_issue_url'`` (see
+        :py:meth:`JiraInstance.resolve_field_id`).
+    :param issue_type_id: resolved ``Test Case`` issue type ID, only needed
+        when creating a new issue.
+    """
+    fields: dict[str, Any] = {
+        'summary': summary,
+        field_ids['tmt_id']: uuid,
+    }
+    if issue_type_id:
+        fields['project'] = {'key': project_id}
+        fields['issuetype'] = {'id': issue_type_id}
+    if description:
+        fields['description'] = _text_to_adf(description)
+    if components:
+        fields['components'] = [{'name': c} for c in components]
+    if labels:
+        fields['labels'] = labels
+    if contact_account_id:
+        fields['assignee'] = {'accountId': contact_account_id}
+    if script_url:
+        fields[field_ids['url']] = script_url
+    if polarion_case_url:
+        fields[field_ids['external_issue_url']] = polarion_case_url
+    return fields
+
+
+def _transition_case(jira_instance: JiraInstance, key: str, enabled: bool) -> None:
+    """Transition a TestCase to Active or Retired, skipping if already there."""
+    target = 'Active' if enabled else 'Retired'
+    current_status = jira_instance.jira.issue(key, fields='status').fields.status.name
+    if current_status == target:
+        return
+    jira_instance.transition_issue(key, target)
+    echo(style('status: ', fg='green') + target)
+
+
+def export_to_jira(
+    test: tmt.base.core.Test, jira_instance: Optional[JiraInstance] = None
+) -> JiraInstance:
+    """
+    Export a single tmt test to a Jira TestCase.
+
+    :param jira_instance: connection to reuse, e.g. across a batch of
+        tests exported in one run; a new one is created and returned if
+        not given.
+    """
+    create = test.opt('create')
+    duplicate = test.opt('duplicate')
+    link_jira = test.opt('link_jira')
+    ignore_git_validation = test.opt('ignore_git_validation')
+    dry_mode = test.is_dry_run
+
+    required = ['jira_url', 'jira_token', 'jira_user', 'project_id']
+    missing = [f"--{opt.replace('_', '-')}" for opt in required if not test.opt(opt)]
+    if missing:
+        raise ConvertError(f"Missing required Jira options: {', '.join(missing)}.")
+
+    jira_url = test.opt('jira_url')
+    token = test.opt('jira_token')
+    user = test.opt('jira_user')
+    project_id = test.opt('project_id')
+    url = jira_url.rstrip('/')
+
+    valid, error_msg = tmt.utils.git.validate_git_status(test)
+    if not valid:
+        if ignore_git_validation:
+            echo(style(f"Exporting regardless: '{error_msg}'.", fg='red'))
+        else:
+            raise ConvertError(
+                f"Can't export due to '{error_msg}'.\n"
+                "Use --ignore-git-validation to export regardless."
+            )
+
+    if jira_instance is None:
+        jira_instance = JiraInstance(url=url, email=user, token=token, logger=test._logger)
+
+    field_tmt_id = jira_instance.resolve_field_id('ID')
+
+    summary = test.summary or test.name
+
+    labels = list(test.tag)
+    if test.tier is not None:
+        labels.append(f'Tier{test.tier}')
+
+    contact_account_id: Optional[str] = None
+    if test.contact:
+        addr = email.utils.parseaddr(test.contact[0])[1]
+        if addr:
+            contact_account_id = jira_instance.resolve_account_id(addr)
+            if not contact_account_id:
+                echo(style(f"Warning: could not resolve Jira account for '{addr}'.", fg='yellow'))
+
+    # Script URL: test-script link takes priority, then extra-task, then fmf repo URL
+    script_url: Optional[str] = None
+    if test.link:
+        for link in test.link.get(relation='test-script'):
+            if isinstance(link.target, str):
+                script_url = link.target
+                break
+    if not script_url:
+        if test.node.get('extra-task'):
+            script_url = test.node.get('extra-task')
+        elif not ignore_git_validation and test.fmf_id.url:
+            script_url = test.fmf_id.url
+
+    # Find or create TestCase
+    case_key: Optional[str] = None
+    if not duplicate:
+        case_key = find_jira_case_key(test, jira_instance, project_id, url, field_tmt_id)
+
+    # UUID always needs to exist in fmf data and Jira:
+    # 1. From fmf if already defined.
+    # 2. From existing Jira issue if available.
+    # 3. Otherwise generate a new one and save into fmf data.
+    uuid: Optional[str] = test.node.get(ID_KEY)
+
+    # Polarion test case link — from implements links or live API lookup.
+    # Only needed to build the fields for an actual create/update call, so
+    # it's resolved lazily and not for a dry run.
+    polarion_case_url: Optional[str] = None
+
+    if case_key is None:
+        if not create:
+            raise ConvertError(
+                f"Jira TestCase not found for '{test}'. Use --create to create a new test case."
+            )
+        if not uuid:
+            uuid = add_uuid_if_not_defined(test.node, dry_mode, test._logger)
+    elif not uuid:
+        jira_issue = jira_instance.jira.issue(case_key)
+        jira_uuid = getattr(jira_issue.fields, field_tmt_id, None)
+        if not jira_uuid and hasattr(jira_issue, 'raw'):
+            jira_uuid = jira_issue.raw.get('fields', {}).get(field_tmt_id)
+        if jira_uuid:
+            uuid = str(jira_uuid)
+            if not dry_mode:
+                with test.node as data:
+                    data[ID_KEY] = uuid
+        else:
+            uuid = add_uuid_if_not_defined(test.node, dry_mode, test._logger)
+    assert uuid is not None
+
+    if not dry_mode:
+        polarion_case_url = _find_polarion_case_url(test)
+        field_ids = {
+            'tmt_id': field_tmt_id,
+            'url': jira_instance.resolve_field_id('URL'),
+            'external_issue_url': jira_instance.resolve_field_id('External issue URL'),
+        }
+        issue_type_id = (
+            jira_instance.resolve_issue_type_id(project_id, 'Test Case')
+            if case_key is None
+            else None
+        )
+        fields = _build_fields(
+            project_id=project_id,
+            summary=summary,
+            description=test.description,
+            uuid=uuid,
+            components=test.component,
+            labels=labels,
+            contact_account_id=contact_account_id,
+            script_url=script_url,
+            polarion_case_url=polarion_case_url,
+            field_ids=field_ids,
+            issue_type_id=issue_type_id,
+        )
+
+    if case_key is None:
+        if dry_mode:
+            echo(style(f"Test case '{summary}' would be created.", fg='blue'))
+        else:
+            case_key = str(jira_instance.jira.create_issue(fields=fields).key)
+            echo(style(f"Test case '{case_key}' created.", fg='blue'))
+    elif dry_mode:
+        echo(style(f"Test case '{case_key}' would be updated.", fg='blue'))
+    else:
+        jira_instance.jira.issue(case_key).update(fields=fields)
+        echo(style(f"Test case '{case_key}' updated.", fg='blue'))
+
+    if polarion_case_url:
+        echo(style('polarion: ', fg='green') + polarion_case_url)
+    elif not dry_mode:
+        echo(style('polarion: ', fg='yellow') + 'not found')
+
+    echo(style('summary: ', fg='green') + summary)
+    if uuid:
+        echo(style('uuid: ', fg='green') + uuid)
+    echo(style('labels: ', fg='green') + ' '.join(labels))
+    echo(style('components: ', fg='green') + ' '.join(test.component))
+    echo(style('enabled: ', fg='green') + str(test.enabled))
+
+    if not dry_mode and case_key:
+        _transition_case(jira_instance, case_key, test.enabled)
+        _create_issue_links(test, case_key, jira_instance, url)
+
+    if not dry_mode and link_jira and case_key:
+        with test.node as data:
+            tmt.convert.add_link(
+                f'{url}/browse/{case_key}',
+                data,
+                system=tmt.convert.SYSTEM_OTHER,
+                type_='implements',
+            )
+        echo(style('implements: ', fg='green') + f'{url}/browse/{case_key}')
+
+    echo(style(f"Test case '{summary}' successfully exported to Jira.", fg='magenta'))
+
+    return jira_instance
+
+
+@tmt.base.core.Test.provides_export('jira')
+class JiraExporter(tmt.export.ExportPlugin):
+    """
+    Export test metadata to Jira as ``Test Case`` work items.
+
+    The ``--jira-url``, ``--jira-user``, ``--jira-token`` and
+    ``--project-id`` options are required. Credentials can also be
+    provided via the corresponding ``TMT_PLUGIN_EXPORT_JIRA_*``
+    environment variables.
+
+    Existing ``Test Case`` issues are located first by an ``implements``
+    link in the fmf metadata pointing to the configured Jira instance,
+    then by the tmt UUID stored in the ``ID`` custom field. Use
+    ``--create`` to create a new ``Test Case`` when none is found, and
+    ``--link-jira`` to write the Jira issue URL back into the fmf
+    metadata as an ``implements`` link for future lookups.
+
+    Polarion test case links present in ``implements`` fmf links or
+    found via a live Polarion API lookup are preserved in the
+    ``External issue URL`` custom field. ``verifies`` fmf links are
+    recreated as Jira issue links (``tests`` type for issues on the
+    same instance, remote links for Bugzilla URLs).
+
+    .. code-block:: shell
+
+        tmt tests export --how jira --create --link-jira \\
+            --jira-url https://issues.redhat.com \\
+            --jira-user me@example.com --jira-token TOKEN \\
+            --project-id RHELTEST
+    """
+
+    @classmethod
+    def export_test_collection(
+        cls,
+        tests: list[tmt.base.core.Test],
+        keys: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Export a collection of tests to Jira."""
+        jira_instance: Optional[JiraInstance] = None
+        for test in tests:
+            jira_instance = export_to_jira(test, jira_instance)
+        return ''

--- a/tmt/utils/jira.py
+++ b/tmt/utils/jira.py
@@ -69,23 +69,77 @@ class JiraInstance:
     A Jira instance configured with url and token
     """
 
-    def __init__(self, issue_tracker: IssueTracker, logger: tmt.log.Logger):
+    def __init__(
+        self,
+        *,
+        url: str,
+        email: str,
+        token: str,
+        logger: tmt.log.Logger,
+        tmt_web_url: Optional[str] = None,
+    ):
         """
-        Initialize Jira instance from the issue tracker config
+        Initialize a Jira instance from raw connection details.
+
+        ``tmt_web_url`` is only needed by :py:meth:`add_link_to_issue`;
+        callers that only export/report test data can leave it unset.
+        Use :py:meth:`from_issue_tracker` to construct one from a
+        configured issue tracker instead.
         """
 
-        self.url = str(issue_tracker.url)
-        self.tmt_web_url = str(issue_tracker.tmt_web_url)
-        self.email = issue_tracker.email
-        self.token = issue_tracker.token
+        self.url = url
+        self.tmt_web_url = tmt_web_url
+        self.email = email
+        self.token = token
 
         self.logger = logger
         jira_module = import_jira(logger)
 
         # ignore[attr-defined]: it is defined, but mypy seems to fail
         # detecting it correctly.
+        #
+        # get_server_info=False: skips an extra server-info request and,
+        # with it, the library's own PyPI update check, neither of which
+        # tmt needs. That request is also how the SDK detects Cloud vs
+        # Server/Data Center (self.jira.deploymentType), which several
+        # SDK methods use to decide which API to call -- e.g. search_issues
+        # falls back to the removed /rest/api/2/search on non-Cloud. Since
+        # this is always Jira Cloud here, set it directly instead.
+        #
+        # options={'rest_api_version': '3'}: the SDK defaults to the v2 API
+        # for everything except search (which it special-cases to v3 for
+        # Cloud). v2 doesn't understand Atlassian Document Format, which
+        # this module relies on for descriptions and comments, and its
+        # search endpoint has since been removed by Atlassian.
         self.jira = jira_module.JIRA(  # type: ignore[attr-defined]
-            server=self.url, basic_auth=(self.email, self.token)
+            server=self.url,
+            basic_auth=(self.email, self.token),
+            get_server_info=False,
+            options={'rest_api_version': '3'},
+        )
+        self.jira.deploymentType = 'Cloud'
+
+        # Caches for schema resolution (issue type IDs and custom field IDs).
+        # Populated on first lookup to minimize network requests.
+        self._issue_types: Optional[dict[str, str]] = None
+        self._fields_by_name: Optional[dict[str, list[str]]] = None
+
+    @classmethod
+    def from_issue_tracker(
+        cls,
+        issue_tracker: IssueTracker,
+        logger: tmt.log.Logger,
+    ) -> 'JiraInstance':
+        """
+        Initialize Jira instance from the issue tracker config
+        """
+
+        return cls(
+            url=str(issue_tracker.url),
+            email=issue_tracker.email,
+            token=issue_tracker.token,
+            tmt_web_url=str(issue_tracker.tmt_web_url),
+            logger=logger,
         )
 
     @classmethod
@@ -114,7 +168,7 @@ class JiraInstance:
 
             # Issue url must match
             if issue_url.startswith(str(issue_tracker.url)):
-                return JiraInstance(issue_tracker, logger=logger)
+                return JiraInstance.from_issue_tracker(issue_tracker, logger=logger)
 
         return None
 
@@ -135,6 +189,7 @@ class JiraInstance:
         )
 
         # Prepare the tmt web service link from all tmt objects
+        assert self.tmt_web_url is not None
         web_link_parameters: dict[str, str] = {}
         for tmt_object in tmt_objects:
             web_link_parameters.update(prepare_url_params(tmt_object))
@@ -147,6 +202,127 @@ class JiraInstance:
         issue_id = link.target.split('/')[-1]
         self.jira.add_simple_link(issue_id, {"url": web_link, "title": title})
         self.logger.print(f"Add link '{title}' to Jira issue '{link.target}'.")
+
+    #
+    # Connection utilities for the export and report plugins. Plain
+    # passthroughs to ``self.jira`` (create_issue, add_comment, ...) don't
+    # get a wrapper here; callers use the ``jira`` SDK client directly.
+    #
+
+    @staticmethod
+    def field_jql_id(field_id: str) -> str:
+        """Extract the numeric part of a ``customfield_XXXXX`` ID for JQL's ``cf[XXXXX]``."""
+        return field_id.rsplit('_', 1)[-1]
+
+    def resolve_issue_type_id(self, project_id: str, name: str) -> str:
+        """
+        Resolve an issue type name (e.g. ``Test Case``) to its ID within a project.
+
+        Issue type IDs are project-specific, so this cannot be a fixed
+        constant shared across Jira instances or projects.
+        """
+        if self._issue_types is None:
+            self._issue_types = {
+                issue_type.name: str(issue_type.id)
+                for issue_type in self.jira.issue_types_for_project(project_id)
+            }
+
+        if name not in self._issue_types:
+            raise tmt.utils.ConvertError(
+                f"No '{name}' issue type found in project '{project_id}'."
+            )
+        return self._issue_types[name]
+
+    def resolve_field_id(self, name: str) -> str:
+        """
+        Resolve a custom field's display name (e.g. ``External issue URL``) to its field ID.
+
+        Field IDs are assigned per Jira instance and are not guaranteed to
+        be the same across different instances or projects.
+        """
+        if self._fields_by_name is None:
+            self._fields_by_name = {}
+            for field in self.jira.fields():
+                field_name = field.get('name')
+                if field_name:
+                    self._fields_by_name.setdefault(field_name, []).append(str(field['id']))
+
+        matches = self._fields_by_name.get(name, [])
+        if not matches:
+            raise tmt.utils.ConvertError(f"No '{name}' custom field found in Jira.")
+        if len(matches) > 1:
+            raise tmt.utils.ConvertError(
+                f"Multiple fields named '{name}' found in Jira: {matches}."
+            )
+        return matches[0]
+
+    def resolve_transition_id(self, issue_key: str, target_status_name: str) -> str:
+        """
+        Resolve the transition ID that moves an issue to ``target_status_name``.
+
+        Transition IDs are defined by the issue's workflow, which can
+        differ between issue types, projects and Jira instances.
+        """
+        for transition in self.jira.transitions(issue_key):
+            if transition.get('to', {}).get('name') == target_status_name:
+                return str(transition['id'])
+        raise tmt.utils.ConvertError(
+            f"No transition to status '{target_status_name}' available for '{issue_key}'."
+        )
+
+    def transition_issue(self, key: str, target_status_name: str) -> None:
+        """Transition an issue to ``target_status_name``, resolving the transition ID first."""
+        self.jira.transition_issue(key, self.resolve_transition_id(key, target_status_name))
+
+    def resolve_account_id(self, email: str) -> Optional[str]:
+        """
+        Resolve a Jira Cloud ``accountId`` from an email address.
+
+        Jira Cloud's REST API no longer accepts a ``name`` (login) when
+        assigning issues; an ``accountId`` looked up via the user search
+        endpoint is required instead.
+
+        The search performs a loose match and, when nothing really
+        matches, has been observed to fall back to returning arbitrary
+        unrelated users rather than an empty list. A candidate is
+        therefore only accepted when its email matches exactly
+        (case-insensitively); this can also legitimately fail to find an
+        existing account whose email is hidden by that user's Jira
+        privacy settings.
+        """
+        for user in self.jira.search_users(query=email):
+            if getattr(user, 'emailAddress', '').lower() == email.lower():
+                return str(user.accountId)
+        return None
+
+    def search_issues(
+        self, jql: str, max_results: int = 50, fields: Optional[list[str]] = None
+    ) -> list[dict[str, Any]]:
+        """Run a JQL search and return the raw matching issues."""
+        result = self.jira.search_issues(
+            jql,
+            maxResults=max_results,
+            json_result=True,
+            fields=fields if fields is not None else ['summary'],
+        )
+        assert isinstance(result, dict)  # json_result=True guarantees a dict
+        return cast(list[dict[str, Any]], result.get('issues', []))
+
+    def get_linked_issue_keys(self, key: str) -> set[str]:
+        """Return the keys of issues already linked to ``key`` via an issue link."""
+        issuelinks = self.jira.issue(key, fields='issuelinks').fields.issuelinks
+        keys: set[str] = set()
+        for issuelink in issuelinks:
+            other = getattr(issuelink, 'inwardIssue', None) or getattr(
+                issuelink, 'outwardIssue', None
+            )
+            if other:
+                keys.add(str(other.key))
+        return keys
+
+    def get_linked_remote_urls(self, key: str) -> set[str]:
+        """Return the URLs of remote (web) links already present on ``key``."""
+        return {str(remote_link.object.url) for remote_link in self.jira.remote_links(key)}
 
 
 def save_link_to_metadata(


### PR DESCRIPTION
Adds a new ``tmt tests export --how jira`` export plugin that creates
and updates Jira ``Test Case`` work items from tmt test metadata.

The plugin supports creating new ``Test Case`` issues (``--create``),
updating existing ones located via an ``implements`` fmf link or the
``ID`` custom field (tmt UUID), and writing the Jira URL back into fmf
as an ``implements`` link (``--link-jira``). ``verifies`` fmf links are
recreated as Jira issue links (for issues on the same instance) or
remote links (for Bugzilla URLs), with deduplication to avoid creating
duplicates on repeated exports.

The plugin uses the ``jira`` Python SDK (``tmt[link-jira]`` extra)
rather than hand-rolled ``requests`` calls. Issue type IDs, custom
field IDs and transition IDs are resolved by name rather than being
hardcoded. ``JiraInstance`` in ``tmt/utils/jira.py`` is extended with
the resolver methods and Jira Cloud connectivity utilities needed by
both this plugin and the forthcoming report plugin.

Generated-by: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: Petr Matyas <pmatyas@redhat.com>

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage
* [x] update the specification
* [x] adjust plugin docstring
* [x] modify the json schema
* [x] include a release note
