### PR TITLE
Add initial support for macOS guests

### DIFF
--- a/docs/releases/pending/macos-guests.fmf
+++ b/docs/releases/pending/macos-guests.fmf
@@ -1,0 +1,11 @@
+description: |
+  The :ref:`connect</plugins/provision/connect>` provision method now
+  works with macOS guests: workdir transfers work with Apple's
+  ``openrsync``, and :ref:`prepare/install</plugins/prepare/install>`
+  installs packages with the new ``homebrew`` package manager. Log in
+  as a regular user with passwordless ``sudo`` and set ``become``: the
+  essential requirements, ``flock`` among them, come from Homebrew,
+  which refuses to run as ``root`` and has to live under ``/opt/homebrew``
+  or ``/usr/local``. With ``become``, the workdir is shared through an
+  inherited ACL that grants everyone read and execute. Reboot handling
+  and hardware requirements are not covered yet.

--- a/tests/unit/test_macos_guests.py
+++ b/tests/unit/test_macos_guests.py
@@ -1,0 +1,720 @@
+"""
+Tests for macOS guest support: guest facts, transfer options, Homebrew and the test wrapper.
+"""
+
+from typing import Optional, Union
+from unittest.mock import MagicMock
+
+import _pytest.monkeypatch
+import pytest
+
+import tmt.steps
+from tmt.guest import (
+    DEFAULT_PULL_OPTIONS,
+    DEFAULT_PUSH_OPTIONS,
+    GuestFacts,
+    GuestSsh,
+    GuestSshData,
+    TransferOptions,
+)
+from tmt.log import Logger
+from tmt.package_managers import (
+    FileSystemPath,
+    Installable,
+    Options,
+    Package,
+    PackageUrl,
+    PrepareError,
+)
+from tmt.package_managers.apk import Apk
+from tmt.package_managers.apt import Apt
+from tmt.package_managers.homebrew import HOMEBREW_PREFIXES, Homebrew, HomebrewEngine
+from tmt.steps.context.pidfile import OUTER_WRAPPER_TEMPLATE
+from tmt.steps.execute.internal import ExecuteInternal
+from tmt.steps.provision import Provision
+from tmt.utils import (
+    Command,
+    CommandOutput,
+    GeneralError,
+    Path,
+    RunError,
+    ShellScript,
+    effective_workdir_root,
+)
+from tmt.utils.environment import Environment, EnvVarValue
+
+OPENRSYNC_VERSION = 'openrsync: protocol version 29\nrsync version 2.6.9 compatible\n'
+RSYNC_VERSION = 'rsync  version 3.4.1  protocol version 32\n'
+
+BREW = 'env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin HOMEBREW_NO_AUTO_UPDATE=1 brew'  # noqa: E501
+
+HOMEBREW_PREFIXES_PATH = ':'.join(HOMEBREW_PREFIXES)
+
+# Commands run by guest facts, as they appear in `execute()` calls.
+UNAME_S = str(Command('uname', '-s'))
+RSYNC_VERSION_COMMAND = str(Command('rsync', '--version'))
+SW_VERS = str(
+    ShellScript('echo "$(sw_vers -productName) $(sw_vers -productVersion)"').to_shell_command()
+)
+SW_VERS_PRODUCT_VERSION = str(Command('sw_vers', '-productVersion'))
+OS_RELEASE = str(Command('cat', '/etc/os-release'))
+
+
+def _guest(outputs: dict[str, str]) -> MagicMock:
+    """
+    Guest mock answering ``execute()`` from a mapping of commands to their stdout.
+
+    Commands missing from the mapping fail.
+    """
+
+    guest = MagicMock()
+
+    def execute(command: Command, **kwargs: object) -> CommandOutput:
+        if str(command) in outputs:
+            return CommandOutput(stdout=outputs[str(command)], stderr='')
+
+        raise RunError('failed', command, 1)
+
+    guest.execute.side_effect = execute
+
+    return guest
+
+
+def _executed(guest: MagicMock, command: str) -> int:
+    """
+    Count how many times the guest mock executed the given command.
+    """
+
+    return sum(1 for call in guest.execute.call_args_list if str(call.args[0]) == command)
+
+
+def _ssh_guest(root_logger: Logger, *, become: bool = False, dry_run: bool = False) -> GuestSsh:
+    step = Provision(
+        plan=MagicMock(name='mock<plan>', is_dry_run=dry_run), raw_data=[{}], logger=root_logger
+    )
+
+    return GuestSsh(
+        logger=root_logger,
+        parent=step,
+        name='foo',
+        data=GuestSshData(primary_address='bar', become=become),
+    )
+
+
+def _homebrew_guest(*, is_superuser: bool = False) -> MagicMock:
+    """
+    Guest mock for Homebrew, logged in as a regular user unless told otherwise.
+    """
+
+    guest = MagicMock()
+    guest.facts = GuestFacts(in_sync=True, is_superuser=is_superuser)
+
+    return guest
+
+
+@pytest.mark.parametrize(
+    ('outputs', 'expected', 'executed_once'),
+    [
+        (
+            {
+                UNAME_S: 'Darwin\n',
+                SW_VERS: 'macOS 15.7.7\n',
+                RSYNC_VERSION_COMMAND: OPENRSYNC_VERSION,
+            },
+            {
+                'is_darwin': True,
+                'has_rsync': True,
+                'has_openrsync': True,
+                'distro': 'macOS 15.7.7',
+                'distro_id': 'macos',
+                'distro_major_version': 15,
+            },
+            [UNAME_S, RSYNC_VERSION_COMMAND, SW_VERS],
+        ),
+        (
+            {
+                OS_RELEASE: 'ID=fedora\nVERSION_ID=43\nPRETTY_NAME="Fedora Linux 43"\n',
+                UNAME_S: 'Linux\n',
+                RSYNC_VERSION_COMMAND: RSYNC_VERSION,
+            },
+            {
+                'is_darwin': False,
+                'has_rsync': True,
+                'has_openrsync': False,
+                'distro': 'Fedora Linux 43',
+                'distro_id': 'fedora',
+                'distro_major_version': 43,
+            },
+            [UNAME_S, RSYNC_VERSION_COMMAND],
+        ),
+        (
+            {
+                UNAME_S: 'Darwin\n',
+                SW_VERS_PRODUCT_VERSION: '26.1\n',
+                RSYNC_VERSION_COMMAND: OPENRSYNC_VERSION,
+            },
+            {
+                'is_darwin': True,
+                'distro': None,
+                'distro_id': 'macos',
+                'distro_major_version': 26,
+            },
+            [UNAME_S, RSYNC_VERSION_COMMAND, SW_VERS, SW_VERS_PRODUCT_VERSION],
+        ),
+    ],
+    ids=['darwin', 'linux', 'darwin-without-distro'],
+)
+def test_facts_sync(
+    outputs: dict[str, str], expected: dict[str, object], executed_once: list[str]
+) -> None:
+    guest = _guest(outputs)
+    facts = GuestFacts()
+
+    facts.sync(guest)
+
+    assert {fact: getattr(facts, fact) for fact in expected} == expected
+    assert {command: _executed(guest, command) for command in executed_once} == dict.fromkeys(
+        executed_once, 1
+    )
+
+
+@pytest.mark.parametrize(
+    ('has_openrsync', 'is_darwin', 'expected_synced'),
+    [
+        (True, True, []),
+        (False, False, []),
+        (None, True, ['has_openrsync']),
+        (True, None, ['is_darwin']),
+        (None, None, ['has_openrsync', 'is_darwin']),
+    ],
+    ids=['macos', 'linux', 'missing-openrsync', 'missing-darwin', 'missing-both'],
+)
+def test_transfer_options_sync_missing_facts(
+    root_logger: Logger,
+    monkeypatch: _pytest.monkeypatch.MonkeyPatch,
+    has_openrsync: Optional[bool],
+    is_darwin: Optional[bool],
+    expected_synced: list[str],
+) -> None:
+    guest = _ssh_guest(root_logger)
+    guest.facts = GuestFacts(in_sync=True, has_openrsync=has_openrsync, is_darwin=is_darwin)
+
+    sync = MagicMock()
+    monkeypatch.setattr(guest.facts, 'sync', sync)
+
+    guest._transfer_options(DEFAULT_PUSH_OPTIONS)
+
+    if expected_synced:
+        sync.assert_called_once_with(guest, *expected_synced)
+    else:
+        sync.assert_not_called()
+
+
+def test_facts_sync_single_darwin_fact() -> None:
+    guest = _guest({UNAME_S: 'Darwin\n', SW_VERS_PRODUCT_VERSION: '15.7.7\n'})
+    facts = GuestFacts()
+
+    facts.sync(guest, 'distro_major_version')
+
+    assert facts.distro_major_version == 15
+    # Asked once, on behalf of the distro fact, since `is_darwin` itself was not synced.
+    assert _executed(guest, UNAME_S) == 1
+    assert facts.is_darwin is None
+
+
+@pytest.mark.parametrize(
+    ('options', 'facts', 'pushing', 'expected'),
+    [
+        (
+            DEFAULT_PUSH_OPTIONS,
+            GuestFacts(),
+            True,
+            ['-z', '--delete', '--links', '-s', '-r', '-R', '--safe-links'],
+        ),
+        (
+            DEFAULT_PUSH_OPTIONS,
+            GuestFacts(has_openrsync=False, is_darwin=False),
+            True,
+            ['-z', '--delete', '--links', '-s', '-r', '-R', '--safe-links'],
+        ),
+        (
+            DEFAULT_PUSH_OPTIONS,
+            GuestFacts(has_openrsync=True, is_darwin=True),
+            True,
+            ['-z', '--delete', '--links', '-r', '-R', '--safe-links', '--no-implied-dirs'],
+        ),
+        (
+            TransferOptions(protect_args=True, preserve_perms=True, chmod=0o755),
+            GuestFacts(has_openrsync=True, is_darwin=True),
+            True,
+            ['--chmod=755', '-p', '--no-implied-dirs'],
+        ),
+        (
+            DEFAULT_PULL_OPTIONS,
+            GuestFacts(),
+            False,
+            ['-z', '--links', '-s', '-r', '-R', '--safe-links'],
+        ),
+        (
+            DEFAULT_PULL_OPTIONS,
+            GuestFacts(has_openrsync=False, is_darwin=False),
+            False,
+            ['-z', '--links', '-s', '-r', '-R', '--safe-links'],
+        ),
+        (
+            DEFAULT_PULL_OPTIONS,
+            GuestFacts(has_openrsync=True, is_darwin=True),
+            False,
+            ['-z', '--links', '-r', '-R', '--safe-links'],
+        ),
+    ],
+    ids=[
+        'push-unknown',
+        'push-linux',
+        'push-macos',
+        'push-macos-wrapper',
+        'pull-unknown',
+        'pull-linux',
+        'pull-macos',
+    ],
+)
+def test_transfer_options_adjusted_for(
+    options: TransferOptions, facts: GuestFacts, pushing: bool, expected: list[str]
+) -> None:
+    assert options.adjusted_for(facts, pushing=pushing).to_rsync() == expected
+
+
+@pytest.mark.parametrize(
+    ('options', 'facts', 'pushing', 'expected_remote', 'protected'),
+    [
+        (
+            None,
+            GuestFacts(in_sync=True, has_rsync=True, has_openrsync=True, is_darwin=True),
+            True,
+            "root@bar:'/var/tmp/work dir/'",
+            False,
+        ),
+        (
+            None,
+            GuestFacts(in_sync=True, has_rsync=True, has_openrsync=False, is_darwin=False),
+            True,
+            'root@bar:/var/tmp/work dir/',
+            True,
+        ),
+        (
+            # Callers that never set `protect_args`, like the artifact file provider.
+            TransferOptions(compress=True),
+            GuestFacts(in_sync=True, has_rsync=True, has_openrsync=False, is_darwin=False),
+            True,
+            "root@bar:'/var/tmp/work dir'",
+            False,
+        ),
+        (
+            None,
+            GuestFacts(in_sync=True, has_rsync=True, has_openrsync=True, is_darwin=True),
+            False,
+            "root@bar:'/var/tmp/work dir'",
+            False,
+        ),
+    ],
+    ids=['push-macos', 'push-linux', 'push-linux-unprotected', 'pull-macos'],
+)
+def test_transfer_remote_path(
+    root_logger: Logger,
+    monkeypatch: _pytest.monkeypatch.MonkeyPatch,
+    options: Optional[TransferOptions],
+    facts: GuestFacts,
+    pushing: bool,
+    expected_remote: str,
+    protected: bool,
+) -> None:
+    guest = _ssh_guest(root_logger)
+    guest.facts = facts
+
+    run_guest_command = MagicMock()
+
+    monkeypatch.setattr(guest, '_assert_ssh_master_process', MagicMock())
+    monkeypatch.setattr(guest, '_run_guest_command', run_guest_command)
+
+    if pushing:
+        guest.push(
+            source=Path('/tmp/source'), destination=Path('/var/tmp/work dir'), options=options
+        )
+    else:
+        monkeypatch.setattr(guest, 'tmpdir', MagicMock())
+        guest.pull(
+            source=Path('/var/tmp/work dir'),
+            destination=Path('/tmp/destination'),
+            options=options,
+        )
+
+    command = run_guest_command.call_args.args[0].to_popen()
+
+    assert command[0] == 'rsync'
+    assert command[-1 if pushing else -2] == expected_remote
+    assert ('-s' in command) is protected
+    # A quoted path must reach the remote shell quoted; rsync 3.2.4 and later escape it otherwise.
+    environment = run_guest_command.call_args.kwargs['environment']
+    assert (environment is None) is protected
+    if not protected:
+        assert environment == Environment({'RSYNC_OLD_ARGS': EnvVarValue('1')})
+    # openrsync accepts the option as the receiver only.
+    assert ('--no-implied-dirs' in command) is (pushing and facts.is_darwin is True)
+
+
+@pytest.mark.parametrize(
+    ('method', 'args', 'options', 'expected'),
+    [
+        (
+            'install',
+            (Package('flock'), FileSystemPath('/usr/bin/flock')),
+            None,
+            f'{BREW} install flock flock',
+        ),
+        (
+            'install',
+            (Package('flock'),),
+            Options(skip_missing=True),
+            f'{BREW} install flock || /bin/true',
+        ),
+        ('reinstall', (Package('bash'),), None, f'{BREW} reinstall bash'),
+        ('refresh_metadata', (), None, f'{BREW} update'),
+        (
+            'check_presence',
+            (Package('rsync'), FileSystemPath('/usr/bin/python3')),
+            None,
+            f'{BREW} list --versions rsync python',
+        ),
+        ('enable_repo', ('homebrew/core',), None, PrepareError),
+        ('disable_repo', ('homebrew/core',), None, PrepareError),
+        ('install', (PackageUrl('https://example.com/flock.rb'),), None, PrepareError),
+        ('install', (FileSystemPath('/usr/bin/unknown-tool'),), None, GeneralError),
+        ('install_debuginfo', (Package('flock'),), None, GeneralError),
+        (
+            'install',
+            (Package('flock'),),
+            Options(excluded_packages=[Package('bash')]),
+            PrepareError,
+        ),
+        (
+            'reinstall',
+            (Package('flock'),),
+            Options(excluded_packages=[Package('bash')]),
+            PrepareError,
+        ),
+    ],
+    ids=[
+        'install',
+        'install-skip-missing',
+        'reinstall',
+        'refresh-metadata',
+        'check-presence',
+        'enable-repo',
+        'disable-repo',
+        'install-url',
+        'install-unknown-path',
+        'install-debuginfo',
+        'install-excluded',
+        'reinstall-excluded',
+    ],
+)
+def test_homebrew_engine(
+    root_logger: Logger,
+    method: str,
+    args: tuple[object, ...],
+    options: Optional[Options],
+    expected: Union[str, type[Exception]],
+) -> None:
+    engine = HomebrewEngine(guest=_homebrew_guest(), logger=root_logger)
+    kwargs = {} if options is None else {'options': options}
+
+    if isinstance(expected, str):
+        assert str(getattr(engine, method)(*args, **kwargs)) == expected
+
+    else:
+        with pytest.raises(expected):
+            getattr(engine, method)(*args, **kwargs)
+
+
+@pytest.mark.parametrize('method', ['install_debuginfo', 'install_local'])
+def test_homebrew_unsupported(root_logger: Logger, method: str) -> None:
+    manager = Homebrew(guest=_homebrew_guest(), logger=root_logger)
+
+    with pytest.raises(PrepareError):
+        getattr(manager, method)(Package('flock'))
+
+
+def test_homebrew_refuses_root(root_logger: Logger) -> None:
+    with pytest.raises(GeneralError, match='does not run as root'):
+        Homebrew(guest=_homebrew_guest(is_superuser=True), logger=root_logger)
+
+
+def test_homebrew_check_presence(root_logger: Logger) -> None:
+    guest = _homebrew_guest()
+    guest.execute.side_effect = RunError(
+        'failed',
+        Command('brew'),
+        1,
+        stdout='flock 0.4.0\npython@3.14 3.14.7\n',
+        stderr='Error: No such keg: /opt/homebrew/Cellar/rsync\n',
+    )
+
+    manager = Homebrew(guest=guest, logger=root_logger)
+
+    presence = manager.check_presence(
+        FileSystemPath('/usr/bin/flock'),
+        Package('rsync'),
+        Package('bash'),
+        FileSystemPath('/usr/bin/python3'),
+        Package('python@3.13'),
+    )
+
+    assert presence == {
+        FileSystemPath('/usr/bin/flock'): True,
+        Package('rsync'): False,
+        Package('bash'): False,
+        FileSystemPath('/usr/bin/python3'): True,
+        Package('python@3.13'): False,
+    }
+
+
+@pytest.mark.parametrize(
+    ('output', 'expected'),
+    [
+        (CommandOutput(stdout=None, stderr=''), GeneralError),
+        (CommandOutput(stdout='flock 0.4.0\n', stderr=None), {Package('flock'): True}),
+    ],
+    ids=['no-stdout', 'no-stderr'],
+)
+def test_homebrew_check_presence_without_output(
+    root_logger: Logger,
+    output: CommandOutput,
+    expected: Union[dict[Installable, bool], type[Exception]],
+) -> None:
+    guest = _homebrew_guest()
+    guest.execute.return_value = output
+
+    manager = Homebrew(guest=guest, logger=root_logger)
+
+    # Only the listing on stdout is read, stderr may be missing.
+    if isinstance(expected, dict):
+        assert manager.check_presence(Package('flock')) == expected
+
+    else:
+        with pytest.raises(expected, match='no output'):
+            manager.check_presence(Package('flock'))
+
+
+def test_homebrew_install_checks_presence_first(root_logger: Logger) -> None:
+    guest = _homebrew_guest()
+    guest.execute.side_effect = [
+        CommandOutput(stdout='flock 0.4.0\n', stderr=''),
+        CommandOutput(stdout='', stderr=''),
+    ]
+
+    manager = Homebrew(guest=guest, logger=root_logger)
+
+    manager.install(Package('flock'), Package('rsync'), options=Options(check_first=True))
+
+    assert [str(call.args[0]) for call in guest.execute.call_args_list] == [
+        f'{BREW} list --versions flock rsync',
+        f'{BREW} install rsync',
+    ]
+
+
+def test_homebrew_failed_installation_pattern(root_logger: Logger) -> None:
+    manager = Homebrew(guest=_homebrew_guest(), logger=root_logger)
+
+    output = (
+        'Warning: No available formula with the name "no-such-formula-zz-9f3a".\n'
+        'Error: No formulae or casks found for no-such-formula-zz-9f3a.\n'
+    )
+
+    assert list(manager.extract_package_name_from_package_manager_output(output)) == [
+        'no-such-formula-zz-9f3a'
+    ]
+
+
+def test_homebrew_probe_command() -> None:
+    assert (
+        str(Homebrew.probe_command)
+        == "/bin/bash -c 'test -x /opt/homebrew/bin/brew || test -x /usr/local/bin/brew'"
+    )
+
+
+def test_homebrew_probe_priority() -> None:
+    # Probed after the package managers a Linux guest would have next to Homebrew.
+    assert Homebrew.probe_priority < min(Apk.probe_priority, Apt.probe_priority)
+
+
+@pytest.mark.parametrize(
+    ('is_darwin', 'expected_command'),
+    [
+        (
+            True,
+            'chmod +a "everyone allow read,execute,file_inherit,directory_inherit,only_inherit"',
+        ),
+        (False, 'setfacl -d -m o:rX'),
+    ],
+    ids=['macos', 'linux'],
+)
+def test_setup_become_acl(
+    root_logger: Logger,
+    monkeypatch: _pytest.monkeypatch.MonkeyPatch,
+    is_darwin: bool,
+    expected_command: str,
+) -> None:
+    guest = _ssh_guest(root_logger, become=True)
+    guest.facts = GuestFacts(in_sync=True, is_superuser=False, is_darwin=is_darwin)
+
+    package_manager = MagicMock()
+    execute = MagicMock()
+
+    monkeypatch.setattr(GuestSsh, 'package_manager', property(lambda _: package_manager))
+    monkeypatch.setattr(guest, 'install_scripts', MagicMock())
+    monkeypatch.setattr(guest, 'execute', execute)
+
+    guest.setup()
+
+    script = str(execute.call_args.args[0])
+    workdir_root = effective_workdir_root()
+
+    assert f'mkdir -p {workdir_root}' in script
+    assert f'{expected_command} {workdir_root}' in script
+
+    if is_darwin:
+        package_manager.install.assert_not_called()
+    else:
+        package_manager.install.assert_called_once_with(FileSystemPath('/usr/bin/setfacl'))
+
+
+@pytest.mark.parametrize(
+    ('dry_run', 'is_superuser', 'become'),
+    [(True, False, True), (False, True, True), (False, False, False)],
+    ids=['dry-run', 'superuser', 'no-become'],
+)
+def test_setup_without_acl(
+    root_logger: Logger,
+    monkeypatch: _pytest.monkeypatch.MonkeyPatch,
+    dry_run: bool,
+    is_superuser: bool,
+    become: bool,
+) -> None:
+    guest = _ssh_guest(root_logger, become=become, dry_run=dry_run)
+    guest.facts = GuestFacts(in_sync=True, is_superuser=is_superuser, is_darwin=True)
+
+    package_manager = MagicMock()
+    execute = MagicMock()
+
+    monkeypatch.setattr(GuestSsh, 'package_manager', property(lambda _: package_manager))
+    monkeypatch.setattr(guest, 'install_scripts', MagicMock())
+    monkeypatch.setattr(guest, 'execute', execute)
+
+    guest.setup()
+
+    execute.assert_not_called()
+    package_manager.install.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ('with_interactive', 'with_tty', 'expected_command'),
+    [
+        (False, False, './inner.sh </dev/null 2>&1 | cat'),
+        (False, True, './inner.sh 2>&1'),
+        (True, False, './inner.sh'),
+    ],
+    ids=['no-tty', 'tty', 'interactive'],
+)
+@pytest.mark.parametrize(
+    ('is_darwin', 'become', 'is_superuser', 'expected_path'),
+    [
+        (True, False, False, f'export PATH={HOMEBREW_PREFIXES_PATH}:${{PATH}}'),
+        (True, False, True, f'export PATH={HOMEBREW_PREFIXES_PATH}:${{PATH}}'),
+        (True, True, False, f'export PATH=${{PATH}}:{HOMEBREW_PREFIXES_PATH}'),
+        (True, True, True, f'export PATH={HOMEBREW_PREFIXES_PATH}:${{PATH}}'),
+        (False, False, False, None),
+        (False, True, True, None),
+    ],
+    ids=[
+        'macos',
+        'macos-superuser',
+        'macos-become',
+        'macos-become-superuser',
+        'linux',
+        'linux-become-superuser',
+    ],
+)
+def test_outer_wrapper(
+    with_interactive: bool,
+    with_tty: bool,
+    expected_command: str,
+    is_darwin: bool,
+    become: bool,
+    is_superuser: bool,
+    expected_path: Optional[str],
+) -> None:
+    guest = MagicMock()
+    guest.facts.is_darwin = is_darwin
+    guest.facts.is_superuser = is_superuser
+    guest.facts.sudo_prefix = '' if is_superuser else 'sudo'
+    guest.become = become
+    guest.scripts_path = '/usr/local/bin'
+
+    # The prefixes are the template's own, not a render variable a caller could forget.
+    wrapper = OUTER_WRAPPER_TEMPLATE.render(
+        GUEST=guest,
+        COMMAND=ShellScript('./inner.sh'),
+        BEFORE_MESSAGE='before',
+        AFTER_MESSAGE=None,
+        WITH_INTERACTIVE=with_interactive,
+        WITH_TTY=with_tty,
+    )
+
+    echo = (
+        'echo "before" > /dev/kmsg'
+        if is_superuser
+        else 'sudo bash -c "echo \\"before\\" > /dev/kmsg"'
+    )
+
+    assert f'if [ -e /dev/kmsg ]; then\n    {echo}\nfi' in wrapper
+
+    # The wrapper has to run under bash 3.2, hence `2>&1 |` rather than `|&`.
+    assert '|&' not in wrapper
+    assert f'\n{expected_command}\n_exit_code="$?"' in wrapper
+
+    if expected_path is None:
+        assert HOMEBREW_PREFIXES[0] not in wrapper
+
+    else:
+        assert wrapper.index(expected_path) < wrapper.index('flock ')
+
+
+def test_execute_resets_rsync_facts(
+    root_logger: Logger, monkeypatch: _pytest.monkeypatch.MonkeyPatch
+) -> None:
+    guest = MagicMock()
+    guest.facts = GuestFacts(in_sync=True, has_rsync=True, has_openrsync=True, is_darwin=True)
+
+    invocation = MagicMock()
+    invocation.guest = guest
+    invocation.pidfile.create_wrappers.return_value = (Path('inner.sh'), Path('outer.sh'))
+    invocation.invoke_test.return_value = CommandOutput(stdout='', stderr='')
+
+    plugin = MagicMock()
+    plugin.data.interactive = False
+    plugin.data.ignore_duration = True
+
+    # The facts as seen by each pull that follows the test.
+    pulled: list[tuple[Optional[bool], Optional[bool]]] = []
+    plugin._post_action_pull.side_effect = lambda **kwargs: pulled.append(
+        (guest.facts.has_rsync, guest.facts.has_openrsync)
+    )
+
+    monkeypatch.setattr(tmt.steps, 'Topology', MagicMock())
+    monkeypatch.setattr(tmt.steps, 'GuestTopology', MagicMock())
+
+    ExecuteInternal.execute(plugin, invocation=invocation, logger=root_logger)
+
+    # A test may install or remove rsync, the pulls that follow have to ask again.
+    assert pulled == [(None, None), (None, None)]
+    assert guest.facts.is_darwin is True

