### PR TITLE
Interruption-aware sleep alternative

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -444,6 +444,7 @@ convention = "pep257"
 builtins-ignorelist = ["help", "format", "input", "filter", "copyright", "max"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
+"time.sleep".msg = "Use tmt.utils.sleep instead."
 "typing.TypeAlias".msg = "Use tmt._compat.typing.TypeAlias instead."
 "typing_extensions.TypeAlias".msg = "Use tmt._compat.typing.TypeAlias instead."
 "typing.Self".msg = "Use tmt._compat.typing.Self instead."

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import queue
 import re
@@ -24,6 +25,7 @@ import tmt.plugins
 import tmt.result
 import tmt.steps.discover
 import tmt.utils
+import tmt.utils._time
 import tmt.utils.git
 import tmt.utils.jira
 import tmt.utils.templates
@@ -1096,7 +1098,7 @@ def test_wait_success_but_too_late(root_logger):
     """
 
     def check():
-        time.sleep(5)
+        tmt.utils._time.sleep(5)
 
     with pytest.raises(WaitingTimedOutError):
         Waiting(Deadline.from_seconds(1)).wait(check, root_logger)
@@ -1842,3 +1844,39 @@ def test_render_template_sandbox() -> None:
 
     with pytest.raises(GeneralError, match=r"Template used forbidden operation\."):
         tmt.utils.templates.render_template('{{ RESULT.__init__.__globals__ }}', RESULT=result)
+
+
+TIME_SLEEP_DELAY = 20.0
+
+
+def test_time_sleep() -> None:
+    start = time.monotonic()
+
+    tmt.utils._time.sleep(TIME_SLEEP_DELAY)
+
+    end = time.monotonic()
+
+    assert (end - start) >= TIME_SLEEP_DELAY
+
+
+def test_time_sleep_interrupted() -> None:
+    start = time.monotonic()
+
+    def _run() -> None:
+        with pytest.raises(tmt.utils.signals.Interrupted):
+            tmt.utils._time.sleep(TIME_SLEEP_DELAY)
+
+    sleeper = threading.Thread(target=_run)
+
+    sleeper.start()
+
+    time.sleep(TIME_SLEEP_DELAY / 4)  # noqa: TID251
+
+    with contextlib.suppress(KeyboardInterrupt):
+        tmt.utils.signals._interrupt_handler(signal.SIGINT, None)
+
+    sleeper.join()
+
+    end = time.monotonic()
+
+    assert (TIME_SLEEP_DELAY / 4) < (end - start) < TIME_SLEEP_DELAY

--- a/tests/utils/http_server.py
+++ b/tests/utils/http_server.py
@@ -2,7 +2,7 @@ import http.server
 import socketserver
 import threading
 
-import tmt.utils.time
+import tmt.utils._time
 
 
 class Handler(http.server.SimpleHTTPRequestHandler):
@@ -38,4 +38,4 @@ if __name__ == '__main__':
     # Keep the script running
 
     while True:
-        tmt.utils.time.sleep(1)
+        tmt.utils._time.sleep(1)

--- a/tests/utils/http_server.py
+++ b/tests/utils/http_server.py
@@ -2,6 +2,8 @@ import http.server
 import socketserver
 import threading
 
+import tmt.utils.time
+
 
 class Handler(http.server.SimpleHTTPRequestHandler):
     def send_error(self, code, message=None):
@@ -34,7 +36,6 @@ def run_server(port=8000):
 if __name__ == '__main__':
     run_server()
     # Keep the script running
-    import time
 
     while True:
-        time.sleep(1)
+        tmt.utils.time.sleep(1)

--- a/tmt/base/run.py
+++ b/tmt/base/run.py
@@ -48,6 +48,7 @@ from tmt.utils import (
     StateFormat,
     WorkdirArgumentType,
 )
+from tmt.utils._time import sleep
 from tmt.utils.environment import Environment, HasEnvironment
 from tmt.utils.feeling_safe import log_feeling_safe
 
@@ -628,7 +629,7 @@ class Run(HasRunWorkdir, HasUserAnchorPath, HasEnvironment, tmt.utils.Common):
                 if line:
                     print(line, end='')
                 else:
-                    time.sleep(0.5)
+                    sleep(0.5)
 
     def show_runner(self, logger: tmt.log.Logger) -> None:
         """

--- a/tmt/checks/avc.py
+++ b/tmt/checks/avc.py
@@ -1,7 +1,6 @@
 import enum
 import re
 import textwrap
-import time
 from re import Pattern
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -21,6 +20,7 @@ from tmt.utils import (
     render_command_report,
     safe_call,
 )
+from tmt.utils._time import sleep
 from tmt.utils.environment import Environment
 from tmt.utils.hints import hints_as_notes
 
@@ -171,7 +171,7 @@ def create_ausearch_mark(
     # Wait one second before storing the mark because ausearch
     # could catch denials from the previous test if they are executed
     # during the same second
-    time.sleep(check.delay_before_report)
+    sleep(check.delay_before_report)
 
     report: list[str] = []
 
@@ -224,7 +224,7 @@ def create_final_report(
     # Wait one second before storing the mark because ausearch
     # could catch denials from the previous test if they are executed
     # during the same second
-    time.sleep(check.delay_before_report)
+    sleep(check.delay_before_report)
 
     # Collect all report components
     report: list[str] = []

--- a/tmt/checks/coredump.py
+++ b/tmt/checks/coredump.py
@@ -1,6 +1,5 @@
 import re
 from re import Pattern
-from time import sleep
 from typing import TYPE_CHECKING, Optional
 
 import tmt.log
@@ -9,6 +8,7 @@ from tmt.checks import Check, CheckPlugin, _RawCheck, provides_check
 from tmt.container import container, field
 from tmt.result import CheckResult, ResultOutcome, save_failures
 from tmt.utils import Command, Path, ShellScript
+from tmt.utils._time import sleep
 from tmt.utils.environment import Environment
 
 if TYPE_CHECKING:

--- a/tmt/checks/watchdog.py
+++ b/tmt/checks/watchdog.py
@@ -1,7 +1,6 @@
 import datetime
 import re
 import threading
-import time
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Optional
 
@@ -16,6 +15,7 @@ from tmt.checks import Check, CheckPlugin, provides_check
 from tmt.container import container, field
 from tmt.result import CheckResult, ResultOutcome
 from tmt.utils import Path, format_timestamp, render_run_exception_streams
+from tmt.utils._time import sleep
 from tmt.utils.environment import Environment
 
 if TYPE_CHECKING:
@@ -482,7 +482,7 @@ class Watchdog(CheckPlugin[WatchdogCheck]):
                 if check.ssh_ping:
                     check.do_ssh_ping(invocation, guest_context, watchdog_logger)
 
-                time.sleep(check.interval)
+                sleep(check.interval)
 
             watchdog_logger.debug(f'Watchdog finished in thread {tid}')
 

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -613,7 +613,7 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
                     abort_execute_exception = AbortStep(abort_message)
 
                 # Handle interrupt
-                if tmt.utils.signals.INTERRUPT_PENDING.is_set():
+                if tmt.utils.signals.is_interrupted():
                     interrupt_exception = tmt.utils.signals.Interrupted()
 
                     invocation.exceptions.append(interrupt_exception)

--- a/tmt/utils/__init__.py
+++ b/tmt/utils/__init__.py
@@ -75,6 +75,7 @@ from tmt._compat.pathlib import Path
 from tmt._compat.typing import ParamSpec, Self
 from tmt.container import container
 from tmt.log import DebugLevel, LoggableValue, VerbosityLevel
+from tmt.utils._time import sleep
 from tmt.utils.environment import Environment
 from tmt.utils.themes import style
 
@@ -4446,14 +4447,14 @@ class RetryStrategy(urllib3.util.retry.Retry):
                         self.logger.info(
                             f"Primary rate limit exceeded. Waiting {wait_time + 1} seconds."
                         )
-                    time.sleep(wait_time)
+                    sleep(wait_time)
 
             if 'Retry-After' in headers:
                 retry_after = int(headers['Retry-After'])
                 retry_after += 1
                 if self.logger:
                     self.logger.info(f"Secondary rate limit hit. Waiting {retry_after} seconds.")
-                time.sleep(retry_after)
+                sleep(retry_after)
 
             # Exponential backoff for unclear rate limit cases
             if self.total is not None:
@@ -4463,7 +4464,7 @@ class RetryStrategy(urllib3.util.retry.Retry):
                         "Rate limit detected but no wait time specified. "
                         f"Using exponential backoff: {wait_time} seconds"
                     )
-                time.sleep(wait_time)
+                sleep(wait_time)
 
         # Handle other 403 cases
         elif 'X-GitHub-Request-Id' in headers:
@@ -6182,7 +6183,7 @@ def retry(
                 f"trying again in {interval:.2f} seconds.",
             )
             logger.fail(str(exc))
-            time.sleep(interval)
+            sleep(interval)
     raise RetryError(label, causes=exceptions)
 
 

--- a/tmt/utils/_time.py
+++ b/tmt/utils/_time.py
@@ -1,0 +1,28 @@
+"""
+Date and time-related helpers.
+"""
+
+
+def sleep(delay: float) -> None:
+    """
+    Delay execution for a given number of seconds.
+
+    An alternative to :py:func:`time.sleep`, this function is aware of
+    tmt interrupt process, and can be safely used in threads. If tmt
+    is interrupted before or while this function sleeps,
+    :py:class:`tmt.utils.signals.Interrupted` is raised instead of
+    returning.
+
+    :param delay: how many seconds to sleep.
+    :raises Interrupted: when tmt was interrupted.
+    """
+
+    from tmt.utils.signals import _INTERRUPT_PENDING, assert_not_interrupted
+
+    # `wait()` will wait for the event to become set for the given delay,
+    # at max. If the event has been set already, `wait()` returns immediately.
+    # Which is nice: we get our delay, and if tmt gets interrupted, or it
+    # got interrupted already, our sleep ends.
+    _INTERRUPT_PENDING.wait(delay)
+
+    assert_not_interrupted()

--- a/tmt/utils/signals.py
+++ b/tmt/utils/signals.py
@@ -51,7 +51,7 @@ _INTERRUPT_LOCK = threading.Lock()
 _INTERRUPT_MASKED = threading.Event()
 
 #: When set, interrupt was delivered to tmt, and tmt should react to it.
-INTERRUPT_PENDING = threading.Event()
+_INTERRUPT_PENDING = threading.Event()
 
 
 class Interrupted(tmt.utils.GeneralError):
@@ -183,9 +183,9 @@ def _interrupt_handler(signum: int, frame: Optional[FrameType]) -> None:
     logger.warning(f'Interrupt requested via {signal.Signals(signum).name} signal.')
 
     with _INTERRUPT_LOCK:
-        repeated = INTERRUPT_PENDING.is_set()
+        repeated = _INTERRUPT_PENDING.is_set()
 
-        INTERRUPT_PENDING.set()
+        _INTERRUPT_PENDING.set()
 
         if _INTERRUPT_MASKED.is_set():
             logger.warning('Interrupt is masked, postponing the reaction.')
@@ -226,9 +226,41 @@ class PreventSignals(contextlib.AbstractContextManager['PreventSignals']):
         with _INTERRUPT_LOCK:
             _INTERRUPT_MASKED.clear()
 
-            if not INTERRUPT_PENDING.is_set():
+            if not _INTERRUPT_PENDING.is_set():
                 self.logger.debug('Interrupt not detected, leaving safe block.', level=2)
 
                 return
 
             _quit_tmt(self.logger)
+
+
+def is_interrupted() -> bool:
+    """
+    Check whether tmt was interrupted.
+
+    :returns: ``True`` when tmt has been interrupted, ``False`` otherwise.
+    """
+
+    return _INTERRUPT_PENDING.is_set()
+
+
+def assert_not_interrupted(on_interrupted: Optional[Callable[[], None]] = None) -> None:
+    """
+    Check whether tmt was interrupted, and act accordingly.
+
+    When tmt was interrupted, the :py:class:`Interrupted` is raised to
+    stop the current code from continuing. When tmt was not interrupted,
+    return back to caller.
+
+    :param on_interrupted: a callback to invoke before raising the
+        :py:class:`Interrupted` exception.
+    :raises Interrupted: when tmt was interrupted.
+    """
+
+    if not is_interrupted():
+        return
+
+    if on_interrupted is not None:
+        on_interrupted()
+
+    raise Interrupted

--- a/tmt/utils/wait.py
+++ b/tmt/utils/wait.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import time
 from functools import cached_property
 from typing import Callable, TypeVar
@@ -7,6 +8,7 @@ import tmt.log
 from tmt._compat.typing import Self
 from tmt.container import container
 from tmt.utils import GeneralError
+from tmt.utils._time import sleep
 
 T = TypeVar('T')
 
@@ -204,13 +206,11 @@ class Waiting:
         :raises Interrupted: when tmt has been interrupted.
         """
 
-        from tmt.utils.signals import INTERRUPT_PENDING, Interrupted
+        from tmt.utils.signals import assert_not_interrupted
 
-        def _check_interrupted() -> None:
-            if INTERRUPT_PENDING.is_set():
-                logger.debug('wait', f"'{check.__name__}' interrupted")
-
-                raise Interrupted
+        _log_on_interrupted = functools.partial(
+            logger.debug, 'wait', f"'{check.__name__}' interrupted"
+        )
 
         logger.debug(
             'wait',
@@ -222,7 +222,7 @@ class Waiting:
         )
 
         while True:
-            _check_interrupted()
+            assert_not_interrupted(_log_on_interrupted)
 
             with self.deadline:
                 if self.deadline.is_due:
@@ -238,8 +238,7 @@ class Waiting:
             try:
                 ret = check()
 
-                # Make sure interrupt is honored.
-                _check_interrupted()
+                assert_not_interrupted(_log_on_interrupted)
 
                 # Perform one extra check: if `check()` succeeded, but took more time than
                 # allowed, it should be recognized as a failed waiting too.
@@ -277,7 +276,7 @@ class Waiting:
                         f" {self.deadline!r}",
                     )
 
-                time.sleep(self.tick)
+                sleep(self.tick)
 
                 self.tick *= self.tick_increase
 


### PR DESCRIPTION
Instead of `time.sleep()` which does not play well with threads and tmt interrupt process.

Related to #5009.

Pull Request Checklist

* [x] implement the feature
* [x] write the documentation
* [x] extend the test coverage