### PR TITLE
Disable system-resolved workaround

### DIFF
--- a/plans/features/extended-unit-tests.fmf
+++ b/plans/features/extended-unit-tests.fmf
@@ -6,27 +6,7 @@ discover:
     how: fmf
     test: '/tests/unit/.*?/extended'
 
-# Disable systemd-resolved to prevent dns failures
-# See: https://github.com/teemtee/tmt/issues/2063
 adjust+:
-  - when: initiator == packit and distro == fedora
-    prepare+:
-      - name: disable systemd resolved
-        how: shell
-        script: |
-            set -x
-            dnf install -y /usr/bin/netstat
-            systemctl unmask systemd-resolved
-            systemctl disable systemd-resolved
-            systemctl stop systemd-resolved
-            systemctl mask systemd-resolved
-            rm -f /etc/resolv.conf
-            systemctl restart NetworkManager
-            sleep 5
-            cat /etc/resolv.conf
-            ps xa | grep resolv
-            netstat -pnl
-
   - when: trigger == commit
     provision:
         hardware:


### PR DESCRIPTION
This is now properly applied via `workarounds.dns` role from Testing Farm profiles and should not be needed anymore.

Pull Request Checklist

* [x] implement the feature