--- a/tmt/guest/__init__.py
+++ b/tmt/guest/__init__.py
@@ -451,10 +451,34 @@ class TransferOptions:
     #: Run a ``mkdir -p`` of the destination before doing transfer
     create_destination: bool = False
 
+    #: Do not replace symlinked directories on the destination path
+    no_implied_dirs: bool = False
+
     def copy(self) -> 'TransferOptions':
         """Create a copy of the options."""
 
         return dataclasses.replace(self, exclude=self.exclude[:])
+
+    def adjusted_for(self, facts: 'GuestFacts', *, pushing: bool = True) -> 'TransferOptions':
+        """
+        Adjust options to the ``rsync`` and filesystem layout of a guest.
+
+        Apple's ``openrsync`` does not implement ``-s``, and macOS keeps
+        ``/var`` as a symlink into the read-only system volume, which a
+        ``--relative`` push would replace unless ``--no-implied-dirs`` is
+        used. ``openrsync`` does not accept that option as a sender,
+        hence it applies to pushes only.
+        """
+
+        options = self
+
+        if facts.has_openrsync:
+            options = dataclasses.replace(options, protect_args=False)
+
+        if facts.is_darwin and pushing:
+            options = dataclasses.replace(options, no_implied_dirs=True)
+
+        return options
 
     def to_rsync(self) -> list[str]:
         """Convert to rsync command line options."""
