### PR TITLE
Instead of changing CWD, use `--root` to point pytest tests to their data dirs

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,17 +2,20 @@ import contextlib
 import functools
 import importlib.metadata
 import os
-from collections.abc import Generator, Iterator, Mapping
+from collections.abc import Generator, Iterator, Mapping, Sequence
 from typing import IO, Any, Callable, Optional, Protocol, TypeVar, Union
 
 import _pytest.monkeypatch
 import click.core
 import click.testing
+import pytest
 
 import tmt.__main__
 import tmt.cli._root
 from tmt._compat.typing import ParamSpec
-from tmt.utils import Path
+from tmt._compat.typing import TypeAlias as TypeAlias
+from tmt.log import Logger as Logger
+from tmt.utils import Command, Path, RawCommandElement
 
 _CLICK_VERSION = tuple(int(_s) for _s in importlib.metadata.version('click').split('.'))
 
@@ -81,6 +84,33 @@ def with_cwd(path: Path) -> Callable[[Callable[P, T]], Callable[P, T]]:
     return _with_cwd
 
 
+def with_fmf_root(path: Path) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """
+    Decorated test will run its ``tmt`` commands in the given fmf root.
+
+    A mere redress of the actual :py:meth:`pytest.mark.parametrize` decorator
+    with the right parameters, parametrizing the :py:func:`fixture_fmf_root`
+    fixture with the path. The fixture then delivers the path to the
+    :py:func:`fixture_run_tmt` fixture to be included by default in all
+    ``tmt`` calls.
+
+    It is possible to combine this decorator with parametrization of
+    other test inputs - just use both decorators:
+
+    .. code-block:: python
+
+        @with_fmf_root(...)
+        @pytest.mark.parametrize(['foo', 'bar'], ...)
+        def test_baz(foo, bar, fmf_root):
+            ...
+    """
+
+    def _with_fmf_root(fn: Callable[P, T]) -> Callable[P, T]:
+        return pytest.mark.parametrize('fmf_root', [path], indirect=['fmf_root'])(fn)
+
+    return _with_fmf_root
+
+
 @contextlib.contextmanager
 def not_feeling_safe(monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> Generator[None]:
     """
@@ -108,7 +138,7 @@ class RunTmt(Protocol):
 
     def __call__(
         self,
-        *args: Union[str, Path],
+        *args: RawCommandElement,
         command: Optional[click.BaseCommand] = None,
         input: Optional[Union[str, bytes, IO[Any]]] = None,
         env: Optional[Mapping[str, Optional[str]]] = None,
@@ -129,8 +159,9 @@ class CliRunner(click.testing.CliRunner):
 
     def invoke(  # type: ignore[override]
         self,
-        *args: Union[str, Path],
+        *args: RawCommandElement,
         command: Optional[click.BaseCommand] = None,
+        extra_tmt_options: Optional[Sequence[RawCommandElement]] = None,
         input: Optional[Union[str, bytes, IO[Any]]] = None,
         env: Optional[Mapping[str, Optional[str]]] = None,
         catch_exceptions: bool = True,
@@ -142,10 +173,11 @@ class CliRunner(click.testing.CliRunner):
         tmt.__main__.import_cli_commands()
 
         command = command or tmt.cli._root.main
+        options = Command(*(*(extra_tmt_options or []), *args))
 
         return super().invoke(
             command,
-            args=[str(arg) for arg in args],
+            args=options.to_popen(),
             input=input,
             env=env,
             catch_exceptions=catch_exceptions,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
+import functools
 import os
 import pathlib
 import shutil
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
+import _pytest.fixtures
 import _pytest.logging
 import _pytest.tmpdir
 import fmf.base
@@ -14,10 +16,24 @@ from tmt.base.plan import Plan
 from tmt.log import Logger
 from tmt.steps.provision import Provision
 from tmt.steps.provision.podman import GuestContainer, PodmanGuestData
-from tmt.utils import Path
+from tmt.utils import Path, RawCommand
 
 if TYPE_CHECKING:
     from pytest_container.container import ContainerData
+
+
+@pytest.fixture(name='_extra_tmt_options')
+def _fixture_extra_tmt_options() -> RawCommand:
+    """
+    Collection of extra options to pass to ``tmt`` command.
+
+    This fixture is not to be used directly in tests. It is used by
+    fixtures to collect additional command-line options for the main
+    command, ``tmt``: fixtures that do wish to enhance the command would
+    require this fixture, and add their options to the provided list.
+    """
+
+    return []
 
 
 @pytest.fixture(name='root_logger')
@@ -29,13 +45,30 @@ def fixture_root_logger(caplog: _pytest.logging.LogCaptureFixture) -> Logger:
     return Logger.create(verbose=0, debug=0, quiet=False, apply_colors_logging=False)
 
 
+@pytest.fixture(name='fmf_root')
+def fixture_fmf_root(
+    _extra_tmt_options: RawCommand, request: _pytest.fixtures.FixtureRequest
+) -> Path:
+    assert isinstance(request.param, Path)
+
+    # Let the main tmt command know it's supposed to use the given fmf
+    # root...
+    _extra_tmt_options += ['-r', request.param]
+
+    # ... but also propagate the path to the test, just like fixtures do.
+    # The test might wish to work with the path as well.
+    return request.param
+
+
 @pytest.fixture(name='run_tmt')
-def fixture_run_tmt() -> RunTmt:
+def fixture_run_tmt(
+    _extra_tmt_options: RawCommand, request: _pytest.fixtures.FixtureRequest
+) -> RunTmt:
     """
     Invoke a ``tmt`` command with given options.
     """
 
-    return CliRunner().invoke
+    return functools.partial(CliRunner().invoke, extra_tmt_options=_extra_tmt_options)
 
 
 # Equivalent fixtures to `tmp_path_factory` and `tmp_path` recasting the paths

--- a/tests/plan/context/test_context.py
+++ b/tests/plan/context/test_context.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 import pytest
-from tests import with_cwd
+from tests import with_fmf_root
 
 from tmt.utils import Path
 
@@ -14,8 +14,8 @@ DATA_DIR = TEST_DIR / 'data'
 
 
 @pytest.mark.nonunit
-@with_cwd(DATA_DIR)
-def test_plan_with_good_context(run_tmt: 'RunTmt') -> None:
+@with_fmf_root(DATA_DIR)
+def test_plan_with_good_context(run_tmt: 'RunTmt', fmf_root: Path) -> None:
     """
     Plan with a good context
     """
@@ -29,8 +29,8 @@ def test_plan_with_good_context(run_tmt: 'RunTmt') -> None:
 
 
 @pytest.mark.nonunit
-@with_cwd(DATA_DIR)
-def test_plan_with_bad_context(run_tmt: 'RunTmt') -> None:
+@with_fmf_root(DATA_DIR)
+def test_plan_with_bad_context(run_tmt: 'RunTmt', fmf_root: Path) -> None:
     """
     Plan with a bad context
     """
@@ -42,8 +42,8 @@ def test_plan_with_bad_context(run_tmt: 'RunTmt') -> None:
 
 
 @pytest.mark.nonunit
-@with_cwd(DATA_DIR)
-def test_plan_with_good_context_and_bad_command_line(run_tmt: 'RunTmt') -> None:
+@with_fmf_root(DATA_DIR)
+def test_plan_with_good_context_and_bad_command_line(run_tmt: 'RunTmt', fmf_root: Path) -> None:
     """
     Plan with a good context, overwritten by command line
     """
@@ -67,8 +67,8 @@ def test_plan_with_good_context_and_bad_command_line(run_tmt: 'RunTmt') -> None:
 
 
 @pytest.mark.nonunit
-@with_cwd(DATA_DIR)
-def test_plan_with_broken_values(run_tmt: 'RunTmt') -> None:
+@with_fmf_root(DATA_DIR)
+def test_plan_with_broken_values(run_tmt: 'RunTmt', fmf_root: Path) -> None:
     """
     Plan with broken values
     """


### PR DESCRIPTION
Changing CWD is a big issue, applies to everything, not just to the tmt command invoked by the test. All threads would be affected, and even though we don't use threads in tests, it's a potential trap.

And tmt offers a way to use a given fmf root instead of CWD. The PR connects the dots: a test decorator notes the fmf root path down, a fixture picks it up and modifies the `run_tmt` helper.

Pull Request Checklist

* [x] implement the feature