@@ -481,6 +505,8 @@ class TransferOptions:
             options.append('-R')
         if self.safe_links:
             options.append('--safe-links')
+        if self.no_implied_dirs:
+            options.append('--no-implied-dirs')
 
         return options
 
@@ -713,6 +739,8 @@ class GuestFacts(SerializableContainer):
     has_selinux: Optional[bool] = None
     has_systemd: Optional[bool] = None
     has_rsync: Optional[bool] = None
+    has_openrsync: Optional[bool] = None
+    is_darwin: Optional[bool] = None
     is_superuser: Optional[bool] = None
     can_sudo: Optional[bool] = None
     sudo_prefix: Optional[str] = None
@@ -883,6 +911,20 @@ class GuestFacts(SerializableContainer):
         if 'DISTRIB_DESCRIPTION' in self.lsb_release_content:
             return self.lsb_release_content['DISTRIB_DESCRIPTION']
 
+        # macOS has no release files, ask `sw_vers` instead.
+        if self._is_darwin(guest):
+            return self._query(
+                guest,
+                [
+                    (
+                        ShellScript(
+                            'echo "$(sw_vers -productName) $(sw_vers -productVersion)"'
+                        ).to_shell_command(),
+                        r'(.+)',
+                    )
+                ],
+            )
+
         # Nope, inspect more files.
         return self._query(
             guest,
@@ -893,16 +935,54 @@ class GuestFacts(SerializableContainer):
         )
 
     def _query_distro_id(self, guest: 'Guest') -> Optional[str]:
+        if self._is_darwin(guest):
+            return 'macos'
+
         return self.os_release_content.get('ID')
 
     def _query_distro_major_version(self, guest: 'Guest') -> Optional[int]:
         version_id = self.os_release_content.get('VERSION_ID')
+
+        if not version_id and self._is_darwin(guest):
+            # The distro fact, "macOS 15.7.7", already carries the answer of `sw_vers`.
+            if self.distro:
+                version_id = self.distro.split()[-1]
+
+            else:
+                version_id = self._query(guest, [(Command('sw_vers', '-productVersion'), r'(.+)')])
+
         if version_id:
             try:
                 return int(version_id.split('.')[0])
             except ValueError:
                 return None
         return None
+
+    def _is_darwin(self, guest: 'Guest') -> Optional[bool]:
+        """
+        Tell whether the guest runs macOS.
+
+        :py:meth:`sync` sets :py:attr:`is_darwin` before the distro
+        queries, so the cached value is normally used, and the guest is
+        asked only when a distro fact is synced on its own.
+        """
+
+        if self.is_darwin is not None:
+            return self.is_darwin
+
+        return self._query_is_darwin(guest)
+
+    def _query_is_darwin(self, guest: 'Guest') -> Optional[bool]:
+        """
+        Detect whether the guest runs macOS.
+        """
+
+        kernel_name = self._query(guest, [(Command('uname', '-s'), r'(.+)')])
+
+        if kernel_name is None:
+            return None
+
+        return kernel_name.strip() == 'Darwin'
 
     def _query_kernel_release(self, guest: 'Guest') -> Optional[str]:
         return self._query(guest, [(Command('uname', '-r'), r'(.+)')])
@@ -995,18 +1075,39 @@ class GuestFacts(SerializableContainer):
 
         return output is not None and output.stdout is not None
 
+    def _fetch_rsync_version(self, guest: 'Guest') -> Optional[tmt.utils.CommandOutput]:
+        """
+        Run ``rsync --version`` on the guest.
+
+        :returns: output of the command, or ``None`` when ``rsync`` is not available.
+        """
+
+        return self._execute(guest, Command('rsync', '--version'))
+
+    @staticmethod
+    def _is_openrsync(output: Optional[tmt.utils.CommandOutput]) -> Optional[bool]:
+        """
+        Tell from the output of ``rsync --version`` whether it is Apple's ``openrsync``.
+        """
+
+        if output is None or output.stdout is None:
+            return None
+
+        return output.stdout.lstrip().startswith('openrsync')
+
     def _query_has_rsync(self, guest: 'Guest') -> Optional[bool]:
         """
         Detect whether ``rsync`` is available.
         """
 
-        try:
-            guest.execute(Command('rsync', '--version'), silent=True)
+        return self._fetch_rsync_version(guest) is not None
 
-            return True
+    def _query_has_openrsync(self, guest: 'Guest') -> Optional[bool]:
+        """
+        Detect whether ``rsync`` on the guest is Apple's ``openrsync``.
+        """
 
-        except tmt.utils.RunError:
-            return False
+        return self._is_openrsync(self._fetch_rsync_version(guest))
 
     def _query_is_superuser(self, guest: 'Guest') -> Optional[bool]:
         output = self._execute(guest, Command('whoami'))
@@ -1133,6 +1234,16 @@ class GuestFacts(SerializableContainer):
             GuestCapability.SYSLOG_ACTION_READ_CLEAR: True,
         }
 
+    def sync_rsync(self, guest: 'Guest') -> None:
+        """
+        Refresh :py:attr:`has_rsync` and :py:attr:`has_openrsync` with one ``rsync --version``.
+        """
+
+        rsync_version = self._fetch_rsync_version(guest)
+
+        self.has_rsync = rsync_version is not None
+        self.has_openrsync = self._is_openrsync(rsync_version)
+
     def sync(self, guest: 'Guest', *facts: str) -> None:
         """
         Update stored facts to reflect the given guest.
@@ -1162,6 +1273,7 @@ class GuestFacts(SerializableContainer):
             self.lsb_release_content = self._fetch_keyval_file(guest, Path('/etc/lsb-release'))
 
             self.arch = self._query_arch(guest)
+            self.is_darwin = self._query_is_darwin(guest)
             self.distro = self._query_distro(guest)
             self.kernel_release = self._query_kernel_release(guest)
             self.package_manager = self._query_package_manager(guest)
@@ -1169,7 +1281,7 @@ class GuestFacts(SerializableContainer):
             self.has_selinux = self._query_has_selinux(guest)
             self.has_systemd = self._query_has_systemd(guest)
             self.systemd_soft_reboot = self._query_systemd_soft_reboot(guest)
-            self.has_rsync = self._query_has_rsync(guest)
+            self.sync_rsync(guest)
             self.is_superuser = self._query_is_superuser(guest)
             self.can_sudo = self._query_can_sudo(guest)
             self.sudo_prefix = self._query_sudo_prefix(guest)
@@ -1217,6 +1329,8 @@ class GuestFacts(SerializableContainer):
         yield _flag('has_systemd', 'systemd')
         yield _flag('systemd_soft_reboot', 'systemd soft-reboot')
         yield _flag('has_rsync', 'rsync')
+        yield _flag('has_openrsync', 'openrsync')
+        yield _flag('is_darwin', 'is darwin')
         yield _flag('is_superuser', 'is superuser')
         yield _flag('can_sudo', 'can sudo')
 
@@ -3740,18 +3854,32 @@ class GuestSsh(Guest, CommandCollector):
 
         if self.is_dry_run:
             return
-        if not self.facts.is_superuser and self.become:
+        if self.facts.is_superuser or not self.become:
+            return
+
+        workdir_root = effective_workdir_root()
+
+        # macOS has no setfacl, an inherited ACL entry replaces the default ACL.
+        # The entry also grants execute on files, which `setfacl o:rX` does not,
+        # since macOS ACLs cannot express conditional execute.
+        if self.facts.is_darwin:
+            acl_command = (
+                'chmod +a "everyone allow read,execute,file_inherit,directory_inherit,'
+                f'only_inherit" {workdir_root}'
+            )
+        else:
             self.package_manager.install(FileSystemPath('/usr/bin/setfacl'))
             self.package_manager.finalize_installation()
-            workdir_root = effective_workdir_root()
-            self.execute(
-                ShellScript(
-                    f"""
-                    mkdir -p {workdir_root};
-                    setfacl -d -m o:rX {workdir_root}
-                    """
-                )
+            acl_command = f'setfacl -d -m o:rX {workdir_root}'
+
+        self.execute(
+            ShellScript(
+                f"""
+                mkdir -p {workdir_root};
+                {acl_command}
+                """
             )
+        )
 
     @overload
     def execute(
@@ -3940,11 +4068,11 @@ class GuestSsh(Guest, CommandCollector):
         Make sure ``rsync`` is installed on the guest.
         """
 
-        # Refresh the fact first if it's unknown. This will prevent us
+        # Refresh the facts first if they are unknown. This will prevent us
         # trying to install rsync if it's (still, or already) installed,
         # with whatever price such an attempt comes with.
         if self.facts.has_rsync is None:
-            self.facts.sync(self, 'has_rsync')
+            self.facts.sync_rsync(self)
 
         if self.facts.has_rsync:
             return
@@ -3966,8 +4094,51 @@ class GuestSsh(Guest, CommandCollector):
                 f" connection itself."
             ) from exc
 
-        # We changed the state of the guest, refresh the fact.
-        self.facts.sync(self, 'has_rsync')
+        # We changed the state of the guest, refresh the facts.
+        self.facts.sync_rsync(self)
+
+    def _transfer_options(
+        self, options: TransferOptions, *, pushing: bool = True
+    ) -> TransferOptions:
+        """
+        Adjust transfer options to the guest, see :py:meth:`TransferOptions.adjusted_for`.
+        """
+
+        missing_facts = [
+            fact for fact in ('has_openrsync', 'is_darwin') if getattr(self.facts, fact) is None
+        ]
+
+        if missing_facts:
+            self.facts.sync(self, *missing_facts)
+
+        return options.adjusted_for(self.facts, pushing=pushing)
+
+    @staticmethod
+    def _remote_path(path: str, options: TransferOptions) -> str:
+        """
+        Prepare a path for the remote side of an ``rsync`` transfer.
+
+        Without ``-s``, the remote shell interprets the path, and it must be quoted.
+        The local ``rsync`` is told to send it as is, see :py:meth:`_transfer_environment`:
+        since 3.2.4 it would otherwise escape the path itself, and the quotes would
+        reach the remote shell as part of the file name.
+        """
+
+        return path if options.protect_args else quote(path)
+
+    @staticmethod
+    def _transfer_environment(options: TransferOptions) -> Optional[Environment]:
+        """
+        Environment for the local ``rsync`` of a transfer.
+
+        ``RSYNC_OLD_ARGS`` keeps ``rsync`` 3.2.4 and later from escaping the remote
+        path on their own, which :py:meth:`_remote_path` has already quoted for the
+        remote shell; older releases never escaped it and ignore the variable. It also
+        turns off the check 3.2.5 added against a remote sender slipping extra top-level
+        items into the file list, which matters for pulls from such a guest only.
+        """
+
+        return None if options.protect_args else Environment({'RSYNC_OLD_ARGS': EnvVarValue('1')})
 
     def push(
         self,
@@ -4005,7 +4176,7 @@ class GuestSsh(Guest, CommandCollector):
         self._assert_ssh_master_process()
 
         # Prepare options and the push command
-        options = options or DEFAULT_PUSH_OPTIONS
+        options = self._transfer_options(options or DEFAULT_PUSH_OPTIONS)
         if destination is None:
             destination = Path("/")
         if source is None:
@@ -4027,14 +4198,16 @@ class GuestSsh(Guest, CommandCollector):
             "-e",
             self._ssh_command.to_element(),
             f"{source}{path_suffix}",
-            f"{self._ssh_guest}:{destination}{path_suffix}",
+            f"{self._ssh_guest}:{self._remote_path(f'{destination}{path_suffix}', options)}",
         ]
 
         try:
             if options.create_destination:
                 self.execute(Command("mkdir", "-p", destination.parent), silent=True)
 
-            self._run_guest_command(cmd, silent=True)
+            self._run_guest_command(
+                cmd, silent=True, environment=self._transfer_environment(options)
+            )
 
         except tmt.utils.RunError as exc:
             # Provide a reasonable error to the user
@@ -4075,7 +4248,7 @@ class GuestSsh(Guest, CommandCollector):
         self._assert_ssh_master_process()
 
         # Prepare options and the pull command
-        options = options or DEFAULT_PULL_OPTIONS
+        options = self._transfer_options(options or DEFAULT_PULL_OPTIONS, pushing=False)
         if destination is None:
             destination = Path("/")
         if source is None:
@@ -4094,10 +4267,11 @@ class GuestSsh(Guest, CommandCollector):
                         *options.to_rsync(),
                         "-e",
                         self._ssh_command.to_element(),
-                        f"{self._ssh_guest}:{source}",
+                        f"{self._ssh_guest}:{self._remote_path(str(source), options)}",
                         destination,
                     ),
                     silent=True,
+                    environment=self._transfer_environment(options),
                 )
 
         except tmt.utils.RunError as exc:

--- a/tmt/package_managers/homebrew.py
+++ b/tmt/package_managers/homebrew.py
@@ -1,0 +1,234 @@
+import re
+from typing import Optional, Union
+
+import tmt.utils
+from tmt.package_managers import (
+    FileSystemPath,
+    Installable,
+    Options,
+    Package,
+    PackageManager,
+    PackageManagerEngine,
+    PackagePath,
+    escape_installables,
+    provides_package_manager,
+)
+from tmt.utils import (
+    Command,
+    CommandOutput,
+    GeneralError,
+    RunError,
+    ShellScript,
+)
+
+ReducedPackages = list[Union[Package, PackagePath]]
+
+#: Homebrew prefixes on Apple silicon and Intel Macs, not on the ``PATH`` of ssh sessions.
+HOMEBREW_PREFIXES = ('/opt/homebrew/bin', '/usr/local/bin')
+
+HOMEBREW_PATH = ':'.join([*HOMEBREW_PREFIXES, '/usr/bin', '/bin', '/usr/sbin', '/sbin'])
+
+PACKAGE_PATH: dict[FileSystemPath, str] = {
+    FileSystemPath('/usr/bin/awk'): 'gawk',
+    FileSystemPath('/usr/bin/flock'): 'flock',
+    FileSystemPath('/usr/bin/python3'): 'python',
+}
+
+
+class HomebrewEngine(PackageManagerEngine):
+    install_command = Command('install')
+
+    def prepare_command(self) -> tuple[Command, Command]:
+        """
+        Prepare installation command for Homebrew, which refuses to run under ``sudo``.
+
+        Homebrew does not run as ``root`` either, so there is no ``sudo_prefix`` to
+        apply, and a guest logged in as ``root`` cannot use it at all.
+        """
+
+        if self.guest.facts.is_superuser:
+            raise GeneralError(
+                f"Homebrew does not run as root, log in to guest '{self.guest.name}' as "
+                "a regular user and use 'become' for elevated privileges."
+            )
+
+        return (
+            Command('env', f'PATH={HOMEBREW_PATH}', 'HOMEBREW_NO_AUTO_UPDATE=1', 'brew'),
+            Command(),
+        )
+
+    def path_to_package(self, path: FileSystemPath) -> Package:
+        """
+        Find a formula providing given filesystem path.
+
+        Homebrew cannot look up files outside its prefix, support a fixed set of mappings.
+        """
+
+        if path in PACKAGE_PATH:
+            return Package(PACKAGE_PATH[path])
+
+        raise GeneralError(f"Unsupported package path '{path}' for Homebrew.")
+
+    def _reduce_to_packages(self, *installables: Installable) -> ReducedPackages:
+        packages: ReducedPackages = []
+
+        for installable in installables:
+            if isinstance(installable, (Package, PackagePath)):
+                packages.append(installable)
+
+            elif isinstance(installable, FileSystemPath):
+                packages.append(self.path_to_package(installable))
+
+            else:
+                raise tmt.utils.PrepareError(
+                    f"Package manager 'homebrew' does not support installing from a remote "
+                    f"URL '{installable}'."
+                )
+
+        return packages
+
+    def _assert_supported_options(self, options: Options) -> None:
+        if options.excluded_packages:
+            raise tmt.utils.PrepareError(
+                "Package manager 'homebrew' does not support excluding packages."
+            )
+
+    def _construct_presence_script(
+        self, *installables: Installable
+    ) -> tuple[ReducedPackages, ShellScript]:
+        reduced_packages = self._reduce_to_packages(*installables)
+
+        shell_script = ShellScript(
+            f'{self.command.to_script()} list --versions '
+            f'{" ".join(escape_installables(*reduced_packages))}'
+        )
+
+        return reduced_packages, shell_script
+
+    def check_presence(self, *installables: Installable) -> ShellScript:
+        return self._construct_presence_script(*installables)[1]
+
+    def refresh_metadata(self) -> ShellScript:
+        return ShellScript(f'{self.command.to_script()} update')
+
+    def enable_repo(self, *repo_ids: str) -> ShellScript:
+        raise tmt.utils.PrepareError(
+            "Package manager 'homebrew' does not support enabling repositories."
+        )
+
+    def disable_repo(self, *repo_ids: str) -> ShellScript:
+        raise tmt.utils.PrepareError(
+            "Package manager 'homebrew' does not support disabling repositories."
+        )
+
+    def install(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> ShellScript:
+        options = options or Options()
+
+        self._assert_supported_options(options)
+
+        packages = self._reduce_to_packages(*installables)
+
+        script = ShellScript(
+            f'{self.command.to_script()} {self.install_command.to_script()} '
+            f'{" ".join(escape_installables(*packages))}'
+        )
+
+        if options.skip_missing:
+            script = script | ShellScript('/bin/true')
+
+        return script
+
+    def reinstall(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> ShellScript:
+        options = options or Options()
+
+        self._assert_supported_options(options)
+
+        packages = self._reduce_to_packages(*installables)
+
+        script = ShellScript(
+            f'{self.command.to_script()} reinstall {" ".join(escape_installables(*packages))}'
+        )
+
+        if options.skip_missing:
+            script = script | ShellScript('/bin/true')
+
+        return script
+
+    def install_debuginfo(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> ShellScript:
+        raise tmt.utils.GeneralError("There is no support for debuginfo packages in Homebrew.")
+
+
+@provides_package_manager('homebrew')
+class Homebrew(PackageManager[HomebrewEngine]):
+    NAME = 'homebrew'
+
+    _engine_class = HomebrewEngine
+
+    _FAILED_PACKAGE_INSTALLATION_PATTERNS = [
+        re.compile(r'No available formula with the name "([^"]+)"', re.IGNORECASE),
+    ]
+
+    # Probed after the package managers with the default priority: a Linux guest with
+    # Homebrew under one of the prefixes keeps its native package manager.
+    probe_priority = -10
+
+    # Probe only the prefixes the engine can run, `brew` elsewhere on the `PATH` would be
+    # detected and then fail to run.
+    probe_command = ShellScript(
+        ' || '.join(f'test -x {prefix}/brew' for prefix in HOMEBREW_PREFIXES)
+    ).to_shell_command()
+
+    def check_presence(self, *installables: Installable) -> dict[Installable, bool]:
+        reduced_packages, presence_script = self.engine._construct_presence_script(*installables)
+
+        try:
+            output = self.guest.execute(presence_script)
+            stdout = output.stdout
+
+        except RunError as exc:
+            stdout = exc.stdout
+
+        if stdout is None:
+            raise GeneralError("Homebrew presence check output provided no output")
+
+        results: dict[Installable, bool] = {}
+
+        for installable, package in zip(installables, reduced_packages):
+            # Aliases such as `python` are listed under the formula they resolve to, `python@3.14`.
+            match = re.search(rf'^{re.escape(str(package))}(@\S+)?\s', stdout, re.MULTILINE)
+
+            results[installable] = match is not None
+
+        return results
+
+    def install_debuginfo(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> CommandOutput:
+        raise tmt.utils.PrepareError(
+            f'Package manager "{self.guest.facts.package_manager}" does not support '
+            'installing debuginfo packages.'
+        )
+
+    def install_local(
+        self,
+        *installables: Installable,
+        options: Optional[Options] = None,
+    ) -> CommandOutput:
+        raise tmt.utils.PrepareError(
+            f'Package manager "{self.guest.facts.package_manager}" does not support '
+            'installing local packages.'
+        )

--- a/tmt/steps/context/pidfile.py
+++ b/tmt/steps/context/pidfile.py
@@ -55,8 +55,8 @@ event, and they do not finish on their own.
 
 The ssh client always allocates a tty, so the timeout handling works
 (#1387). Because the allocated tty is generally not suitable for the
-execution of test, or scripts in general, the wrapper uses ``|& cat`` to
-emulate execution without a tty. In certain cases, where the execution
+execution of test, or scripts in general, the wrapper uses ``2>&1 | cat``
+to emulate execution without a tty. In certain cases, where the execution
 of given action with available tty is required (#2381), the tty can be
 enabled in the outer script.
 
@@ -65,7 +65,7 @@ The outer wrapper handles the following 3 execution modes:
 * In the interactive mode, stdin and stdout are unhandled, it is expected
   user interacts with the executed command.
 * In the non-interactive mode without a tty, stdin is fed with
-  ``/dev/null`` (EOF), and ``|& cat`` is used to simulate the "no tty
+  ``/dev/null`` (EOF), and ``2>&1 | cat`` is used to simulate the "no tty
   available" for the running action.
 * In the non-interactive mode with a tty, stdin is available to the
   action, and the simulation of "tty not available" for output is not
@@ -82,6 +82,7 @@ import tmt.log
 import tmt.steps
 from tmt.container import container
 from tmt.guest import Guest, TransferOptions
+from tmt.package_managers.homebrew import HOMEBREW_PREFIXES
 from tmt.steps import safe_filename
 from tmt.utils import Path, ShellScript
 from tmt.utils.environment import Environment, EnvVarValue, HasEnvironment
@@ -102,13 +103,14 @@ INNER_WRAPPER_TEMPLATE = jinja2.Template("""
 #: orchestration and invokes the inner wrapper.
 OUTER_WRAPPER_TEMPLATE = jinja2.Template("""
 {% macro log_to_dmesg(msg) %}
+# Logging test into kernel log
+if [ -e /dev/kmsg ]; then
     {%- if not GUEST.facts.is_superuser %}
-# Logging test into kernel log
-{{ GUEST.facts.sudo_prefix }} bash -c "echo \\\"{{ msg }}\\\" > /dev/kmsg"
+    {{ GUEST.facts.sudo_prefix }} bash -c "echo \\\"{{ msg }}\\\" > /dev/kmsg"
     {%- else %}
-# Logging test into kernel log
-echo "{{ msg }}" > /dev/kmsg
+    echo "{{ msg }}" > /dev/kmsg
     {%- endif %}
+fi
 {% endmacro %}
 
 {% macro enter() %}
@@ -139,6 +141,18 @@ flock "$TMT_TEST_PIDFILE_LOCK" -c "rm -f ${TMT_TEST_PIDFILE}" || exit 123
 if ! grep -q "{{ GUEST.scripts_path }}" <<< "${PATH}"; then
     export PATH={{ GUEST.scripts_path }}:${PATH}
 fi
+{%- if GUEST.facts.is_darwin %}
+{%- if GUEST.become and not GUEST.facts.is_superuser %}
+
+# Root deliberately runs Homebrew binaries owned by the ssh user, macOS has no system flock. On an
+# Intel Mac the scripts path above is the Homebrew prefix, which then comes first regardless.
+export PATH=${PATH}:{{ HOMEBREW_PREFIXES | join(':') }}
+{%- else %}
+
+# Make sure Homebrew binaries are searched by shell
+export PATH={{ HOMEBREW_PREFIXES | join(':') }}:${PATH}
+{%- endif %}
+{%- endif %}
 
 [ ! -z "$TMT_DEBUG" ] && set -x
 
@@ -167,7 +181,7 @@ set -o pipefail
 
 {{ enter() }}
 
-{{ COMMAND }} </dev/null |& cat
+{{ COMMAND }} </dev/null 2>&1 | cat
 _exit_code="$?"
 
 {{ exit () }}
@@ -176,6 +190,9 @@ _exit_code="$?"
 # Return the original exit code of the test script
 exit $_exit_code
 """)  # noqa: E501
+
+# A constant of the template, not a render variable, so that no caller can leave the prefixes out.
+OUTER_WRAPPER_TEMPLATE.globals['HOMEBREW_PREFIXES'] = HOMEBREW_PREFIXES
 
 
 def effective_pidfile_root() -> Path:

--- a/tmt/steps/execute/internal.py
+++ b/tmt/steps/execute/internal.py
@@ -70,7 +70,7 @@ from tmt.utils.themes import style
 #
 # The ssh client always allocates a tty, so test timeout handling
 # works (#1387). Because the allocated tty is generally not suitable
-# for test execution, the wrapper uses `|& cat` to emulate execution
+# for test execution, the wrapper uses `2>&1 | cat` to emulate execution
 # without a tty. In certain cases, where test execution with available
 # tty is required (#2381), the tty can be kept on request with
 # the `tty: true` test attribute.
@@ -81,7 +81,7 @@ from tmt.utils.themes import style
 #   user interacts with the executed command.
 #
 # * In non-interactive mode without a tty, stdin is fed with /dev/null (EOF)
-#   and `|& cat` is used to simulate no tty available for script output.
+#   and `2>&1 | cat` is used to simulate no tty available for script output.
 #
 # * In non-interactive mode with a tty, stdin is available to the tests
 #   and simulation of tty not available for output is not run.
@@ -446,11 +446,12 @@ class ExecuteInternal(tmt.steps.execute.ExecutePlugin[ExecuteInternalData]):
             invocation.path / TEST_OUTPUT_FILENAME, output.stdout or '', mode='a', debug_level=3
         )
 
-        # Reset `has-rsync` fact: tmt is expected to install rsync if it
+        # Reset the rsync facts: tmt is expected to install rsync if it
         # is missing after a test. To achieve that, pretend we don't
         # know whether rsync is installed, and let any attempt to use
         # rsync answer and react before calling the command.
         guest.facts.has_rsync = None
+        guest.facts.has_openrsync = None
 
         pull_options = test.test_framework.get_pull_options(
             invocation, DEFAULT_PULL_OPTIONS, logger

--- a/tmt/steps/prepare/install.py
+++ b/tmt/steps/prepare/install.py
@@ -173,6 +173,14 @@ class PrepareInstall(tmt.steps.prepare.PreparePlugin[PrepareInstallData]):
 
         * Cannot install new version of already installed local rpm.
         * No support for installing debuginfo packages at this time.
+
+    .. note::
+
+        On macOS guests tmt installs packages with Homebrew, which has to
+        live under ``/opt/homebrew`` or ``/usr/local``. Only formulae are
+        supported, and Homebrew refuses to run as ``root``, so log in to
+        the guest as a regular user and use ``become`` where root is
+        needed.
     """
 
     _data_class = PrepareInstallData

--- a/tmt/steps/provision/connect.py
+++ b/tmt/steps/provision/connect.py
@@ -273,6 +273,18 @@ class ProvisionConnect(tmt.steps.provision.ProvisionPlugin[ProvisionConnectData]
             how: connect
             guest: host.example.org
 
+    A macOS guest is reached as a regular user with passwordless ``sudo``
+    and ``become`` set, since Homebrew, which provides the essential
+    requirements, refuses to run as ``root``:
+
+    .. code-block:: yaml
+
+        provision:
+            how: connect
+            guest: mac.example.org
+            user: admin
+            become: true
+
     To support hard reboot of a guest, ``hard-reboot`` must be set to
     an executable command or script. Without this key set, hard reboot
     will remain unsupported and result in an error. In comparison,


### PR DESCRIPTION
Detect macOS and Apple's openrsync in guest facts and adjust the rsync options accordingly, keep the test wrapper compatible with bash 3.2 and hosts without /dev/kmsg, and add a Homebrew package manager so the essential requirements can be installed.

Generated-by: Claude Code (Claude Fable 5.1)

Part of Testing Farm's macOS guests work, whose main piece is the Artemis Orchard driver, https://gitlab.com/testing-farm/artemis/-/merge_requests/1632. This PR is independent of it and works with any macOS guest reached through `connect`. Testing Farm can use it once it is released and its container's tmt is bumped, with https://gitlab.com/testing-farm/gluetool-modules/-/merge_requests/1098 passing the guest's user.

Besides the unit tests, exercised end to end through that driver on macOS 15 guests provisioned by Testing Farm's Artemis: plans ran through the driver's worker port, plain, with `become` and with a Homebrew package install, all passing.

Pull Request Checklist

* [X] implement the feature
* [X] write the documentation
* [X] extend the test coverage
* [X] adjust plugin docstring
* [X] include a release note
